### PR TITLE
Fix failing tests in UploadProcessingJob and PostProcessingJob

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -192,6 +192,9 @@ class RequestsController < ApplicationController
   def create_zip_file(source_dir, zip_path)
     require "zip"
 
+    # Delete existing zip to avoid "Entry already exists" errors
+    File.delete(zip_path) if File.exist?(zip_path)
+
     source_dir_real = File.realpath(source_dir)
 
     Zip::File.open(zip_path, create: true) do |zipfile|


### PR DESCRIPTION
Issues fixed:
1. UploadProcessingJob tests were making real HTTP calls to Open Library API
   - Added VCR.turned_off blocks with WebMock stubs for all tests
   - Stub returns empty search results to focus tests on file operations

2. PostProcessingJob tests were using ebook fixture instead of audiobook
   - Changed test setup to create audiobook fixture
   - Audiobookshelf integration only works with audiobooks
   - Added missing scan endpoint stub for error test

3. RequestsController zip creation had "Entry already exists" error
   - Delete existing zip file before creating new one
   - Prevents duplicate entry errors when recreating cached zips

All 328 tests now pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where zip file creation would fail if a file with the same name already existed, improving reliability of file export functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->