### PR TITLE
Fix: Remove upgrade-insecure-requests CSP directive

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,8 +21,9 @@ Rails.application.configure do
     # Connect sources for Turbo/Stimulus and API calls
     policy.connect_src :self
 
-    # Upgrade insecure requests in production
-    policy.upgrade_insecure_requests true if Rails.env.production?
+    # Note: upgrade_insecure_requests is intentionally NOT enabled
+    # This allows access via HTTP on local networks without SSL
+    # If you're exposing Shelfarr over the internet, use a reverse proxy with SSL instead
   end
 
   # Generate session nonces for permitted importmap and inline scripts.


### PR DESCRIPTION
## Summary
- Removes the `upgrade-insecure-requests` CSP directive that was breaking local network access
- This directive caused browsers to automatically upgrade HTTP to HTTPS, resulting in `ERR_SSL_PROTOCOL_ERROR` when accessing Shelfarr via local IP addresses

## Problem
After the security PR (#9) was merged, accessing Shelfarr via `http://192.168.x.x:3000` fails with SSL errors because the browser automatically tries to use HTTPS.

## Solution
Remove the directive. For users exposing Shelfarr to the internet, a reverse proxy with proper SSL termination is the recommended approach.

## Test plan
- [ ] Access Shelfarr via local IP address over HTTP
- [ ] Verify no SSL errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Modified Content Security Policy configuration to allow HTTP connections on local networks without SSL enforcement. SSL/HTTPS is no longer automatically upgraded in the application; implement SSL termination via reverse proxy for internet-exposed deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->