### PR TITLE
Fix: Allow Open Library images from archive.org in CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
     policy.font_src    :self, :data
-    policy.img_src     :self, :data, "https://covers.openlibrary.org"
+    policy.img_src     :self, :data, "https://covers.openlibrary.org", "https://*.archive.org"
     policy.object_src  :none
     policy.script_src  :self
     policy.style_src   :self, :unsafe_inline  # Required for Tailwind and inline SVG styles


### PR DESCRIPTION
## Summary
- Open Library redirects cover images to `archive.org` (`ia*.us.archive.org`)
- CSP was blocking these redirected images
- Added `https://*.archive.org` to `img-src` directive

## Test plan
- [ ] Book covers load correctly on dashboard, library, and search pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)