### PR TITLE
Fix: Add bare archive.org domain to CSP img-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
     policy.font_src    :self, :data
-    policy.img_src     :self, :data, "https://covers.openlibrary.org", "https://*.archive.org"
+    policy.img_src     :self, :data, "https://covers.openlibrary.org", "https://archive.org", "https://*.archive.org"
     policy.object_src  :none
     policy.script_src  :self
     policy.style_src   :self, :unsafe_inline  # Required for Tailwind and inline SVG styles


### PR DESCRIPTION
The wildcard `*.archive.org` doesn't match `archive.org` (bare domain). Open Library redirects first to `archive.org` then to `ia*.archive.org`, so we need both.