### PR TITLE
Fix: Session cookie secure flag breaks HTTP login

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -66,7 +66,8 @@ module Authentication
           expires: max_age_days.days.from_now,
           httponly: true,
           same_site: :lax,
-          secure: Rails.env.production?
+          # Only set secure flag if actually using HTTPS (allows HTTP on local networks)
+          secure: request.ssl?
         }
       end
     end


### PR DESCRIPTION
The session cookie was set with `secure: Rails.env.production?` which always sets the secure flag in production. This prevents cookies from being sent over HTTP connections on local networks.

Changed to `secure: request.ssl?` so it only sets the secure flag when actually using HTTPS.