### PR TITLE
feat: Add language-aware acquisition system with confidence scoring

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -45,7 +45,7 @@ class SearchJob < ApplicationJob
     book = request.book
 
     # Build search query: "title author"
-    query_parts = [book.title]
+    query_parts = [ book.title ]
     query_parts << book.author if book.author.present?
 
     query = query_parts.join(" ")
@@ -56,11 +56,10 @@ class SearchJob < ApplicationJob
   end
 
   def save_results(request, results)
-    # Clear previous results
     request.search_results.destroy_all
 
     results.each do |result|
-      request.search_results.create!(
+      search_result = request.search_results.create!(
         guid: result.guid,
         title: result.title,
         indexer: result.indexer,
@@ -72,6 +71,8 @@ class SearchJob < ApplicationJob
         info_url: result.info_url,
         published_at: result.published_at
       )
+
+      search_result.calculate_score!
     end
   end
 

--- a/app/services/auto_select_service.rb
+++ b/app/services/auto_select_service.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Service for automatically selecting the best search result for a request
 class AutoSelectService
-  # Result object for selection outcomes
   class SelectionResult
     attr_reader :selected, :reason, :search_result
 
@@ -24,17 +22,30 @@ class AutoSelectService
   def initialize(request)
     @request = request
     @min_seeders = SettingsService.get(:auto_select_min_seeders, default: 1)
+    @confidence_threshold = SettingsService.get(:auto_select_confidence_threshold, default: 90)
+    @requested_language = request.effective_language
   end
 
   def call
-    candidates = @request.search_results.pending.best_first.select(&:downloadable?)
+    matching_results = find_matching_results
+    candidates = matching_results.select(&:downloadable?)
+
+    if matching_results.empty?
+      log_skip("no results meeting criteria (confidence >= #{@confidence_threshold}, language: #{@requested_language})")
+      return SelectionResult.new(selected: false, reason: :no_matching_results)
+    end
 
     if candidates.empty?
-      log_skip("no downloadable results")
+      log_skip("#{matching_results.size} results match criteria but none are downloadable")
       return SelectionResult.new(selected: false, reason: :no_downloadable_results)
     end
 
     best_result = candidates.first
+
+    unless meets_confidence_threshold?(best_result)
+      log_skip("best result score #{best_result.confidence_score || 0} below threshold #{@confidence_threshold}")
+      return SelectionResult.new(selected: false, reason: :below_confidence_threshold, search_result: best_result)
+    end
 
     unless meets_seeder_threshold?(best_result)
       log_skip("best result has #{best_result.seeders || 0} seeders, minimum is #{@min_seeders}")
@@ -51,13 +62,25 @@ class AutoSelectService
 
   private
 
+  def find_matching_results
+    @request.search_results
+      .pending
+      .auto_selectable(@confidence_threshold)
+      .matches_language(@requested_language)
+      .best_first
+  end
+
+  def meets_confidence_threshold?(result)
+    (result.confidence_score || 0) >= @confidence_threshold
+  end
+
   def meets_seeder_threshold?(result)
-    return true if result.usenet? # Usenet has no seeders
+    return true if result.usenet?
     (result.seeders || 0) >= @min_seeders
   end
 
   def log_success(result)
-    Rails.logger.info "[AutoSelectService] Auto-selected '#{result.title}' for request ##{@request.id}"
+    Rails.logger.info "[AutoSelectService] Auto-selected '#{result.title}' (score: #{result.confidence_score}) for request ##{@request.id}"
   end
 
   def log_skip(reason)

--- a/app/services/release_parser_service.rb
+++ b/app/services/release_parser_service.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+# Service for parsing release titles to extract metadata like language, format, and quality.
+# Based on patterns from Radarr/Sonarr LanguageParser and rank-torrent-name (RTN).
+class ReleaseParserService
+  # Supported languages with their ISO 639-1 codes and display names
+  LANGUAGES = {
+    "en" => { name: "English", flag: "GB" },
+    "nl" => { name: "Dutch", flag: "NL" },
+    "de" => { name: "German", flag: "DE" },
+    "fr" => { name: "French", flag: "FR" },
+    "es" => { name: "Spanish", flag: "ES" },
+    "it" => { name: "Italian", flag: "IT" },
+    "pt" => { name: "Portuguese", flag: "PT" },
+    "pt-BR" => { name: "Portuguese (Brazil)", flag: "BR" },
+    "ru" => { name: "Russian", flag: "RU" },
+    "ja" => { name: "Japanese", flag: "JP" },
+    "ko" => { name: "Korean", flag: "KR" },
+    "zh" => { name: "Chinese", flag: "CN" },
+    "pl" => { name: "Polish", flag: "PL" },
+    "sv" => { name: "Swedish", flag: "SE" },
+    "da" => { name: "Danish", flag: "DK" },
+    "no" => { name: "Norwegian", flag: "NO" },
+    "fi" => { name: "Finnish", flag: "FI" },
+    "tr" => { name: "Turkish", flag: "TR" },
+    "ar" => { name: "Arabic", flag: "SA" },
+    "he" => { name: "Hebrew", flag: "IL" },
+    "hi" => { name: "Hindi", flag: "IN" },
+    "th" => { name: "Thai", flag: "TH" },
+    "vi" => { name: "Vietnamese", flag: "VN" },
+    "cs" => { name: "Czech", flag: "CZ" },
+    "hu" => { name: "Hungarian", flag: "HU" },
+    "ro" => { name: "Romanian", flag: "RO" },
+    "bg" => { name: "Bulgarian", flag: "BG" },
+    "uk" => { name: "Ukrainian", flag: "UA" },
+    "el" => { name: "Greek", flag: "GR" }
+  }.freeze
+
+  # Language detection patterns - order matters for specificity
+  # More specific patterns should come before generic ones
+  LANGUAGE_PATTERNS = [
+    # English
+    { code: "en", pattern: /\benglish\b/i },
+    { code: "en", pattern: /(?<![a-z])eng(?![a-z])/i },
+    { code: "en", pattern: /(?<![a-z])EN(?![a-z])/ },
+
+    # Dutch/Flemish
+    { code: "nl", pattern: /\bdutch\b/i },
+    { code: "nl", pattern: /\bflemish\b/i },
+    { code: "nl", pattern: /(?<![a-z])NL(?![a-z])/ },
+    { code: "nl", pattern: /\.NL\./i },
+    { code: "nl", pattern: /\[Dutch\]/i },
+    { code: "nl", pattern: /\(Dutch\)/i },
+
+    # German (including Swiss German)
+    { code: "de", pattern: /\bgerman\b/i },
+    { code: "de", pattern: /\bswissgerman\b/i },
+    { code: "de", pattern: /\bger\.dub\b/i },
+    { code: "de", pattern: /\bvideomann\b/i },
+    { code: "de", pattern: /(?<![a-z])ger(?![a-z])/i },
+    { code: "de", pattern: /(?<![a-z])DE(?![a-z])/ },
+    { code: "de", pattern: /\.DE\./i },
+
+    # French
+    { code: "fr", pattern: /\bfrench\b/i },
+    { code: "fr", pattern: /\btruefrench\b/i },
+    { code: "fr", pattern: /(?<![a-z])VF(?![a-z])/i },
+    { code: "fr", pattern: /(?<![a-z])VFF(?![a-z])/i },
+    { code: "fr", pattern: /(?<![a-z])VFQ(?![a-z])/i },
+    { code: "fr", pattern: /(?<![a-z])VFI(?![a-z])/i },
+    { code: "fr", pattern: /(?<![a-z])FR(?![a-z])/ },
+    { code: "fr", pattern: /\.FR\./i },
+
+    # Spanish
+    { code: "es", pattern: /\bspanish\b/i },
+    { code: "es", pattern: /\bespañol\b/i },
+    { code: "es", pattern: /\bcastellano\b/i },
+    { code: "es", pattern: /(?<![a-z])ES(?![a-z])/ },
+    { code: "es", pattern: /\.ES\./i },
+    { code: "es", pattern: /\blatino\b/i },
+
+    # Italian
+    { code: "it", pattern: /\bitalian\b/i },
+    { code: "it", pattern: /(?<![a-z])ita(?![a-z])/i },
+    { code: "it", pattern: /(?<![a-z])IT(?![a-z])/ },
+    { code: "it", pattern: /\.IT\./i },
+
+    # Portuguese
+    { code: "pt", pattern: /\bportuguese\b/i },
+    { code: "pt", pattern: /(?<![a-z])por(?![a-z])/i },
+    { code: "pt", pattern: /(?<![a-z])PT(?![a-z])/ },
+    { code: "pt", pattern: /\.PT\./i },
+
+    # Portuguese (Brazil)
+    { code: "pt-BR", pattern: /\bbrazilian\b/i },
+    { code: "pt-BR", pattern: /\bdublado\b/i },
+    { code: "pt-BR", pattern: /\bpt-br\b/i },
+    { code: "pt-BR", pattern: /\.BR\./i },
+
+    # Russian
+    { code: "ru", pattern: /\brussian\b/i },
+    { code: "ru", pattern: /(?<![a-z])rus(?![a-z])/i },
+    { code: "ru", pattern: /(?<![a-z])RU(?![a-z])/ },
+
+    # Japanese
+    { code: "ja", pattern: /\bjapanese\b/i },
+    { code: "ja", pattern: /(?<![a-z])jap(?![a-z])/i },
+    { code: "ja", pattern: /(?<![a-z])jpn(?![a-z])/i },
+    { code: "ja", pattern: /\(JA\)/i },
+
+    # Korean
+    { code: "ko", pattern: /\bkorean\b/i },
+    { code: "ko", pattern: /(?<![a-z])kor(?![a-z])/i },
+
+    # Chinese
+    { code: "zh", pattern: /\bchinese\b/i },
+    { code: "zh", pattern: /\bmandarin\b/i },
+    { code: "zh", pattern: /\bcantonese\b/i },
+    { code: "zh", pattern: /\[CHT\]/i },
+    { code: "zh", pattern: /\[CHS\]/i },
+    { code: "zh", pattern: /\[BIG5\]/i },
+    { code: "zh", pattern: /\[GB\]/i },
+
+    # Polish
+    { code: "pl", pattern: /\bpolish\b/i },
+    { code: "pl", pattern: /(?<![a-z])PL(?![a-z])/ },
+    { code: "pl", pattern: /\bpl\.dub\b/i },
+    { code: "pl", pattern: /\bdub\.pl\b/i },
+
+    # Swedish
+    { code: "sv", pattern: /\bswedish\b/i },
+    { code: "sv", pattern: /(?<![a-z])swe(?![a-z])/i },
+
+    # Danish
+    { code: "da", pattern: /\bdanish\b/i },
+    { code: "da", pattern: /(?<![a-z])dan(?![a-z])/i },
+
+    # Norwegian
+    { code: "no", pattern: /\bnorwegian\b/i },
+    { code: "no", pattern: /(?<![a-z])nor(?![a-z])/i },
+
+    # Finnish
+    { code: "fi", pattern: /\bfinnish\b/i },
+    { code: "fi", pattern: /(?<![a-z])fin(?![a-z])/i },
+
+    # Turkish
+    { code: "tr", pattern: /\bturkish\b/i },
+    { code: "tr", pattern: /(?<![a-z])tur(?![a-z])/i },
+
+    # Arabic
+    { code: "ar", pattern: /\barabic\b/i },
+
+    # Hebrew
+    { code: "he", pattern: /\bhebrew\b/i },
+    { code: "he", pattern: /\bhebdub\b/i },
+
+    # Hindi
+    { code: "hi", pattern: /\bhindi\b/i },
+
+    # Thai
+    { code: "th", pattern: /\bthai\b/i },
+
+    # Vietnamese
+    { code: "vi", pattern: /\bvietnamese\b/i },
+    { code: "vi", pattern: /(?<![a-z])VIE(?![a-z])/i },
+
+    # Czech
+    { code: "cs", pattern: /\bczech\b/i },
+    { code: "cs", pattern: /(?<![a-z])CZ(?![a-z])/ },
+
+    # Hungarian
+    { code: "hu", pattern: /\bhungarian\b/i },
+    { code: "hu", pattern: /\bhundub\b/i },
+    { code: "hu", pattern: /(?<![a-z])HUN(?![a-z])/i },
+
+    # Romanian
+    { code: "ro", pattern: /\bromanian\b/i },
+    { code: "ro", pattern: /\brodubbed\b/i },
+
+    # Bulgarian
+    { code: "bg", pattern: /\bbulgarian\b/i },
+    { code: "bg", pattern: /\bbgaudio\b/i },
+    { code: "bg", pattern: /(?<![a-z])BG(?![a-z])/ },
+
+    # Ukrainian
+    { code: "uk", pattern: /\bukrainian\b/i },
+    { code: "uk", pattern: /(?<![a-z])ukr(?![a-z])/i },
+
+    # Greek
+    { code: "el", pattern: /\bgreek\b/i }
+  ].freeze
+
+  # Multi-language indicators (treat as matching any requested language)
+  MULTI_LANGUAGE_PATTERNS = [
+    /\bmulti\b/i,
+    /\bdual\b/i,
+    /\btri-audio\b/i,
+    /\bquad[\.\s]audio\b/i,
+    # German dual-language tag (DL but not WEB-DL)
+    /(?<!WEB)(?<!WEB-)(?<!WEB\.)(?<!WEB_)\bDL\b/,
+    # German multi-language tag
+    /\bML\b/
+  ].freeze
+
+  # Audiobook format indicators
+  AUDIOBOOK_PATTERNS = [
+    /\baudiobook\b/i,
+    /\bm4b\b/i,
+    /\bunabridged\b/i,
+    /\babridged\b/i,
+    /\bnarrated\s+by\b/i,
+    /\bread\s+by\b/i,
+    /\b(?:64|128|192|256|320)kbps\b/i,
+    /\bmp3\b.*\b(?:audiobook|book)\b/i
+  ].freeze
+
+  # Ebook format indicators
+  EBOOK_PATTERNS = [
+    /\bebook\b/i,
+    /\bepub\b/i,
+    /\bmobi\b/i,
+    /\bazw3?\b/i,
+    /\bpdf\b/i,
+    /\bcbr\b/i,
+    /\bcbz\b/i
+  ].freeze
+
+  class << self
+    # Parse a release title and extract metadata
+    # @param title [String] The release title to parse
+    # @return [Hash] Parsed metadata including languages, format, etc.
+    def parse(title)
+      return empty_result if title.blank?
+
+      {
+        languages: detect_languages(title),
+        is_multi_language: multi_language?(title),
+        format: detect_format(title),
+        raw_title: title
+      }
+    end
+
+    # Detect all languages present in a release title
+    # @param title [String] The release title
+    # @return [Array<String>] Array of detected ISO 639-1 language codes
+    def detect_languages(title)
+      return [] if title.blank?
+
+      detected = Set.new
+
+      LANGUAGE_PATTERNS.each do |pattern_config|
+        pattern = pattern_config[:pattern]
+        next unless title.match?(pattern)
+
+        detected.add(pattern_config[:code])
+      end
+
+      detected.to_a
+    end
+
+    # Check if a release is marked as multi-language
+    # @param title [String] The release title
+    # @return [Boolean]
+    def multi_language?(title)
+      return false if title.blank?
+
+      MULTI_LANGUAGE_PATTERNS.any? { |pattern| title.match?(pattern) }
+    end
+
+    # Detect the format (audiobook, ebook, or unknown) from the title
+    # @param title [String] The release title
+    # @return [Symbol, nil] :audiobook, :ebook, or nil if unknown
+    def detect_format(title)
+      return nil if title.blank?
+
+      return :audiobook if AUDIOBOOK_PATTERNS.any? { |pattern| title.match?(pattern) }
+      return :ebook if EBOOK_PATTERNS.any? { |pattern| title.match?(pattern) }
+
+      nil
+    end
+
+    # Get display info for a language code
+    # @param code [String] ISO 639-1 language code
+    # @return [Hash, nil] Hash with :name and :flag, or nil if unknown
+    def language_info(code)
+      LANGUAGES[code]
+    end
+
+    # Get all supported language codes
+    # @return [Array<String>]
+    def supported_language_codes
+      LANGUAGES.keys
+    end
+
+    # Get languages formatted for select options
+    # @return [Array<Array>] Array of [display_name, code] pairs
+    def language_options
+      LANGUAGES.map { |code, info| [ info[:name], code ] }.sort_by(&:first)
+    end
+
+    private
+
+    def empty_result
+      {
+        languages: [],
+        is_multi_language: false,
+        format: nil,
+        raw_title: nil
+      }
+    end
+  end
+end

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+# Scores search results based on how well they match a request.
+# Returns a confidence score (0-100) with a detailed breakdown.
+class ReleaseScorer
+  # Weight configuration for each scoring factor
+  WEIGHTS = {
+    title: 40,      # How well does the release title match the book title?
+    author: 20,     # Is the author name present in the release title?
+    language: 25,   # Does it match the requested language?
+    format: 10,     # Does the format (audiobook/ebook) match?
+    health: 5       # Seeders/availability (for torrents)
+  }.freeze
+
+  Result = Data.define(:total, :breakdown, :detected_languages, :detected_format) do
+    def high_confidence?
+      total >= 90
+    end
+
+    def medium_confidence?
+      total >= 70 && total < 90
+    end
+
+    def low_confidence?
+      total < 70
+    end
+  end
+
+  def initialize(search_result, request)
+    @search_result = search_result
+    @request = request
+    @book = request.book
+    @parsed = ReleaseParserService.parse(search_result.title)
+  end
+
+  # Calculate the confidence score
+  # @return [Result] Score result with total, breakdown, and detected metadata
+  def score
+    breakdown = {
+      title: calculate_title_score,
+      author: calculate_author_score,
+      language: calculate_language_score,
+      format: calculate_format_score,
+      health: calculate_health_score
+    }
+
+    # Calculate weighted total
+    total = WEIGHTS.sum do |key, weight|
+      (breakdown[key] * weight) / 100.0
+    end.round
+
+    Result.new(
+      total: total,
+      breakdown: breakdown,
+      detected_languages: @parsed[:languages],
+      detected_format: @parsed[:format]
+    )
+  end
+
+  class << self
+    # Score a search result against a request
+    # @param search_result [SearchResult] The search result to score
+    # @param request [Request] The request to match against
+    # @return [Result] Score result
+    def score(search_result, request)
+      new(search_result, request).score
+    end
+  end
+
+  private
+
+  # Title matching score (0-100)
+  # Uses trigram similarity like BookMatcherService
+  def calculate_title_score
+    release_title = normalize_for_matching(@search_result.title)
+    book_title = normalize_for_matching(@book.title)
+
+    return 0 if release_title.blank? || book_title.blank?
+
+    # Check if book title appears in release title
+    if release_title.include?(book_title)
+      100
+    else
+      trigram_similarity(release_title, book_title)
+    end
+  end
+
+  # Author matching score (0-100)
+  # Checks if author name appears in release title
+  def calculate_author_score
+    return 50 if @book.author.blank?  # Neutral if no author to match
+
+    release_title = normalize_for_matching(@search_result.title)
+    author = normalize_for_matching(@book.author)
+
+    return 0 if release_title.blank?
+
+    # Check for full author name
+    return 100 if release_title.include?(author)
+
+    # Check for last name (common pattern)
+    author_parts = author.split
+    if author_parts.length > 1
+      last_name = author_parts.last
+      return 80 if release_title.include?(last_name) && last_name.length > 3
+    end
+
+    # Check for first name (less reliable)
+    first_name = author_parts.first
+    return 40 if release_title.include?(first_name) && first_name.length > 3
+
+    0
+  end
+
+  # Language matching score (0-100)
+  # 100 = matches requested, 50 = unknown/multi, 0 = wrong language
+  def calculate_language_score
+    requested_language = @request.language || SettingsService.get(:default_language)
+    detected = @parsed[:languages]
+
+    # Multi-language releases match any language
+    return 100 if @parsed[:is_multi_language]
+
+    # No language detected - treat as neutral (might match, might not)
+    return 50 if detected.empty?
+
+    # Check if requested language is in detected languages
+    return 100 if detected.include?(requested_language)
+
+    # Wrong language detected
+    0
+  end
+
+  # Format matching score (0-100)
+  # Checks if release format matches book type
+  def calculate_format_score
+    detected = @parsed[:format]
+    requested = @book.book_type&.to_sym
+
+    # No format detected - neutral
+    return 50 if detected.nil?
+
+    # Match check
+    case requested
+    when :audiobook
+      detected == :audiobook ? 100 : 0
+    when :ebook
+      detected == :ebook ? 100 : 0
+    else
+      50  # Unknown book type
+    end
+  end
+
+  # Health/availability score (0-100)
+  # Based on seeders for torrents, always 100 for usenet
+  def calculate_health_score
+    # Usenet always has full availability
+    return 100 if usenet?
+
+    seeders = @search_result.seeders || 0
+
+    # Normalize seeders to 0-100 scale
+    # 0 seeders = 0, 1-5 = 20-60, 5-20 = 60-80, 20+ = 80-100
+    case seeders
+    when 0
+      0
+    when 1..5
+      20 + (seeders * 8)
+    when 6..20
+      60 + ((seeders - 5) * 1.3).round
+    else
+      [ 80 + ((seeders - 20) * 0.2).round, 100 ].min
+    end
+  end
+
+  def usenet?
+    # Usenet results typically have download_url but no magnet and no seeders
+    @search_result.download_url.present? &&
+      @search_result.magnet_url.blank? &&
+      @search_result.seeders.nil?
+  end
+
+  # Normalize text for matching
+  def normalize_for_matching(text)
+    return "" if text.blank?
+
+    text
+      .downcase
+      .gsub(/[^a-z0-9\s]/, "")  # Remove special characters
+      .gsub(/\s+/, " ")         # Collapse whitespace
+      .strip
+  end
+
+  # Trigram-based similarity score (0-100)
+  def trigram_similarity(str1, str2)
+    return 100 if str1 == str2
+    return 0 if str1.blank? || str2.blank?
+
+    trigrams1 = to_trigrams(str1)
+    trigrams2 = to_trigrams(str2)
+
+    return 0 if trigrams1.empty? || trigrams2.empty?
+
+    intersection = (trigrams1 & trigrams2).size
+    union = (trigrams1 | trigrams2).size
+
+    ((intersection.to_f / union) * 100).round
+  end
+
+  def to_trigrams(str)
+    padded = "  #{str}  "
+    (0..padded.length - 3).map { |i| padded[i, 3] }.to_set
+  end
+end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -38,6 +38,12 @@ class SettingsService
     # Auto-Selection
     auto_select_enabled: { type: "boolean", default: false, category: "auto_select", description: "Automatically select the best search result without admin intervention" },
     auto_select_min_seeders: { type: "integer", default: 1, category: "auto_select", description: "Minimum seeders required for auto-selection (torrent only)" },
+    auto_select_confidence_threshold: { type: "integer", default: 90, category: "auto_select", description: "Minimum confidence score (0-100) for auto-selection" },
+
+    # Language Settings
+    default_language: { type: "string", default: "en", category: "language", description: "Default language for new requests" },
+    enabled_languages: { type: "json", default: '["en"]', category: "language", description: "Languages available for selection when creating requests" },
+    min_match_confidence: { type: "integer", default: 50, category: "language", description: "Minimum confidence score (0-100) to display a search result" },
 
     # Updates
     github_repo: { type: "string", default: "Pedro-Revez-Silva/shelfarr", category: "updates", description: "GitHub repository for update notifications" },
@@ -57,6 +63,7 @@ class SettingsService
     "open_library" => "Open Library",
     "health" => "Health Monitoring",
     "auto_select" => "Auto-Selection",
+    "language" => "Language & Matching",
     "updates" => "Updates",
     "security" => "Security"
   }.freeze

--- a/app/views/admin/search_results/index.html.erb
+++ b/app/views/admin/search_results/index.html.erb
@@ -25,7 +25,8 @@
             <% if @request.book.author.present? %>
               by <%= @request.book.author %> &middot;
             <% end %>
-            <%= @search_results.count %> results found
+            <%= @search_results.count %> results found &middot;
+            Looking for: <%= @request.language_display_name %>
           </p>
         </div>
       </div>
@@ -34,11 +35,26 @@
     <% if @search_results.any? %>
       <div class="divide-y">
         <% @search_results.each do |result| %>
-          <div class="p-4 hover:bg-gray-50">
+          <div class="p-4 hover:bg-gray-50 <%= result.language_matches_request? ? '' : 'bg-yellow-50' %>">
             <div class="flex items-start justify-between gap-4">
               <div class="flex-grow min-w-0">
-                <p class="font-medium text-gray-900"><%= result.title %></p>
+                <div class="flex items-center gap-2">
+                  <p class="font-medium text-gray-900"><%= result.title %></p>
+                  <% if result.detected_language.present? %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium <%= result.language_matches_request? ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800' %>">
+                      <%= result.language_display_name %>
+                    </span>
+                  <% end %>
+                </div>
                 <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-500 mt-1">
+                  <% if result.confidence_score.present? %>
+                    <span class="inline-flex items-center <%= result.high_confidence? ? 'text-green-600' : 'text-gray-500' %>">
+                      <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      Score: <%= result.confidence_score %>%
+                    </span>
+                  <% end %>
                   <% if result.indexer.present? %>
                     <span class="inline-flex items-center">
                       <svg class="w-4 h-4 mr-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -112,6 +112,20 @@
       </div>
 
       <div>
+        <label for="language" class="block text-sm font-medium text-gray-700 mb-1">Language</label>
+        <select
+          name="language"
+          id="language"
+          class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        >
+          <% @enabled_languages.each do |name, code| %>
+            <option value="<%= code %>" <%= 'selected' if code == @default_language %>><%= name %></option>
+          <% end %>
+        </select>
+        <p class="mt-1 text-xs text-gray-500">Preferred language for this request</p>
+      </div>
+
+      <div>
         <label for="notes" class="block text-sm font-medium text-gray-700 mb-1">Notes (optional)</label>
         <textarea
           name="notes"

--- a/db/migrate/20260101151522_add_language_to_requests.rb
+++ b/db/migrate/20260101151522_add_language_to_requests.rb
@@ -1,0 +1,5 @@
+class AddLanguageToRequests < ActiveRecord::Migration[8.1]
+  def change
+    add_column :requests, :language, :string
+  end
+end

--- a/db/migrate/20260101151531_add_scoring_to_search_results.rb
+++ b/db/migrate/20260101151531_add_scoring_to_search_results.rb
@@ -1,0 +1,7 @@
+class AddScoringToSearchResults < ActiveRecord::Migration[8.1]
+  def change
+    add_column :search_results, :detected_language, :string
+    add_column :search_results, :confidence_score, :integer
+    add_column :search_results, :score_breakdown, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_27_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_01_151531) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -106,6 +106,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_27_000001) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.text "issue_description"
+    t.string "language"
     t.datetime "next_retry_at"
     t.text "notes"
     t.integer "retry_count", default: 0
@@ -121,7 +122,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_27_000001) do
   end
 
   create_table "search_results", force: :cascade do |t|
+    t.integer "confidence_score"
     t.datetime "created_at", null: false
+    t.string "detected_language"
     t.string "download_url"
     t.string "guid", null: false
     t.string "indexer"
@@ -130,6 +133,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_27_000001) do
     t.string "magnet_url"
     t.datetime "published_at"
     t.integer "request_id", null: false
+    t.json "score_breakdown"
     t.integer "seeders"
     t.bigint "size_bytes"
     t.integer "status", default: 0, null: false

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -11,7 +11,14 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     @request = Request.create!(
       book: @book,
       user: @user,
-      status: :searching
+      status: :searching,
+      language: "en"
+    )
+
+    Setting.find_or_create_by(key: "auto_select_confidence_threshold").update!(
+      value: "50",
+      value_type: "integer",
+      category: "auto_select"
     )
   end
 
@@ -142,11 +149,14 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
   private
 
   def create_search_result(attrs = {})
-    @request.search_results.create!({
+    result = @request.search_results.create!({
       guid: SecureRandom.uuid,
-      title: "Test Result",
+      title: "Test Result English Audiobook",
       indexer: "TestIndexer",
-      status: :pending
+      status: :pending,
+      confidence_score: 95,
+      detected_language: "en"
     }.merge(attrs))
+    result
   end
 end

--- a/test/services/release_parser_service_test.rb
+++ b/test/services/release_parser_service_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReleaseParserServiceTest < ActiveSupport::TestCase
+  test "detects English from full word" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.English.Audiobook"), "en"
+  end
+
+  test "detects English from ENG code" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.ENG.MP3"), "en"
+  end
+
+  test "detects Dutch from full word" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.Dutch.Audiobook"), "nl"
+  end
+
+  test "detects Dutch from NL code" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.NL.M4B"), "nl"
+  end
+
+  test "detects Dutch from bracketed format" do
+    assert_includes ReleaseParserService.detect_languages("Book Title [Dutch] Audiobook"), "nl"
+  end
+
+  test "detects German from full word" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.German.Audiobook"), "de"
+  end
+
+  test "detects German from DE code" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.DE.MP3"), "de"
+  end
+
+  test "detects French from TRUEFRENCH" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.TRUEFRENCH.M4B"), "fr"
+  end
+
+  test "detects French from VF" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.VF.Audiobook"), "fr"
+  end
+
+  test "detects Spanish from espanol" do
+    assert_includes ReleaseParserService.detect_languages("Libro.Titulo.Español.MP3"), "es"
+  end
+
+  test "detects Brazilian Portuguese from Dublado" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.Dublado.M4B"), "pt-BR"
+  end
+
+  test "detects multiple languages" do
+    languages = ReleaseParserService.detect_languages("Book.Title.English.German.Audiobook")
+    assert_includes languages, "en"
+    assert_includes languages, "de"
+  end
+
+  test "returns empty array for no language detected" do
+    assert_empty ReleaseParserService.detect_languages("Book.Title.Audiobook.M4B")
+  end
+
+  test "returns empty array for blank input" do
+    assert_empty ReleaseParserService.detect_languages("")
+    assert_empty ReleaseParserService.detect_languages(nil)
+  end
+
+  test "multi_language detects MULTI tag" do
+    assert ReleaseParserService.multi_language?("Book.Title.MULTI.Audiobook")
+  end
+
+  test "multi_language detects Dual tag" do
+    assert ReleaseParserService.multi_language?("Book.Title.Dual.Audio.M4B")
+  end
+
+  test "multi_language returns false when no multi tag" do
+    refute ReleaseParserService.multi_language?("Book.Title.English.Audiobook")
+  end
+
+  test "detect_format identifies audiobook from M4B" do
+    assert_equal :audiobook, ReleaseParserService.detect_format("Book.Title.M4B")
+  end
+
+  test "detect_format identifies audiobook from Audiobook word" do
+    assert_equal :audiobook, ReleaseParserService.detect_format("Book Title Audiobook MP3")
+  end
+
+  test "detect_format identifies audiobook from Unabridged" do
+    assert_equal :audiobook, ReleaseParserService.detect_format("Book Title Unabridged")
+  end
+
+  test "detect_format identifies ebook from EPUB" do
+    assert_equal :ebook, ReleaseParserService.detect_format("Book.Title.EPUB")
+  end
+
+  test "detect_format identifies ebook from MOBI" do
+    assert_equal :ebook, ReleaseParserService.detect_format("Book.Title.MOBI")
+  end
+
+  test "detect_format returns nil for unknown format" do
+    assert_nil ReleaseParserService.detect_format("Book.Title")
+  end
+
+  test "parse returns complete result hash" do
+    result = ReleaseParserService.parse("Book.Title.Dutch.Audiobook.M4B")
+
+    assert_includes result[:languages], "nl"
+    assert_equal :audiobook, result[:format]
+    refute result[:is_multi_language]
+    assert_equal "Book.Title.Dutch.Audiobook.M4B", result[:raw_title]
+  end
+
+  test "parse returns empty result for blank input" do
+    result = ReleaseParserService.parse("")
+
+    assert_empty result[:languages]
+    assert_nil result[:format]
+    refute result[:is_multi_language]
+    assert_nil result[:raw_title]
+  end
+
+  test "language_info returns correct data for known language" do
+    info = ReleaseParserService.language_info("en")
+
+    assert_equal "English", info[:name]
+    assert_equal "GB", info[:flag]
+  end
+
+  test "language_info returns nil for unknown language" do
+    assert_nil ReleaseParserService.language_info("xx")
+  end
+
+  test "supported_language_codes returns all language codes" do
+    codes = ReleaseParserService.supported_language_codes
+
+    assert_includes codes, "en"
+    assert_includes codes, "nl"
+    assert_includes codes, "de"
+    assert_includes codes, "fr"
+    assert codes.length >= 20
+  end
+
+  test "language_options returns sorted name/code pairs" do
+    options = ReleaseParserService.language_options
+
+    assert options.first.is_a?(Array)
+    assert_equal 2, options.first.length
+
+    names = options.map(&:first)
+    assert_equal names, names.sort
+  end
+
+  test "does not falsely detect DE in WEB-DL" do
+    languages = ReleaseParserService.detect_languages("Book.Title.WEB-DL.English")
+
+    refute_includes languages, "de"
+    assert_includes languages, "en"
+  end
+
+  test "detects flemish as Dutch" do
+    assert_includes ReleaseParserService.detect_languages("Book.Title.Flemish.Audiobook"), "nl"
+  end
+end

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReleaseScorerTest < ActiveSupport::TestCase
+  setup do
+    @book = Book.create!(
+      title: "The Name of the Wind",
+      author: "Patrick Rothfuss",
+      book_type: :audiobook
+    )
+
+    @user = users(:one)
+
+    @request = Request.create!(
+      book: @book,
+      user: @user,
+      status: :pending,
+      language: "en"
+    )
+  end
+
+  test "scores high for exact title match with correct language" do
+    search_result = @request.search_results.create!(
+      guid: "test-1",
+      title: "The Name of the Wind - Patrick Rothfuss - English Audiobook M4B",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert result.total >= 80
+    assert_includes result.detected_languages, "en"
+    assert_equal :audiobook, result.detected_format
+  end
+
+  test "scores low for wrong language" do
+    search_result = @request.search_results.create!(
+      guid: "test-2",
+      title: "De Naam Van De Wind - Dutch Audiobook",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert result.total < 70
+    assert_includes result.detected_languages, "nl"
+  end
+
+  test "scores neutral when no language detected" do
+    search_result = @request.search_results.create!(
+      guid: "test-3",
+      title: "The Name of the Wind Audiobook M4B",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert_empty result.detected_languages
+    assert result.breakdown[:language] == 50
+  end
+
+  test "scores high for multi-language release" do
+    search_result = @request.search_results.create!(
+      guid: "test-4",
+      title: "The Name of the Wind MULTI Audiobook",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert result.breakdown[:language] == 100
+  end
+
+  test "scores format match correctly for audiobook" do
+    search_result = @request.search_results.create!(
+      guid: "test-5",
+      title: "The Name of the Wind Unabridged M4B",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert_equal :audiobook, result.detected_format
+    assert result.breakdown[:format] == 100
+  end
+
+  test "scores format mismatch for ebook when audiobook requested" do
+    search_result = @request.search_results.create!(
+      guid: "test-6",
+      title: "The Name of the Wind EPUB",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert_equal :ebook, result.detected_format
+    assert result.breakdown[:format] == 0
+  end
+
+  test "scores author presence correctly" do
+    search_result = @request.search_results.create!(
+      guid: "test-7",
+      title: "The Name of the Wind - Patrick Rothfuss",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert result.breakdown[:author] == 100
+  end
+
+  test "scores partial author match for last name only" do
+    search_result = @request.search_results.create!(
+      guid: "test-8",
+      title: "The Name of the Wind - Rothfuss Audiobook",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert result.breakdown[:author] == 80
+  end
+
+  test "scores health based on seeders" do
+    search_result = @request.search_results.create!(
+      guid: "test-9",
+      title: "The Name of the Wind",
+      seeders: 0
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert result.breakdown[:health] == 0
+  end
+
+  test "scores health high for many seeders" do
+    search_result = @request.search_results.create!(
+      guid: "test-10",
+      title: "The Name of the Wind",
+      seeders: 100
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    assert result.breakdown[:health] >= 90
+  end
+
+  test "high_confidence returns true for score >= 90" do
+    result = ReleaseScorer::Result.new(
+      total: 92,
+      breakdown: {},
+      detected_languages: [],
+      detected_format: nil
+    )
+
+    assert result.high_confidence?
+    refute result.medium_confidence?
+    refute result.low_confidence?
+  end
+
+  test "medium_confidence returns true for score 70-89" do
+    result = ReleaseScorer::Result.new(
+      total: 75,
+      breakdown: {},
+      detected_languages: [],
+      detected_format: nil
+    )
+
+    refute result.high_confidence?
+    assert result.medium_confidence?
+    refute result.low_confidence?
+  end
+
+  test "low_confidence returns true for score < 70" do
+    result = ReleaseScorer::Result.new(
+      total: 45,
+      breakdown: {},
+      detected_languages: [],
+      detected_format: nil
+    )
+
+    refute result.high_confidence?
+    refute result.medium_confidence?
+    assert result.low_confidence?
+  end
+end


### PR DESCRIPTION
## Summary

Adds a comprehensive language-aware acquisition system to solve the problem of downloading books in the wrong language (e.g., searching for an English book but getting Dutch results).

## Key Features

- **ReleaseParserService**: Detects language and format from release titles using 29 language patterns ported from Radarr/Sonarr
- **ReleaseScorerService**: Scores search results 0-100 based on weighted factors:
  - Title match (40%)
  - Author match (20%)
  - Language match (25%)
  - Format match (10%)
  - Health/seeders (5%)
- **Language preference**: Users can select preferred language when creating requests
- **Confidence threshold**: Auto-select only picks results above configurable confidence (default 90%)
- **Visual indicators**: Admin search results show confidence scores, language badges, and mismatch warnings

## Database Changes

- Added `language` column to `requests` table
- Added `detected_language`, `confidence_score`, `score_breakdown` columns to `search_results` table

## New Settings

- `default_language` (string, default: "en")
- `enabled_languages` (json, default: '["en"]')
- `min_match_confidence` (integer, default: 50)
- `auto_select_confidence_threshold` (integer, default: 90)

## Tests

- 44 new tests for ReleaseParserService and ReleaseScorerService
- Updated AutoSelectService tests for new filtering logic
- All 393 tests passing