### PR TITLE
feat: Copy files instead of move + per-client download paths

### DIFF
--- a/app/controllers/admin/download_clients_controller.rb
+++ b/app/controllers/admin/download_clients_controller.rb
@@ -72,7 +72,7 @@ module Admin
     end
 
     def download_client_params
-      params.require(:download_client).permit(:name, :client_type, :url, :username, :password, :api_key, :category, :enabled)
+      params.require(:download_client).permit(:name, :client_type, :url, :username, :password, :api_key, :category, :download_path, :enabled)
     end
 
     def next_priority_for(client_type)

--- a/app/views/admin/download_clients/_form.html.erb
+++ b/app/views/admin/download_clients/_form.html.erb
@@ -53,6 +53,12 @@
   </div>
 
   <div class="my-5">
+    <%= form.label :download_path, "Download Path", class: "block text-gray-300 font-medium" %>
+    <%= form.text_field :download_path, placeholder: "/downloads", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+    <p class="mt-1 text-sm text-gray-500">Container path where completed downloads appear (e.g., /downloads). Leave blank to use global settings.</p>
+  </div>
+
+  <div class="my-5">
     <%= form.label :enabled, class: "flex items-center gap-2 cursor-pointer" %>
     <div class="flex items-center">
       <%= form.check_box :enabled, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>

--- a/db/migrate/20260103161938_add_download_path_to_download_clients.rb
+++ b/db/migrate/20260103161938_add_download_path_to_download_clients.rb
@@ -1,0 +1,5 @@
+class AddDownloadPathToDownloadClients < ActiveRecord::Migration[8.1]
+  def change
+    add_column :download_clients, :download_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_03_154727) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_03_161938) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -54,6 +54,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_03_154727) do
     t.string "category"
     t.string "client_type", null: false
     t.datetime "created_at", null: false
+    t.string "download_path"
     t.boolean "enabled", default: true, null: false
     t.string "name", null: false
     t.string "password"


### PR DESCRIPTION
## Summary
- **Copy instead of move**: Files are now copied to the library folder instead of moved, preserving the original files for private tracker seeding
- **Per-client download paths**: Each download client (qBittorrent, SABnzbd) can now have its own download path mapping, instead of relying only on global settings
- **Backward compatible**: Falls back to global `download_remote_path`/`download_local_path` settings when no client-specific path is configured

## Changes
- `PostProcessingJob`: Changed `move_files` to `copy_files` using `FileUtils.cp_r`
- `DownloadClient`: Added `download_path` column for client-specific path mapping
- Admin UI: Added download path field to download client form
- Path remapping: Now checks client-specific path before global settings

## Test plan
- [x] Tests for file copy behavior (original files preserved after processing)
- [x] Tests for per-client download path support
- [x] All 424 tests pass

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)