### PR TITLE
Fix duplicate flash notification banners

### DIFF
--- a/app/views/admin/download_clients/index.html.erb
+++ b/app/views/admin/download_clients/index.html.erb
@@ -4,14 +4,6 @@
     <%= link_to "New Client", new_admin_download_client_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
   </div>
 
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-500/10 border border-green-500/20 mb-5 text-green-400 font-medium rounded-lg inline-block"><%= notice %></p>
-  <% end %>
-
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-500/10 border border-red-500/20 mb-5 text-red-400 font-medium rounded-lg inline-block"><%= alert %></p>
-  <% end %>
-
   <% if @download_clients.empty? %>
     <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 text-center">
       <p class="text-gray-400 mb-4">No download clients configured yet.</p>

--- a/app/views/admin/issues/index.html.erb
+++ b/app/views/admin/issues/index.html.erb
@@ -6,14 +6,6 @@
     <% end %>
   </div>
 
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-500/10 border border-green-500/20 mb-5 text-green-400 font-medium rounded-lg inline-block"><%= notice %></p>
-  <% end %>
-
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-500/10 border border-red-500/20 mb-5 text-red-400 font-medium rounded-lg inline-block"><%= alert %></p>
-  <% end %>
-
   <% if @requests.empty? %>
     <div class="bg-gray-900 border border-gray-800 rounded-lg p-12 text-center">
       <svg class="mx-auto h-12 w-12 text-green-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/views/admin/search_results/index.html.erb
+++ b/app/views/admin/search_results/index.html.erb
@@ -5,14 +5,6 @@
         method: :post, class: "px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition" %>
   </div>
 
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block"><%= notice %></p>
-  <% end %>
-
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block"><%= alert %></p>
-  <% end %>
-
   <div class="bg-white rounded-lg shadow overflow-hidden mb-6">
     <div class="p-4 border-b bg-gray-50">
       <div class="flex items-center gap-4">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,14 +4,6 @@
     <%= link_to "New User", new_admin_user_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
   </div>
 
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-500/10 border border-green-500/20 mb-5 text-green-400 font-medium rounded-lg inline-block"><%= notice %></p>
-  <% end %>
-
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-500/10 border border-red-500/20 mb-5 text-red-400 font-medium rounded-lg inline-block"><%= alert %></p>
-  <% end %>
-
   <div class="bg-gray-900 rounded-lg border border-gray-800 overflow-hidden">
     <table class="min-w-full divide-y divide-gray-800">
       <thead class="bg-gray-800/50">

--- a/app/views/profiles/backup_codes.html.erb
+++ b/app/views/profiles/backup_codes.html.erb
@@ -13,12 +13,6 @@
       </p>
     </div>
 
-    <% if flash[:notice] %>
-      <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-        <p class="text-sm text-blue-700"><%= flash[:notice] %></p>
-      </div>
-    <% end %>
-
     <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
       <div class="flex">
         <svg class="w-5 h-5 text-yellow-600 mr-2 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,12 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-500/10 border border-red-500/20 mb-5 text-red-400 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-500/10 border border-green-500/20 mb-5 text-green-400 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl text-white"><%= User.none? ? "Create your account" : "Create new user" %></h1>
   <% if User.none? %>
     <p class="text-gray-400 mt-2">You'll be the first user and will have admin privileges.</p>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,12 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-500/10 border border-red-500/20 mb-5 text-red-400 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-500/10 border border-green-500/20 mb-5 text-green-400 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl text-white">Sign in</h1>
 
   <%= form_with url: session_url, class: "contents" do |form| %>


### PR DESCRIPTION
## Summary
- Remove redundant flash message handling from individual views
- The application layout already renders flash messages, causing duplicates

## Affected Views
- `admin/download_clients/index.html.erb`
- `admin/users/index.html.erb`
- `admin/issues/index.html.erb`
- `admin/search_results/index.html.erb`
- `registrations/new.html.erb`
- `sessions/new.html.erb`
- `profiles/backup_codes.html.erb`

## Test plan
- [ ] Visit Download Clients page after an action - verify single notification
- [ ] Visit Users page after an action - verify single notification
- [ ] Test other affected pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)