### PR TITLE
Fix Download.external_id being nil for torrent downloads

### DIFF
--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -38,6 +38,7 @@ class DownloadJobTest < ActiveJob::TestCase
 
       assert @download.downloading?
       assert_equal @client.id.to_s, @download.download_client_id
+      assert_equal "abc123def456", @download.external_id
     end
   end
 
@@ -111,5 +112,13 @@ class DownloadJobTest < ActiveJob::TestCase
     # Stub add torrent
     stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
       .to_return(status: 200, body: "Ok.")
+
+    # Stub torrent info query (for getting hash after adding .torrent URL)
+    stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: [{ "hash" => "abc123def456", "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "save_path" => "/downloads" }].to_json
+      )
   end
 end


### PR DESCRIPTION
## Summary
- qBittorrent downloads were stuck in "downloading" status forever because `external_id` was `nil`
- The `DownloadMonitorJob` needs `external_id` to correlate downloads with qBittorrent torrents

## Root Cause
- `add_torrent()` returned boolean only, not the torrent hash
- `extract_external_id()` only worked for magnet links (extracted from `btih:` parameter)
- For `.torrent` file URLs, there was no hash to extract → `nil`

## Fix
- `Qbittorrent.add_torrent()` now returns the torrent hash instead of boolean
- For magnet links: extracts hash directly from URL
- For `.torrent` URLs: queries qBittorrent API after adding to get the hash
- `DownloadJob` uses the returned hash as `external_id`

## Test plan
- [x] Existing tests updated and passing
- [x] Added test for `.torrent` URL hash extraction
- [ ] Manual test with real qBittorrent

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)