### PR TITLE
Fix post-processing using wrong output paths

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -48,13 +48,9 @@ class PostProcessingJob < ApplicationJob
   end
 
   def get_base_path(book)
-    lib_id = library_id_for(book)
-    if AudiobookshelfClient.configured? && lib_id.present?
-      library = AudiobookshelfClient.library(lib_id)
-      return library.folder_paths.first if library&.folder_paths&.any?
-    end
-
-    # Return path based on book type
+    # Always use Shelfarr's configured output paths.
+    # Audiobookshelf library paths are from ABS's container perspective,
+    # not ours, so we can't use them for file operations.
     if book.ebook?
       SettingsService.get(:ebook_output_path, default: "/ebooks")
     else


### PR DESCRIPTION
## Summary
- Fixes post-processing ignoring UI-configured output paths when Audiobookshelf is configured
- `PostProcessingJob.get_base_path()` was fetching folder paths from Audiobookshelf's API and using them directly, causing permission errors when those paths don't exist in Shelfarr's container

## Changes
- Simplified `get_base_path()` to always use Shelfarr's configured `audiobook_output_path` / `ebook_output_path` settings
- Audiobookshelf library IDs are still used for triggering scans after processing
- Updated tests to verify new behavior

## Test plan
- [x] All 14 PostProcessingJob tests pass
- [x] New test verifies processing succeeds even when ABS API fails
- [x] Full test suite passes (452 tests)

Fixes #58
Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)