### PR TITLE
Fix qBittorrent importing all files from category directory (#61)

### DIFF
--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -173,7 +173,7 @@ module DownloadClients
         progress: (data["progress"] * 100).round,
         state: normalize_state(data["state"]),
         size_bytes: data["size"],
-        download_path: data["save_path"]
+        download_path: data["content_path"]
       )
     end
 

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -118,7 +118,7 @@ class DownloadJobTest < ActiveJob::TestCase
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
-        body: [{ "hash" => "abc123def456", "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "save_path" => "/downloads" }].to_json
+        body: [{ "hash" => "abc123def456", "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json
       )
   end
 end

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -187,7 +187,7 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
             "progress" => progress / 100.0,
             "state" => state,
             "size" => 1073741824,
-            "save_path" => "/downloads/complete"
+            "content_path" => "/downloads/complete/Test Audiobook"
           }
         ].to_json
       )

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -88,7 +88,7 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
               "progress" => 0.75,
               "state" => "downloading",
               "size" => 1073741824,
-              "save_path" => "/downloads"
+              "content_path" => "/downloads/Test Torrent"
             }
           ].to_json
         )


### PR DESCRIPTION
Fixed bug where post-processing would import all files from the qBittorrent
category directory instead of just the files belonging to the completed download.

Changes:
- Changed qBittorrent client to use 'content_path' instead of 'save_path'
  when parsing torrent info
- 'save_path' returns the category directory (e.g., /downloads/shelfarr/)
- 'content_path' returns the specific torrent's directory
  (e.g., /downloads/shelfarr/The Old Man and the Sea/)
- Updated all tests to reflect this change

This ensures only files from the completed request are imported, not all
files in the category directory.

Fixes #61