### PR TITLE
Fix retry behavior and Anna's Archive downloadable check

### DIFF
--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -44,6 +44,9 @@ class SearchResult < ApplicationRecord
   }
 
   def downloadable?
+    # Anna's Archive results are always downloadable - URL is fetched at download time
+    return true if from_anna_archive?
+
     download_url.present? || magnet_url.present?
   end
 

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -81,6 +81,18 @@ class SearchResultTest < ActiveSupport::TestCase
     assert_not @no_link_result.downloadable?
   end
 
+  test "downloadable? returns true for Anna's Archive results even without links" do
+    anna_result = SearchResult.new(
+      request: requests(:pending_request),
+      guid: "anna-test-md5",
+      title: "Anna's Archive Book",
+      source: SearchResult::SOURCE_ANNA_ARCHIVE,
+      download_url: nil,
+      magnet_url: nil
+    )
+    assert anna_result.downloadable?, "Anna's Archive results should always be downloadable via API"
+  end
+
   test "download_link prefers magnet_url over download_url" do
     result = SearchResult.new(
       magnet_url: "magnet:?xt=test",


### PR DESCRIPTION
## Summary

- **Smart retry logic**: `retry_now!` now detects when there's an already-selected result with a failed download and retries the download instead of re-searching
- **Anna's Archive fix**: Results from Anna's Archive are now marked as downloadable since their download URLs are fetched on-demand via the API

## Issues Fixed

1. **Retry re-searches instead of downloading**: When a user selected a result and the download failed (e.g., no client configured), clicking "Retry" in admin issues would destroy the selected result and re-search. Now it properly retries the download.

2. **Anna's Archive "No link" button**: Anna's Archive results showed "No link" and couldn't be selected because `download_url` and `magnet_url` are stored as `nil` (they're fetched at download time). Now `downloadable?` correctly returns `true` for Anna's Archive results.

## Test plan

- [x] Tests added for `retry_now!` with selected result and failed download
- [x] Tests added for Anna's Archive `downloadable?` check
- [x] All existing tests pass
- [ ] Manual test: select a result, fail the download (e.g., wrong client config), click retry - should retry download, not re-search
- [ ] Manual test: Anna's Archive results should now show "Select" button instead of "No link"

🤖 Generated with [Claude Code](https://claude.com/claude-code)