### PR TITLE
Fix tests and improve torrent hash detection with category filter

### DIFF
--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -113,12 +113,12 @@ class DownloadJobTest < ActiveJob::TestCase
     stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
       .to_return(status: 200, body: "Ok.")
 
-    # Stub torrent info query (for getting hash after adding .torrent URL)
+    # Stub torrent info query - first call returns empty (before adding),
+    # subsequent calls return the new torrent (after adding)
     stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
       .to_return(
-        status: 200,
-        headers: { "Content-Type" => "application/json" },
-        body: [{ "hash" => "abc123def456", "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json
+        { status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json },
+        { status: 200, headers: { "Content-Type" => "application/json" }, body: [{ "hash" => "abc123def456", "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json }
       )
   end
 end

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -53,12 +53,12 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
       stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
         .to_return(status: 200, body: "Ok.")
 
-      # Stub torrent info for getting hash after adding
+      # Stub torrent info - first call returns empty (before adding),
+      # subsequent calls return the new torrent (after adding)
       stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
         .to_return(
-          status: 200,
-          headers: { "Content-Type" => "application/json" },
-          body: [{ "hash" => "def456abc789" }].to_json
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json },
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [{ "hash" => "def456abc789" }].to_json }
         )
 
       result = @client.add_torrent("http://example.com/file.torrent")


### PR DESCRIPTION
## Summary
- Fix qBittorrent and DownloadJob tests to properly simulate before/after torrent list states
- Filter torrent queries by category when detecting new hashes, reducing false positives from torrents added by other programs
- Fix race condition in CleanupTempFilesJob where file can be deleted between Dir.glob and File.mtime calls

## Test plan
- [x] All existing tests pass
- [ ] Test torrent download with category configured in qBittorrent client settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)