### PR TITLE
Add admin delete functionality for requests and books (#70)

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -13,9 +13,91 @@ class LibraryController < ApplicationController
     @user_request = @book.requests.find_by(user: Current.user)
   end
 
+  def destroy
+    unless Current.user.admin?
+      redirect_to library_index_path, alert: "Only admins can delete books from the library"
+      return
+    end
+
+    @book = Book.find(params[:id])
+
+    # Optionally remove torrents from download clients
+    if params[:remove_torrent] == "1"
+      remove_associated_torrents(@book)
+    end
+
+    # Delete book files from disk if requested
+    if params[:delete_files] == "1" && @book.file_path.present?
+      delete_book_files(@book)
+    end
+
+    # Track activity before destroying
+    ActivityTracker.track("book.deleted", trackable: @book, user: Current.user)
+
+    # Destroy all associated requests and the book
+    @book.requests.destroy_all
+    @book.destroy!
+
+    redirect_to library_index_path, notice: "\"#{@book.title}\" has been removed from the library"
+  end
+
   private
 
   def record_not_found
     head :not_found
+  end
+
+  def remove_associated_torrents(book)
+    book.requests.each do |request|
+      request.downloads.each do |download|
+        next unless download.external_id.present? && download.download_client.present?
+
+        begin
+          client = download.download_client.adapter
+          client.remove_torrent(download.external_id, delete_files: false)
+          Rails.logger.info "[LibraryController] Removed torrent #{download.external_id} for download ##{download.id}"
+        rescue DownloadClients::Base::Error => e
+          Rails.logger.warn "[LibraryController] Failed to remove torrent: #{e.message}"
+        end
+      end
+    end
+  end
+
+  def delete_book_files(book)
+    path = book.file_path
+    return unless path.present?
+
+    # Security: Validate path is within allowed directories
+    unless path_within_allowed_directories?(path)
+      Rails.logger.warn "[LibraryController] Attempted to delete file outside allowed directories: #{path}"
+      return
+    end
+
+    if File.exist?(path)
+      if File.directory?(path)
+        FileUtils.rm_rf(path)
+        Rails.logger.info "[LibraryController] Deleted directory: #{path}"
+      else
+        FileUtils.rm_f(path)
+        Rails.logger.info "[LibraryController] Deleted file: #{path}"
+      end
+    end
+  rescue => e
+    Rails.logger.error "[LibraryController] Failed to delete files: #{e.message}"
+  end
+
+  def path_within_allowed_directories?(path)
+    return false if path.blank?
+
+    expanded_path = File.expand_path(path)
+    allowed_paths = [
+      SettingsService.get(:audiobook_output_path),
+      SettingsService.get(:ebook_output_path)
+    ].compact.reject(&:blank?)
+
+    allowed_paths.any? do |allowed|
+      expanded_allowed = File.expand_path(allowed)
+      expanded_path.start_with?(expanded_allowed + "/") || expanded_path == expanded_allowed
+    end
   end
 end

--- a/app/javascript/controllers/delete_modal_controller.js
+++ b/app/javascript/controllers/delete_modal_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Handles delete confirmation modals with optional checkboxes
+export default class extends Controller {
+  static targets = ["modal", "checkbox"]
+  static values = {
+    title: String,
+    message: String
+  }
+
+  open(event) {
+    event.preventDefault()
+    this.modalTarget.showModal()
+  }
+
+  close() {
+    this.modalTarget.close()
+  }
+
+  confirm() {
+    // Find the form within the modal and submit it
+    const form = this.modalTarget.querySelector("form")
+    if (form) {
+      form.submit()
+    }
+  }
+
+  // Handle clicking outside the modal to close it
+  backdropClick(event) {
+    if (event.target === this.modalTarget) {
+      this.close()
+    }
+  }
+}

--- a/app/services/download_clients/base.rb
+++ b/app/services/download_clients/base.rb
@@ -54,6 +54,13 @@ module DownloadClients
       raise NotImplementedError, "Subclass must implement test_connection"
     end
 
+    # Remove a torrent by hash
+    # delete_files: if true, also delete downloaded files
+    # Returns true on success, false otherwise
+    def remove_torrent(hash, delete_files: false)
+      raise NotImplementedError, "Subclass must implement remove_torrent"
+    end
+
     protected
 
     def base_url

--- a/app/views/library/show.html.erb
+++ b/app/views/library/show.html.erb
@@ -79,6 +79,57 @@
           <h3 class="text-sm font-medium text-gray-500 mb-2">File Location</h3>
           <code class="text-sm text-gray-900 bg-gray-100 px-2 py-1 rounded block break-all"><%= @book.file_path %></code>
         </div>
+
+        <div class="mt-6 pt-6 border-t" data-controller="delete-modal">
+          <h3 class="text-sm font-medium text-gray-500 mb-2">Admin Actions</h3>
+          <button type="button"
+                  class="px-4 py-2 bg-red-600 hover:bg-red-500 text-white font-medium rounded-lg transition text-sm"
+                  data-action="click->delete-modal#open">
+            Delete from Library
+          </button>
+
+          <dialog data-delete-modal-target="modal"
+                  class="bg-gray-900 border border-gray-700 rounded-lg p-0 backdrop:bg-black/50 max-w-md w-full"
+                  data-action="click->delete-modal#backdropClick">
+            <div class="p-6">
+              <h3 class="text-lg font-semibold text-white mb-2">Delete Book</h3>
+              <p class="text-gray-400 mb-4">Are you sure you want to delete "<%= @book.title %>" from the library? This will also remove all associated requests.</p>
+
+              <%= form_with url: library_path(@book), method: :delete, local: true, class: "space-y-4" do |f| %>
+                <div class="space-y-3">
+                  <% if @book.file_path.present? %>
+                    <label class="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                      <input type="checkbox" name="delete_files" value="1"
+                             class="w-4 h-4 rounded border-gray-600 bg-gray-800 text-red-600 focus:ring-red-500">
+                      <span>Delete book files from disk</span>
+                    </label>
+                  <% end %>
+
+                  <% has_torrents = @book.requests.any? { |r| r.downloads.any? { |d| d.external_id.present? && d.download_client.present? } } %>
+                  <% if has_torrents %>
+                    <label class="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                      <input type="checkbox" name="remove_torrent" value="1"
+                             class="w-4 h-4 rounded border-gray-600 bg-gray-800 text-red-600 focus:ring-red-500">
+                      <span>Remove torrent from download client</span>
+                    </label>
+                  <% end %>
+                </div>
+
+                <div class="flex justify-end gap-3 pt-2">
+                  <button type="button"
+                          class="px-4 py-2 text-gray-400 hover:text-white transition"
+                          data-action="click->delete-modal#close">
+                    Cancel
+                  </button>
+                  <button type="submit"
+                          class="px-4 py-2 bg-red-600 hover:bg-red-500 text-white font-medium rounded-lg transition">
+                    Delete Book
+                  </button>
+                </div>
+              <% end %>
+            </div>
+          </dialog>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -211,8 +211,43 @@
     </div>
 
     <% if @request.can_be_cancelled? %>
-      <div class="px-6 py-4 bg-gray-800/50 border-t border-gray-800 flex justify-end">
-        <%= button_to "Cancel Request", @request, method: :delete, class: "px-4 py-2 bg-red-600 hover:bg-red-500 text-white font-medium rounded-lg transition", data: { confirm: "Are you sure you want to cancel this request?" } %>
+      <div class="px-6 py-4 bg-gray-800/50 border-t border-gray-800 flex justify-end" data-controller="delete-modal">
+        <button type="button"
+                class="px-4 py-2 bg-red-600 hover:bg-red-500 text-white font-medium rounded-lg transition"
+                data-action="click->delete-modal#open">
+          Cancel Request
+        </button>
+
+        <dialog data-delete-modal-target="modal"
+                class="bg-gray-900 border border-gray-700 rounded-lg p-0 backdrop:bg-black/50 max-w-md w-full"
+                data-action="click->delete-modal#backdropClick">
+          <div class="p-6">
+            <h3 class="text-lg font-semibold text-white mb-2">Cancel Request</h3>
+            <p class="text-gray-400 mb-4">Are you sure you want to cancel this request for "<%= @request.book.title %>"?</p>
+
+            <%= form_with url: request_path(@request), method: :delete, local: true, class: "space-y-4" do |f| %>
+              <% if @request.downloads.any? { |d| d.external_id.present? && d.download_client.present? } %>
+                <label class="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
+                  <input type="checkbox" name="remove_torrent" value="1"
+                         class="w-4 h-4 rounded border-gray-600 bg-gray-800 text-red-600 focus:ring-red-500">
+                  <span>Also remove torrent from download client</span>
+                </label>
+              <% end %>
+
+              <div class="flex justify-end gap-3 pt-2">
+                <button type="button"
+                        class="px-4 py-2 text-gray-400 hover:text-white transition"
+                        data-action="click->delete-modal#close">
+                  Keep Request
+                </button>
+                <button type="submit"
+                        class="px-4 py-2 bg-red-600 hover:bg-red-500 text-white font-medium rounded-lg transition">
+                  Cancel Request
+                </button>
+              </div>
+            <% end %>
+          </div>
+        </dialog>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   get "search/results", to: "search#results"
 
   # Library
-  resources :library, only: [:index, :show]
+  resources :library, only: [:index, :show, :destroy]
 
   # Profile
   resource :profile, only: [:show, :edit, :update] do


### PR DESCRIPTION
Features:
- Delete request: Cancels request and optionally removes torrent from download client
- Delete book: Removes book from library, associated requests, optionally deletes files from disk and removes torrents from download client
- Confirmation modal with checkboxes for optional torrent/file removal

Implementation:
- Add remove_torrent method to qBittorrent and SABnzbd clients
- Add destroy action to LibraryController with file deletion support
- Update RequestsController destroy to handle torrent removal
- Add delete_modal_controller.js for Stimulus-powered confirmation modals
- Security: Validate file paths are within allowed directories before deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)