### PR TITLE
Replace sticky notifications with floating toast notifications

### DIFF
--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Handles toast notifications that auto-dismiss
+export default class extends Controller {
+  static values = {
+    duration: { type: Number, default: 5000 }
+  }
+
+  connect() {
+    // Start auto-dismiss timer
+    this.timeout = setTimeout(() => {
+      this.dismiss()
+    }, this.durationValue)
+
+    // Trigger enter animation
+    requestAnimationFrame(() => {
+      this.element.classList.remove("translate-x-full", "opacity-0")
+      this.element.classList.add("translate-x-0", "opacity-100")
+    })
+  }
+
+  disconnect() {
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+    }
+  }
+
+  dismiss() {
+    // Trigger exit animation
+    this.element.classList.remove("translate-x-0", "opacity-100")
+    this.element.classList.add("translate-x-full", "opacity-0")
+
+    // Remove element after animation
+    setTimeout(() => {
+      this.element.remove()
+    }, 300)
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,17 +70,41 @@
     </nav>
 
     <main class="max-w-7xl mx-auto mt-8 px-4 sm:px-6 lg:px-8 pb-12">
+      <%= yield %>
+    </main>
+
+    <%# Toast notifications - bottom right, auto-dismiss %>
+    <div id="toast-container" class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm">
       <% if flash[:notice].present? %>
-        <div class="mb-6 bg-green-500/10 border border-green-500/20 rounded-lg p-4 text-green-400">
-          <%= flash[:notice] %>
+        <div data-controller="toast"
+             data-toast-duration-value="5000"
+             class="transform translate-x-full opacity-0 transition-all duration-300 ease-out bg-gray-900 border border-green-500/30 rounded-lg p-4 shadow-lg flex items-start gap-3">
+          <svg class="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+          </svg>
+          <p class="text-green-400 text-sm flex-grow"><%= flash[:notice] %></p>
+          <button type="button" data-action="click->toast#dismiss" class="text-gray-500 hover:text-white">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </button>
         </div>
       <% end %>
       <% if flash[:alert].present? %>
-        <div class="mb-6 bg-red-500/10 border border-red-500/20 rounded-lg p-4 text-red-400">
-          <%= flash[:alert] %>
+        <div data-controller="toast"
+             data-toast-duration-value="8000"
+             class="transform translate-x-full opacity-0 transition-all duration-300 ease-out bg-gray-900 border border-red-500/30 rounded-lg p-4 shadow-lg flex items-start gap-3">
+          <svg class="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+          </svg>
+          <p class="text-red-400 text-sm flex-grow"><%= flash[:alert] %></p>
+          <button type="button" data-action="click->toast#dismiss" class="text-gray-500 hover:text-white">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+          </button>
         </div>
       <% end %>
-      <%= yield %>
-    </main>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Replaces the sticky top-of-page notifications with floating toast notifications in the bottom-right corner that auto-dismiss.

## Changes
- Add `toast_controller.js` Stimulus controller for auto-dismissing notifications
- Toasts slide in from the right with smooth animation
- Success toasts (green) dismiss after 5 seconds
- Alert toasts (red) dismiss after 8 seconds
- Manual dismiss with X button
- Page no longer scrolls to top when showing notifications

## Test plan
- [x] All existing tests pass
- [ ] Test settings update shows toast without scrolling
- [ ] Test toast auto-dismisses after timeout
- [ ] Test manual dismiss with X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)