### PR TITLE
Add dev branch to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
     tags: ['v*']
 
 env:


### PR DESCRIPTION
## Summary
Enables Docker image builds when pushing to the `dev` branch, creating images tagged with `dev`.

## Changes
- Add `dev` to the branches list in docker.yml workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)