### PR TITLE
Fix settings page scroll on save

### DIFF
--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto max-w-4xl" data-controller="settings-form">
-  <%= form_with url: bulk_update_admin_settings_path, method: :patch, data: { settings_form_target: "form" } do |form| %>
+  <%= form_with url: bulk_update_admin_settings_path, method: :patch, data: { settings_form_target: "form", turbo_action: "replace" } do |form| %>
     <div class="flex justify-between items-center mb-8">
       <h1 class="font-bold text-4xl text-white">Settings</h1>
       <div class="flex items-center gap-4">


### PR DESCRIPTION
## Summary
Fixes the page scrolling to top when saving settings.

## Changes
- Add `turbo_action: "replace"` to settings form to preserve scroll position

🤖 Generated with [Claude Code](https://claude.com/claude-code)