### PR TITLE
Put latest tag first in Docker metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,11 +40,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- Reorder tags in docker/metadata-action so `latest` appears first
- GitHub Packages uses the first tag for installation instructions, so this ensures users see `docker pull ghcr.io/.../shelfarr:latest` instead of the commit SHA

## Test plan
- [ ] Merge and push to main
- [ ] Verify GitHub Packages page shows `latest` in the installation command

🤖 Generated with [Claude Code](https://claude.com/claude-code)