### PR TITLE
Add debug logging for download URL flow (#79)

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -232,14 +232,18 @@ class DownloadJob < ApplicationJob
 
     Rails.logger.info "[DownloadJob] Using client '#{client_record.name}' for download ##{download.id}"
 
+    download_link = search_result.download_link
+    Rails.logger.info "[DownloadJob] Download link type: #{is_usenet ? 'usenet' : 'torrent'}, length: #{download_link.to_s.length} chars"
+    Rails.logger.debug "[DownloadJob] Full download URL: #{download_link}"
+
     if is_usenet
       # SABnzbd returns a hash with nzo_ids
-      result = client.add_torrent(search_result.download_link)
+      result = client.add_torrent(download_link)
       external_id = result.is_a?(Hash) ? result["nzo_ids"]&.first : nil
       success = external_id.present?
     else
       # qBittorrent now returns the torrent hash directly
-      external_id = client.add_torrent(search_result.download_link)
+      external_id = client.add_torrent(download_link)
       success = external_id.present?
     end
 

--- a/app/services/prowlarr_client.rb
+++ b/app/services/prowlarr_client.rb
@@ -191,6 +191,7 @@ class ProwlarrClient
       return nil if url.blank?
       return nil if url.start_with?("magnet:")
 
+      Rails.logger.debug "[ProwlarrClient] Received download URL from indexer '#{item['indexer']}' (#{url.length} chars): #{url.truncate(100)}"
       url
     end
 


### PR DESCRIPTION
## Summary
- Adds logging throughout the download URL flow to help diagnose "Invalid Prowlarr link" errors
- Logs received download URLs from Prowlarr indexers
- Logs download link details before sending to clients
- Logs SABnzbd API requests and responses

## Context
Issue #79 reported "Invalid Prowlarr link" errors when Shelfarr tries to start usenet downloads. This is likely a Prowlarr/indexer configuration issue (expired tokens, reconfigured indexers, etc.), but this logging will help users diagnose where the issue occurs.

## Changes
| File | Change |
|------|--------|
| `app/services/prowlarr_client.rb` | Log download URLs received from indexers with indexer name and URL length |
| `app/jobs/download_job.rb` | Log download link type, length, and full URL before sending to client |
| `app/services/download_clients/sabnzbd.rb` | Log URLs sent to API and detailed response/error information |

## Test plan
- [x] Existing tests pass
- [ ] Manual testing: trigger a usenet download and check logs for new entries

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)