### PR TITLE
Add configurable HTTP_PORT environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,5 +76,6 @@ COPY --chown=rails:rails --from=build /rails /rails
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start server via Thruster by default, this can be overwritten at runtime
+# Set HTTP_PORT env var to change the listening port (default: 80)
 EXPOSE 80
 CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ A secret key is auto-generated on first run and saved to the data volume.
 
 Visit `http://localhost:5056` — the first user to register becomes admin.
 
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HTTP_PORT` | `80` | Internal container port. Change if port 80 is in use (e.g., behind gluetun) |
+| `RAILS_MASTER_KEY` | Auto-generated | Encryption key for secrets. Auto-generated on first run if not set |
+
+Example with custom port:
+```yaml
+environment:
+  - HTTP_PORT=8080
+ports:
+  - "5056:8080"  # Map to the custom port
+```
+
 ### Configuration
 
 After logging in, go to **Admin → Settings**:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,7 +13,7 @@ services:
     container_name: shelfarr
     restart: unless-stopped
     ports:
-      - "5056:80"
+      - "5056:${HTTP_PORT:-80}"
     volumes:
       # Database and app storage (required - contains auto-generated secret key)
       - ./data:/rails/storage
@@ -25,10 +25,12 @@ services:
       - /path/to/downloads:/downloads
     environment:
       - SOLID_QUEUE_IN_PUMA=1
+      # Optional: Change internal port (default: 80)
+      # - HTTP_PORT=8080
       # Optional: Set your own key instead of auto-generating
       # - RAILS_MASTER_KEY=your-64-char-hex-key
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/up"]
+      test: ["CMD", "curl", "-f", "http://localhost:${HTTP_PORT:-80}/up"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Adds `HTTP_PORT` environment variable support for users running behind gluetun or other network containers where port 80 is in use
- Updates `docker-compose.example.yml` with port variable and healthcheck
- Documents in README with examples

Fixes #64

## Changes
- `docker-compose.example.yml`: Add HTTP_PORT to environment, update port mapping and healthcheck
- `Dockerfile`: Add comment documenting HTTP_PORT support
- `README.md`: Add Environment Variables section with HTTP_PORT and RAILS_MASTER_KEY

## Backwards Compatibility
- Default is still port 80 - existing configs work unchanged
- Thruster already supports HTTP_PORT, this just documents and exposes it

## Test plan
- [ ] Build and run with default (no HTTP_PORT): should work on port 80
- [ ] Build and run with `HTTP_PORT=8080`: should work on port 8080
- [ ] Verify healthcheck works in both scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)