### PR TITLE
Release: Shared library access

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -10,7 +10,7 @@ class LibraryController < ApplicationController
 
   def show
     @book = Book.acquired.find(params[:id])
-    @user_request = @book.requests.find_by(user: Current.user)
+    @user_request = @book.requests.completed.first
   end
 
   def destroy

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class RequestsController < ApplicationController
-  before_action :set_request, only: [ :show, :destroy, :download ]
+  before_action :set_request, only: [ :show, :destroy ]
+  before_action :set_request_for_download, only: [ :download ]
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def index
@@ -244,6 +245,15 @@ class RequestsController < ApplicationController
       Request.find(params[:id])
     else
       Request.for_user(Current.user).find(params[:id])
+    end
+  end
+
+  # Allow any user to download from any request if the book is acquired
+  # This enables shared library access where users can download books added by others
+  def set_request_for_download
+    @request = Request.find(params[:id])
+    unless @request.book.acquired?
+      redirect_to library_index_path, alert: "This book is not available for download"
     end
   end
 

--- a/app/views/library/show.html.erb
+++ b/app/views/library/show.html.erb
@@ -69,8 +69,7 @@
         </div>
       <% else %>
         <div class="mt-6 pt-6 border-t">
-          <p class="text-sm text-gray-500">This book was added by another user. You can request your own copy.</p>
-          <%= link_to "Search for this book", search_path(q: @book.title), class: "text-blue-600 hover:text-blue-800 text-sm" %>
+          <p class="text-sm text-gray-500">This book is in your library but has no associated download request.</p>
         </div>
       <% end %>
 

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -205,7 +205,7 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_not request.book.acquired?
 
     get download_request_path(request)
-    assert_redirected_to request_path(request)
+    assert_redirected_to library_index_path
     assert_equal "This book is not available for download", flash[:alert]
   end
 
@@ -270,7 +270,7 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     FileUtils.rm_rf(temp_dir)
   end
 
-  test "user cannot download another user's request" do
+  test "user can download another user's request when book is acquired" do
     temp_dir = Dir.mktmpdir
     temp_file = File.join(temp_dir, "test.m4b")
     File.write(temp_file, "content")
@@ -286,8 +286,9 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     )
     other_request = Request.create!(book: book, user: @admin, status: :completed)
 
+    # Users can download any acquired book, regardless of who requested it
     get download_request_path(other_request)
-    assert_response :not_found
+    assert_response :success
   ensure
     FileUtils.rm_rf(temp_dir)
   end


### PR DESCRIPTION
## Summary
- All users can now download any book in the library, regardless of who originally requested it

## Changes
- fix: allow all users to download books from shared library (#98)

Fixes #97