### PR TITLE
feat: Add setting for immediate search on request creation

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -83,6 +83,11 @@ class RequestsController < ApplicationController
       if request.save
         ActivityTracker.track("request.created", trackable: request)
         created_requests << request
+
+        # Trigger immediate search if enabled
+        if SettingsService.get(:immediate_search_enabled, default: false)
+          SearchJob.perform_later(request.id)
+        end
       else
         errors << "#{book_type.titleize}: #{request.errors.full_messages.join(', ')}"
       end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -25,6 +25,7 @@ class SettingsService
     download_local_path: { type: "string", default: "/downloads", category: "paths", description: "Container path for downloads (e.g., /downloads)" },
 
     # Queue Settings
+    immediate_search_enabled: { type: "boolean", default: false, category: "queue", description: "Start searching immediately when a request is created (instead of waiting for queue cycle)" },
     queue_batch_size: { type: "integer", default: 5, category: "queue", description: "Number of requests to process per queue run" },
     rate_limit_delay: { type: "integer", default: 2, category: "queue", description: "Seconds between API calls" },
     max_retries: { type: "integer", default: 10, category: "queue", description: "Maximum retry attempts before flagging for attention" },


### PR DESCRIPTION
## Summary

Adds a new boolean setting **"Immediate Search Enabled"** in Queue Settings that triggers a search immediately when a book request is created, instead of waiting for the RequestQueueJob cycle (every 5 minutes).

<img width="986" height="326" alt="Screenshot 2026-01-19 at 13 04 54" src="https://github.com/user-attachments/assets/a0e9aa79-7d98-4145-aa43-9ec0345f71c1" />

### How it works

- **Setting OFF (default)**: Existing behavior - requests are created as `pending` and wait for the next `RequestQueueJob` run (every 5 minutes) to be searched
- **Setting ON**: When a request is created, a `SearchJob` is immediately enqueued, starting the search right away

### Why this is useful

Users reported delays between creating a request and seeing search results. This setting provides an option for users who prefer faster feedback over batch processing.

## Changes

- Added `immediate_search_enabled` boolean setting in `SettingsService` (Queue Settings category)
- Modified `RequestsController#create` to enqueue `SearchJob` immediately when setting is enabled

## Test plan

- [ ] Create a request with setting OFF - verify it waits for queue cycle
- [ ] Enable setting in Admin > Settings > Queue Settings
- [ ] Create a request with setting ON - verify search starts immediately