### PR TITLE
fix: Resolve race condition in torrent hash detection for concurrent downloads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem "faraday"
 gem "oj"
 # Create zip archives for directory downloads
 gem "rubyzip", require: "zip"
+# Parse .torrent files to extract info hash
+gem "bencode"
 # TOTP for two-factor authentication
 gem "rotp"
 # QR code generation for 2FA setup

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bcrypt_pbkdf (1.1.2-arm64-darwin)
     bcrypt_pbkdf (1.1.2-x86_64-darwin)
+    bencode (1.0.0)
     bigdecimal (4.0.1)
     bindata (2.5.1)
     bindex (0.8.1)
@@ -499,6 +500,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
+  bencode
   bootsnap
   brakeman
   bundler-audit

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -203,6 +203,9 @@ class DownloadJob < ApplicationJob
     torrent_hash = client.add_torrent(download_url)
 
     if torrent_hash
+      # Defensive check: warn if another download already has this external_id
+      check_for_duplicate_external_id(torrent_hash, download.id)
+
       download.update!(
         status: :downloading,
         download_client: client_record,
@@ -248,6 +251,10 @@ class DownloadJob < ApplicationJob
     end
 
     if success
+      # Defensive check: warn if another download already has this external_id
+      # This should not happen with the race condition fix, but log it if it does
+      check_for_duplicate_external_id(external_id, download.id)
+
       download.update!(
         status: :downloading,
         download_client: client_record,
@@ -259,6 +266,22 @@ class DownloadJob < ApplicationJob
       download.update!(status: :failed)
       download.request.mark_for_attention!("Failed to add to #{client_record.name}")
       Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
+    end
+  end
+
+  def check_for_duplicate_external_id(external_id, current_download_id)
+    return if external_id.blank?
+
+    existing = Download.where(external_id: external_id)
+                       .where.not(id: current_download_id)
+                       .where.not(status: :failed)
+                       .first
+
+    if existing
+      Rails.logger.error "[DownloadJob] DUPLICATE EXTERNAL_ID DETECTED! " \
+                         "Download ##{current_download_id} is being assigned external_id #{external_id}, " \
+                         "but Download ##{existing.id} (request ##{existing.request_id}) already has this ID. " \
+                         "This indicates a potential race condition that should be investigated."
     end
   end
 

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "bencode"
+require "digest/sha1"
 
 class DownloadJobTest < ActiveJob::TestCase
   setup do
@@ -38,7 +40,9 @@ class DownloadJobTest < ActiveJob::TestCase
 
       assert @download.downloading?
       assert_equal @client.id.to_s, @download.download_client_id
-      assert_equal "abc123def456", @download.external_id
+      # Hash is computed from the test torrent file
+      assert @download.external_id.present?, "external_id should be set"
+      assert_match(/^[a-f0-9]{40}$/, @download.external_id, "external_id should be a SHA1 hash")
     end
   end
 
@@ -101,6 +105,26 @@ class DownloadJobTest < ActiveJob::TestCase
   private
 
   def stub_qbittorrent_success
+    # Create a valid torrent file for hash extraction
+    info_dict = {
+      "name" => "Test Torrent",
+      "piece length" => 16384,
+      "pieces" => "x" * 20,
+      "length" => 1000
+    }
+    torrent_data = { "info" => info_dict }.bencode
+    # The hash will be SHA1 of the bencoded info dict
+    # We use a fixed hash in the test since we control the torrent data
+    expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+    # Stub torrent file download (used for hash extraction)
+    stub_request(:get, "http://example.com/download/test.torrent")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/x-bittorrent" },
+        body: torrent_data
+      )
+
     # Stub authentication
     stub_request(:post, "http://localhost:8080/api/v2/auth/login")
       .to_return(
@@ -113,12 +137,13 @@ class DownloadJobTest < ActiveJob::TestCase
     stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
       .to_return(status: 200, body: "Ok.")
 
-    # Stub torrent info query - first call returns empty (before adding),
-    # subsequent calls return the new torrent (after adding)
+    # Note: With pre-computed hash, we should NOT need to poll for torrent info
+    # But stub it anyway in case fallback is triggered
     stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
       .to_return(
-        { status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json },
-        { status: 200, headers: { "Content-Type" => "application/json" }, body: [{ "hash" => "abc123def456", "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json }
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: [{ "hash" => expected_hash, "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json
       )
   end
 end

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -39,7 +39,7 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
     end
   end
 
-  test "add_torrent returns hash from API for torrent URLs" do
+  test "add_torrent falls back to polling when torrent file cannot be downloaded" do
     VCR.turned_off do
       # Stub authentication
       stub_request(:post, "http://localhost:8080/api/v2/auth/login")
@@ -48,6 +48,10 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
           headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
           body: "Ok."
         )
+
+      # Stub torrent file download - connection fails (simulates network issue)
+      stub_request(:get, "http://example.com/file.torrent")
+        .to_timeout
 
       # Stub add torrent
       stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
@@ -186,6 +190,303 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
       torrent = torrents.first
       # Should fall back to save_path + name
       assert_equal "/downloads/category/Test Torrent", torrent.download_path
+    end
+  end
+
+  # === Hash Extraction Tests (Race Condition Fix) ===
+
+  test "add_torrent extracts hash from downloaded torrent file" do
+    VCR.turned_off do
+      # Create a valid bencoded torrent file
+      info_dict = {
+        "name" => "Test Book.epub",
+        "piece length" => 16384,
+        "pieces" => "12345678901234567890", # 20 bytes (1 SHA1 hash)
+        "length" => 1024
+      }
+      torrent_data = { "info" => info_dict }.bencode
+
+      # Calculate expected hash (SHA1 of bencoded info dict)
+      expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub torrent file download - this should be called BEFORE adding to qBittorrent
+      stub_request(:get, "http://tracker.example.com/download/123.torrent")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/x-bittorrent" },
+          body: torrent_data
+        )
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      # Note: We should NOT need to stub /api/v2/torrents/info because
+      # the hash should be pre-computed from the torrent file
+      result = @client.add_torrent("http://tracker.example.com/download/123.torrent")
+
+      assert_equal expected_hash, result
+      # Verify torrent file was downloaded
+      assert_requested(:get, "http://tracker.example.com/download/123.torrent")
+    end
+  end
+
+  test "add_torrent extracts hash from torrent URL with query parameters" do
+    VCR.turned_off do
+      # Create a valid bencoded torrent file
+      info_dict = {
+        "name" => "Another Book.epub",
+        "piece length" => 16384,
+        "pieces" => "abcdefghijklmnopqrst", # 20 bytes
+        "length" => 2048
+      }
+      torrent_data = { "info" => info_dict }.bencode
+      expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub torrent file download with query params (common for private trackers)
+      stub_request(:get, "http://tracker.example.com/download.php?id=456&passkey=abc123")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/x-bittorrent" },
+          body: torrent_data
+        )
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      result = @client.add_torrent("http://tracker.example.com/download.php?id=456&passkey=abc123")
+
+      assert_equal expected_hash, result
+    end
+  end
+
+  test "add_torrent falls back to polling when torrent download fails" do
+    VCR.turned_off do
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub torrent file download - fails with 404
+      stub_request(:get, "http://tracker.example.com/download/missing.torrent")
+        .to_return(status: 404, body: "Not Found")
+
+      # Since torrent download failed, it should capture existing hashes first
+      # First call: get existing hashes (empty)
+      # Second call: after adding, find new hash
+      stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
+        .to_return(
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json },
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [{ "hash" => "fallback123" }].to_json }
+        )
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      result = @client.add_torrent("http://tracker.example.com/download/missing.torrent")
+
+      # Should fall back to polling and find the hash
+      assert_equal "fallback123", result
+    end
+  end
+
+  test "add_torrent falls back to polling when torrent file is invalid" do
+    VCR.turned_off do
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub torrent file download - returns invalid data (not bencode)
+      stub_request(:get, "http://tracker.example.com/download/invalid.torrent")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "text/html" },
+          body: "<html>Login required</html>"
+        )
+
+      # Should fall back to polling
+      stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
+        .to_return(
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json },
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [{ "hash" => "polled456" }].to_json }
+        )
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      result = @client.add_torrent("http://tracker.example.com/download/invalid.torrent")
+
+      assert_equal "polled456", result
+    end
+  end
+
+  test "add_torrent handles torrent file without info dict" do
+    VCR.turned_off do
+      # Create an invalid torrent file (missing info dict)
+      torrent_data = { "announce" => "http://tracker.example.com/announce" }.bencode
+
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub torrent file download
+      stub_request(:get, "http://tracker.example.com/download/noinfo.torrent")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/x-bittorrent" },
+          body: torrent_data
+        )
+
+      # Should fall back to polling
+      stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
+        .to_return(
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json },
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [{ "hash" => "noinfo789" }].to_json }
+        )
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      result = @client.add_torrent("http://tracker.example.com/download/noinfo.torrent")
+
+      assert_equal "noinfo789", result
+    end
+  end
+
+  test "add_torrent skips polling when hash is pre-computed from torrent file" do
+    VCR.turned_off do
+      # Create a valid torrent file
+      info_dict = { "name" => "Book.epub", "piece length" => 16384, "pieces" => "x" * 20, "length" => 100 }
+      torrent_data = { "info" => info_dict }.bencode
+      expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub torrent download
+      stub_request(:get, "http://tracker.example.com/file.torrent")
+        .to_return(status: 200, body: torrent_data)
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      # Stub torrent info - but this should NOT be called since we pre-compute the hash
+      info_stub = stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      result = @client.add_torrent("http://tracker.example.com/file.torrent")
+
+      assert_equal expected_hash, result
+      # Verify that polling was NOT used (torrent info endpoint not called)
+      assert_not_requested(info_stub)
+    end
+  end
+
+  test "concurrent add_torrent calls get different hashes when pre-computed" do
+    VCR.turned_off do
+      # Create two different torrent files
+      info_dict_a = { "name" => "Book A.epub", "piece length" => 16384, "pieces" => "a" * 20, "length" => 100 }
+      info_dict_b = { "name" => "Book B.epub", "piece length" => 16384, "pieces" => "b" * 20, "length" => 200 }
+      torrent_data_a = { "info" => info_dict_a }.bencode
+      torrent_data_b = { "info" => info_dict_b }.bencode
+      expected_hash_a = Digest::SHA1.hexdigest(info_dict_a.bencode).downcase
+      expected_hash_b = Digest::SHA1.hexdigest(info_dict_b.bencode).downcase
+
+      # Sanity check - hashes should be different
+      assert_not_equal expected_hash_a, expected_hash_b
+
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub torrent downloads
+      stub_request(:get, "http://tracker.example.com/book_a.torrent")
+        .to_return(status: 200, body: torrent_data_a)
+      stub_request(:get, "http://tracker.example.com/book_b.torrent")
+        .to_return(status: 200, body: torrent_data_b)
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      # Simulate concurrent calls - each should get its own correct hash
+      result_a = @client.add_torrent("http://tracker.example.com/book_a.torrent")
+      result_b = @client.add_torrent("http://tracker.example.com/book_b.torrent")
+
+      assert_equal expected_hash_a, result_a, "First torrent should get hash A"
+      assert_equal expected_hash_b, result_b, "Second torrent should get hash B"
+      assert_not_equal result_a, result_b, "Hashes should be different"
+    end
+  end
+
+  test "add_torrent follows redirects when downloading torrent file" do
+    VCR.turned_off do
+      info_dict = { "name" => "Redirect Book.epub", "piece length" => 16384, "pieces" => "r" * 20, "length" => 100 }
+      torrent_data = { "info" => info_dict }.bencode
+      expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+      # Stub authentication
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      # Stub redirect chain
+      stub_request(:get, "http://tracker.example.com/download/redirect.torrent")
+        .to_return(status: 302, headers: { "Location" => "http://cdn.example.com/actual.torrent" })
+      stub_request(:get, "http://cdn.example.com/actual.torrent")
+        .to_return(status: 200, body: torrent_data)
+
+      # Stub add torrent
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.")
+
+      result = @client.add_torrent("http://tracker.example.com/download/redirect.torrent")
+
+      assert_equal expected_hash, result
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes a race condition where concurrent ebook downloads could get mixed up - the wrong file being associated with the wrong request.

### Root Cause

When adding torrents via `.torrent` URL (common with private trackers like MyAnonamouse), the qBittorrent API doesn't return the torrent hash directly. The previous code worked around this by:
1. Capturing existing torrent hashes before adding
2. Polling qBittorrent to detect "new" hashes after adding
3. Returning the first new hash found

When multiple downloads ran concurrently, both could detect the same "new" hash, causing both downloads to be assigned the same torrent.

### The Fix

Pre-compute the torrent hash before adding to qBittorrent by:
1. Downloading the `.torrent` file from the tracker
2. Parsing the bencoded content and extracting the "info" dictionary
3. Computing SHA1 hash of the bencoded info dict (the standard torrent info hash)

This eliminates the race condition because each download job now has a deterministic hash computed from its own torrent file.

## Changes

- Add `bencode` gem for parsing `.torrent` files
- Add `precompute_torrent_hash()` and `download_and_extract_hash()` methods to qBittorrent client
- Add defensive logging to detect duplicate `external_id` assignments
- Add comprehensive tests for hash extraction and concurrent downloads
- Polling fallback retained for edge cases where hash extraction fails

## Test Plan

- [x] All existing tests pass
- [x] New tests for hash extraction from torrent files
- [x] Tests for fallback behavior when extraction fails
- [x] Tests verifying concurrent downloads get different hashes