### PR TITLE
fix: verify torrent exists after adding to qBittorrent (#114)

### DIFF
--- a/app/jobs/download_monitor_job.rb
+++ b/app/jobs/download_monitor_job.rb
@@ -64,10 +64,11 @@ class DownloadMonitorJob < ApplicationJob
   end
 
   def handle_missing(download)
-    Rails.logger.error "[DownloadMonitorJob] Download #{download.id} not found in client"
+    client_name = download.download_client&.name || "unknown"
+    Rails.logger.error "[DownloadMonitorJob] Download #{download.id} (hash: #{download.external_id}) not found in client '#{client_name}'"
 
     download.update!(status: :failed)
-    download.request.mark_for_attention!("Download not found in client (may have been removed)")
+    download.request.mark_for_attention!("Download not found in client '#{client_name}' (hash: #{download.external_id})")
   end
 
   def schedule_next_run


### PR DESCRIPTION
## Summary

- Adds verification step after adding torrent to qBittorrent to confirm it was actually added
- qBittorrent returns "Ok." even when failing silently (disk permissions, invalid save path, duplicate rejection)
- Returns nil immediately if verification fails, giving immediate feedback instead of delayed failure in monitor job
- Improves error logging with hash and client name for easier debugging

## Test plan

- [x] Unit tests pass (19 tests, 31 assertions)
- [x] Full test suite passes (516 tests)
- [ ] Deploy to homeserver and test with real torrent download
- [ ] Verify torrent appears in qBittorrent WebUI after adding
- [ ] Confirm error message shows hash and client name when torrent is not found

Fixes #114