### PR TITLE
feat: add FlareSolverr integration for Anna's Archive DDoS protection

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -37,6 +37,7 @@ module Admin
       # Reset cached connections when relevant settings change
       AudiobookshelfClient.reset_connection! if params[:settings]&.keys&.any? { |k| k.to_s.start_with?("audiobookshelf") }
       ProwlarrClient.reset_connection! if params[:settings]&.keys&.any? { |k| k.to_s.start_with?("prowlarr") }
+      FlaresolverrClient.reset_connection! if params[:settings]&.keys&.any? { |k| k.to_s == "flaresolverr_url" }
 
       @settings_by_category = SettingsService.all_by_category
       @audiobookshelf_libraries = fetch_audiobookshelf_libraries
@@ -106,6 +107,21 @@ module Admin
       end
     rescue AudiobookshelfClient::Error => e
       respond_with_flash(alert: "Audiobookshelf error: #{e.message}")
+    end
+
+    def test_flaresolverr
+      unless FlaresolverrClient.configured?
+        respond_with_flash(alert: "FlareSolverr URL is not configured.")
+        return
+      end
+
+      if FlaresolverrClient.test_connection
+        respond_with_flash(notice: "FlareSolverr connection successful!")
+      else
+        respond_with_flash(alert: "FlareSolverr connection failed.")
+      end
+    rescue FlaresolverrClient::Error => e
+      respond_with_flash(alert: "FlareSolverr error: #{e.message}")
     end
 
     def test_oidc

--- a/app/services/flaresolverr_client.rb
+++ b/app/services/flaresolverr_client.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Client for interacting with FlareSolverr to bypass DDoS protection
+# https://github.com/FlareSolverr/FlareSolverr
+class FlaresolverrClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class TimeoutError < Error; end
+
+  class << self
+    # Check if FlareSolverr is configured
+    def configured?
+      SettingsService.flaresolverr_configured?
+    end
+
+    # Perform a GET request through FlareSolverr
+    # Returns the HTML content of the page
+    def get(url, timeout: 60000)
+      ensure_configured!
+
+      Rails.logger.info "[FlaresolverrClient] Requesting: #{url}"
+
+      response = connection.post("/v1") do |req|
+        req.body = {
+          cmd: "request.get",
+          url: url,
+          maxTimeout: timeout
+        }.to_json
+      end
+
+      data = JSON.parse(response.body)
+
+      if data["status"] != "ok"
+        error_message = data["message"] || "Unknown FlareSolverr error"
+        Rails.logger.error "[FlaresolverrClient] Error: #{error_message}"
+        raise Error, error_message
+      end
+
+      solution = data["solution"]
+      Rails.logger.info "[FlaresolverrClient] Success - Status: #{solution['status']}"
+
+      solution["response"]
+    rescue Faraday::ConnectionFailed => e
+      raise ConnectionError, "Failed to connect to FlareSolverr: #{e.message}"
+    rescue Faraday::TimeoutError => e
+      raise TimeoutError, "FlareSolverr request timed out: #{e.message}"
+    rescue JSON::ParserError => e
+      raise Error, "Failed to parse FlareSolverr response: #{e.message}"
+    end
+
+    # Test connection to FlareSolverr
+    def test_connection
+      ensure_configured!
+
+      # Test by fetching a simple page
+      response = connection.post("/v1") do |req|
+        req.body = {
+          cmd: "request.get",
+          url: "https://example.com",
+          maxTimeout: 30000
+        }.to_json
+      end
+
+      data = JSON.parse(response.body)
+      data["status"] == "ok"
+    rescue Error, Faraday::Error, JSON::ParserError
+      false
+    end
+
+    # Reset connection (useful when settings change)
+    def reset_connection!
+      @connection = nil
+    end
+
+    private
+
+    def ensure_configured!
+      unless configured?
+        raise Error, "FlareSolverr is not configured"
+      end
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: base_url) do |f|
+        f.request :json
+        f.adapter Faraday.default_adapter
+        f.headers["Content-Type"] = "application/json"
+        f.options.timeout = 120
+        f.options.open_timeout = 10
+      end
+    end
+
+    def base_url
+      SettingsService.get(:flaresolverr_url)
+    end
+  end
+end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -62,6 +62,7 @@ class SettingsService
     anna_archive_enabled: { type: "boolean", default: false, category: "anna_archive", description: "Enable Anna's Archive as an additional search source for ebooks" },
     anna_archive_url: { type: "string", default: "https://annas-archive.se", category: "anna_archive", description: "Base URL for Anna's Archive (change if domain moves)" },
     anna_archive_api_key: { type: "string", default: "", category: "anna_archive", description: "Member API key from Anna's Archive (requires donation)" },
+    flaresolverr_url: { type: "string", default: "", category: "anna_archive", description: "FlareSolverr URL for bypassing DDoS protection (e.g., http://flaresolverr:8191)" },
 
     # OIDC/SSO Authentication
     oidc_enabled: { type: "boolean", default: false, category: "oidc", description: "Enable OpenID Connect (OIDC) single sign-on authentication" },
@@ -181,6 +182,10 @@ class SettingsService
 
     def anna_archive_configured?
       get(:anna_archive_enabled, default: false) && configured?(:anna_archive_api_key)
+    end
+
+    def flaresolverr_configured?
+      configured?(:flaresolverr_url)
     end
 
     def oidc_configured?

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -52,7 +52,17 @@
         <% end %>
 
         <%# Test connection buttons for services - using link_to with turbo-method to avoid nested forms %>
-        <% if category == "prowlarr" %>
+        <% if category == "anna_archive" %>
+          <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+            <div class="md:w-1/3">
+              <span class="font-medium text-gray-300">Test FlareSolverr</span>
+              <p class="text-sm text-gray-500">Verify FlareSolverr is reachable (required to bypass DDoS protection)</p>
+            </div>
+            <div class="md:w-2/3">
+              <%= link_to "Test FlareSolverr Connection", test_flaresolverr_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+            </div>
+          </div>
+        <% elsif category == "prowlarr" %>
           <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
             <div class="md:w-1/3">
               <span class="font-medium text-gray-300">Test Connection</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
         patch :bulk_update
         post :test_prowlarr
         post :test_audiobookshelf
+        post :test_flaresolverr
         post :test_oidc
       end
     end

--- a/test/services/flaresolverr_client_test.rb
+++ b/test/services/flaresolverr_client_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FlaresolverrClientTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:flaresolverr_url, "http://localhost:8191")
+  end
+
+  teardown do
+    SettingsService.set(:flaresolverr_url, "")
+    FlaresolverrClient.reset_connection!
+  end
+
+  test "configured? returns true when URL is set" do
+    assert FlaresolverrClient.configured?
+  end
+
+  test "configured? returns false when URL is empty" do
+    SettingsService.set(:flaresolverr_url, "")
+    assert_not FlaresolverrClient.configured?
+  end
+
+  test "get raises error when not configured" do
+    SettingsService.set(:flaresolverr_url, "")
+
+    assert_raises FlaresolverrClient::Error do
+      FlaresolverrClient.get("https://example.com")
+    end
+  end
+
+  test "get returns HTML content on success" do
+    VCR.turned_off do
+      stub_flaresolverr_success
+
+      html = FlaresolverrClient.get("https://example.com")
+
+      assert_equal "<html>Test content</html>", html
+    end
+  end
+
+  test "get raises Error on FlareSolverr error response" do
+    VCR.turned_off do
+      stub_flaresolverr_error("Challenge failed")
+
+      error = assert_raises FlaresolverrClient::Error do
+        FlaresolverrClient.get("https://example.com")
+      end
+
+      assert_equal "Challenge failed", error.message
+    end
+  end
+
+  test "get raises ConnectionError on connection failure" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8191/v1")
+        .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+
+      assert_raises FlaresolverrClient::ConnectionError do
+        FlaresolverrClient.get("https://example.com")
+      end
+    end
+  end
+
+  test "get raises TimeoutError on timeout" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8191/v1")
+        .to_raise(Faraday::TimeoutError.new("Request timed out"))
+
+      assert_raises FlaresolverrClient::TimeoutError do
+        FlaresolverrClient.get("https://example.com")
+      end
+    end
+  end
+
+  test "test_connection returns true on success" do
+    VCR.turned_off do
+      stub_flaresolverr_success
+
+      assert FlaresolverrClient.test_connection
+    end
+  end
+
+  test "test_connection returns false on error" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8191/v1")
+        .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+
+      assert_not FlaresolverrClient.test_connection
+    end
+  end
+
+  private
+
+  def stub_flaresolverr_success
+    stub_request(:post, "http://localhost:8191/v1")
+      .with(
+        body: hash_including("cmd" => "request.get"),
+        headers: { "Content-Type" => "application/json" }
+      )
+      .to_return(
+        status: 200,
+        body: {
+          status: "ok",
+          message: "",
+          solution: {
+            status: 200,
+            response: "<html>Test content</html>"
+          }
+        }.to_json
+      )
+  end
+
+  def stub_flaresolverr_error(message)
+    stub_request(:post, "http://localhost:8191/v1")
+      .to_return(
+        status: 200,
+        body: {
+          status: "error",
+          message: message
+        }.to_json
+      )
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #112 - Anna's Archive 403 errors due to DDoS-Guard protection.

- Add FlareSolverr integration to bypass DDoS protection when configured
- Create new `FlaresolverrClient` service for FlareSolverr API interaction
- Add `flaresolverr_url` setting in Anna's Archive category
- Update `AnnaArchiveClient` to detect bot protection and use FlareSolverr
- Add helpful error messages when bot protection is detected without FlareSolverr
- Add test connection button for FlareSolverr in admin settings

## Test plan

- [ ] Deploy without FlareSolverr configured
- [ ] Search for a book → Should show helpful error about FlareSolverr if bot protection detected
- [ ] Add FlareSolverr to docker-compose and configure URL in settings
- [ ] Test FlareSolverr connection button should succeed
- [ ] Search for a book → Should work through FlareSolverr
- [ ] Run test suite: `rails test` (534 tests pass)