### PR TITLE
feat: add NZBGet support as usenet download client

### DIFF
--- a/app/services/download_clients/nzbget.rb
+++ b/app/services/download_clients/nzbget.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+module DownloadClients
+  # NZBGet JSON-RPC API client for usenet downloads
+  # https://nzbget.net/api
+  class Nzbget < Base
+    # Add an NZB by URL (method named add_torrent for interface compatibility with Base)
+    def add_torrent(url, options = {})
+      Rails.logger.info "[Nzbget] Adding URL to queue (#{url.to_s.length} chars)"
+
+      # appendurl params: URL, NZBFilename, Category, Priority, AddToTop, AddPaused, DupeKey, DupeScore, DupeMode
+      result = rpc_call("appendurl", [
+        url,                              # URL
+        "",                               # NZBFilename
+        config.category.presence || "",   # Category
+        0,                                # Priority
+        false,                            # AddToTop
+        false,                            # AddPaused
+        "",                               # DupeKey
+        0,                                # DupeScore
+        "SCORE"                           # DupeMode
+      ])
+
+      if result && result > 0
+        Rails.logger.info "[Nzbget] Added NZB with ID: #{result}"
+        { "nzo_ids" => [ result.to_s ] }
+      else
+        Rails.logger.error "[Nzbget] Failed to add NZB, result: #{result.inspect}"
+        false
+      end
+    rescue Faraday::Error => e
+      Rails.logger.error "[Nzbget] Connection error: #{e.message}"
+      raise Base::ConnectionError, "Failed to connect to NZBGet: #{e.message}"
+    end
+
+    # Get info for a specific download by ID
+    def torrent_info(nzbget_id)
+      # Check queue first, then history
+      queue_item = find_in_queue(nzbget_id)
+      return queue_item if queue_item
+
+      find_in_history(nzbget_id)
+    end
+
+    # List all downloads (queue + recent history)
+    def list_torrents(filter = {})
+      queue = list_queue
+      history = list_history(limit: filter[:limit] || 50)
+      queue + history
+    end
+
+    # Test connection to NZBGet
+    def test_connection
+      result = rpc_call("version")
+      if result.is_a?(String) && result.present?
+        Rails.logger.info "[Nzbget] Connection test passed - version: #{result}"
+        true
+      else
+        Rails.logger.error "[Nzbget] Connection test failed - unexpected response: #{result.inspect}"
+        false
+      end
+    rescue Base::Error, Faraday::Error => e
+      Rails.logger.error "[Nzbget] Connection test failed: #{e.message}"
+      false
+    end
+
+    # Remove a download by ID
+    # delete_files: if true, also delete downloaded files
+    def remove_torrent(nzbget_id, delete_files: false)
+      id = nzbget_id.to_i
+
+      # Try to delete from queue first using editqueue
+      # EditQueue(Command, Offset, EditText, IDs)
+      # GroupDelete removes the group and its files
+      result = rpc_call("editqueue", [ "GroupDelete", 0, "", [ id ] ])
+
+      if result == true
+        Rails.logger.info "[Nzbget] Removed download #{nzbget_id} from queue"
+        return true
+      end
+
+      # If not in queue, try history
+      # HistoryDelete removes from history but keeps files
+      # HistoryFinalDelete removes from history and deletes files
+      history_command = delete_files ? "HistoryFinalDelete" : "HistoryDelete"
+      result = rpc_call("editqueue", [ history_command, 0, "", [ id ] ])
+
+      if result == true
+        Rails.logger.info "[Nzbget] Removed download #{nzbget_id} from history (delete_files=#{delete_files})"
+        true
+      else
+        Rails.logger.error "[Nzbget] Failed to remove download #{nzbget_id}"
+        false
+      end
+    rescue Faraday::Error => e
+      raise Base::ConnectionError, "Failed to connect to NZBGet: #{e.message}"
+    end
+
+    private
+
+    def rpc_call(method, params = [])
+      response = connection.post do |req|
+        req.url "/jsonrpc"
+        req.headers["Content-Type"] = "application/json"
+        req.body = {
+          method: method,
+          params: params
+        }.to_json
+      end
+
+      handle_response(response)
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: base_url) do |f|
+        f.request :authorization, :basic, config.username, config.password
+        f.response :json, parser_options: { symbolize_names: false }
+        f.adapter Faraday.default_adapter
+        f.options.timeout = 15
+        f.options.open_timeout = 5
+      end
+    end
+
+    def handle_response(response)
+      case response.status
+      when 200
+        body = response.body
+        if body.is_a?(Hash)
+          if body["error"]
+            Rails.logger.error "[Nzbget] API returned error: #{body['error']}"
+            raise Base::Error, "NZBGet error: #{body['error']}"
+          end
+          body["result"]
+        else
+          Rails.logger.error "[Nzbget] Unexpected response format: #{body.inspect.truncate(200)}"
+          raise Base::Error, "NZBGet returned unexpected response format"
+        end
+      when 401, 403
+        Rails.logger.error "[Nzbget] Authentication failed (status #{response.status})"
+        raise Base::AuthenticationError, "NZBGet authentication failed"
+      else
+        Rails.logger.error "[Nzbget] API error (status #{response.status}): #{response.body.inspect.truncate(200)}"
+        raise Base::Error, "NZBGet API error: #{response.status}"
+      end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      Rails.logger.error "[Nzbget] Connection error: #{e.message}"
+      raise Base::ConnectionError, "Failed to connect to NZBGet: #{e.message}"
+    end
+
+    def list_queue
+      result = rpc_call("listgroups", [ 0 ])  # 0 = return all fields
+      return [] unless result.is_a?(Array)
+
+      result.map { |item| parse_queue_item(item) }
+    end
+
+    def list_history(limit: 50)
+      # history(Hidden) - Hidden=false to get normal history
+      result = rpc_call("history", [ false ])
+      return [] unless result.is_a?(Array)
+
+      result.take(limit).map { |item| parse_history_item(item) }
+    end
+
+    def find_in_queue(nzbget_id)
+      id = nzbget_id.to_i
+      list_queue.find { |item| item.hash == nzbget_id.to_s }
+    rescue Base::Error
+      nil
+    end
+
+    def find_in_history(nzbget_id)
+      list_history.find { |item| item.hash == nzbget_id.to_s }
+    rescue Base::Error
+      nil
+    end
+
+    def parse_queue_item(data)
+      Base::TorrentInfo.new(
+        hash: data["NZBID"].to_s,
+        name: data["NZBName"],
+        progress: calculate_progress(data),
+        state: normalize_queue_state(data["Status"]),
+        size_bytes: data["FileSizeMB"].to_f * 1024 * 1024,
+        download_path: data["DestDir"].presence || ""
+      )
+    end
+
+    def parse_history_item(data)
+      Base::TorrentInfo.new(
+        hash: data["NZBID"].to_s,
+        name: data["Name"],
+        progress: 100,
+        state: normalize_history_state(data["Status"]),
+        size_bytes: data["FileSizeMB"].to_f * 1024 * 1024,
+        download_path: data["DestDir"].presence || ""
+      )
+    end
+
+    def calculate_progress(data)
+      total = data["FileSizeMB"].to_f
+      remaining = data["RemainingSizeMB"].to_f
+      return 0 if total <= 0
+
+      progress = ((total - remaining) / total * 100).to_i
+      progress.clamp(0, 100)
+    end
+
+    def normalize_queue_state(status)
+      case status&.upcase
+      when "DOWNLOADING"
+        :downloading
+      when "PAUSED", "PAUSING"
+        :paused
+      when "QUEUED", "FETCHING", "LOADING_PARS", "VERIFYING_SOURCES",
+           "REPAIRING", "VERIFYING_REPAIRED", "RENAMING", "UNPACKING",
+           "MOVING", "EXECUTING_SCRIPT", "PP_QUEUED", "POST-PROCESSING"
+        :queued
+      else
+        :queued
+      end
+    end
+
+    def normalize_history_state(status)
+      case status&.upcase
+      when "SUCCESS"
+        :completed
+      when "FAILURE", "DELETED"
+        :failed
+      else
+        :completed
+      end
+    end
+  end
+end

--- a/test/services/download_clients/nzbget_test.rb
+++ b/test/services/download_clients/nzbget_test.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DownloadClients::NzbgetTest < ActiveSupport::TestCase
+  setup do
+    @client_record = DownloadClient.create!(
+      name: "Test NZBGet",
+      client_type: "nzbget",
+      url: "http://localhost:6789",
+      username: "nzbget",
+      password: "tegbzn6789",
+      priority: 0,
+      enabled: true
+    )
+    @client = @client_record.adapter
+  end
+
+  test "add_torrent adds NZB successfully" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "appendurl"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => 12345 }.to_json
+        )
+
+      result = @client.add_torrent("http://example.com/test.nzb")
+      assert result
+      assert_equal [ "12345" ], result["nzo_ids"]
+    end
+  end
+
+  test "add_torrent returns false on failure" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(basic_auth: [ "nzbget", "tegbzn6789" ])
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => 0 }.to_json
+        )
+
+      result = @client.add_torrent("http://example.com/test.nzb")
+      assert_not result
+    end
+  end
+
+  test "list_torrents returns queue and history items" do
+    VCR.turned_off do
+      # Stub listgroups (queue)
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "listgroups"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => [
+              {
+                "NZBID" => 1001,
+                "NZBName" => "Test Download",
+                "Status" => "DOWNLOADING",
+                "FileSizeMB" => 1024,
+                "RemainingSizeMB" => 512,
+                "DestDir" => "/downloads/incomplete"
+              }
+            ]
+          }.to_json
+        )
+
+      # Stub history
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "history"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => [
+              {
+                "NZBID" => 1000,
+                "Name" => "Completed Download",
+                "Status" => "SUCCESS",
+                "FileSizeMB" => 2048,
+                "DestDir" => "/downloads/complete/Completed Download"
+              }
+            ]
+          }.to_json
+        )
+
+      torrents = @client.list_torrents
+
+      assert_kind_of Array, torrents
+      assert_equal 2, torrents.size
+
+      queue_item = torrents.find { |t| t.hash == "1001" }
+      assert_equal "Test Download", queue_item.name
+      assert_equal 50, queue_item.progress
+      assert_equal :downloading, queue_item.state
+
+      history_item = torrents.find { |t| t.hash == "1000" }
+      assert_equal "Completed Download", history_item.name
+      assert_equal 100, history_item.progress
+      assert_equal :completed, history_item.state
+    end
+  end
+
+  test "test_connection returns true on success" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "version"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "21.1" }.to_json
+        )
+
+      assert @client.test_connection
+    end
+  end
+
+  test "test_connection returns false on auth failure" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(basic_auth: [ "nzbget", "tegbzn6789" ])
+        .to_return(status: 401)
+
+      assert_not @client.test_connection
+    end
+  end
+
+  test "test_connection returns false on connection error" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(basic_auth: [ "nzbget", "tegbzn6789" ])
+        .to_timeout
+
+      assert_not @client.test_connection
+    end
+  end
+
+  test "torrent_info returns item from queue" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "listgroups"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => [
+              {
+                "NZBID" => 999,
+                "NZBName" => "Test Item",
+                "Status" => "DOWNLOADING",
+                "FileSizeMB" => 1000,
+                "RemainingSizeMB" => 250,
+                "DestDir" => "/downloads"
+              }
+            ]
+          }.to_json
+        )
+
+      info = @client.torrent_info("999")
+
+      assert_not_nil info
+      assert_equal "999", info.hash
+      assert_equal "Test Item", info.name
+      assert_equal 75, info.progress
+      assert_equal :downloading, info.state
+    end
+  end
+
+  test "torrent_info returns item from history when not in queue" do
+    VCR.turned_off do
+      # Queue returns empty
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "listgroups"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => [] }.to_json
+        )
+
+      # History returns the item
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "history"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => [
+              {
+                "NZBID" => 888,
+                "Name" => "Completed Item",
+                "Status" => "SUCCESS",
+                "FileSizeMB" => 500,
+                "DestDir" => "/downloads/complete"
+              }
+            ]
+          }.to_json
+        )
+
+      info = @client.torrent_info("888")
+
+      assert_not_nil info
+      assert_equal "888", info.hash
+      assert_equal "Completed Item", info.name
+      assert_equal :completed, info.state
+    end
+  end
+
+  test "remove_torrent removes from queue" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "editqueue"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => true }.to_json
+        )
+
+      assert @client.remove_torrent("12345")
+    end
+  end
+
+  test "normalizes queue states correctly" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(body: hash_including("method" => "listgroups"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => [
+              { "NZBID" => 1, "NZBName" => "Downloading", "Status" => "DOWNLOADING", "FileSizeMB" => 100, "RemainingSizeMB" => 50, "DestDir" => "" },
+              { "NZBID" => 2, "NZBName" => "Paused", "Status" => "PAUSED", "FileSizeMB" => 100, "RemainingSizeMB" => 50, "DestDir" => "" },
+              { "NZBID" => 3, "NZBName" => "Queued", "Status" => "QUEUED", "FileSizeMB" => 100, "RemainingSizeMB" => 100, "DestDir" => "" },
+              { "NZBID" => 4, "NZBName" => "PostProcessing", "Status" => "UNPACKING", "FileSizeMB" => 100, "RemainingSizeMB" => 0, "DestDir" => "" }
+            ]
+          }.to_json
+        )
+
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(body: hash_including("method" => "history"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => [] }.to_json
+        )
+
+      torrents = @client.list_torrents
+
+      assert_equal :downloading, torrents.find { |t| t.hash == "1" }.state
+      assert_equal :paused, torrents.find { |t| t.hash == "2" }.state
+      assert_equal :queued, torrents.find { |t| t.hash == "3" }.state
+      assert_equal :queued, torrents.find { |t| t.hash == "4" }.state  # post-processing is queued
+    end
+  end
+
+  test "normalizes history states correctly" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(body: hash_including("method" => "listgroups"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => [] }.to_json
+        )
+
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(body: hash_including("method" => "history"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => [
+              { "NZBID" => 1, "Name" => "Success", "Status" => "SUCCESS", "FileSizeMB" => 100, "DestDir" => "" },
+              { "NZBID" => 2, "Name" => "Failed", "Status" => "FAILURE", "FileSizeMB" => 100, "DestDir" => "" },
+              { "NZBID" => 3, "Name" => "Deleted", "Status" => "DELETED", "FileSizeMB" => 100, "DestDir" => "" }
+            ]
+          }.to_json
+        )
+
+      torrents = @client.list_torrents
+
+      assert_equal :completed, torrents.find { |t| t.hash == "1" }.state
+      assert_equal :failed, torrents.find { |t| t.hash == "2" }.state
+      assert_equal :failed, torrents.find { |t| t.hash == "3" }.state
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds NZBGet as an alternative usenet download client alongside SABnzbd
- NZBGet uses JSON-RPC API with HTTP Basic authentication
- Useful for users who prefer NZBGet's lower resource footprint

## Features

- Add NZBs by URL via `appendurl` API
- List downloads from queue and history
- Track download progress and states (downloading, paused, queued, completed, failed)
- Remove downloads with optional file deletion (`HistoryDelete` vs `HistoryFinalDelete`)
- Connection testing via `version` API call

## Changes

| File | Change |
|------|--------|
| `app/services/download_clients/nzbget.rb` | New NZBGet client implementation |
| `app/models/download_client.rb` | Added `nzbget` to enum, updated scopes and adapter |
| `test/services/download_clients/nzbget_test.rb` | Comprehensive test coverage (11 tests) |

## Test plan

- [x] All 569 tests pass
- [x] NZBGet-specific tests cover: add, list, info, remove, connection test, state normalization
- [ ] Manual test with real NZBGet instance

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)