### PR TITLE
feat: add RAILS_RELATIVE_URL_ROOT support for sub-path deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Visit `http://localhost:5056` — the first user to register becomes admin.
 | `PGID` | `1000` | Group ID for file permissions. Should match the group of your mounted volumes |
 | `HTTP_PORT` | `80` | Internal container port. Change if port 80 is in use (e.g., behind gluetun) |
 | `RAILS_MASTER_KEY` | Auto-generated | Encryption key for secrets. Auto-generated on first run if not set |
+| `RAILS_RELATIVE_URL_ROOT` | `/` | Base path for running behind a reverse proxy at a sub-path (e.g., `/shelfarr`) |
 
 Example with custom port:
 ```yaml
@@ -79,6 +80,12 @@ environment:
   - HTTP_PORT=8080
 ports:
   - "5056:8080"  # Map to the custom port
+```
+
+Example running at a sub-path (e.g., behind a reverse proxy at `/shelfarr`):
+```yaml
+environment:
+  - RAILS_RELATIVE_URL_ROOT=/shelfarr
 ```
 
 ### Configuration

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  # Returns the path for assets in the public folder, respecting RAILS_RELATIVE_URL_ROOT
+  # Use this for static assets like /icon.png or /images/no-cover.svg
+  def public_asset_path(path)
+    # Use request.script_name which is set by Rack::URLMap when app is mounted at a subpath
+    base = request.script_name.to_s
+    "#{base}/#{path.to_s.delete_prefix('/')}"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,8 @@
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
     <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
 
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="apple-touch-icon" href="/icon.png">
+    <link rel="icon" href="<%= public_asset_path('icon.png') %>" type="image/png">
+    <link rel="apple-touch-icon" href="<%= public_asset_path('icon.png') %>">
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
@@ -28,7 +28,7 @@
         <div class="flex justify-between h-16">
           <div class="flex items-center gap-6">
             <%= link_to root_path, class: "flex items-center gap-2 text-xl font-bold text-white" do %>
-              <img src="/icon.png" alt="Shelfarr" class="w-8 h-8 rounded-md">
+              <img src="<%= public_asset_path('icon.png') %>" alt="Shelfarr" class="w-8 h-8 rounded-md">
               <span>Shelfarr</span>
             <% end %>
             <% if authenticated? %>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,21 +1,22 @@
+<% base_path = request.script_name.to_s %>
 {
   "name": "Shelfarr",
   "icons": [
     {
-      "src": "/icon.png",
+      "src": "<%= base_path %>/icon.png",
       "type": "image/png",
       "sizes": "512x512"
     },
     {
-      "src": "/icon.png",
+      "src": "<%= base_path %>/icon.png",
       "type": "image/png",
       "sizes": "512x512",
       "purpose": "maskable"
     }
   ],
-  "start_url": "/",
+  "start_url": "<%= base_path.presence || "/" %>",
   "display": "standalone",
-  "scope": "/",
+  "scope": "<%= base_path.presence || "/" %>",
   "description": "Shelfarr.",
   "theme_color": "red",
   "background_color": "red"

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -9,7 +9,7 @@
             src="<%= @cover_url %>"
             alt="Cover of <%= @title %>"
             class="w-full rounded shadow"
-            onerror="this.onerror=null; this.src='/images/no-cover.svg';"
+            onerror="this.onerror=null; this.src='<%= public_asset_path('images/no-cover.svg') %>';"
           >
         <% else %>
           <div class="w-full aspect-[2/3] bg-gray-700 rounded shadow flex items-center justify-center">

--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,16 @@
 
 require_relative "config/environment"
 
-run Rails.application
+# Support running the app at a sub-path via RAILS_RELATIVE_URL_ROOT
+# This properly sets SCRIPT_NAME so route helpers include the prefix
+relative_url_root = ENV.fetch("RAILS_RELATIVE_URL_ROOT", "/")
+
+if relative_url_root != "/" && relative_url_root.present?
+  map relative_url_root do
+    run Rails.application
+  end
+else
+  run Rails.application
+end
+
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,10 @@ module Shelfarr
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1
 
+    # Support running the app at a sub-path (e.g., /shelfarr)
+    # Set RAILS_RELATIVE_URL_ROOT environment variable to configure
+    config.relative_url_root = ENV.fetch("RAILS_RELATIVE_URL_ROOT", "/")
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.


### PR DESCRIPTION
Allow running the app behind a reverse proxy at a sub-path (e.g., /shelfarr) by setting the RAILS_RELATIVE_URL_ROOT environment variable.

- Use Rack::URLMap to mount app at subpath, properly setting SCRIPT_NAME
- Add public_asset_path helper for static assets in public folder
- Fix hardcoded /icon.png paths in layout and PWA manifest
- Fix hardcoded /images/no-cover.svg fallback path
- Update README with documentation and example