### PR TITLE
fix: handle copy_file_range EACCES on NFS mounts

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -91,7 +91,7 @@ class PostProcessingJob < ApplicationJob
       files = Dir.entries(source).reject { |f| f.start_with?(".") }
       Rails.logger.info "[PostProcessingJob] Found #{files.size} files/folders to copy"
       files.each do |file|
-        FileUtils.cp_r(File.join(source, file), destination)
+        FileCopyService.cp_r(File.join(source, file), destination)
       end
     else
       # Copy single file with renamed filename based on template
@@ -103,7 +103,7 @@ class PostProcessingJob < ApplicationJob
       destination_file = handle_duplicate_filename(destination_file) if File.exist?(destination_file)
 
       Rails.logger.info "[PostProcessingJob] Renaming file to: #{new_filename}"
-      FileUtils.cp(source, destination_file)
+      FileCopyService.cp(source, destination_file)
     end
 
     Rails.logger.info "[PostProcessingJob] Copy completed successfully"

--- a/app/jobs/upload_processing_job.rb
+++ b/app/jobs/upload_processing_job.rb
@@ -230,7 +230,7 @@ class UploadProcessingJob < ApplicationJob
       FileUtils.mv(source_path, destination_file)
     rescue Errno::EXDEV
       # Cross-device move, use copy then delete
-      FileUtils.cp(source_path, destination_file)
+      FileCopyService.cp(source_path, destination_file)
       FileUtils.rm(source_path)
     end
 

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# NFS-safe file copy operations.
+#
+# Ruby's IO.copy_stream (used by FileUtils.cp/cp_r) attempts the
+# copy_file_range syscall for efficient file-to-file copies. This syscall
+# fails with Errno::EACCES on NFS mounts even when the user has full
+# read/write permissions. This service catches that specific failure and
+# falls back to a buffered read/write copy.
+#
+# See: https://github.com/Pedro-Revez-Silva/shelfarr/issues/131
+class FileCopyService
+  BUFFER_SIZE = 1024 * 1024 # 1 MB
+
+  class << self
+    def cp(src, dest)
+      FileUtils.cp(src, dest)
+    rescue Errno::EACCES => e
+      raise unless e.message.include?("copy_file_range")
+
+      Rails.logger.info "[FileCopyService] copy_file_range failed on NFS, falling back to buffered copy for #{File.basename(src)}"
+      buffered_copy(src, dest)
+    end
+
+    def cp_r(src, dest)
+      FileUtils.cp_r(src, dest)
+    rescue Errno::EACCES => e
+      raise unless e.message.include?("copy_file_range")
+
+      Rails.logger.info "[FileCopyService] copy_file_range failed on NFS, falling back to buffered recursive copy"
+      recursive_buffered_copy(src, dest)
+    end
+
+    private
+
+    def buffered_copy(src, dest)
+      dest = File.join(dest, File.basename(src)) if File.directory?(dest)
+
+      File.open(src, "rb") do |source|
+        File.open(dest, "wb") do |target|
+          buf = +""
+          target.write(buf) while source.read(BUFFER_SIZE, buf)
+        end
+      end
+
+      stat = File.stat(src)
+      FileUtils.chmod(stat.mode, dest)
+      File.utime(stat.atime, stat.mtime, dest)
+    end
+
+    def recursive_buffered_copy(src, dest)
+      if File.directory?(src)
+        dest_dir = File.directory?(dest) ? File.join(dest, File.basename(src)) : dest
+        FileUtils.mkdir_p(dest_dir)
+        FileUtils.chmod(File.stat(src).mode, dest_dir)
+
+        (Dir.entries(src) - %w[. ..]).each do |entry|
+          recursive_buffered_copy(File.join(src, entry), dest_dir)
+        end
+      else
+        buffered_copy(src, dest)
+      end
+    end
+  end
+end

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FileCopyServiceTest < ActiveSupport::TestCase
+  setup do
+    @tmp_dir = Dir.mktmpdir
+    @src_file = File.join(@tmp_dir, "source.txt")
+    @dest_dir = File.join(@tmp_dir, "dest")
+    FileUtils.mkdir_p(@dest_dir)
+    File.write(@src_file, "test content")
+  end
+
+  teardown do
+    FileUtils.rm_rf(@tmp_dir)
+  end
+
+  test "cp copies a file normally" do
+    dest_file = File.join(@dest_dir, "output.txt")
+    FileCopyService.cp(@src_file, dest_file)
+
+    assert File.exist?(dest_file)
+    assert_equal "test content", File.read(dest_file)
+  end
+
+  test "cp falls back to buffered copy on NFS copy_file_range EACCES" do
+    dest_file = File.join(@dest_dir, "output.txt")
+
+    FileUtils.stub(:cp, ->(_s, _d) { raise Errno::EACCES, "copy_file_range" }) do
+      FileCopyService.cp(@src_file, dest_file)
+    end
+
+    assert File.exist?(dest_file)
+    assert_equal "test content", File.read(dest_file)
+  end
+
+  test "cp re-raises EACCES when not from copy_file_range" do
+    dest_file = File.join(@dest_dir, "output.txt")
+
+    FileUtils.stub(:cp, ->(_s, _d) { raise Errno::EACCES, "some other permission error" }) do
+      assert_raises(Errno::EACCES) do
+        FileCopyService.cp(@src_file, dest_file)
+      end
+    end
+  end
+
+  test "cp_r copies directory contents normally" do
+    src_dir = File.join(@tmp_dir, "src_dir")
+    FileUtils.mkdir_p(src_dir)
+    File.write(File.join(src_dir, "a.txt"), "file a")
+    File.write(File.join(src_dir, "b.txt"), "file b")
+
+    FileCopyService.cp_r(src_dir, @dest_dir)
+
+    copied_dir = File.join(@dest_dir, "src_dir")
+    assert File.exist?(File.join(copied_dir, "a.txt"))
+    assert_equal "file a", File.read(File.join(copied_dir, "a.txt"))
+    assert_equal "file b", File.read(File.join(copied_dir, "b.txt"))
+  end
+
+  test "cp_r falls back to buffered copy on NFS copy_file_range EACCES" do
+    src_dir = File.join(@tmp_dir, "src_dir")
+    FileUtils.mkdir_p(src_dir)
+    File.write(File.join(src_dir, "a.txt"), "file a")
+
+    FileUtils.stub(:cp_r, ->(_s, _d) { raise Errno::EACCES, "copy_file_range" }) do
+      FileCopyService.cp_r(src_dir, @dest_dir)
+    end
+
+    copied_dir = File.join(@dest_dir, "src_dir")
+    assert File.exist?(File.join(copied_dir, "a.txt"))
+    assert_equal "file a", File.read(File.join(copied_dir, "a.txt"))
+  end
+
+  test "cp into directory places file inside it" do
+    FileUtils.stub(:cp, ->(_s, _d) { raise Errno::EACCES, "copy_file_range" }) do
+      FileCopyService.cp(@src_file, @dest_dir)
+    end
+
+    assert File.exist?(File.join(@dest_dir, "source.txt"))
+    assert_equal "test content", File.read(File.join(@dest_dir, "source.txt"))
+  end
+
+  test "cp_r re-raises EACCES when not from copy_file_range" do
+    src_dir = File.join(@tmp_dir, "src_dir")
+    FileUtils.mkdir_p(src_dir)
+
+    FileUtils.stub(:cp_r, ->(_s, _d) { raise Errno::EACCES, "some other error" }) do
+      assert_raises(Errno::EACCES) do
+        FileCopyService.cp_r(src_dir, @dest_dir)
+      end
+    end
+  end
+
+  test "cp_r fallback handles nested directories" do
+    src_dir = File.join(@tmp_dir, "src_dir")
+    sub_dir = File.join(src_dir, "subdir")
+    FileUtils.mkdir_p(sub_dir)
+    File.write(File.join(src_dir, "root.txt"), "root file")
+    File.write(File.join(sub_dir, "nested.txt"), "nested file")
+
+    FileUtils.stub(:cp_r, ->(_s, _d) { raise Errno::EACCES, "copy_file_range" }) do
+      FileCopyService.cp_r(src_dir, @dest_dir)
+    end
+
+    copied_dir = File.join(@dest_dir, "src_dir")
+    assert File.exist?(File.join(copied_dir, "root.txt"))
+    assert_equal "root file", File.read(File.join(copied_dir, "root.txt"))
+    assert File.exist?(File.join(copied_dir, "subdir", "nested.txt"))
+    assert_equal "nested file", File.read(File.join(copied_dir, "subdir", "nested.txt"))
+  end
+
+  test "cp_r fallback copies hidden files" do
+    src_dir = File.join(@tmp_dir, "src_dir")
+    FileUtils.mkdir_p(src_dir)
+    File.write(File.join(src_dir, ".hidden"), "hidden content")
+    File.write(File.join(src_dir, "visible.txt"), "visible content")
+
+    FileUtils.stub(:cp_r, ->(_s, _d) { raise Errno::EACCES, "copy_file_range" }) do
+      FileCopyService.cp_r(src_dir, @dest_dir)
+    end
+
+    copied_dir = File.join(@dest_dir, "src_dir")
+    assert File.exist?(File.join(copied_dir, ".hidden")), "Hidden file should be copied"
+    assert_equal "hidden content", File.read(File.join(copied_dir, ".hidden"))
+    assert_equal "visible content", File.read(File.join(copied_dir, "visible.txt"))
+  end
+end


### PR DESCRIPTION
## Summary
- Add `FileCopyService` that wraps `FileUtils.cp`/`cp_r` with NFS-safe fallback
- When `copy_file_range` syscall fails with `EACCES` on NFS mounts, falls back to buffered read/write copy
- Apply to `PostProcessingJob` and `UploadProcessingJob` file copy operations

## Test plan
- [x] 9 unit tests covering normal copy, NFS fallback, re-raise for non-NFS errors, nested directories, and hidden files
- [x] Full test suite passes (611 tests, 0 failures)
- [ ] Manual test on NFS mount environment if available

Closes #131