### PR TITLE
fix: add grace period before marking downloads as failed when not found in client

### DIFF
--- a/db/migrate/20260206111153_add_not_found_count_to_downloads.rb
+++ b/db/migrate/20260206111153_add_not_found_count_to_downloads.rb
@@ -1,0 +1,5 @@
+class AddNotFoundCountToDownloads < ActiveRecord::Migration[8.1]
+  def change
+    add_column :downloads, :not_found_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_30_120752) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_06_111153) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -77,6 +77,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_30_120752) do
     t.string "download_type"
     t.string "external_id"
     t.string "name"
+    t.integer "not_found_count", default: 0, null: false
     t.integer "progress", default: 0
     t.integer "request_id", null: false
     t.bigint "size_bytes"


### PR DESCRIPTION
## Summary
- Adds `not_found_count` column to downloads table to track consecutive "not found" responses from download clients
- `DownloadMonitorJob#handle_missing` now increments the counter instead of immediately failing — downloads are only marked as failed after 3 consecutive misses (~3 minutes at default 60s interval)
- Counter resets to 0 when the download is found again in the client
- Intermediate misses log at warn level; final failure logs at error level

## Motivation
Related to #124 — on seedbox setups with reverse proxies (Cloudflare tunnels, NPM), a single transient API failure was permanently killing downloads. This grace period tolerates brief connectivity issues while still detecting genuinely missing downloads.

## Test plan
- [x] New test: download not immediately failed on first "not found"
- [x] New test: download marked failed after threshold exceeded
- [x] New test: `not_found_count` reset when download found again
- [x] Full test suite passes (613 tests, 0 failures)