### PR TITLE
fix: handle Hardcover API search response format change

### DIFF
--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -166,11 +166,20 @@ class MetadataServiceTest < ActiveSupport::TestCase
   private
 
   def stub_hardcover_search(results)
+    typesense_response = {
+      "facet_counts" => [],
+      "found" => results.size,
+      "hits" => results.map { |r| { "document" => r } },
+      "request_params" => {},
+      "search_cutoff" => false,
+      "search_time_ms" => 5
+    }
+
     stub_request(:post, HardcoverClient::BASE_URL)
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
-        body: { "data" => { "search" => { "results" => results } } }.to_json
+        body: { "data" => { "search" => { "results" => typesense_response } } }.to_json
       )
   end
 


### PR DESCRIPTION
Hardcover changed their search API response format. Used to return the results array directly, now it's wrapped in a `{"hits": [...]}` object. This broke search because `filter_map` on a Hash yields `[key, value]` tuples instead of result objects, so everything silently failed.

Fixed by extracting the hits array before processing. Also handles cover images that are either plain strings or `{url: "..."}` objects now.

Changes:
- Parse Hash wrapper to get hits array
- Handle both String and Hash cover image formats
- Keep author fallback

Tests updated to mock the new format and cover edge cases.