### PR TITLE
fix: remove usenet downloads from client after successful import

### DIFF
--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -9,6 +9,7 @@ class SettingsService
     # Download Settings (clients are now managed separately via Admin > Download Clients)
     preferred_download_type: { type: "string", default: "torrent", category: "download", description: "Preferred download type when both available (torrent or usenet)" },
     download_check_interval: { type: "integer", default: 60, category: "download", description: "Seconds between download status checks" },
+    remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
     # Audiobookshelf Integration
     audiobookshelf_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for Audiobookshelf (e.g., http://localhost:13378)" },


### PR DESCRIPTION
## Summary
- Usenet downloads (SABnzbd/NZBGet) are now automatically removed from the download client after files are successfully copied to the library
- Torrent downloads are preserved for seeding (no change to existing behavior)
- New setting `remove_completed_usenet_downloads` (default: enabled) to control this behavior
- Cleanup failures are non-fatal and don't prevent import completion

Closes #141

## Test plan
- [x] All tests pass (4 new tests for cleanup behavior)
- [ ] Verify SABnzbd downloads are removed after successful import
- [ ] Verify NZBGet downloads are removed after successful import
- [ ] Verify torrent downloads are NOT removed (preserved for seeding)
- [ ] Verify disabling the setting prevents cleanup
- [ ] Verify import completes even if cleanup fails