### PR TITLE
feat: add Audiobookshelf duplicate-warning sync flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Agent instructions (local development reference only)
+/AGENTS.md

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -5,6 +5,7 @@ module Admin
     def index
       @settings_by_category = SettingsService.all_by_category
       @audiobookshelf_libraries = fetch_audiobookshelf_libraries
+      load_audiobookshelf_cache_summary
     end
 
     def update
@@ -39,6 +40,7 @@ module Admin
 
       if changed_keys.any? { |k| k.start_with?("audiobookshelf") }
         AudiobookshelfClient.reset_connection!
+        AudiobookshelfLibrarySyncJob.perform_later if AudiobookshelfClient.configured?
         run_service_health_check("audiobookshelf")
       end
       if changed_keys.any? { |k| k.start_with?("prowlarr") }
@@ -58,6 +60,7 @@ module Admin
 
       @settings_by_category = SettingsService.all_by_category
       @audiobookshelf_libraries = fetch_audiobookshelf_libraries
+      load_audiobookshelf_cache_summary
 
       respond_to do |format|
         if errors.any?
@@ -83,6 +86,7 @@ module Admin
     rescue ArgumentError => e
       @settings_by_category = SettingsService.all_by_category
       @audiobookshelf_libraries = fetch_audiobookshelf_libraries
+      load_audiobookshelf_cache_summary
 
       respond_to do |format|
         format.html { redirect_to admin_settings_path, alert: e.message }
@@ -136,6 +140,16 @@ module Admin
     rescue AudiobookshelfClient::Error => e
       health&.check_failed!(message: e.message)
       respond_with_flash(alert: "Audiobookshelf error: #{e.message}")
+    end
+
+    def sync_audiobookshelf_library
+      unless AudiobookshelfClient.configured?
+        redirect_to admin_settings_path, alert: "Audiobookshelf is not configured. Enter URL and API key first."
+        return
+      end
+
+      AudiobookshelfLibrarySyncJob.perform_later
+      redirect_to admin_settings_path, notice: "Audiobookshelf library sync started."
     end
 
     # FlareSolverr is not tracked in SystemHealth::SERVICES, so no SystemHealth sync here
@@ -249,6 +263,12 @@ module Admin
     rescue AudiobookshelfClient::Error => e
       Rails.logger.warn "[SettingsController] Failed to fetch Audiobookshelf libraries: #{e.message}"
       []
+    end
+
+    def load_audiobookshelf_cache_summary
+      @audiobookshelf_library_items = LibraryItem.by_synced_at_desc.limit(50)
+      @audiobookshelf_library_items_count = LibraryItem.count
+      @audiobookshelf_library_items_last_synced_at = @audiobookshelf_library_items.maximum(:synced_at)
     end
 
     def ensure_settings_seeded

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,16 +11,24 @@ class SearchController < ApplicationController
     if @query.blank?
       @results = []
       @error = nil
+      @audiobookshelf_matches = []
     else
       begin
         @results = MetadataService.search(@query)
+        @audiobookshelf_matches = if LibraryItem.exists?
+          AudiobookshelfLibraryMatcherService.matches_for_many(@results, limit_per_result: 2)
+        else
+          Array.new(@results.size) { [] }
+        end
         @error = nil
       rescue HardcoverClient::ConnectionError, OpenLibraryClient::ConnectionError => e
         @results = []
+        @audiobookshelf_matches = []
         @error = "Unable to connect to metadata service. Please try again later."
         Rails.logger.error("Metadata service connection error: #{e.message}")
       rescue HardcoverClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
         @results = []
+        @audiobookshelf_matches = []
         @error = "Search failed. Please try again."
         Rails.logger.error("Metadata service error: #{e.message}")
       end

--- a/app/jobs/audiobookshelf_library_sync_job.rb
+++ b/app/jobs/audiobookshelf_library_sync_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AudiobookshelfLibrarySyncJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return unless AudiobookshelfClient.configured?
+
+    AudiobookshelfLibrarySyncService.new.sync!
+  ensure
+    schedule_next_run
+  end
+
+  private
+
+  def schedule_next_run
+    interval = SettingsService.get(:audiobookshelf_library_sync_interval, default: 3600).to_i
+    return if interval <= 0
+
+    AudiobookshelfLibrarySyncJob.set(wait: interval.seconds).perform_later
+  end
+end

--- a/app/models/library_item.rb
+++ b/app/models/library_item.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class LibraryItem < ApplicationRecord
+  validates :library_id, presence: true
+  validates :audiobookshelf_id, presence: true
+  validates :library_id, uniqueness: { scope: :audiobookshelf_id }
+
+  scope :by_synced_at_desc, -> { order(synced_at: :desc, title: :asc) }
+  scope :for_libraries, ->(ids) { where(library_id: ids) }
+
+  def audiobookshelf_url
+    base_url = SettingsService.get(:audiobookshelf_url)
+    return nil if base_url.blank? || audiobookshelf_id.blank?
+
+    "#{base_url.to_s.chomp("/")}/item/#{audiobookshelf_id}"
+  end
+
+  def sync_stale?(threshold:)
+    synced_at.blank? || synced_at < threshold
+  end
+end

--- a/app/services/audiobookshelf_library_matcher_service.rb
+++ b/app/services/audiobookshelf_library_matcher_service.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+class AudiobookshelfLibraryMatcherService
+  Match = Data.define(:item, :score, :match_type)
+
+  FuzzyThreshold = 85
+
+  def self.matches_for_many(results, limit_per_result: 3)
+    results = Array(results)
+    return Array.new(results.size) { [] } if results.empty?
+
+    matcher = new
+    results.map do |result|
+      matcher.matches_for(
+        title: result.respond_to?(:title) ? result.title : nil,
+        author: result.respond_to?(:author) ? result.author : nil,
+        limit: limit_per_result
+      )
+    end
+  end
+
+  def matches_for(title:, author:, limit: 3)
+    return [] if library_items.empty?
+    return [] if title.blank? && author.blank?
+
+    query_title = normalize_text(title)
+    query_author = normalize_text(author)
+
+    matches = library_items.each_with_object([]) do |item, acc|
+      item_title = normalize_text(item.title)
+      item_author = normalize_text(item.author)
+      next if item_title.blank? && item_author.blank?
+
+      score = match_score(
+        query_title: query_title,
+        query_author: query_author,
+        item_title: item_title,
+        item_author: item_author
+      )
+      next if score < FuzzyThreshold
+
+      match_type = score == 100 ? :exact : :fuzzy
+      acc << Match.new(item: item, score: score, match_type: match_type)
+    end
+
+    matches.sort_by { |match| [-match.score, match.item.title.to_s.downcase] }.take(limit)
+  end
+
+  private
+
+  def library_items
+    @library_items ||= LibraryItem.by_synced_at_desc.to_a
+  end
+
+  def match_score(query_title:, query_author:, item_title:, item_author:)
+    return 100 if query_title == item_title && query_author == item_author
+
+    title_score = trigram_similarity(query_title, item_title)
+    return title_score if query_author.blank? || item_author.blank?
+
+    author_score = trigram_similarity(query_author, item_author)
+    ((title_score * 0.7) + (author_score * 0.3)).round
+  end
+
+  def normalize_text(text)
+    return "" if text.blank?
+
+    text
+      .downcase
+      .gsub(/[^a-z0-9\s]/, " ")
+      .gsub(/\s+/, " ")
+      .strip
+  end
+
+  def trigram_similarity(left, right)
+    return 0 if left.blank? || right.blank?
+    return 100 if left == right
+
+    trigrams_left = trigrams(left)
+    trigrams_right = trigrams(right)
+
+    return 0 if trigrams_left.empty? || trigrams_right.empty?
+
+    intersection = (trigrams_left & trigrams_right).size
+    union = (trigrams_left | trigrams_right).size
+    ((intersection.to_f / union) * 100).round
+  end
+
+  def trigrams(text)
+    return Set.new if text.blank?
+
+    padded = "  #{text}  "
+    (0..padded.length - 3).map { |i| padded[i, 3] }.to_set
+  end
+end

--- a/app/services/audiobookshelf_library_sync_service.rb
+++ b/app/services/audiobookshelf_library_sync_service.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class AudiobookshelfLibrarySyncService
+  Result = Data.define(:success, :items_synced, :libraries_synced, :errors) do
+    def success?
+      success
+    end
+  end
+
+  def sync!
+    errors = []
+    items_synced = 0
+    libraries_synced = 0
+    now = Time.current
+
+    library_ids = configured_library_ids
+    if library_ids.empty?
+      return Result.new(
+        success: false,
+        items_synced: 0,
+        libraries_synced: 0,
+        errors: [ "No Audiobookshelf library IDs configured or available." ]
+      )
+    end
+
+    library_ids.each do |library_id|
+      begin
+        items = AudiobookshelfClient.library_items(library_id)
+        sync_library_items(library_id, items, synced_at: now)
+        libraries_synced += 1
+        items_synced += items.size
+      rescue AudiobookshelfClient::Error, StandardError => e
+        errors << "#{library_id}: #{e.message}"
+        Rails.logger.warn "[AudiobookshelfLibrarySyncService] Failed to sync library #{library_id}: #{e.message}"
+      end
+    end
+
+    synced = errors.empty? || items_synced.positive?
+    Result.new(
+      success: synced,
+      items_synced: items_synced,
+      libraries_synced: libraries_synced,
+      errors: errors
+    )
+  end
+
+  def configured_library_ids
+    return @configured_library_ids if defined?(@configured_library_ids)
+
+    @configured_library_ids = begin
+      configured_ids = [
+        SettingsService.get(:audiobookshelf_audiobook_library_id),
+        SettingsService.get(:audiobookshelf_ebook_library_id)
+      ].filter_map(&:presence).uniq
+
+      if configured_ids.any?
+        configured_ids
+      else
+        load_library_ids_from_configured_client
+      end
+    end
+  end
+
+  private
+
+  def sync_library_items(library_id, items, synced_at:)
+    item_ids = []
+    now = synced_at
+
+    items.each do |item|
+      audiobookshelf_id = item["audiobookshelf_id"]
+      next if audiobookshelf_id.blank?
+
+      cached = LibraryItem.find_or_initialize_by(library_id: library_id, audiobookshelf_id: audiobookshelf_id)
+      cached.title = item["title"]
+      cached.author = item["author"]
+      cached.synced_at = now
+      cached.save!
+      item_ids << audiobookshelf_id
+    end
+
+    LibraryItem.where(library_id: library_id).where.not(audiobookshelf_id: item_ids).delete_all
+  end
+
+  def load_library_ids_from_configured_client
+    return [] unless AudiobookshelfClient.configured?
+
+    libraries = AudiobookshelfClient.libraries
+    libraries.select(&:audiobook_library?).map(&:id)
+  end
+end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -16,6 +16,7 @@ class SettingsService
     audiobookshelf_api_key: { type: "string", default: "", category: "audiobookshelf", description: "API token from Audiobookshelf user settings" },
     audiobookshelf_audiobook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for audiobooks" },
     audiobookshelf_ebook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for ebooks" },
+    audiobookshelf_library_sync_interval: { type: "integer", default: 3600, category: "audiobookshelf", description: "Seconds between automatic Audiobookshelf library sync jobs" },
 
     # Output Paths
     audiobook_output_path: { type: "string", default: "/audiobooks", category: "paths", description: "Directory for completed audiobooks" },

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -80,6 +80,39 @@
             </div>
           </div>
         <% elsif category == "audiobookshelf" %>
+          <div class="grid grid-cols-1 gap-2 border-t border-gray-800 pt-4">
+            <div class="space-y-2">
+              <p class="text-sm text-gray-300 font-medium">Library Sync</p>
+              <% if @audiobookshelf_library_items_count.to_i > 0 %>
+                <p class="text-xs text-gray-500">
+                  Cached items: <%= @audiobookshelf_library_items_count %> ·
+                  Last synced: <%= @audiobookshelf_library_items_last_synced_at ? time_ago_in_words(@audiobookshelf_library_items_last_synced_at) + " ago" : "never" %>
+                </p>
+              <% else %>
+                <p class="text-xs text-gray-500">
+                  No cached items yet. Run a sync to populate.
+                </p>
+              <% end %>
+              <%= link_to "Sync Audiobookshelf Library", sync_audiobookshelf_library_admin_settings_path, data: { turbo_method: :post }, class: "inline-block rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm cursor-pointer" %>
+            </div>
+            <div>
+              <% if @audiobookshelf_library_items.any? %>
+                <p class="text-xs text-gray-400 mb-2">Recent cached items:</p>
+                <ul class="space-y-1 max-h-32 overflow-y-auto">
+                  <% @audiobookshelf_library_items.each do |item| %>
+                    <li class="text-xs text-gray-300 truncate">
+                      <% item_label = [item.title, item.author].compact.join(" · ").truncate(90) %>
+                      <% if item.audiobookshelf_url.present? %>
+                        <%= link_to item_label, item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "text-blue-400 hover:text-blue-300 underline" %>
+                      <% else %>
+                        <%= item_label %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% end %>
+            </div>
+          </div>
           <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
             <div class="md:w-1/3">
               <span class="font-medium text-gray-300">Test Connection</span>

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -1,4 +1,6 @@
 <%
+  audiobookshelf_matches ||= []
+
   # Check if this book already exists in our system
   existing_audiobook = Book.find_by_work_id(result.work_id, book_type: :audiobook)
   existing_ebook = Book.find_by_work_id(result.work_id, book_type: :ebook)
@@ -41,6 +43,14 @@
 
     <%# Status Badges (top right) %>
     <div class="absolute top-2 right-2 flex flex-col gap-1">
+      <% if audiobookshelf_matches.any? %>
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-500/90 text-white backdrop-blur-sm">
+          <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M10 18a1 1 0 100-2H2a1 1 0 100-2h8V8a1 1 0 102 0v6h8a1 1 0 100 2h-8v2h8a1 1 0 100 2H10z"></path>
+          </svg>
+          Similar book may already exist
+        </span>
+      <% end %>
       <% if audiobook_status == :acquired %>
         <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-500/90 text-white backdrop-blur-sm">
           <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
@@ -134,6 +144,24 @@
     <h3 class="font-semibold text-white text-sm leading-tight line-clamp-2"><%= result.title %></h3>
     <% if result.author.present? %>
       <p class="text-xs text-gray-400 mt-1 truncate"><%= result.author %></p>
+    <% end %>
+    <% if audiobookshelf_matches.any? %>
+      <div class="mt-2 pt-2 border-t border-gray-700">
+        <p class="text-[11px] text-amber-300">A similar book may already exist in your library:</p>
+        <ul class="text-[11px] text-amber-200 space-y-1 mt-1">
+          <% audiobookshelf_matches.each do |match| %>
+            <li class="truncate">
+              <% label = [match.item.title, match.item.author].compact.join(" · ").truncate(70) %>
+              <% if match.item.audiobookshelf_url.present? %>
+                <%= link_to label, match.item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "hover:text-amber-100 underline" %>
+              <% else %>
+                <%= label %>
+              <% end %>
+              <span class="text-amber-400">(<%= match.match_type.to_s.titleize %>)</span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/search/_results.html.erb
+++ b/app/views/search/_results.html.erb
@@ -14,8 +14,8 @@
   <p class="text-sm text-gray-500 mb-6"><%= @results.size %> result<%= @results.size == 1 ? '' : 's' %> for "<span class="font-medium text-gray-300"><%= @query %></span>"</p>
 
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-    <% @results.each do |result| %>
-      <%= render "result_card", result: result %>
+    <% @results.each_with_index do |result, index| %>
+      <%= render "result_card", result: result, audiobookshelf_matches: Array(@audiobookshelf_matches)[index] %>
     <% end %>
   </div>
 <% end %>

--- a/config/initializers/audiobookshelf_library_sync.rb
+++ b/config/initializers/audiobookshelf_library_sync.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Start the periodic Audiobookshelf library sync job when the server boots
+Rails.application.config.after_initialize do
+  if defined?(Rails::Server) && AudiobookshelfClient.configured?
+    Rails.logger.info "[Shelfarr] Starting AudiobookshelfLibrarySyncJob"
+    AudiobookshelfLibrarySyncJob.perform_later
+  end
+rescue => e
+  Rails.logger.error "[Shelfarr] Failed to start AudiobookshelfLibrarySyncJob: #{e.message}"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
       collection do
         patch :bulk_update
         post :test_prowlarr
+        post :sync_audiobookshelf_library
         post :test_audiobookshelf
         post :test_flaresolverr
         post :test_hardcover

--- a/db/migrate/20260219000001_create_library_items.rb
+++ b/db/migrate/20260219000001_create_library_items.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateLibraryItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :library_items do |t|
+      t.string :library_id, null: false
+      t.string :audiobookshelf_id, null: false
+      t.string :title
+      t.string :author
+      t.datetime :synced_at
+
+      t.timestamps
+    end
+
+    add_index :library_items, [ :library_id, :audiobookshelf_id ], unique: true
+    add_index :library_items, :library_id
+    add_index :library_items, :synced_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_005649) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_000001) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -105,6 +105,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_005649) do
     t.index ["user_id", "created_at"], name: "index_notifications_on_user_id_and_created_at"
     t.index ["user_id", "read_at"], name: "index_notifications_on_user_id_and_read_at"
     t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
+  create_table "library_items", force: :cascade do |t|
+    t.string "library_id", null: false
+    t.string "audiobookshelf_id", null: false
+    t.string "title"
+    t.string "author"
+    t.datetime "synced_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["library_id", "audiobookshelf_id"], name: "index_library_items_on_library_id_and_audiobookshelf_id", unique: true
+    t.index ["library_id"], name: "index_library_items_on_library_id"
+    t.index ["synced_at"], name: "index_library_items_on_synced_at"
   end
 
   create_table "requests", force: :cascade do |t|

--- a/test/cassettes/open_library/edition_details.yml
+++ b/test/cassettes/open_library/edition_details.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.28.1
+      - nginx/1.28.2
       Date:
-      - Mon, 19 Jan 2026 19:20:17 GMT
+      - Thu, 19 Feb 2026 12:23:36 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Access-Control-Max-Age:
       - '86400'
       X-Ol-Stats:
-      - '"MC 2 0.002 TT 0 0.028"'
+      - '"MC 2 0.001 TT 0 0.008"'
       Referrer-Policy:
       - no-referrer-when-downgrade
     body:
@@ -63,5 +63,5 @@ http_interactions:
         [{"key": "/works/OL82563W"}], "latest_revision": 29, "revision": 29, "created":
         {"type": "/type/datetime", "value": "2009-01-07T23:46:06.178276"}, "last_modified":
         {"type": "/type/datetime", "value": "2025-04-16T10:17:08.981375"}}'
-  recorded_at: Mon, 19 Jan 2026 19:20:17 GMT
+  recorded_at: Thu, 19 Feb 2026 12:23:36 GMT
 recorded_with: VCR 6.3.1

--- a/test/cassettes/open_library/search_fiction.yml
+++ b/test/cassettes/open_library/search_fiction.yml
@@ -56,9 +56,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.28.1
+      - nginx/1.28.2
       Date:
-      - Fri, 30 Jan 2026 12:17:12 GMT
+      - Thu, 19 Feb 2026 12:53:30 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -71,16 +71,16 @@ http_interactions:
       - no-referrer-when-downgrade
     body:
       encoding: ASCII-8BIT
-      string: '{"numFound":1711121,"start":0,"numFoundExact":true,"num_found":1711121,"documentation_url":"https://openlibrary.org/dev/docs/api/search","q":"fiction","offset":null,"docs":[{"author_name":["Isaac
+      string: '{"numFound":1713160,"start":0,"numFoundExact":true,"num_found":1713160,"documentation_url":"https://openlibrary.org/dev/docs/api/search","q":"fiction","offset":null,"docs":[{"author_name":["Isaac
         Asimov"],"cover_i":14612610,"edition_count":97,"first_publish_year":1951,"key":"/works/OL46125W","title":"Foundation"},{"author_name":["Jorge
         Luis Borges"],"cover_i":10832290,"edition_count":78,"first_publish_year":1945,"key":"/works/OL110971W","title":"Ficciones"},{"author_name":["Agatha
         Christie"],"cover_i":13699667,"edition_count":1091,"first_publish_year":1920,"key":"/works/OL472715W","title":"The
         Mysterious Affair at Styles"},{"author_name":["Bram Stoker"],"cover_i":12216503,"edition_count":736,"first_publish_year":1897,"key":"/works/OL85892W","title":"Dracula"},{"author_name":["Toni
-        Morrison"],"cover_i":8261367,"edition_count":104,"first_publish_year":1987,"key":"/works/OL50548W","title":"Beloved"},{"author_name":["Mary
+        Morrison","MorrisonToni","Toni Morrison"],"cover_i":8261367,"edition_count":107,"first_publish_year":1987,"key":"/works/OL50548W","title":"Beloved"},{"author_name":["Mary
         Shelley"],"cover_i":882662,"edition_count":430,"first_publish_year":1826,"key":"/works/OL450124W","title":"The
-        Last Man"},{"author_name":["Charlotte Perkins Gilman"],"cover_i":448130,"edition_count":541,"first_publish_year":1915,"key":"/works/OL2771987W","title":"Herland"},{"author_name":["H.
-        G. Wells"],"cover_i":9009316,"edition_count":1154,"first_publish_year":1895,"key":"/works/OL52267W","title":"The
-        Time Machine"},{"author_name":["H. G. Wells"],"cover_i":6419199,"edition_count":563,"first_publish_year":0,"key":"/works/OL52266W","title":"The
+        Last Man"},{"author_name":["H. G. Wells"],"cover_i":9009316,"edition_count":1146,"first_publish_year":1895,"key":"/works/OL52267W","title":"The
+        Time Machine"},{"author_name":["Charlotte Perkins Gilman"],"cover_i":448130,"edition_count":541,"first_publish_year":1915,"key":"/works/OL2771987W","title":"Herland"},{"author_name":["H.
+        G. Wells"],"cover_i":6419199,"edition_count":563,"first_publish_year":0,"key":"/works/OL52266W","title":"The
         Invisible Man"},{"author_name":["Frank Herbert"],"cover_i":11481354,"edition_count":121,"first_publish_year":1965,"key":"/works/OL893415W","title":"Dune"}]}'
-  recorded_at: Fri, 30 Jan 2026 12:17:12 GMT
+  recorded_at: Thu, 19 Feb 2026 12:53:30 GMT
 recorded_with: VCR 6.3.1

--- a/test/cassettes/open_library/search_harry_potter.yml
+++ b/test/cassettes/open_library/search_harry_potter.yml
@@ -2,64 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://openlibrary.org/search.json?fields=key,title,author_name,first_publish_year,cover_i,edition_count&limit=20&q=harry%20potter
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v2.14.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.28.1
-      Date:
-      - Mon, 19 Jan 2026 19:20:17 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - FastAPI
-      Referrer-Policy:
-      - no-referrer-when-downgrade
-    body:
-      encoding: ASCII-8BIT
-      string: '{"numFound":3765,"start":0,"numFoundExact":true,"num_found":3765,"documentation_url":"https://openlibrary.org/dev/docs/api/search","q":"harry
-        potter","offset":null,"docs":[{"author_name":["J. K. Rowling"],"cover_i":15155833,"edition_count":392,"first_publish_year":1900,"key":"/works/OL82563W","title":"Harry
-        Potter and the Philosopher''s Stone"},{"author_name":["J. K. Rowling"],"cover_i":15158660,"edition_count":144,"first_publish_year":2007,"key":"/works/OL82586W","title":"Harry
-        Potter and the Deathly Hallows"},{"author_name":["J. K. Rowling"],"cover_i":10580435,"edition_count":271,"first_publish_year":1999,"key":"/works/OL82536W","title":"Harry
-        Potter and the Prisoner of Azkaban"},{"author_name":["J. K. Rowling"],"cover_i":12059372,"edition_count":223,"first_publish_year":2000,"key":"/works/OL82560W","title":"Harry
-        Potter and the Goblet of Fire"},{"author_name":["J. K. Rowling"],"cover_i":15158666,"edition_count":246,"first_publish_year":2003,"key":"/works/OL82548W","title":"Harry
-        Potter and the Order of the Phoenix"},{"author_name":["J. K. Rowling"],"cover_i":10716273,"edition_count":176,"first_publish_year":2005,"key":"/works/OL82565W","title":"Harry
-        Potter and the Half-Blood Prince"},{"author_name":["J. K. Rowling"],"cover_i":15158664,"edition_count":303,"first_publish_year":1998,"key":"/works/OL82537W","title":"Harry
-        Potter and the Chamber of Secrets"},{"author_name":["J.K. Rowling"],"cover_i":8457523,"edition_count":16,"first_publish_year":1999,"key":"/works/OL14981609W","title":"Harry
-        Potter (series) 1-7"},{"author_name":["J. K. Rowling"],"edition_count":2,"first_publish_year":2001,"key":"/works/OL21385222W","title":"Harry
-        Potter"},{"author_name":["Warner Bros. Entertainment Inc"],"cover_i":10195373,"edition_count":1,"first_publish_year":2007,"key":"/works/OL20874116W","title":"Harry
-        Potter poster annual 2008"},{"author_name":["Jack Thorne","John Tiffany","J.
-        K. Rowling"],"cover_i":8763851,"edition_count":35,"first_publish_year":2001,"key":"/works/OL17360811W","title":"Harry
-        Potter and the Cursed Child"},{"author_name":["Joan Moloney"],"cover_i":8244695,"edition_count":1,"first_publish_year":2003,"key":"/works/OL17920096W","title":"Harry
-        Potter Deluxe Coloring Book"},{"author_name":["Drew Struzan"],"cover_i":6509920,"edition_count":1,"first_publish_year":2001,"key":"/works/OL15141632W","title":"Harry
-        Potter and the sorcerer''s stone poster book"},{"author_name":["J. K. Rowling"],"cover_i":8761929,"edition_count":11,"first_publish_year":1999,"key":"/works/OL8460139W","title":"Harry
-        Potter (series) 1-4"},{"author_name":["Adele Books"],"edition_count":1,"first_publish_year":2019,"key":"/works/OL30530361W","title":"Harry
-        Potter"},{"author_name":["Felicity Baker"],"cover_i":10515161,"edition_count":1,"first_publish_year":2016,"key":"/works/OL23577451W","title":"Harry
-        Potter, A Cinematic Guide (e-Book)"},{"author_name":["J. K. Rowling"],"cover_i":10229037,"edition_count":1,"first_publish_year":2013,"key":"/works/OL20895240W","title":"Harry
-        Potter"},{"author_name":["Edition Coloriage Hp"],"edition_count":55,"first_publish_year":2020,"key":"/works/OL25926206W","title":"Livre
-        de Coloriage Harry Potter"},{"author_name":["Kevin Wilson","Matthew Reinhart"],"cover_i":9211955,"edition_count":6,"first_publish_year":2018,"key":"/works/OL20569879W","title":"Harry
-        Potter"},{"author_name":["Rick DeMonico"],"cover_i":6984750,"edition_count":3,"first_publish_year":2001,"key":"/works/OL16058211W","title":"Harry
-        Potter Poster Book"}]}'
-  recorded_at: Mon, 19 Jan 2026 19:20:17 GMT
-- request:
-    method: get
     uri: https://openlibrary.org/search.json?fields=key,title,author_name,first_publish_year,cover_i,edition_count&limit=10&q=harry%20potter
     body:
       encoding: US-ASCII
@@ -105,4 +47,62 @@ http_interactions:
         Potter"},{"author_name":["Warner Bros. Entertainment Inc"],"cover_i":10195373,"edition_count":1,"first_publish_year":2007,"key":"/works/OL20874116W","title":"Harry
         Potter poster annual 2008"}]}'
   recorded_at: Fri, 30 Jan 2026 12:11:04 GMT
+- request:
+    method: get
+    uri: https://openlibrary.org/search.json?fields=key,title,author_name,first_publish_year,cover_i,edition_count&limit=20&q=harry%20potter
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.28.2
+      Date:
+      - Thu, 19 Feb 2026 12:23:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - FastAPI
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+    body:
+      encoding: ASCII-8BIT
+      string: '{"numFound":3757,"start":0,"numFoundExact":true,"num_found":3757,"documentation_url":"https://openlibrary.org/dev/docs/api/search","q":"harry
+        potter","offset":null,"docs":[{"author_name":["J. K. Rowling"],"cover_i":15155833,"edition_count":396,"first_publish_year":1997,"key":"/works/OL82563W","title":"Harry
+        Potter and the Philosopher''s Stone"},{"author_name":["J. K. Rowling"],"cover_i":15158660,"edition_count":144,"first_publish_year":2007,"key":"/works/OL82586W","title":"Harry
+        Potter and the Deathly Hallows"},{"author_name":["J. K. Rowling"],"cover_i":10580435,"edition_count":278,"first_publish_year":1999,"key":"/works/OL82536W","title":"Harry
+        Potter and the Prisoner of Azkaban"},{"author_name":["J. K. Rowling"],"cover_i":12059372,"edition_count":242,"first_publish_year":2000,"key":"/works/OL82560W","title":"Harry
+        Potter and the Goblet of Fire"},{"author_name":["J. K. Rowling"],"cover_i":15158666,"edition_count":246,"first_publish_year":2003,"key":"/works/OL82548W","title":"Harry
+        Potter and the Order of the Phoenix"},{"author_name":["J. K. Rowling"],"cover_i":10716273,"edition_count":176,"first_publish_year":2005,"key":"/works/OL82565W","title":"Harry
+        Potter and the Half-Blood Prince"},{"author_name":["J. K. Rowling"],"cover_i":15158664,"edition_count":304,"first_publish_year":1998,"key":"/works/OL82537W","title":"Harry
+        Potter and the Chamber of Secrets"},{"author_name":["J. K. Rowling"],"cover_i":8457523,"edition_count":16,"first_publish_year":1999,"key":"/works/OL14981609W","title":"Harry
+        Potter (series) 1-7"},{"author_name":["J. K. Rowling"],"edition_count":2,"first_publish_year":2001,"key":"/works/OL21385222W","title":"Harry
+        Potter"},{"author_name":["Warner Bros. Entertainment Inc"],"cover_i":10195373,"edition_count":1,"first_publish_year":2007,"key":"/works/OL20874116W","title":"Harry
+        Potter poster annual 2008"},{"author_name":["Jack Thorne","John Tiffany","J.
+        K. Rowling"],"cover_i":8763851,"edition_count":35,"first_publish_year":2001,"key":"/works/OL17360811W","title":"Harry
+        Potter and the Cursed Child"},{"author_name":["Joan Moloney"],"cover_i":8244695,"edition_count":1,"first_publish_year":2003,"key":"/works/OL17920096W","title":"Harry
+        Potter Deluxe Coloring Book"},{"author_name":["Drew Struzan"],"cover_i":6509920,"edition_count":1,"first_publish_year":2001,"key":"/works/OL15141632W","title":"Harry
+        Potter and the sorcerer''s stone poster book"},{"author_name":["J. K. Rowling"],"cover_i":8761929,"edition_count":11,"first_publish_year":1999,"key":"/works/OL8460139W","title":"Harry
+        Potter (series) 1-4"},{"author_name":["Adele Books"],"edition_count":1,"first_publish_year":2019,"key":"/works/OL30530361W","title":"Harry
+        Potter"},{"author_name":["Felicity Baker"],"cover_i":10515161,"edition_count":1,"first_publish_year":2016,"key":"/works/OL23577451W","title":"Harry
+        Potter, A Cinematic Guide (e-Book)"},{"author_name":["J. K. Rowling"],"cover_i":10229037,"edition_count":1,"first_publish_year":2013,"key":"/works/OL20895240W","title":"Harry
+        Potter"},{"author_name":["Edition Coloriage Hp"],"edition_count":55,"first_publish_year":2020,"key":"/works/OL25926206W","title":"Livre
+        de Coloriage Harry Potter"},{"author_name":["Kevin Wilson","Matthew Reinhart"],"cover_i":9211955,"edition_count":6,"first_publish_year":2018,"key":"/works/OL20569879W","title":"Harry
+        Potter"},{"author_name":["Rick DeMonico"],"cover_i":6984750,"edition_count":3,"first_publish_year":2001,"key":"/works/OL16058211W","title":"Harry
+        Potter Poster Book"}]}'
+  recorded_at: Thu, 19 Feb 2026 12:23:36 GMT
 recorded_with: VCR 6.3.1

--- a/test/cassettes/open_library/search_no_results.yml
+++ b/test/cassettes/open_library/search_no_results.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.28.1
+      - nginx/1.28.2
       Date:
-      - Mon, 19 Jan 2026 19:20:17 GMT
+      - Thu, 19 Feb 2026 12:23:36 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"numFound":0,"start":0,"numFoundExact":true,"num_found":0,"documentation_url":"https://openlibrary.org/dev/docs/api/search","q":"asdfghjklqwertyuiop123456789","offset":null,"docs":[]}'
-  recorded_at: Mon, 19 Jan 2026 19:20:17 GMT
+  recorded_at: Thu, 19 Feb 2026 12:23:36 GMT
 recorded_with: VCR 6.3.1

--- a/test/cassettes/open_library/search_with_limit.yml
+++ b/test/cassettes/open_library/search_with_limit.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.28.1
+      - nginx/1.28.2
       Date:
-      - Mon, 19 Jan 2026 19:20:18 GMT
+      - Thu, 19 Feb 2026 12:23:38 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -34,11 +34,11 @@ http_interactions:
       - no-referrer-when-downgrade
     body:
       encoding: ASCII-8BIT
-      string: '{"numFound":1710246,"start":0,"numFoundExact":true,"num_found":1710246,"documentation_url":"https://openlibrary.org/dev/docs/api/search","q":"fiction","offset":null,"docs":[{"author_name":["Isaac
+      string: '{"numFound":1713158,"start":0,"numFoundExact":true,"num_found":1713158,"documentation_url":"https://openlibrary.org/dev/docs/api/search","q":"fiction","offset":null,"docs":[{"author_name":["Isaac
         Asimov"],"cover_i":14612610,"edition_count":97,"first_publish_year":1951,"key":"/works/OL46125W","title":"Foundation"},{"author_name":["Jorge
         Luis Borges"],"cover_i":10832290,"edition_count":78,"first_publish_year":1945,"key":"/works/OL110971W","title":"Ficciones"},{"author_name":["Agatha
         Christie"],"cover_i":13699667,"edition_count":1091,"first_publish_year":1920,"key":"/works/OL472715W","title":"The
         Mysterious Affair at Styles"},{"author_name":["Bram Stoker"],"cover_i":12216503,"edition_count":736,"first_publish_year":1897,"key":"/works/OL85892W","title":"Dracula"},{"author_name":["Toni
-        Morrison"],"cover_i":8261367,"edition_count":104,"first_publish_year":1987,"key":"/works/OL50548W","title":"Beloved"}]}'
-  recorded_at: Mon, 19 Jan 2026 19:20:18 GMT
+        Morrison","MorrisonToni","Toni Morrison"],"cover_i":8261367,"edition_count":107,"first_publish_year":1987,"key":"/works/OL50548W","title":"Beloved"}]}'
+  recorded_at: Thu, 19 Feb 2026 12:23:38 GMT
 recorded_with: VCR 6.3.1

--- a/test/cassettes/open_library/work_details.yml
+++ b/test/cassettes/open_library/work_details.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.28.1
+      - nginx/1.28.2
       Date:
-      - Mon, 19 Jan 2026 19:20:17 GMT
+      - Thu, 19 Feb 2026 12:23:36 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,7 +35,7 @@ http_interactions:
       Access-Control-Max-Age:
       - '86400'
       X-Ol-Stats:
-      - '"MC 2 0.001 TT 0 0.005"'
+      - '"MC 2 0.001 TT 0 0.003"'
       Referrer-Policy:
       - no-referrer-when-downgrade
     body:
@@ -73,5 +73,5 @@ http_interactions:
         "latest_revision": 19, "revision": 19, "created": {"type": "/type/datetime",
         "value": "2009-10-15T11:34:21.437031"}, "last_modified": {"type": "/type/datetime",
         "value": "2024-01-19T11:02:25.815878"}}'
-  recorded_at: Mon, 19 Jan 2026 19:20:17 GMT
+  recorded_at: Thu, 19 Feb 2026 12:23:36 GMT
 recorded_with: VCR 6.3.1

--- a/test/cassettes/open_library/work_not_found.yml
+++ b/test/cassettes/open_library/work_not_found.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: Not Found
     headers:
       Server:
-      - nginx/1.28.1
+      - nginx/1.28.2
       Date:
-      - Mon, 19 Jan 2026 19:20:17 GMT
+      - Thu, 19 Feb 2026 12:23:36 GMT
       Transfer-Encoding:
       - chunked
       Connection:
@@ -33,9 +33,9 @@ http_interactions:
       Access-Control-Max-Age:
       - '86400'
       X-Ol-Stats:
-      - '"IB 3 0.014 MC 3 0.001 TT 0 0.017"'
+      - '"IB 3 0.012 MC 3 0.001 TT 0 0.016"'
     body:
       encoding: UTF-8
       string: '{"error": "notfound", "key": "/works/OL999999999W"}'
-  recorded_at: Mon, 19 Jan 2026 19:20:17 GMT
+  recorded_at: Thu, 19 Feb 2026 12:23:36 GMT
 recorded_with: VCR 6.3.1

--- a/test/jobs/audiobookshelf_library_sync_job_test.rb
+++ b/test/jobs/audiobookshelf_library_sync_job_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AudiobookshelfLibrarySyncJobTest < ActiveJob::TestCase
+  setup do
+    SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "lib-audio")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    SettingsService.set(:audiobookshelf_library_sync_interval, 3600)
+  end
+
+  test "schedules next run after syncing" do
+    LibraryItem.destroy_all
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:13378/api/libraries/lib-audio/items")
+        .with(
+          headers: { "Authorization" => "Bearer test-api-key" },
+          query: hash_including("limit" => "500", "page" => "1")
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "results" => [
+              {
+                "id" => "ab-1",
+                "title" => "The Hobbit",
+                "author" => "J.R.R. Tolkien"
+              }
+            ],
+            "total" => 1
+          }.to_json
+        )
+
+      assert_enqueued_with(job: AudiobookshelfLibrarySyncJob) do
+        AudiobookshelfLibrarySyncJob.perform_now
+      end
+    end
+
+    assert_equal 1, LibraryItem.count
+    assert_equal "The Hobbit", LibraryItem.first.title
+  end
+
+  test "does not reschedule when interval is zero" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobookshelf_api_key, "")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    SettingsService.set(:audiobookshelf_library_sync_interval, 0)
+
+    assert_no_enqueued_jobs do
+      assert_nothing_raised do
+        AudiobookshelfLibrarySyncJob.perform_now
+      end
+    end
+  end
+end

--- a/test/services/audiobookshelf_library_matcher_service_test.rb
+++ b/test/services/audiobookshelf_library_matcher_service_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
+  setup do
+    LibraryItem.destroy_all
+
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-1",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      synced_at: Time.current
+    )
+
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-2",
+      title: "Dune",
+      author: "Frank Herbert",
+      synced_at: Time.current
+    )
+  end
+
+  test "finds exact and fuzzy matches" do
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 3
+    )
+
+    assert_equal 1, matches.size
+    assert_equal "ab-1", matches.first.item.audiobookshelf_id
+    assert_equal :exact, matches.first.match_type
+  end
+
+  test "returns no matches for unrelated titles" do
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "Completely Different Book",
+      author: "Unknown Author",
+      limit: 3
+    )
+
+    assert_empty matches
+  end
+
+  test "supports matching against many metadata results" do
+    results = [
+      OpenStruct.new(title: "Dune", author: "Frank Herbert"),
+      OpenStruct.new(title: "Unknown", author: nil)
+    ]
+
+    matches = AudiobookshelfLibraryMatcherService.matches_for_many(results, limit_per_result: 1)
+
+    assert_equal 2, matches.size
+    assert_equal 1, matches.first.size
+    assert_empty matches.last
+  end
+end

--- a/test/services/audiobookshelf_library_sync_service_test.rb
+++ b/test/services/audiobookshelf_library_sync_service_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
+  setup do
+    LibraryItem.destroy_all
+    SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "lib-audio")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "lib-ebook")
+  end
+
+  test "syncs items from configured libraries and removes stale entries" do
+    LibraryItem.create!(library_id: "lib-audio", audiobookshelf_id: "ab-stale", title: "Old Title", author: "Old Author", synced_at: 1.day.ago)
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:13378/api/libraries/lib-audio/items})
+        .with(query: hash_including("limit" => "500", "page" => "1"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "results" => [
+              {
+                "id" => "ab-1",
+                "title" => "The Hobbit",
+                "author" => "J.R.R. Tolkien"
+              }
+            ],
+            "total" => 1
+          }.to_json
+        )
+
+      stub_request(:get, %r{localhost:13378/api/libraries/lib-ebook/items})
+        .with(query: hash_including("limit" => "500", "page" => "1"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "results" => [
+              {
+                "id" => "ab-2",
+                "title" => "Good Omens",
+                "author" => "Neil Gaiman"
+              }
+            ],
+            "total" => 1
+          }.to_json
+        )
+
+      result = AudiobookshelfLibrarySyncService.new.sync!
+      assert result.success?
+      assert_equal 2, result.items_synced
+      assert_equal 2, result.libraries_synced
+      assert_empty result.errors
+      assert_equal 2, LibraryItem.count
+      assert_not LibraryItem.exists?(audiobookshelf_id: "ab-stale")
+    end
+  end
+
+  test "returns false when no configurable libraries are available" do
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:13378/api/libraries")
+        .with(headers: { "Authorization" => "Bearer test-api-key" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { libraries: [] }.to_json
+        )
+
+      result = AudiobookshelfLibrarySyncService.new.sync!
+
+      assert_not result.success?
+      assert_equal "No Audiobookshelf library IDs configured or available.", result.errors.first
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds Audiobookshelf duplicate-prevention warning flow (issue #37):
  - Fetches Audiobookshelf library items into a local `LibraryItem` cache.
  - Runs periodic and manual sync jobs so the cache stays fresh.
  - Applies soft matching (title/author fuzzy) during search results rendering.
  - Shows a tag + match list in search cards warning users when a similar book may already exist in their library.
  - Adds admin UI controls for manual sync status and recent cached items.
- Updates `AudiobookshelfClient` with library item parsing, including nested metadata author formats.
- Adds schema coverage for `library_items` and test coverage for new service/job/controller paths.

## Notes
- Deluge and Transmission client support is already present in dev and included in this PR as requested.
- #152 and #153 are already closed in the current branch.

## Closes
- Closes #37

## Testing
- `bundle exec rails test`
