### PR TITLE
fix: upload torrent files directly to qBittorrent instead of passing URLs (#170)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "image_processing", "~> 1.2"
 
 # HTTP client for external API integrations (Prowlarr, Open Library, etc.)
 gem "faraday"
+# Multipart file upload support for Faraday (used to upload .torrent files to qBittorrent)
+gem "faraday-multipart"
 # Fast JSON parser
 gem "oj"
 # Create zip archives for directory downloads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     ffi (1.17.2-aarch64-linux-gnu)
@@ -212,6 +214,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
+    multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.2)
@@ -522,6 +525,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   faraday
+  faraday-multipart
   id3tag
   image_processing (~> 1.2)
   importmap-rails


### PR DESCRIPTION
When qBittorrent runs on a remote seedbox, it often can't reach the
torrent download URL provided by a local indexer (Prowlarr/Jackett).
The code already downloaded the .torrent file for hash pre-computation
but discarded the data and told qBittorrent to re-download it.

Now Shelfarr uploads the torrent file data directly to qBittorrent via
multipart form upload (the `torrents` API parameter), eliminating the
need for qBittorrent to reach the indexer. Magnet links still use the
`urls` parameter since they don't require downloading.

https://claude.ai/code/session_01V4B3YsQFvKKBZQh7v6JJkz