### PR TITLE
fix: handle malformed Audiobookshelf URLs in admin settings

### DIFF
--- a/app/services/audiobookshelf_client.rb
+++ b/app/services/audiobookshelf_client.rb
@@ -140,7 +140,7 @@ class AudiobookshelfClient
 
     def request
       yield
-    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError, URI::Error => e
       raise ConnectionError, "Failed to connect to Audiobookshelf: #{e.message}"
     end
 
@@ -156,7 +156,14 @@ class AudiobookshelfClient
     end
 
     def base_url
-      SettingsService.get(:audiobookshelf_url)
+      url = SettingsService.get(:audiobookshelf_url).to_s.strip
+      parsed_url = URI.parse(url)
+
+      unless parsed_url.is_a?(URI::HTTP) && parsed_url.host.present?
+        raise URI::InvalidURIError, "Audiobookshelf URL must include http:// or https://"
+      end
+
+      url
     end
 
     def api_key

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -92,6 +92,16 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "index handles malformed audiobookshelf url gracefully" do
+    SettingsService.set(:audiobookshelf_url, "audiobookshelf:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
+
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "input[name='settings[audiobookshelf_audiobook_library_id]']"
+  end
+
   test "bulk_update updates multiple settings" do
     patch bulk_update_admin_settings_url, params: {
       settings: {
@@ -270,6 +280,16 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
       assert_redirected_to admin_settings_path
       assert flash[:alert].present?
     end
+  end
+
+  test "test_audiobookshelf handles malformed urls" do
+    SettingsService.set(:audiobookshelf_url, "audiobookshelf:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
+
+    post test_audiobookshelf_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match(/failed/i, flash[:alert])
   end
 
   test "sync_audiobookshelf_library fails when not configured" do

--- a/test/services/audiobookshelf_client_test.rb
+++ b/test/services/audiobookshelf_client_test.rb
@@ -218,6 +218,14 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "raises ConnectionError on malformed url" do
+    SettingsService.set(:audiobookshelf_url, "audiobookshelf:13378")
+
+    assert_raises AudiobookshelfClient::ConnectionError do
+      AudiobookshelfClient.libraries
+    end
+  end
+
   # SSL error handling tests
   test "test_connection returns false on SSL error" do
     VCR.turned_off do
@@ -237,5 +245,11 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
         AudiobookshelfClient.libraries
       end
     end
+  end
+
+  test "test_connection returns false on malformed url" do
+    SettingsService.set(:audiobookshelf_url, "audiobookshelf:13378")
+
+    assert_not AudiobookshelfClient.test_connection
   end
 end


### PR DESCRIPTION
## Summary
- validate the configured Audiobookshelf base URL before building the Faraday connection
- treat malformed URLs as handled connection errors so `/admin/settings` does not return 500
- add regression coverage for the settings page and Audiobookshelf test connection flow

## Testing
- `eval "$(rbenv init - zsh)" && bundle exec rails test test/services/audiobookshelf_client_test.rb test/controllers/admin/settings_controller_test.rb`

Closes #179