### PR TITLE
fix: align transmission rpc integration

### DIFF
--- a/app/services/download_clients/transmission.rb
+++ b/app/services/download_clients/transmission.rb
@@ -23,9 +23,9 @@ module DownloadClients
         filename: url
       }
       args[:paused] = options[:paused] unless options[:paused].nil?
-      args["download-dir"] = options[:save_path] if options[:save_path].present?
+      args[:download_dir] = options[:save_path] if options[:save_path].present?
 
-      response = rpc_request("torrent-add", args: args)
+      response = rpc_request("torrent-add", args)
       added = response.dig("torrent-added", "hashString")
       duplicate = response.dig("torrent-duplicate", "hashString")
 
@@ -73,7 +73,7 @@ module DownloadClients
     def remove_torrent(hash, delete_files: false)
       ensure_authenticated!
 
-      response = rpc_request("torrent-remove", ids: [hash], "delete-local-data": delete_files)
+      response = rpc_request("torrent-remove", ids: [hash], delete_local_data: delete_files)
       !response.nil?
     rescue Faraday::Error => e
       raise Base::ConnectionError, "Failed to connect to Transmission: #{e.message}"
@@ -167,7 +167,7 @@ module DownloadClients
         hash: data["hashString"],
         name: data["name"],
         progress: normalize_progress(data["percentDone"]),
-        state: normalize_state(data["status"]),
+        state: normalize_state(data["status"], error: data["error"]),
         size_bytes: data["totalSize"],
         download_path: data["downloadDir"].to_s
       )
@@ -178,7 +178,9 @@ module DownloadClients
       (progress.to_f * 100).round
     end
 
-    def normalize_state(status)
+    def normalize_state(status, error: nil)
+      return :failed if error.to_i == 3
+
       case status.to_i
       when 0
         :paused
@@ -198,7 +200,7 @@ module DownloadClients
     end
 
     def connection
-      Faraday.new(url: base_url) do |f|
+      Faraday.new(url: rpc_url) do |f|
         f.request :json
         if config.username.present? || config.password.present?
           f.request :authorization, :basic, config.username.to_s, config.password.to_s
@@ -212,6 +214,21 @@ module DownloadClients
 
     def session_id
       Thread.current[:transmission_sessions]&.[](config.id)
+    end
+
+    def rpc_url
+      uri = URI.parse(base_url)
+      path = uri.path.to_s
+
+      if path.blank? || path == "/"
+        uri.path = "/transmission/rpc"
+      elsif path.end_with?("/transmission/rpc/")
+        uri.path = path.delete_suffix("/")
+      end
+
+      uri.to_s
+    rescue URI::InvalidURIError
+      base_url
     end
   end
 end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -6,6 +6,7 @@ require "digest/sha1"
 
 class DownloadJobTest < ActiveJob::TestCase
   setup do
+    DownloadClient.destroy_all
     @request = requests(:pending_request)
     @selected_result = search_results(:selected_result)
 
@@ -94,6 +95,63 @@ class DownloadJobTest < ActiveJob::TestCase
 
     # Status should not change
     assert @download.downloading?
+  end
+
+  test "uses transmission client for torrent downloads" do
+    @client.destroy!
+    transmission = DownloadClient.create!(
+      name: "Test Transmission",
+      client_type: "transmission",
+      url: "http://localhost:9091",
+      username: "admin",
+      password: "adminadmin",
+      priority: 0,
+      enabled: true
+    )
+    Thread.current[:transmission_sessions] = {}
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with(body: /"method"\s*:\s*"session-get"/)
+        .to_return(
+          {
+            status: 409,
+            headers: { "x-transmission-session-id" => "session-id" },
+            body: { "result" => "session", "arguments" => {} }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => "success", "arguments" => {} }.to_json
+          }
+        )
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with(body: /"method"\s*:\s*"torrent-get"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "success", "arguments" => { "torrents" => [] } }.to_json
+        )
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "torrent-add" &&
+            body["arguments"]["filename"] == "http://example.com/download/test.torrent"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "success", "arguments" => { "torrent-added" => { "hashString" => "transmission-hash" } } }.to_json
+        )
+
+      DownloadJob.perform_now(@download.id)
+      @download.reload
+
+      assert @download.downloading?
+      assert_equal transmission.id.to_s, @download.download_client_id
+      assert_equal "transmission-hash", @download.external_id
+      assert_equal "torrent", @download.download_type
+    end
   end
 
   test "skips non-existent downloads" do

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class DownloadMonitorJobTest < ActiveJob::TestCase
   setup do
+    DownloadClient.destroy_all
     @request = requests(:pending_request)
 
     # Create a qBittorrent client
@@ -127,6 +128,71 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     VCR.turned_off do
       stub_qbittorrent_auth
       stub_qbittorrent_torrent_info(progress: 0, state: "error")
+
+      DownloadMonitorJob.perform_now
+      @download.reload
+      @request.reload
+
+      assert @download.failed?
+      assert @request.attention_needed?
+      assert_includes @request.issue_description, "failed in client"
+    end
+  end
+
+  test "marks transmission download as failed when client reports local error" do
+    transmission = DownloadClient.create!(
+      name: "Test Transmission",
+      client_type: "transmission",
+      url: "http://localhost:9091",
+      username: "admin",
+      password: "adminadmin",
+      priority: 0,
+      enabled: true
+    )
+    Thread.current[:transmission_sessions] = {}
+    @download.update!(
+      external_id: "transmission-hash",
+      download_client: transmission
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with(body: /"method"\s*:\s*"session-get"/)
+        .to_return(
+          {
+            status: 409,
+            headers: { "x-transmission-session-id" => "session-id" },
+            body: { "result" => "session", "arguments" => {} }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => "success", "arguments" => {} }.to_json
+          }
+        )
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with(body: /"method"\s*:\s*"torrent-get"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => "success",
+            "arguments" => {
+              "torrents" => [
+                {
+                  "hashString" => "transmission-hash",
+                  "name" => "Test Audiobook",
+                  "percentDone" => 0.0,
+                  "status" => 4,
+                  "error" => 3,
+                  "errorString" => "Permission denied",
+                  "totalSize" => 1073741824,
+                  "downloadDir" => "/downloads/complete/Test Audiobook"
+                }
+              ]
+            }
+          }.to_json
+        )
 
       DownloadMonitorJob.perform_now
       @download.reload

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class DownloadClientTest < ActiveSupport::TestCase
+  setup do
+    DownloadClient.destroy_all
+  end
+
   test "validates presence of name" do
     client = DownloadClient.new(client_type: "qbittorrent", url: "http://localhost:8080")
     assert_not client.valid?

--- a/test/services/download_client_selector_test.rb
+++ b/test/services/download_client_selector_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class DownloadClientSelectorTest < ActiveSupport::TestCase
   setup do
+    DownloadClient.destroy_all
     Thread.current[:qbittorrent_sessions] = {}
     Thread.current[:deluge_sessions] = {}
     Thread.current[:transmission_sessions] = {}

--- a/test/services/download_clients/transmission_test.rb
+++ b/test/services/download_clients/transmission_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class DownloadClients::TransmissionTest < ActiveSupport::TestCase
   setup do
+    DownloadClient.destroy_all
     @client_record = DownloadClient.create!(
       name: "Test Transmission",
       client_type: "transmission",
@@ -29,7 +30,12 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
           body: { "result" => "success", "arguments" => { "torrents" => [ { "hashString" => "existing" } ] } }.to_json
         )
       stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with(body: /"method"\s*:\s*"torrent-add"/)
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "torrent-add" &&
+            body["arguments"] == { "filename" => "magnet:?xt=urn:btih:abcdef" } &&
+            !body["arguments"].key?("args")
+        end
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -37,6 +43,38 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
         )
 
       result = @client.add_torrent("magnet:?xt=urn:btih:abcdef")
+      assert_equal "new-torrent-id", result
+    end
+  end
+
+  test "add_torrent uses canonical Transmission argument keys" do
+    VCR.turned_off do
+      stub_session_handshake("http://localhost:9091/transmission/rpc")
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with(body: /"method"\s*:\s*"torrent-get"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "success", "arguments" => { "torrents" => [] } }.to_json
+        )
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "torrent-add" &&
+            body["arguments"] == {
+              "filename" => "http://example.com/download/test.torrent",
+              "paused" => true,
+              "download_dir" => "/downloads/books"
+            } &&
+            !body["arguments"].key?("download-dir")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "success", "arguments" => { "torrent-added" => { "hashString" => "new-torrent-id" } } }.to_json
+        )
+
+      result = @client.add_torrent("http://example.com/download/test.torrent", paused: true, save_path: "/downloads/books")
       assert_equal "new-torrent-id", result
     end
   end
@@ -122,11 +160,53 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
     end
   end
 
+  test "torrent_info maps local errors to failed state" do
+    VCR.turned_off do
+      stub_session_handshake("http://localhost:9091/transmission/rpc")
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with(body: /"method"\s*:\s*"torrent-get"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "result" => "success",
+            "arguments" => {
+              "torrents" => [
+                {
+                  "hashString" => "abc123",
+                  "name" => "Broken Transmission Book",
+                  "percentDone" => 0.2,
+                  "status" => 4,
+                  "error" => 3,
+                  "errorString" => "Permission denied",
+                  "totalSize" => 1073741824,
+                  "downloadDir" => "/downloads/Broken Transmission Book"
+                }
+              ]
+            }
+          }.to_json
+        )
+
+      info = @client.torrent_info("abc123")
+
+      assert_equal :failed, info.state
+      assert info.failed?
+    end
+  end
+
   test "remove_torrent returns true on success" do
     VCR.turned_off do
       stub_session_handshake("http://localhost:9091/transmission/rpc")
       stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with(body: /"method"\s*:\s*"torrent-remove"/)
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "torrent-remove" &&
+            body["arguments"] == {
+              "ids" => [ "abc123" ],
+              "delete_local_data" => true
+            } &&
+            !body["arguments"].key?("delete-local-data")
+        end
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -152,6 +232,17 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
   end
 
   test "test_connection returns true on success" do
+    VCR.turned_off do
+      stub_session_handshake("http://localhost:9091/transmission/rpc")
+
+      assert @client.test_connection
+    end
+  end
+
+  test "test_connection uses rpc path when configured url is host root" do
+    @client_record.update!(url: "http://localhost:9091")
+    @client = @client_record.adapter
+
     VCR.turned_off do
       stub_session_handshake("http://localhost:9091/transmission/rpc")
 


### PR DESCRIPTION
## Summary
- fix Transmission `torrent-add` payload serialization so `filename` is sent in the RPC arguments Transmission expects
- normalize Transmission RPC requests to canonical argument names and accept root URLs by appending `/transmission/rpc`
- treat Transmission local errors as failed downloads and add end-to-end coverage for selection, submission, and monitoring

Fixes #178

## Testing
- bundle exec rails test test/services/download_clients/transmission_test.rb test/services/download_client_selector_test.rb test/models/download_client_test.rb test/jobs/download_job_test.rb test/jobs/download_monitor_job_test.rb