### PR TITLE
feat: allow non-admin users to upload books

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class UploadsController < ApplicationController
+  before_action :require_user_uploads_enabled
+  before_action :set_upload, only: [ :show ]
+
+  def index
+    @uploads = if Current.user.admin?
+      Upload.includes(:user, :book).recent
+    else
+      Upload.for_user(Current.user).includes(:book).recent
+    end
+  end
+
+  def show
+  end
+
+  def new
+    @upload = Upload.new
+  end
+
+  def create
+    uploaded_file = params[:file]
+
+    unless uploaded_file
+      redirect_to new_upload_path, alert: "Please select a file to upload"
+      return
+    end
+
+    extension = File.extname(uploaded_file.original_filename).delete(".").downcase
+    unless Upload::SUPPORTED_EXTENSIONS.include?(extension)
+      redirect_to new_upload_path,
+        alert: "Unsupported file type. Supported: #{Upload::SUPPORTED_EXTENSIONS.join(", ")}"
+      return
+    end
+
+    temp_path = save_uploaded_file(uploaded_file)
+
+    @upload = Upload.new(
+      user: Current.user,
+      original_filename: uploaded_file.original_filename,
+      file_path: temp_path,
+      file_size: uploaded_file.size,
+      content_type: uploaded_file.content_type,
+      status: :pending
+    )
+
+    if @upload.save
+      UploadProcessingJob.perform_later(@upload.id)
+      redirect_to uploads_path, notice: "File uploaded successfully. Processing started."
+    else
+      FileUtils.rm_f(temp_path)
+      redirect_to new_upload_path, alert: @upload.errors.full_messages.join(", ")
+    end
+  end
+
+  private
+
+  def require_user_uploads_enabled
+    unless SettingsService.user_uploads_allowed? || Current.user&.admin?
+      redirect_to root_path, alert: "Uploads are not currently enabled."
+    end
+  end
+
+  def set_upload
+    @upload = if Current.user.admin?
+      Upload.find(params[:id])
+    else
+      Upload.for_user(Current.user).find(params[:id])
+    end
+  end
+
+  def save_uploaded_file(uploaded_file)
+    upload_dir = Rails.root.join("tmp", "uploads")
+    FileUtils.mkdir_p(upload_dir)
+
+    timestamp = Time.current.strftime("%Y%m%d%H%M%S")
+    random = SecureRandom.hex(4)
+    extension = File.extname(uploaded_file.original_filename)
+    filename = "#{timestamp}_#{random}#{extension}"
+
+    path = upload_dir.join(filename)
+
+    File.open(path, "wb") do |file|
+      file.write(uploaded_file.read)
+    end
+
+    path.to_s
+  end
+end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -23,6 +23,7 @@ class Upload < ApplicationRecord
 
   scope :recent, -> { order(created_at: :desc) }
   scope :pending_or_processing, -> { where(status: [:pending, :processing]) }
+  scope :for_user, ->(user) { where(user: user) }
 
   def file_extension
     File.extname(original_filename).delete(".").downcase

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -63,6 +63,7 @@ class SettingsService
     login_lockout_threshold: { type: "integer", default: 5, category: "security", description: "Failed login attempts before temporary lockout" },
     login_lockout_duration_minutes: { type: "integer", default: 15, category: "security", description: "Duration of login lockout in minutes" },
     api_token: { type: "string", category: "security", default: SecureRandom.base58(32), description: "Authentication token for the API" },
+    allow_user_uploads: { type: "boolean", default: false, category: "security", description: "Allow non-admin users to upload book files directly" },
 
     # Anna's Archive
     anna_archive_enabled: { type: "boolean", default: false, category: "anna_archive", description: "Enable Anna's Archive as an additional search source for ebooks" },
@@ -224,6 +225,10 @@ class SettingsService
 
     def auth_disabled?
       ENV["DISABLE_AUTH"]&.downcase == "true" || get(:auth_disabled, default: false)
+    end
+
+    def user_uploads_allowed?
+      get(:allow_user_uploads, default: false)
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,9 @@
                 <% end %>
               </div>
               <%= link_to "Library", library_index_path, class: "text-gray-400 hover:text-white font-medium transition" %>
+              <% if SettingsService.user_uploads_allowed? || Current.user&.admin? %>
+                <%= link_to "Upload", new_upload_path, class: "text-gray-400 hover:text-white font-medium transition" %>
+              <% end %>
             <% end %>
           </div>
           <div class="flex items-center gap-4">

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -1,0 +1,67 @@
+<div class="mx-auto max-w-6xl">
+  <div class="flex justify-between items-center mb-8">
+    <h1 class="font-bold text-4xl text-white">My Uploads</h1>
+    <%= link_to "Upload File", new_upload_path,
+        class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
+  </div>
+
+  <% if @uploads.empty? %>
+    <div class="text-center py-12">
+      <p class="text-xl text-gray-400">No uploads yet</p>
+      <p class="mt-2 text-gray-500">Upload your first book file to get started</p>
+    </div>
+  <% else %>
+    <div class="bg-gray-900 border border-gray-800 overflow-hidden rounded-lg">
+      <table class="min-w-full divide-y divide-gray-800">
+        <thead class="bg-gray-800/50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase">File</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase">Parsed Info</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase">Matched Book</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase">Status</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          <% @uploads.each do |upload| %>
+            <tr class="hover:bg-gray-800/50 transition">
+              <td class="px-6 py-4">
+                <div class="text-sm font-medium text-white">
+                  <%= truncate(upload.original_filename, length: 40) %>
+                </div>
+                <div class="text-sm text-gray-500">
+                  <%= number_to_human_size(upload.file_size) if upload.file_size %>
+                  <% if upload.book_type.present? %>
+                    - <%= upload.book_type.humanize %>
+                  <% end %>
+                </div>
+              </td>
+              <td class="px-6 py-4">
+                <% if upload.parsed_title.present? %>
+                  <div class="text-sm text-white"><%= upload.parsed_title %></div>
+                  <div class="text-sm text-gray-500">by <%= upload.parsed_author || "Unknown" %></div>
+                  <div class="text-xs text-gray-500">Confidence: <%= upload.match_confidence %>%</div>
+                <% else %>
+                  <span class="text-gray-500">Not parsed yet</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4">
+                <% if upload.book %>
+                  <span class="text-gray-200"><%= upload.book.display_name %></span>
+                <% else %>
+                  <span class="text-gray-500">-</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4">
+                <%= render_upload_status(upload) %>
+              </td>
+              <td class="px-6 py-4 text-sm">
+                <%= link_to "View", upload_path(upload), class: "text-blue-400 hover:text-blue-300" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -1,0 +1,61 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl mb-8 text-white">Upload Book</h1>
+
+  <%= form_with url: uploads_path, method: :post,
+      multipart: true,
+      class: "space-y-6",
+      data: { controller: "upload-form" } do |f| %>
+
+    <div class="border-2 border-dashed border-gray-700 rounded-lg p-8 text-center bg-gray-900"
+         data-upload-form-target="dropzone"
+         data-action="drop->upload-form#drop dragover->upload-form#dragover dragleave->upload-form#dragleave">
+
+      <div class="space-y-4">
+        <div class="text-gray-500">
+          <svg class="mx-auto h-12 w-12" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+            <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
+                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </div>
+
+        <div>
+          <label class="cursor-pointer">
+            <span class="text-blue-400 hover:text-blue-300 font-medium">Choose a file</span>
+            <input type="file"
+                   name="file"
+                   class="hidden"
+                   data-upload-form-target="input"
+                   data-action="change->upload-form#fileSelected"
+                   accept=".m4b,.mp3,.zip,.rar,.epub,.pdf,.mobi,.azw3">
+          </label>
+          <span class="text-gray-500"> or drag and drop</span>
+        </div>
+
+        <p class="text-sm text-gray-500">
+          Audiobooks: m4b, mp3, zip, rar | Ebooks: epub, pdf, mobi, azw3
+        </p>
+
+        <div data-upload-form-target="filename" class="hidden text-sm font-medium text-gray-300 mt-4">
+          Selected: <span class="text-blue-400"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-4">
+      <%= f.submit "Upload",
+          class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer disabled:opacity-50",
+          data: { upload_form_target: "submit" } %>
+      <%= link_to "Cancel", uploads_path, class: "text-gray-400 hover:text-gray-300" %>
+    </div>
+  <% end %>
+
+  <div class="mt-8 p-4 bg-gray-900 border border-gray-800 rounded-lg">
+    <h3 class="font-medium text-gray-300 mb-2">Filename Tips</h3>
+    <p class="text-sm text-gray-400 mb-2">For best results, name your files using one of these patterns:</p>
+    <ul class="text-sm text-gray-500 list-disc list-inside space-y-1">
+      <li>Author Name - Book Title.m4b</li>
+      <li>Book Title (Author Name).epub</li>
+      <li>Book Title [Author Name].pdf</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -1,0 +1,74 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl mb-8 text-white">Upload Details</h1>
+
+  <div class="bg-gray-900 shadow rounded-lg divide-y divide-gray-800 border border-gray-800">
+    <div class="px-6 py-4">
+      <h3 class="text-sm font-medium text-gray-500">Original Filename</h3>
+      <p class="mt-1 text-lg text-white"><%= @upload.original_filename %></p>
+    </div>
+
+    <div class="px-6 py-4">
+      <h3 class="text-sm font-medium text-gray-500">Status</h3>
+      <div class="mt-1"><%= render_upload_status(@upload) %></div>
+      <% if @upload.error_message.present? %>
+        <p class="mt-2 text-sm text-red-400"><%= @upload.error_message %></p>
+      <% end %>
+    </div>
+
+    <div class="px-6 py-4 grid grid-cols-2 gap-4">
+      <div>
+        <h3 class="text-sm font-medium text-gray-500">File Size</h3>
+        <p class="mt-1 text-gray-200"><%= number_to_human_size(@upload.file_size) if @upload.file_size %></p>
+      </div>
+      <div>
+        <h3 class="text-sm font-medium text-gray-500">Book Type</h3>
+        <p class="mt-1 text-gray-200"><%= @upload.book_type&.humanize || "Pending" %></p>
+      </div>
+    </div>
+
+    <div class="px-6 py-4">
+      <h3 class="text-sm font-medium text-gray-500">Parsed Information</h3>
+      <% if @upload.parsed_title.present? %>
+        <p class="mt-1 text-gray-200">
+          <strong><%= @upload.parsed_title %></strong>
+          by <%= @upload.parsed_author || "Unknown Author" %>
+        </p>
+        <p class="mt-1 text-sm text-gray-500">
+          Match confidence: <%= @upload.match_confidence %>%
+        </p>
+      <% else %>
+        <p class="mt-1 text-gray-500">Not yet parsed</p>
+      <% end %>
+    </div>
+
+    <% if @upload.book %>
+      <div class="px-6 py-4">
+        <h3 class="text-sm font-medium text-gray-500">Matched Book</h3>
+        <p class="mt-1">
+          <span class="text-gray-200"><%= @upload.book.display_name %></span>
+          <% if @upload.book.acquired? %>
+            <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-900/50 text-green-400">
+              Acquired
+            </span>
+          <% end %>
+        </p>
+      </div>
+    <% end %>
+
+    <div class="px-6 py-4">
+      <h3 class="text-sm font-medium text-gray-500">Uploaded</h3>
+      <p class="mt-1 text-gray-200"><%= time_ago_in_words(@upload.created_at) %> ago</p>
+    </div>
+
+    <% if @upload.processed_at %>
+      <div class="px-6 py-4">
+        <h3 class="text-sm font-medium text-gray-500">Processed</h3>
+        <p class="mt-1 text-gray-200"><%= time_ago_in_words(@upload.processed_at) %> ago</p>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-6">
+    <%= link_to "Back to Uploads", uploads_path, class: "text-gray-400 hover:text-gray-200" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # User Uploads
+  resources :uploads, only: [ :index, :new, :create, :show ]
+
   # API
   namespace :api, defaults: { format: :json } do
     namespace :v1 do


### PR DESCRIPTION
## Summary

Closes #185

- Adds a new `allow_user_uploads` admin setting (Security section, default off) that enables a user-facing upload flow outside the admin namespace
- When enabled, an "Upload" link appears in the navbar for all authenticated users
- Users can upload books and see their own upload history; admin upload management (retry, delete) remains admin-only
- No database migration needed — uses the existing dynamic settings table and uploads table

## Changes

- **`app/services/settings_service.rb`** — new `allow_user_uploads` setting + `user_uploads_allowed?` method
- **`app/models/upload.rb`** — new `for_user` scope
- **`app/controllers/uploads_controller.rb`** — new user-facing controller (index, new, create, show)
- **`config/routes.rb`** — `resources :uploads` route
- **`app/views/uploads/`** — new, index, show views (matching existing admin styling)
- **`app/views/layouts/application.html.erb`** — conditional "Upload" navbar link

## Test plan

- [ ] Enable "Allow non-admin users to upload book files directly" in Admin > Settings > Security
- [ ] As a non-admin user, verify "Upload" link appears in navbar
- [ ] Upload an ebook (epub) — verify metadata extraction, book matching, and library filing work
- [ ] Verify non-admin users only see their own uploads in the index
- [ ] Verify non-admin users cannot access `/admin/uploads`
- [ ] With setting disabled, verify non-admin users are redirected from `/uploads`
- [ ] Verify admin always has access to `/uploads` regardless of setting