### PR TITLE
fix: harden prowlarr book search fallback

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -70,22 +70,54 @@ class SearchJob < ApplicationJob
   private
 
   def search_indexer(request)
-    book = request.book
-
-    # Build search query: "title author [language]"
-    query_parts = [ book.title ]
-    query_parts << book.author if book.author.present?
-    # Add language to query for non-English requests to help find localized releases
-    query_parts << language_search_term(request) if should_add_language_to_search?(request)
-
-    query = query_parts.join(" ")
-    Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} for: #{query} (type: #{book.book_type})"
-
-    results = IndexerClient.search(query, book_type: book.book_type)
+    if IndexerClient.provider == SearchResult::SOURCE_PROWLARR
+      results = search_prowlarr(request)
+    else
+      results = search_generic_indexer(request)
+    end
 
     results.map do |r|
       { result: r, source: IndexerClient.provider }
     end
+  end
+
+  def search_prowlarr(request)
+    book = request.book
+    query = indexer_language_hint(request)
+
+    Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} book query for title='#{book.title}' author='#{book.author}' extra='#{query}' (type: #{book.book_type})"
+
+    results = IndexerClient.search(
+      query,
+      book_type: book.book_type,
+      title: book.title,
+      author: book.author
+    )
+
+    return results if results.any?
+
+    fallback_query = generic_indexer_query(request)
+    Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query '#{fallback_query}'"
+
+    IndexerClient.search(fallback_query, book_type: book.book_type)
+  end
+
+  def search_generic_indexer(request)
+    book = request.book
+    query = generic_indexer_query(request)
+    Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} for: #{query} (type: #{book.book_type})"
+
+    IndexerClient.search(query, book_type: book.book_type)
+  end
+
+  def generic_indexer_query(request)
+    [ request.book.title, indexer_language_hint(request) ].reject(&:blank?).join(" ")
+  end
+
+  def indexer_language_hint(request)
+    return nil unless should_add_language_to_search?(request)
+
+    language_search_term(request)
   end
 
   def search_anna_archive(request)

--- a/app/services/indexer_clients/jackett.rb
+++ b/app/services/indexer_clients/jackett.rb
@@ -5,7 +5,7 @@ module IndexerClients
     DEFAULT_INDEXER_FILTER = "all"
 
     class << self
-      def search(query, categories: nil, book_type: nil, limit: 100)
+      def search(query, categories: nil, book_type: nil, limit: 100, **)
         ensure_configured!
 
         params = {

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -5,10 +5,14 @@ module IndexerClients
     Result = IndexerClients::Result
 
     class << self
-      def search(query, categories: nil, book_type: nil, limit: 100)
+      def search(query, categories: nil, book_type: nil, limit: 100, title: nil, author: nil)
         ensure_configured!
 
-        params = { query: query, type: "search", limit: limit }
+        params = {
+          query: build_query(query, title: title, author: author),
+          type: search_type_for(title: title, author: author),
+          limit: limit
+        }
 
         cats = categories || categories_for_type(book_type)
         params[:categories] = Array(cats) if cats.present?
@@ -188,6 +192,27 @@ module IndexerClients
         Time.parse(date_string)
       rescue ArgumentError
         nil
+      end
+
+      def search_type_for(title:, author:)
+        sanitized_book_value(title).present? || sanitized_book_value(author).present? ? "book" : "search"
+      end
+
+      def build_query(query, title:, author:)
+        return query if search_type_for(title: title, author: author) == "search"
+
+        parts = []
+        sanitized_title = sanitized_book_value(title)
+        sanitized_author = sanitized_book_value(author)
+
+        parts << "{title:#{sanitized_title}}" if sanitized_title.present?
+        parts << "{author:#{sanitized_author}}" if sanitized_author.present?
+        parts << query if query.present?
+        parts.join(" ")
+      end
+
+      def sanitized_book_value(value)
+        value.to_s.tr("{}", "  ").squish.presence
       end
     end
   end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -147,13 +147,19 @@ class SearchJobTest < ActiveJob::TestCase
     @request.update!(language: "fr")
 
     VCR.turned_off do
-      # Stub that verifies "French" is in the query
+      # Prowlarr book search should keep language as free text while title/author are structured
       stub_request(:get, %r{localhost:9696/api/v1/search})
-        .with { |req| req.uri.query_values["query"].include?("French") }
+        .with do |req|
+          query = req.uri.query_values["query"]
+          req.uri.query_values["type"] == "book" &&
+            query.include?("French") &&
+            query.include?("{title:#{@request.book.title}}") &&
+            query.include?("{author:#{@request.book.author}}")
+        end
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: [].to_json
+          body: [ prowlarr_result_payload ].to_json
         )
 
       assert_nothing_raised do
@@ -167,17 +173,164 @@ class SearchJobTest < ActiveJob::TestCase
     @request.update!(language: "en")
 
     VCR.turned_off do
-      # Stub that verifies "English" is NOT in the query (just title and author)
+      # Prowlarr book search should omit the English language hint
       stub_request(:get, %r{localhost:9696/api/v1/search})
-        .with { |req| !req.uri.query_values["query"].include?("English") }
+        .with do |req|
+          query = req.uri.query_values["query"]
+          req.uri.query_values["type"] == "book" &&
+            !query.include?("English") &&
+            query.include?("{title:#{@request.book.title}}") &&
+            query.include?("{author:#{@request.book.author}}")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      assert_nothing_raised do
+        SearchJob.perform_now(@request.id)
+      end
+    end
+  end
+
+  test "uses structured Prowlarr book search with title and author" do
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values["query"]
+          req.uri.query_values["type"] == "book" &&
+            query.include?("{title:#{@request.book.title}}") &&
+            query.include?("{author:#{@request.book.author}}")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      assert_nothing_raised do
+        SearchJob.perform_now(@request.id)
+      end
+    end
+  end
+
+  test "falls back to generic Prowlarr search when book search returns no results" do
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values["query"]
+          req.uri.query_values["type"] == "book" &&
+            query.include?("{title:#{@request.book.title}}") &&
+            query.include?("{author:#{@request.book.author}}")
+        end
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
           body: [].to_json
         )
 
+      fallback_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == @request.book.title
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested structured_stub
+      assert_requested fallback_stub
+      assert_equal "Test Result Book", @request.search_results.first.title
+    end
+  end
+
+  test "sanitizes braces in structured Prowlarr query values" do
+    book = Book.create!(
+      title: "The {Brace} Book",
+      author: "Author {Name}",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values["query"]
+          req.uri.query_values["type"] == "book" &&
+            query.include?("{title:The Brace Book}") &&
+            query.include?("{author:Author Name}") &&
+            !query.include?("{Brace}") &&
+            !query.include?("{Name}")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert request.search_results.any?
+    end
+  end
+
+  test "keeps Jackett on title-only generic search" do
+    SettingsService.set(:indexer_provider, "jackett")
+    SettingsService.set(:jackett_url, "http://localhost:9117")
+    SettingsService.set(:jackett_api_key, "jackett-key")
+
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+        <channel></channel>
+      </rss>
+    XML
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9117/api/v2\.0/indexers/all/results/torznab/api})
+        .with do |req|
+          query = req.uri.query_values["q"]
+          req.uri.query_values["t"] == "search" &&
+            query.include?(@request.book.title) &&
+            !query.include?(@request.book.author)
+        end
+        .to_return(status: 200, body: body, headers: { "Content-Type" => "application/xml" })
+
       assert_nothing_raised do
         SearchJob.perform_now(@request.id)
+      end
+    end
+  end
+
+  test "still appends author to Anna's Archive search query" do
+    SettingsService.set(:prowlarr_api_key, "")
+    result = AnnaArchiveClient::Result.new(
+      md5: "abc123def456",
+      title: @request.book.title,
+      author: @request.book.author,
+      year: 2019,
+      file_type: "epub",
+      file_size: "5 MB",
+      language: "en"
+    )
+
+    AnnaArchiveClient.stub :configured?, true do
+      AnnaArchiveClient.stub :search, ->(query, **_) {
+        assert_includes query, @request.book.title
+        assert_includes query, @request.book.author
+        [ result ]
+      } do
+        SearchJob.perform_now(@request.id)
+        @request.reload
+
+        assert_equal SearchResult::SOURCE_ANNA_ARCHIVE, @request.search_results.first.source
       end
     end
   end
@@ -244,20 +397,7 @@ class SearchJobTest < ActiveJob::TestCase
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
-        body: [
-          {
-            "guid" => "test-guid-123",
-            "title" => "Test Result Book",
-            "indexer" => "TestIndexer",
-            "size" => 52428800,
-            "seeders" => 25,
-            "leechers" => 5,
-            "downloadUrl" => "http://example.com/download",
-            "magnetUrl" => "magnet:?xt=urn:btih:test123",
-            "infoUrl" => "http://example.com/info",
-            "publishDate" => "2024-01-15T10:00:00Z"
-          }
-        ].to_json
+        body: [ prowlarr_result_payload ].to_json
       )
   end
 
@@ -268,5 +408,20 @@ class SearchJobTest < ActiveJob::TestCase
         headers: { "Content-Type" => "application/json" },
         body: [].to_json
       )
+  end
+
+  def prowlarr_result_payload
+    {
+      "guid" => "test-guid-123",
+      "title" => "Test Result Book",
+      "indexer" => "TestIndexer",
+      "size" => 52_428_800,
+      "seeders" => 25,
+      "leechers" => 5,
+      "downloadUrl" => "http://example.com/download",
+      "magnetUrl" => "magnet:?xt=urn:btih:test123",
+      "infoUrl" => "http://example.com/info",
+      "publishDate" => "2024-01-15T10:00:00Z"
+    }
   end
 end

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -73,6 +73,63 @@ class ProwlarrClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "search uses Prowlarr book search when title or author are provided" do
+    VCR.turned_off do
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values
+          query["type"] == "book" &&
+            query["query"].include?("{title:Harry Potter and the Goblet of Fire}") &&
+            query["query"].include?("{author:J.K. Rowling}") &&
+            query["query"].include?("French")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      results = ProwlarrClient.search(
+        "French",
+        book_type: :ebook,
+        title: "Harry Potter and the Goblet of Fire",
+        author: "J.K. Rowling"
+      )
+
+      assert_equal [], results
+      assert_requested search_stub
+    end
+  end
+
+  test "search sanitizes braces in structured book query values" do
+    VCR.turned_off do
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values
+          query["type"] == "book" &&
+            query["query"].include?("{title:The Example Title}") &&
+            query["query"].include?("{author:Ada Lovelace}") &&
+            !query["query"].include?("{Title}") &&
+            !query["query"].include?("{Ada}")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      results = ProwlarrClient.search(
+        "",
+        book_type: :ebook,
+        title: "The {Example} Title",
+        author: "{Ada} Lovelace"
+      )
+
+      assert_equal [], results
+      assert_requested search_stub
+    end
+  end
+
   test "search handles empty results" do
     VCR.turned_off do
       stub_request(:get, %r{localhost:9696/api/v1/search})


### PR DESCRIPTION
## Summary
- add a generic fallback when Prowlarr book-search returns no results so unsupported indexers can retry with the title-based search path
- sanitize structured Prowlarr title/author tokens before building the `type=book` query
- expand regression coverage for structured search, fallback behavior, and special-character handling

## Testing
- bundle exec rails test

Fixes #211