### PR TITLE
feat: add format preferences and oidc login improvements

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server
+web: SOLID_QUEUE_IN_PUMA=1 bin/rails server
 css: bin/rails tailwindcss:watch

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -9,7 +9,12 @@ module Auth
       auth_hash = request.env["omniauth.auth"]
 
       unless auth_hash
-        redirect_to new_session_path, alert: "Authentication failed: No data received from provider"
+        redirect_to oidc_failure_redirect_path, alert: "Authentication failed: No data received from provider"
+        return
+      end
+
+      if oidc_link_in_progress?
+        complete_oidc_link(auth_hash)
         return
       end
 
@@ -29,16 +34,20 @@ module Auth
     def failure
       message = params[:message] || "Unknown error"
       Rails.logger.warn "[OIDC] Authentication failed: #{message}"
-      redirect_to new_session_path, alert: "SSO authentication failed: #{message}"
+      redirect_to oidc_failure_redirect_path, alert: "SSO authentication failed: #{message}"
     end
 
     private
+
+    def oidc_link_in_progress?
+      session[:pending_oidc_link_user_id].present?
+    end
 
     def complete_oidc_login(user, auth_hash)
       # Check if account is locked
       if user.locked?
         log_security_event("oidc_login.blocked_locked", user)
-        redirect_to new_session_path, alert: "Account is locked. Try again in #{user.unlock_in_words}."
+        redirect_to oidc_failure_redirect_path, alert: "Account is locked. Try again in #{user.unlock_in_words}."
         return
       end
 
@@ -53,8 +62,29 @@ module Auth
       redirect_to after_authentication_url, notice: "Signed in via #{provider_name}"
     end
 
+    def complete_oidc_link(auth_hash)
+      user = User.active.find_by(id: session.delete(:pending_oidc_link_user_id))
+
+      unless user
+        redirect_to oidc_failure_redirect_path, alert: "OIDC link session expired. Sign in locally and try again."
+        return
+      end
+
+      user.link_oidc_identity!(provider: auth_hash["provider"], uid: auth_hash["uid"])
+
+      ActivityTracker.track("user.oidc_linked", user: user)
+      log_security_event("oidc_link.success", user)
+
+      provider_name = SettingsService.get(:oidc_provider_name, default: "SSO")
+      redirect_to profile_path, notice: "#{provider_name} is now linked to your account."
+    rescue User::OidcIdentityAlreadyLinkedError
+      redirect_to profile_path, alert: "That OIDC account is already linked to another Shelfarr user."
+    rescue User::OidcIdentityConflictError
+      redirect_to profile_path, alert: "This Shelfarr account is already linked to a different OIDC identity."
+    end
+
     def handle_oidc_failure(message)
-      redirect_to new_session_path, alert: message
+      redirect_to oidc_failure_redirect_path, alert: message
     end
 
     def log_security_event(event_type, user = nil)
@@ -68,6 +98,15 @@ module Auth
       details[:username] = user&.username
 
       Rails.logger.info "[Security] #{event_type}: #{details.to_json}"
+    end
+
+    def oidc_failure_redirect_path
+      if oidc_link_in_progress?
+        session.delete(:pending_oidc_link_user_id)
+        return profile_path
+      end
+
+      SettingsService.oidc_auto_redirect? ? new_session_path(local: 1) : new_session_path
     end
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -43,6 +43,43 @@ class ProfilesController < ApplicationController
     end
   end
 
+  def link_oidc
+    @user = Current.user
+
+    unless SettingsService.oidc_configured?
+      redirect_to profile_path, alert: "OIDC must be fully configured before you can link an account."
+      return
+    end
+
+    if @user.oidc_user?
+      redirect_to profile_path, notice: "Your account is already linked to OIDC."
+      return
+    end
+
+    session[:pending_oidc_link_user_id] = @user.id
+    render :link_oidc_redirect
+  end
+
+  def unlink_oidc
+    @user = Current.user
+
+    unless @user.oidc_user?
+      redirect_to profile_path, notice: "Your account is not linked to OIDC."
+      return
+    end
+
+    unless SettingsService.auth_disabled? || @user.authenticate(params[:current_password])
+      redirect_to profile_path, alert: "Current password is incorrect."
+      return
+    end
+
+    @user.unlink_oidc_identity!
+    session.delete(:pending_oidc_link_user_id)
+
+    ActivityTracker.track("user.oidc_unlinked", user: @user)
+    redirect_to profile_path, notice: "OIDC sign-in has been removed from your account."
+  end
+
   # Two-factor authentication setup
   def two_factor
     @user = Current.user

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -271,9 +271,9 @@ class RequestsController < ApplicationController
 
   def set_request
     @request = if Current.user.admin?
-      Request.find(params[:id])
+      Request.includes(:search_results).find(params[:id])
     else
-      Request.for_user(Current.user).find(params[:id])
+      Request.for_user(Current.user).includes(:search_results).find(params[:id])
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,14 @@ class SessionsController < ApplicationController
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
 
   def new
-    redirect_to sign_up_path if User.active.none?
+    if User.active.none?
+      redirect_to sign_up_path
+      return
+    end
+
+    return unless auto_redirect_to_oidc?
+
+    render :oidc_redirect
   end
 
   def create
@@ -89,10 +96,14 @@ class SessionsController < ApplicationController
   def destroy
     ActivityTracker.track("user.logout")
     terminate_session
-    redirect_to new_session_path, status: :see_other
+    redirect_to post_logout_redirect_path, status: :see_other
   end
 
   private
+
+  def auto_redirect_to_oidc?
+    SettingsService.oidc_auto_redirect? && params[:local].blank?
+  end
 
   def complete_login(user)
     user.reset_failed_logins!
@@ -130,5 +141,9 @@ class SessionsController < ApplicationController
     details[:username] = user&.username || attempted_username
 
     Rails.logger.info "[Security] #{event_type}: #{details.to_json}"
+  end
+
+  def post_logout_redirect_path
+    SettingsService.oidc_auto_redirect? ? new_session_path(local: 1) : new_session_path
   end
 end

--- a/app/javascript/controllers/download_type_preferences_controller.js
+++ b/app/javascript/controllers/download_type_preferences_controller.js
@@ -1,0 +1,88 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "item", "list"]
+
+  connect() {
+    this.draggedItem = null
+    this.syncInput()
+    this.refreshButtons()
+  }
+
+  dragStart(event) {
+    this.draggedItem = event.currentTarget
+    event.dataTransfer.effectAllowed = "move"
+    event.dataTransfer.setData("text/plain", event.currentTarget.dataset.type)
+    event.currentTarget.classList.add("opacity-60")
+  }
+
+  dragOver(event) {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "move"
+  }
+
+  drop(event) {
+    event.preventDefault()
+
+    const targetItem = event.currentTarget
+    if (!this.draggedItem || this.draggedItem === targetItem) return
+
+    const targetBounds = targetItem.getBoundingClientRect()
+    const insertAfter = event.clientY > targetBounds.top + (targetBounds.height / 2)
+
+    if (insertAfter) {
+      targetItem.insertAdjacentElement("afterend", this.draggedItem)
+    } else {
+      targetItem.insertAdjacentElement("beforebegin", this.draggedItem)
+    }
+
+    this.persist()
+  }
+
+  dragEnd(event) {
+    event.currentTarget.classList.remove("opacity-60")
+    this.draggedItem = null
+  }
+
+  moveUp(event) {
+    const item = event.currentTarget.closest("[data-download-type-preferences-target='item']")
+    const previous = item?.previousElementSibling
+    if (!item || !previous) return
+
+    previous.insertAdjacentElement("beforebegin", item)
+    this.persist()
+  }
+
+  moveDown(event) {
+    const item = event.currentTarget.closest("[data-download-type-preferences-target='item']")
+    const next = item?.nextElementSibling
+    if (!item || !next) return
+
+    next.insertAdjacentElement("afterend", item)
+    this.persist()
+  }
+
+  persist() {
+    this.syncInput(true)
+    this.refreshButtons()
+  }
+
+  syncInput(notify = false) {
+    const order = this.itemTargets.map((item) => item.dataset.type)
+    this.inputTarget.value = JSON.stringify(order)
+
+    if (notify) {
+      this.inputTarget.dispatchEvent(new Event("change", { bubbles: true }))
+    }
+  }
+
+  refreshButtons() {
+    this.itemTargets.forEach((item, index) => {
+      const buttons = item.querySelectorAll("[data-download-type-preferences-target$='Button']")
+      const [moveUpButton, moveDownButton] = buttons
+
+      if (moveUpButton) moveUpButton.disabled = index === 0
+      if (moveDownButton) moveDownButton.disabled = index === this.itemTargets.length - 1
+    })
+  }
+}

--- a/app/javascript/controllers/oidc_redirect_controller.js
+++ b/app/javascript/controllers/oidc_redirect_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["form"]
+
+  connect() {
+    this.submitted = false
+
+    requestAnimationFrame(() => {
+      this.submit()
+    })
+  }
+
+  submit() {
+    if (!this.hasFormTarget || this.submitted) return
+
+    this.submitted = true
+    this.formTarget.requestSubmit()
+  }
+}

--- a/app/javascript/controllers/search_results_controller.js
+++ b/app/javascript/controllers/search_results_controller.js
@@ -10,6 +10,10 @@ export default class extends Controller {
   }
 
   connect() {
+    // Respect initial expanded state (e.g. show page starts expanded)
+    if (this.hasContentTarget) {
+      this.contentTarget.classList.toggle("hidden", !this.expandedValue)
+    }
     this.updateVisibility()
   }
 

--- a/app/javascript/controllers/settings_tabs_controller.js
+++ b/app/javascript/controllers/settings_tabs_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Progressive enhancement for settings tabs.
+// Panels render visible by default so the page remains usable if JS fails.
+export default class extends Controller {
+  static targets = ["tab", "panel"]
+  static values = {
+    active: { type: String, default: "search" }
+  }
+
+  connect() {
+    const hash = window.location.hash.replace("#", "")
+    if (hash && this.panelTargets.some((panel) => panel.dataset.tab === hash)) {
+      this.activeValue = hash
+    }
+
+    this.showTab()
+  }
+
+  switch(event) {
+    event.preventDefault()
+
+    const tab = event.currentTarget.dataset.tab
+    if (!tab) return
+
+    this.activeValue = tab
+    this.showTab()
+    history.replaceState(null, "", `#${tab}`)
+  }
+
+  showTab() {
+    const active = this.activeValue
+
+    this.tabTargets.forEach((tab) => {
+      const isActive = tab.dataset.tab === active
+      tab.classList.toggle("border-blue-500", isActive)
+      tab.classList.toggle("text-blue-400", isActive)
+      tab.classList.toggle("border-transparent", !isActive)
+      tab.classList.toggle("text-gray-400", !isActive)
+      tab.classList.toggle("hover:text-gray-300", !isActive)
+      tab.classList.toggle("hover:border-gray-600", !isActive)
+      tab.setAttribute("aria-selected", isActive ? "true" : "false")
+    })
+
+    this.panelTargets.forEach((panel) => {
+      const isActive = panel.dataset.tab === active
+      panel.classList.toggle("hidden", !isActive)
+      panel.setAttribute("aria-hidden", isActive ? "false" : "true")
+    })
+  }
+}

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -20,12 +20,17 @@ class SearchResult < ApplicationRecord
   scope :selectable, -> { pending }
 
   scope :preferred_first, -> {
-    preferred = SettingsService.get(:preferred_download_type, default: "torrent")
-    if preferred == "usenet"
-      order(Arel.sql("CASE WHEN download_url IS NOT NULL AND magnet_url IS NULL AND seeders IS NULL THEN 0 ELSE 1 END"))
-    else
-      order(Arel.sql("CASE WHEN magnet_url IS NOT NULL THEN 0 ELSE 1 END"))
-    end
+    ordered_types = SettingsService.preferred_download_types
+    type_order_sql = ordered_types.each_with_index.map { |type, index| "WHEN '#{type}' THEN #{index}" }.join(" ")
+    download_type_sql = <<~SQL.squish
+      CASE
+        WHEN source = '#{SOURCE_ANNA_ARCHIVE}' THEN 'direct'
+        WHEN download_url IS NOT NULL AND magnet_url IS NULL AND seeders IS NULL THEN 'usenet'
+        ELSE 'torrent'
+      END
+    SQL
+
+    order(Arel.sql("CASE #{download_type_sql} #{type_order_sql} ELSE #{ordered_types.length} END"))
   }
 
   scope :best_first, -> { preferred_first.order(confidence_score: :desc, seeders: :desc, size_bytes: :asc) }
@@ -65,6 +70,18 @@ class SearchResult < ApplicationRecord
   # Check if this is a torrent result
   def torrent?
     magnet_url.present? || (download_url.present? && !usenet?)
+  end
+
+  def direct_download?
+    from_anna_archive?
+  end
+
+  def download_type
+    return "direct" if direct_download?
+    return "usenet" if usenet?
+    return "torrent" if torrent?
+
+    nil
   end
 
   def size_human

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -126,6 +126,35 @@ class SearchResult < ApplicationRecord
     end
   end
 
+  def primary_extension
+    score_detail(:extension).presence
+  end
+
+  def detected_extensions
+    Array(score_detail(:extensions)).map(&:to_s)
+  end
+
+  def audiobook_structure
+    structure = score_detail(:audiobook_structure)
+    structure&.to_sym
+  end
+
+  def audio_bitrate_kbps
+    bitrate = score_detail(:audio_bitrate_kbps)
+    bitrate.present? ? bitrate.to_i : nil
+  end
+
+  def auto_select_allowed_by_preferences?
+    auto_select_allowed = score_detail(:auto_select_allowed)
+    return auto_select_allowed unless auto_select_allowed.nil?
+
+    FormatPreferenceService.evaluate(title: title, book_type: request&.book&.book_type).auto_select_allowed
+  end
+
+  def preference_adjustment
+    score_detail(:preference_adjustment).to_i
+  end
+
   # Source helpers
   def from_prowlarr?
     source == SOURCE_PROWLARR || source.blank?
@@ -152,5 +181,16 @@ class SearchResult < ApplicationRecord
     else
       indexer.presence || "Prowlarr"
     end
+  end
+
+  private
+
+  def score_detail(key)
+    return nil unless score_breakdown.is_a?(Hash)
+
+    return score_breakdown[key.to_s] if score_breakdown.key?(key.to_s)
+    return score_breakdown[key.to_sym] if score_breakdown.key?(key.to_sym)
+
+    nil
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  class OidcIdentityAlreadyLinkedError < StandardError; end
+  class OidcIdentityConflictError < StandardError; end
+
   has_secure_password
   has_many :sessions, dependent: :destroy
   has_many :requests, dependent: :destroy
@@ -19,6 +22,12 @@ class User < ApplicationRecord
   validates :username, presence: true, uniqueness: { conditions: -> { where(deleted_at: nil) } },
     format: { with: /\A[a-z0-9_]+\z/, message: "only allows lowercase letters, numbers, and underscores" }
   validates :name, presence: true
+  validates :oidc_provider, presence: true, if: -> { oidc_uid.present? }
+  validates :oidc_uid, presence: true, if: -> { oidc_provider.present? }
+  validates :oidc_uid, uniqueness: {
+    scope: :oidc_provider,
+    conditions: -> { where(deleted_at: nil) }
+  }, allow_nil: true
   validates :password, length: { minimum: 12 },
     format: {
       with: /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+\z/,
@@ -156,6 +165,21 @@ class User < ApplicationRecord
     oidc_uid.present? && oidc_provider.present?
   end
 
+  def link_oidc_identity!(provider:, uid:)
+    existing_user = self.class.active.find_by(oidc_provider: provider, oidc_uid: uid)
+    raise OidcIdentityAlreadyLinkedError, "OIDC identity is already linked to another user" if existing_user && existing_user != self
+
+    if oidc_user? && (oidc_provider != provider || oidc_uid != uid)
+      raise OidcIdentityConflictError, "User is already linked to a different OIDC identity"
+    end
+
+    update!(oidc_provider: provider, oidc_uid: uid)
+  end
+
+  def unlink_oidc_identity!
+    update!(oidc_provider: nil, oidc_uid: nil)
+  end
+
   # Find existing user or create new one from OIDC auth data
   def self.from_oidc(auth_hash)
     provider = auth_hash["provider"]
@@ -166,20 +190,11 @@ class User < ApplicationRecord
     user = active.find_by(oidc_provider: provider, oidc_uid: uid)
     return user if user
 
-    # Try to find by email and link the OIDC identity
-    email = info["email"].to_s.strip.downcase
-    if email.present?
-      user = active.find_by(username: email.split("@").first.gsub(/[^a-z0-9_]/, "_"))
-      if user && !user.oidc_user?
-        user.update!(oidc_provider: provider, oidc_uid: uid)
-        return user
-      end
-    end
-
     # Auto-create user if enabled
     return nil unless SettingsService.get(:oidc_auto_create_users, default: false)
 
     # Generate username from email or name
+    email = info["email"].to_s.strip.downcase
     base_username = if email.present?
       email.split("@").first.gsub(/[^a-z0-9_]/, "_").downcase
     else

--- a/app/services/auto_select_service.rb
+++ b/app/services/auto_select_service.rb
@@ -68,6 +68,7 @@ class AutoSelectService
       .auto_selectable(@confidence_threshold)
       .matches_language(@requested_language)
       .best_first
+      .select(&:auto_select_allowed_by_preferences?)
   end
 
   def meets_confidence_threshold?(result)

--- a/app/services/format_preference_service.rb
+++ b/app/services/format_preference_service.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+class FormatPreferenceService
+  Result = Data.define(
+    :score_adjustment,
+    :auto_select_allowed,
+    :matched_extension,
+    :detected_extensions,
+    :audiobook_structure,
+    :audio_bitrate_kbps
+  )
+
+  REJECTED_FORMAT_PENALTY = -35
+  NON_APPROVED_FORMAT_PENALTY = -20
+  NON_PREFERRED_FORMAT_PENALTY = -6
+  SINGLE_FILE_BONUS = 6
+  MULTI_FILE_PENALTY = -6
+  PREFERRED_FORMAT_BONUSES = [ 12, 8, 4, 2 ].freeze
+
+  def self.evaluate(title:, book_type:)
+    new(title:, book_type:).evaluate
+  end
+
+  def initialize(title:, book_type:)
+    @title = title
+    @book_type = book_type.to_s
+    @parsed = ReleaseParserService.parse(title)
+    @preferences = SettingsService.format_preferences_for(@book_type)
+  end
+
+  def evaluate
+    matched_extension = select_extension
+    score_adjustment = 0
+    auto_select_allowed = true
+
+    if rejected_format?(matched_extension)
+      score_adjustment += REJECTED_FORMAT_PENALTY
+      auto_select_allowed = false
+    elsif disallowed_by_approved_formats?(matched_extension)
+      score_adjustment += NON_APPROVED_FORMAT_PENALTY
+      auto_select_allowed = false
+    end
+
+    score_adjustment += preferred_format_adjustment(matched_extension)
+    score_adjustment += audiobook_structure_adjustment
+    score_adjustment += bitrate_adjustment
+
+    Result.new(
+      score_adjustment: score_adjustment,
+      auto_select_allowed: auto_select_allowed,
+      matched_extension: matched_extension,
+      detected_extensions: @parsed[:extensions],
+      audiobook_structure: @parsed[:audiobook_structure],
+      audio_bitrate_kbps: @parsed[:audio_bitrate_kbps]
+    )
+  end
+
+  private
+
+  def select_extension
+    detected_extensions = @parsed[:extensions]
+    return @parsed[:primary_extension].presence if detected_extensions.empty?
+
+    @preferences[:preferred_formats].each do |extension|
+      return extension if detected_extensions.include?(extension)
+    end
+
+    @preferences[:approved_formats].each do |extension|
+      return extension if detected_extensions.include?(extension)
+    end
+
+    @parsed[:primary_extension].presence || detected_extensions.first
+  end
+
+  def rejected_format?(_matched_extension)
+    return false if @parsed[:extensions].empty?
+
+    (@parsed[:extensions] & @preferences[:rejected_formats]).any?
+  end
+
+  def disallowed_by_approved_formats?(_matched_extension)
+    approved_formats = @preferences[:approved_formats]
+    return false if approved_formats.empty? || @parsed[:extensions].empty?
+
+    (@parsed[:extensions] & approved_formats).empty?
+  end
+
+  def preferred_format_adjustment(matched_extension)
+    preferred_formats = @preferences[:preferred_formats]
+    return 0 if preferred_formats.empty? || matched_extension.blank?
+
+    preferred_index = preferred_formats.index(matched_extension)
+    return NON_PREFERRED_FORMAT_PENALTY if preferred_index.nil?
+
+    PREFERRED_FORMAT_BONUSES.fetch(preferred_index, 1)
+  end
+
+  def audiobook_structure_adjustment
+    return 0 unless @book_type == "audiobook"
+    return 0 unless @preferences[:prefer_single_file]
+
+    case @parsed[:audiobook_structure]
+    when :single_file then SINGLE_FILE_BONUS
+    when :multi_file then MULTI_FILE_PENALTY
+    else 0
+    end
+  end
+
+  def bitrate_adjustment
+    return 0 unless @book_type == "audiobook"
+    return 0 unless @preferences[:prefer_higher_bitrate]
+
+    bitrate = @parsed[:audio_bitrate_kbps].to_i
+
+    case bitrate
+    when 256.. then 6
+    when 192...256 then 4
+    when 128...192 then 2
+    else 0
+    end
+  end
+end

--- a/app/services/release_parser_service.rb
+++ b/app/services/release_parser_service.rb
@@ -225,6 +225,39 @@ class ReleaseParserService
     /\bcbz\b/i
   ].freeze
 
+  EXTENSION_PATTERNS = {
+    "m4b" => /\bm4b\b/i,
+    "m4a" => /\bm4a\b/i,
+    "mp3" => /\bmp3\b/i,
+    "epub" => /\bepub\b/i,
+    "pdf" => /\bpdf\b/i,
+    "mobi" => /\bmobi\b/i,
+    "azw3" => /\bazw3\b/i,
+    "azw" => /\bazw\b/i,
+    "cbz" => /\bcbz\b/i,
+    "cbr" => /\bcbr\b/i
+  }.freeze
+
+  AUDIOBOOK_SINGLE_FILE_PATTERNS = [
+    /\bsingle[\s\-_]?file\b/i,
+    /\bone[\s\-_]?file\b/i,
+    /\b1[\s\-_]?file\b/i,
+    /\bm4b\b/i,
+    /\bm4a\b/i
+  ].freeze
+
+  AUDIOBOOK_MULTI_FILE_PATTERNS = [
+    /\bmulti[\s\-_]?file\b/i,
+    /\bchapters?\b/i,
+    /\bchaptered\b/i,
+    /\bcd\s?\d+\b/i,
+    /\bdisc\s?\d+\b/i,
+    /\bpart\s?\d+\b/i,
+    /\bmp3\b/i
+  ].freeze
+
+  BITRATE_PATTERN = /(?<!\d)(\d{2,3})\s?kbps\b/i
+
   class << self
     # Parse a release title and extract metadata
     # @param title [String] The release title to parse
@@ -236,6 +269,10 @@ class ReleaseParserService
         languages: detect_languages(title),
         is_multi_language: multi_language?(title),
         format: detect_format(title),
+        extensions: detect_extensions(title),
+        primary_extension: detect_primary_extension(title),
+        audio_bitrate_kbps: detect_audio_bitrate(title),
+        audiobook_structure: detect_audiobook_structure(title),
         raw_title: title
       }
     end
@@ -279,6 +316,45 @@ class ReleaseParserService
       nil
     end
 
+    def detect_extensions(title)
+      return [] if title.blank?
+
+      EXTENSION_PATTERNS.each_with_object([]) do |(extension, pattern), detected|
+        detected << extension if title.match?(pattern)
+      end
+    end
+
+    def detect_primary_extension(title)
+      return nil if title.blank?
+
+      EXTENSION_PATTERNS
+        .filter_map do |extension, pattern|
+          match = title.match(pattern)
+          next unless match
+
+          [ extension, match.begin(0) ]
+        end
+        .min_by(&:last)
+        &.first
+    end
+
+    def detect_audio_bitrate(title)
+      return nil if title.blank?
+
+      match = title.match(BITRATE_PATTERN)
+      match && match[1].to_i
+    end
+
+    def detect_audiobook_structure(title)
+      return nil if title.blank?
+      return nil unless detect_format(title) == :audiobook
+
+      return :multi_file if AUDIOBOOK_MULTI_FILE_PATTERNS.any? { |pattern| title.match?(pattern) }
+      return :single_file if AUDIOBOOK_SINGLE_FILE_PATTERNS.any? { |pattern| title.match?(pattern) }
+
+      nil
+    end
+
     # Get display info for a language code
     # @param code [String] ISO 639-1 language code
     # @return [Hash, nil] Hash with :name and :flag, or nil if unknown
@@ -305,6 +381,10 @@ class ReleaseParserService
         languages: [],
         is_multi_language: false,
         format: nil,
+        extensions: [],
+        primary_extension: nil,
+        audio_bitrate_kbps: nil,
+        audiobook_structure: nil,
         raw_title: nil
       }
     end

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -31,6 +31,7 @@ class ReleaseScorer
     @request = request
     @book = request.book
     @parsed = ReleaseParserService.parse(search_result.title)
+    @format_preferences = FormatPreferenceService.evaluate(title: search_result.title, book_type: @book.book_type)
   end
 
   # Calculate the confidence score
@@ -41,13 +42,21 @@ class ReleaseScorer
       author: calculate_author_score,
       language: calculate_language_score,
       format: calculate_format_score,
-      health: calculate_health_score
+      health: calculate_health_score,
+      preference_adjustment: @format_preferences.score_adjustment,
+      auto_select_allowed: @format_preferences.auto_select_allowed,
+      extension: @format_preferences.matched_extension,
+      extensions: @format_preferences.detected_extensions,
+      audiobook_structure: @format_preferences.audiobook_structure,
+      audio_bitrate_kbps: @format_preferences.audio_bitrate_kbps
     }
 
     # Calculate weighted total
-    total = WEIGHTS.sum do |key, weight|
+    base_total = WEIGHTS.sum do |key, weight|
       (breakdown[key] * weight) / 100.0
     end.round
+
+    total = (base_total + @format_preferences.score_adjustment).clamp(0, 100)
 
     Result.new(
       total: total,

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -1,4 +1,20 @@
 class SettingsService
+  DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
+  DOWNLOAD_TYPE_OPTIONS = {
+    "torrent" => {
+      label: "Torrent",
+      description: "Tracker and magnet-link releases"
+    },
+    "usenet" => {
+      label: "Usenet",
+      description: "NZB releases sent to a usenet client"
+    },
+    "direct" => {
+      label: "Direct",
+      description: "Integration downloads such as Anna's Archive"
+    }
+  }.freeze
+
   # Define all expected settings with their defaults and types
   DEFINITIONS = {
     # Indexer Integration
@@ -11,7 +27,7 @@ class SettingsService
     jackett_indexer_filter: { type: "string", default: "all", category: "indexer", description: "Jackett indexer filter for Torznab queries. Use 'all' for every indexer, or a specific Jackett filter such as 'tag:books'." },
 
     # Download Settings (clients are now managed separately via Admin > Download Clients)
-    preferred_download_type: { type: "string", default: "torrent", category: "download", description: "Preferred download type when both available (torrent or usenet)" },
+    preferred_download_types: { type: "json", default: '["torrent","usenet","direct"]', category: "download", description: "Download types in preference order. Higher-ranked types are preferred when multiple result types are available." },
     download_check_interval: { type: "integer", default: 60, category: "download", description: "Seconds between download status checks" },
     download_enqueue_timeout_minutes: { type: "integer", default: 5, category: "download", description: "Minutes a download may stay queued in Shelfarr before being flagged as never dispatched to the download client" },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
@@ -132,17 +148,13 @@ class SettingsService
     # Primary getter with default fallback
     def get(key, default: nil)
       key = key.to_sym
+      return preferred_download_types if key == :preferred_download_types
+
+      value = raw_setting_value(key)
+      return value unless value.nil?
+
       definition = DEFINITIONS[key]
-
-      setting = Setting.find_by(key: key.to_s)
-
-      if setting
-        setting.typed_value
-      elsif definition
-        definition[:default]
-      else
-        default
-      end
+      definition ? definition[:default] : default
     end
 
     # Primary setter
@@ -283,6 +295,25 @@ class SettingsService
       get(:auto_approve_requests, default: false)
     end
 
+    def preferred_download_types
+      stored_preferred_types = Setting.find_by(key: "preferred_download_types")&.typed_value
+      ordered_types = normalize_download_types(stored_preferred_types)
+
+      if ordered_types.empty?
+        legacy_type = normalize_download_types(Setting.find_by(key: "preferred_download_type")&.typed_value).first
+        ordered_types = legacy_type ? [ legacy_type ] : []
+      end
+
+      ordered_types + (DOWNLOAD_TYPES - ordered_types)
+    end
+
+    def download_type_options
+      preferred_download_types.map do |type|
+        DOWNLOAD_TYPE_OPTIONS.fetch(type)
+          .merge(value: type)
+      end
+    end
+
     def format_preferences_for(book_type)
       type = book_type.to_s
       return default_format_preferences unless %w[audiobook ebook].include?(type)
@@ -297,6 +328,20 @@ class SettingsService
     end
 
     private
+
+    def raw_setting_value(key)
+      setting = Setting.find_by(key: key.to_s)
+      return setting.typed_value if setting
+
+      DEFINITIONS[key.to_sym]&.dig(:default)
+    end
+
+    def normalize_download_types(values)
+      Array(values).filter_map do |value|
+        normalized = value.to_s.strip.downcase
+        normalized if DOWNLOAD_TYPES.include?(normalized)
+      end.uniq
+    end
 
     def normalized_list_setting(key)
       Array(get(key)).filter_map do |value|

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -116,6 +116,7 @@ class SettingsService
 
     # OIDC/SSO Authentication
     oidc_enabled: { type: "boolean", default: false, category: "oidc", description: "Enable OpenID Connect (OIDC) single sign-on authentication" },
+    oidc_auto_redirect: { type: "boolean", default: false, category: "oidc", description: "Automatically start OIDC sign-in for unauthenticated users. Use /session/new?local=1 to access the local login form." },
     oidc_provider_name: { type: "string", default: "SSO", category: "oidc", description: "Display name for the OIDC provider (shown on login button)" },
     oidc_issuer: { type: "string", default: "", category: "oidc", description: "OIDC issuer URL (e.g., https://auth.example.com/realms/master)" },
     oidc_client_id: { type: "string", default: "", category: "oidc", description: "OIDC client ID from your identity provider" },
@@ -266,6 +267,12 @@ class SettingsService
         configured?(:oidc_issuer) &&
         configured?(:oidc_client_id) &&
         configured?(:oidc_client_secret)
+    end
+
+    def oidc_auto_redirect?
+      oidc_configured? &&
+        !auth_disabled? &&
+        get(:oidc_auto_redirect, default: false)
     end
 
     def hardcover_configured?

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -55,6 +55,16 @@ class SettingsService
     auto_select_min_seeders: { type: "integer", default: 1, category: "auto_select", description: "Minimum seeders required for auto-selection (torrent only)" },
     auto_select_confidence_threshold: { type: "integer", default: 90, category: "auto_select", description: "Minimum confidence score (0-100) for auto-selection" },
 
+    # Format Preferences
+    ebook_approved_formats: { type: "json", default: "[]", category: "format_preferences", description: "Comma-separated ebook formats that may be auto-selected (leave blank to allow any detected format)" },
+    ebook_rejected_formats: { type: "json", default: "[]", category: "format_preferences", description: "Comma-separated ebook formats that should never be auto-selected" },
+    ebook_preferred_formats: { type: "json", default: "[]", category: "format_preferences", description: "Comma-separated ebook formats in preference order, from best to worst" },
+    audiobook_approved_formats: { type: "json", default: "[]", category: "format_preferences", description: "Comma-separated audiobook formats that may be auto-selected (leave blank to allow any detected format)" },
+    audiobook_rejected_formats: { type: "json", default: "[]", category: "format_preferences", description: "Comma-separated audiobook formats that should never be auto-selected" },
+    audiobook_preferred_formats: { type: "json", default: "[]", category: "format_preferences", description: "Comma-separated audiobook formats in preference order, from best to worst" },
+    audiobook_prefer_single_file: { type: "boolean", default: false, category: "format_preferences", description: "Prefer single-file audiobook releases (for example .m4b) over chapter-split releases when detected" },
+    audiobook_prefer_higher_bitrate: { type: "boolean", default: false, category: "format_preferences", description: "Prefer higher bitrate audiobook releases when the bitrate can be inferred from the title" },
+
     # Language Settings
     default_language: { type: "string", default: "en", category: "language", description: "Default language for new requests" },
     enabled_languages: { type: "json", default: '["en"]', category: "language", description: "Languages available for selection when creating requests" },
@@ -110,6 +120,7 @@ class SettingsService
     "open_library" => "Open Library",
     "health" => "Health Monitoring",
     "auto_select" => "Auto-Selection",
+    "format_preferences" => "Format Preferences",
     "language" => "Language & Matching",
     "updates" => "Updates",
     "security" => "Security",
@@ -270,6 +281,38 @@ class SettingsService
 
     def auto_approve_requests?
       get(:auto_approve_requests, default: false)
+    end
+
+    def format_preferences_for(book_type)
+      type = book_type.to_s
+      return default_format_preferences unless %w[audiobook ebook].include?(type)
+
+      {
+        approved_formats: normalized_list_setting("#{type}_approved_formats"),
+        rejected_formats: normalized_list_setting("#{type}_rejected_formats"),
+        preferred_formats: normalized_list_setting("#{type}_preferred_formats"),
+        prefer_single_file: type == "audiobook" && get(:audiobook_prefer_single_file, default: false),
+        prefer_higher_bitrate: type == "audiobook" && get(:audiobook_prefer_higher_bitrate, default: false)
+      }
+    end
+
+    private
+
+    def normalized_list_setting(key)
+      Array(get(key)).filter_map do |value|
+        normalized = value.to_s.strip.downcase
+        normalized.presence
+      end.uniq
+    end
+
+    def default_format_preferences
+      {
+        approved_formats: [],
+        rejected_formats: [],
+        preferred_formats: [],
+        prefer_single_file: false,
+        prefer_higher_bitrate: false
+      }
     end
   end
 end

--- a/app/views/admin/search_results/index.html.erb
+++ b/app/views/admin/search_results/index.html.erb
@@ -1,19 +1,19 @@
 <div class="mx-auto max-w-4xl">
   <div class="mb-6 flex items-center justify-between">
-    <%= link_to "&larr; Back to Request".html_safe, request_path(@request), class: "text-blue-600 hover:text-blue-800" %>
+    <%= link_to "&larr; Back to Request".html_safe, request_path(@request), class: "text-blue-400 hover:text-blue-300" %>
     <%= button_to "Refresh Search", refresh_admin_request_search_results_path(@request),
-        method: :post, class: "px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition" %>
+        method: :post, class: "px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white font-medium rounded-lg transition" %>
   </div>
 
-  <div class="bg-white rounded-lg shadow overflow-hidden mb-6">
-    <div class="p-4 border-b bg-gray-50">
+  <div class="bg-gray-900 rounded-lg border border-gray-800 shadow overflow-hidden mb-6">
+    <div class="p-4 border-b border-gray-800 bg-gray-900">
       <div class="flex items-center gap-4">
         <% if @request.book.cover_url.present? %>
           <img src="<%= @request.book.cover_url %>" alt="Cover" class="w-12 h-auto rounded shadow">
         <% end %>
         <div>
-          <h2 class="font-bold text-lg">Search Results for "<%= @request.book.title %>"</h2>
-          <p class="text-sm text-gray-600">
+          <h2 class="font-bold text-lg text-white">Search Results for "<%= @request.book.title %>"</h2>
+          <p class="text-sm text-gray-400">
             <% if @request.book.author.present? %>
               by <%= @request.book.author %> &middot;
             <% end %>
@@ -25,84 +25,85 @@
     </div>
 
     <% if @search_results.any? %>
-      <div class="divide-y">
+      <div class="space-y-2 p-3">
         <% @search_results.each do |result| %>
-          <div class="p-4 hover:bg-gray-50 <%= result.language_matches_request? ? '' : 'bg-yellow-50' %>">
-            <div class="flex items-start justify-between gap-4">
-              <div class="flex-grow min-w-0">
-                <div class="flex items-center gap-2">
-                  <p class="font-medium text-gray-900"><%= result.title %></p>
-                  <% if result.detected_language.present? %>
-                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium <%= result.language_matches_request? ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800' %>">
-                      <%= result.language_display_name %>
-                    </span>
+          <% row_classes = ["rounded-lg border px-3 py-3 transition"] %>
+          <% row_classes << if result.language_matches_request?
+            "border-gray-800 bg-gray-800/70 hover:bg-gray-800"
+          else
+            "border-yellow-600/30 bg-yellow-950/10 hover:bg-yellow-950/20"
+          end %>
+
+          <div class="<%= row_classes.join(' ') %>">
+            <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+              <div class="min-w-0 flex-grow">
+                <p class="text-sm font-medium leading-6 text-white break-words" title="<%= result.title %>"><%= result.title %></p>
+
+                <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400">
+                  <% if result.size_bytes.present? %>
+                    <span><%= result.size_human %></span>
                   <% end %>
-                </div>
-                <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-500 mt-1">
+                  <% if result.seeders.present? %>
+                    <span class="text-green-400"><%= result.seeders %> seeds</span>
+                  <% end %>
+                  <% if result.leechers.present? %>
+                    <span class="text-orange-400"><%= result.leechers %> leeches</span>
+                  <% end %>
                   <% if result.confidence_score.present? %>
-                    <span class="inline-flex items-center <%= result.high_confidence? ? 'text-green-600' : 'text-gray-500' %>">
-                      <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
+                    <span class="<%= result.high_confidence? ? 'text-green-400' : 'text-gray-400' %>">
                       Score: <%= result.confidence_score %>%
                     </span>
                   <% end %>
                   <% if result.indexer.present? %>
-                    <span class="inline-flex items-center">
-                      <svg class="w-4 h-4 mr-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
-                      </svg>
-                      <%= result.indexer %>
+                    <span class="text-gray-500"><%= result.indexer %></span>
+                  <% end %>
+                </div>
+
+                <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400">
+                  <% if result.detected_language.present? %>
+                    <span class="<%= result.language_matches_request? ? 'text-green-400' : 'text-yellow-400' %>">
+                      <%= result.language_display_name %>
                     </span>
                   <% end %>
-                  <% if result.size_bytes.present? %>
-                    <span class="inline-flex items-center">
-                      <svg class="w-4 h-4 mr-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
-                      </svg>
-                      <%= result.size_human %>
+                  <% if result.primary_extension.present? %>
+                    <span class="text-gray-300"><%= result.primary_extension.upcase %></span>
+                  <% end %>
+                  <% if result.audiobook_structure.present? %>
+                    <span class="text-gray-300"><%= result.audiobook_structure == :single_file ? "Single file" : "Multi-file" %></span>
+                  <% end %>
+                  <% if result.audio_bitrate_kbps.present? %>
+                    <span class="text-gray-300"><%= result.audio_bitrate_kbps %> kbps</span>
+                  <% end %>
+                  <% if result.preference_adjustment != 0 %>
+                    <span class="<%= result.preference_adjustment.positive? ? 'text-blue-400' : 'text-red-400' %>">
+                      Preference <%= result.preference_adjustment.positive? ? '+' : '' %><%= result.preference_adjustment %>
                     </span>
                   <% end %>
-                  <% if result.seeders.present? %>
-                    <span class="inline-flex items-center text-green-600">
-                      <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
-                      </svg>
-                      <%= result.seeders %> seeders
-                    </span>
-                  <% end %>
-                  <% if result.leechers.present? %>
-                    <span class="inline-flex items-center text-orange-600">
-                      <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
-                      </svg>
-                      <%= result.leechers %> leechers
+                  <% unless result.auto_select_allowed_by_preferences? %>
+                    <span class="inline-flex items-center rounded-full bg-red-500/10 px-2 py-0.5 font-medium text-red-400 ring-1 ring-inset ring-red-500/20">
+                      Manual review
                     </span>
                   <% end %>
                 </div>
               </div>
-              <div class="flex items-center gap-2 flex-shrink-0">
+
+              <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap">
                 <% if result.info_url.present? %>
                   <%= link_to "Info", result.info_url, target: "_blank", rel: "noopener",
-                      class: "px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition" %>
+                      class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
                 <% end %>
                 <% if result.pending? %>
                   <% if result.downloadable? %>
                     <%= button_to "Select", select_admin_request_search_result_path(@request, result),
                         method: :post,
-                        class: "px-4 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition" %>
+                        class: "px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
                   <% else %>
-                    <span class="px-3 py-1.5 text-sm bg-gray-100 text-gray-500 rounded-lg">No link</span>
+                    <span class="px-2 py-1 text-xs bg-gray-700 text-gray-500 rounded">No link</span>
                   <% end %>
                 <% elsif result.selected? %>
-                  <span class="inline-flex items-center px-3 py-1.5 bg-green-100 text-green-800 rounded-lg text-sm font-medium">
-                    <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
-                      <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                    </svg>
-                    Selected
-                  </span>
+                  <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
                 <% elsif result.rejected? %>
-                  <span class="px-3 py-1.5 bg-gray-100 text-gray-500 rounded-lg text-sm">Skipped</span>
+                  <span class="px-2 py-1 text-xs bg-gray-700 text-gray-400 rounded">Skipped</span>
                 <% end %>
               </div>
             </div>
@@ -110,12 +111,12 @@
         <% end %>
       </div>
     <% else %>
-      <div class="p-8 text-center text-gray-500">
-        <svg class="mx-auto h-12 w-12 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div class="p-8 text-center text-gray-400">
+        <svg class="mx-auto h-12 w-12 text-gray-500 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
-        <h3 class="text-lg font-medium text-gray-900 mb-2">No search results</h3>
-        <p class="mb-4">No results have been found yet. The search may still be in progress.</p>
+        <h3 class="text-lg font-medium text-white mb-2">No search results</h3>
+        <p class="mb-4 text-gray-500">No results have been found yet. The search may still be in progress.</p>
         <%= button_to "Run Search", refresh_admin_request_search_results_path(@request),
             method: :post,
             class: "px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition" %>

--- a/app/views/admin/settings/_download_type_preferences_field.html.erb
+++ b/app/views/admin/settings/_download_type_preferences_field.html.erb
@@ -1,0 +1,57 @@
+<div class="space-y-3"
+     data-controller="download-type-preferences">
+  <%= form.hidden_field "settings[#{key}]",
+      value: ordered_types.to_json,
+      id: "settings_#{key}",
+      data: {
+        download_type_preferences_target: "input",
+        action: "change->settings-form#autoSave"
+      } %>
+
+  <p class="text-sm text-gray-400">Most preferred first. Drag rows into place or use the arrow buttons.</p>
+
+  <div class="space-y-2" data-download-type-preferences-target="list">
+    <% ordered_types.each do |type| %>
+      <% option = SettingsService::DOWNLOAD_TYPE_OPTIONS.fetch(type) %>
+      <div class="flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800/80 px-3 py-3"
+           draggable="true"
+           data-download-type-preferences-target="item"
+           data-type="<%= type %>"
+           data-action="dragstart->download-type-preferences#dragStart dragover->download-type-preferences#dragOver drop->download-type-preferences#drop dragend->download-type-preferences#dragEnd">
+        <button type="button"
+                class="cursor-grab text-gray-500 hover:text-gray-300"
+                aria-label="Drag <%= option[:label] %>">
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" />
+          </svg>
+        </button>
+
+        <div class="min-w-0 flex-grow">
+          <p class="text-sm font-medium text-white"><%= option[:label] %></p>
+          <p class="text-xs text-gray-400"><%= option[:description] %></p>
+        </div>
+
+        <div class="flex items-center gap-1">
+          <button type="button"
+                  class="rounded-md p-2 text-gray-400 transition hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                  data-action="click->download-type-preferences#moveUp"
+                  data-download-type-preferences-target="moveUpButton"
+                  aria-label="Move <%= option[:label] %> up">
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+            </svg>
+          </button>
+          <button type="button"
+                  class="rounded-md p-2 text-gray-400 transition hover:bg-gray-700 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                  data-action="click->download-type-preferences#moveDown"
+                  data-download-type-preferences-target="moveDownButton"
+                  aria-label="Move <%= option[:label] %> down">
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -1,5 +1,31 @@
+<%
+  # Define which categories belong to each tab
+  tab_groups = {
+    "search" => {
+      label: "Search",
+      categories: %w[indexer anna_archive language auto_select]
+    },
+    "downloads" => {
+      label: "Downloads",
+      categories: %w[download paths format_preferences]
+    },
+    "integrations" => {
+      label: "Integrations",
+      categories: %w[audiobookshelf hardcover open_library]
+    },
+    "system" => {
+      label: "Queue & System",
+      categories: %w[queue health updates]
+    },
+    "security" => {
+      label: "Security",
+      categories: %w[security oidc webhook]
+    }
+  }
+%>
+
 <%= form_with url: bulk_update_admin_settings_path, method: :patch, data: { settings_form_target: "form" } do |form| %>
-  <div class="flex justify-between items-center mb-8">
+  <div class="flex justify-between items-center mb-6">
     <h1 class="font-bold text-4xl text-white">Settings</h1>
     <div class="flex items-center gap-4">
       <span data-settings-form-target="status" class="text-sm text-gray-500 hidden">Saving...</span>
@@ -7,150 +33,178 @@
     </div>
   </div>
 
-  <%= render "admin/settings/indexer_section", form: form, settings: @settings_by_category["indexer"] || {} %>
-
-  <% @settings_by_category.each do |category, settings| %>
-    <% next if category == "indexer" %>
-    <% if category == "format_preferences" %>
-      <%= render "admin/settings/format_preferences_section", form: form, settings: settings %>
-      <% next %>
-    <% end %>
-    <div class="bg-gray-900 rounded-lg border border-gray-800 mb-6">
-      <div class="px-6 py-4 border-b border-gray-800">
-        <h2 class="font-bold text-xl text-white"><%= SettingsService::CATEGORIES[category] || category.titleize %></h2>
-      </div>
-      <div class="p-6 space-y-6">
-        <% settings.each do |key, data| %>
-          <div class="flex flex-col md:flex-row md:items-start gap-4">
-            <div class="md:w-1/3">
-              <label for="settings_<%= key %>" class="font-medium text-gray-300"><%= key.to_s.titleize %></label>
-              <p class="text-sm text-gray-500"><%= data[:definition][:description] %></p>
-            </div>
-            <div class="md:w-2/3">
-              <% case data[:definition][:type] %>
-              <% when "boolean" %>
-                <% if key.to_s == "auth_disabled" %>
-                  <label class="inline-flex items-center gap-2 cursor-pointer">
-                    <%= form.check_box "settings[#{key}]", { checked: data[:value] == true || data[:value] == "true", id: "settings_#{key}", class: "w-5 h-5 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-2", data: { action: "change->settings-form#handleAuthDisabledToggle" } }, "true", "false" %>
-                  </label>
-                  <p class="mt-2 text-sm text-yellow-500">Warning: This removes password and 2FA authentication. Confirm carefully.</p>
-                <% else %>
-                <label class="inline-flex items-center cursor-pointer">
-                  <%= form.check_box "settings[#{key}]", { checked: data[:value] == true || data[:value] == "true", id: "settings_#{key}", class: "w-5 h-5 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-2", data: { action: "change->settings-form#autoSave" } }, "true", "false" %>
-                </label>
-                <% end %>
-              <% when "integer" %>
-                <%= form.number_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-              <% when "json" %>
-                <%= form.text_field "settings[#{key}]", value: data[:value].is_a?(Array) ? data[:value].join(', ') : data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                <p class="mt-1 text-xs text-gray-500">For multiple values, use comma-separated format (e.g., en, fr, de)</p>
-              <% else %>
-                <% if key.to_s.end_with?("_library_id") && @audiobookshelf_libraries.any? %>
-                  <%# Library picker dropdown when Audiobookshelf is configured %>
-                  <% library_options = @audiobookshelf_libraries.map { |lib| ["#{lib.name} (#{lib.media_type})", lib.id] } %>
-                  <%= form.select "settings[#{key}]", options_for_select([["Select a library...", ""]] + library_options, data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                <% elsif key.to_s.end_with?("_library_id") %>
-                  <%# Library ID text field when Audiobookshelf is not configured %>
-                  <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure Audiobookshelf URL and API key first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                  <p class="mt-1 text-xs text-yellow-500">Enter Audiobookshelf URL and API key above to select from available libraries</p>
-                <% elsif key.to_s == "oidc_default_role" %>
-                  <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                <% elsif key.to_s.include?("password") || key.to_s.include?("api_key") || key.to_s.include?("token") || key.to_s.include?("secret") %>
-                  <%= form.password_field "settings[#{key}]", value: data[:value], placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                <% else %>
-                  <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                <% end %>
-              <% end %>
-            </div>
-          </div>
+  <%# Tab navigation %>
+  <div data-controller="settings-tabs" data-settings-tabs-active-value="search">
+    <div class="border-b border-gray-800 mb-6">
+      <nav class="flex gap-1 -mb-px overflow-x-auto" role="tablist">
+        <% tab_groups.each do |tab_key, tab_config| %>
+          <button type="button"
+              data-settings-tabs-target="tab"
+              data-tab="<%= tab_key %>"
+              data-action="click->settings-tabs#switch"
+              role="tab"
+              class="px-4 py-3 text-sm font-medium border-b-2 transition whitespace-nowrap
+                     <%= tab_key == 'search' ? 'border-blue-500 text-blue-400' : 'border-transparent text-gray-400 hover:text-gray-300 hover:border-gray-600' %>">
+            <%= tab_config[:label] %>
+          </button>
         <% end %>
-
-        <%# Test connection buttons for services - using link_to with turbo-method to avoid nested forms %>
-        <% if category == "anna_archive" %>
-          <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
-            <div class="md:w-1/3">
-              <span class="font-medium text-gray-300">Test FlareSolverr</span>
-              <p class="text-sm text-gray-500">Verify FlareSolverr is reachable (required to bypass DDoS protection)</p>
-            </div>
-            <div class="md:w-2/3">
-              <%= link_to "Test FlareSolverr Connection", test_flaresolverr_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
-            </div>
-          </div>
-        <% elsif category == "audiobookshelf" %>
-          <div class="grid grid-cols-1 gap-2 border-t border-gray-800 pt-4">
-            <div class="space-y-2">
-              <p class="text-sm text-gray-300 font-medium">Library Sync</p>
-              <% if @audiobookshelf_library_items_count.to_i > 0 %>
-                <p class="text-xs text-gray-500">
-                  Cached items: <%= @audiobookshelf_library_items_count %> ·
-                  Last synced: <%= @audiobookshelf_library_items_last_synced_at ? time_ago_in_words(@audiobookshelf_library_items_last_synced_at) + " ago" : "never" %>
-                </p>
-              <% else %>
-                <p class="text-xs text-gray-500">
-                  No cached items yet. Run a sync to populate.
-                </p>
-              <% end %>
-              <%= link_to "Sync Audiobookshelf Library", sync_audiobookshelf_library_admin_settings_path, data: { turbo_method: :post }, class: "inline-block rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm cursor-pointer" %>
-            </div>
-            <div>
-              <% if @audiobookshelf_library_items.any? %>
-                <p class="text-xs text-gray-400 mb-2">Recent cached items:</p>
-                <ul class="space-y-1 max-h-32 overflow-y-auto">
-                  <% @audiobookshelf_library_items.each do |item| %>
-                    <li class="text-xs text-gray-300 truncate">
-                      <% item_label = [item.title, item.author].compact.join(" · ").truncate(90) %>
-                      <% if item.audiobookshelf_url.present? %>
-                        <%= link_to item_label, item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "text-blue-400 hover:text-blue-300 underline" %>
-                      <% else %>
-                        <%= item_label %>
-                      <% end %>
-                    </li>
-                  <% end %>
-                </ul>
-              <% end %>
-            </div>
-          </div>
-          <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
-            <div class="md:w-1/3">
-              <span class="font-medium text-gray-300">Test Connection</span>
-              <p class="text-sm text-gray-500">Verify Audiobookshelf is reachable</p>
-            </div>
-            <div class="md:w-2/3">
-              <%= link_to "Test Audiobookshelf Connection", test_audiobookshelf_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
-            </div>
-          </div>
-        <% elsif category == "hardcover" %>
-          <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
-            <div class="md:w-1/3">
-              <span class="font-medium text-gray-300">Test Connection</span>
-              <p class="text-sm text-gray-500">Verify Hardcover API token is valid</p>
-            </div>
-            <div class="md:w-2/3">
-              <%= link_to "Test Hardcover Connection", test_hardcover_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
-            </div>
-          </div>
-        <% elsif category == "webhook" %>
-          <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
-            <div class="md:w-1/3">
-              <span class="font-medium text-gray-300">Test Webhook</span>
-              <p class="text-sm text-gray-500">Send a sample JSON webhook payload using the current settings</p>
-            </div>
-            <div class="md:w-2/3">
-              <%= link_to "Send Test Webhook", test_webhook_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
-            </div>
-          </div>
-        <% elsif category == "oidc" %>
-          <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
-            <div class="md:w-1/3">
-              <span class="font-medium text-gray-300">Test Configuration</span>
-              <p class="text-sm text-gray-500">Verify OIDC provider discovery works</p>
-            </div>
-            <div class="md:w-2/3">
-              <%= link_to "Test OIDC Configuration", test_oidc_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
-            </div>
-          </div>
-        <% end %>
-      </div>
+      </nav>
     </div>
-  <% end %>
+
+    <%# Tab panels — all rendered in DOM so form fields are always submitted %>
+    <% tab_groups.each do |tab_key, tab_config| %>
+      <div data-settings-tabs-target="panel"
+           data-tab="<%= tab_key %>"
+           role="tabpanel"
+           class="space-y-6">
+
+        <% tab_config[:categories].each do |category| %>
+          <% settings = @settings_by_category[category] || {} %>
+          <% next if settings.empty? && category != "indexer" %>
+
+          <% if category == "indexer" %>
+            <%= render "admin/settings/indexer_section", form: form, settings: @settings_by_category["indexer"] || {} %>
+          <% elsif category == "format_preferences" %>
+            <%= render "admin/settings/format_preferences_section", form: form, settings: settings %>
+          <% else %>
+            <div class="bg-gray-900 rounded-lg border border-gray-800">
+              <div class="px-6 py-4 border-b border-gray-800">
+                <h2 class="font-bold text-xl text-white"><%= SettingsService::CATEGORIES[category] || category.titleize %></h2>
+              </div>
+              <div class="p-6 space-y-6">
+                <% settings.each do |key, data| %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4">
+                    <div class="md:w-1/3">
+                      <label for="settings_<%= key %>" class="font-medium text-gray-300"><%= key.to_s.titleize %></label>
+                      <p class="text-sm text-gray-500"><%= data[:definition][:description] %></p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <% case data[:definition][:type] %>
+                      <% when "boolean" %>
+                        <% if key.to_s == "auth_disabled" %>
+                          <label class="inline-flex items-center gap-2 cursor-pointer">
+                            <%= form.check_box "settings[#{key}]", { checked: data[:value] == true || data[:value] == "true", id: "settings_#{key}", class: "w-5 h-5 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-2", data: { action: "change->settings-form#handleAuthDisabledToggle" } }, "true", "false" %>
+                          </label>
+                          <p class="mt-2 text-sm text-yellow-500">Warning: This removes password and 2FA authentication. Confirm carefully.</p>
+                        <% else %>
+                        <label class="inline-flex items-center cursor-pointer">
+                          <%= form.check_box "settings[#{key}]", { checked: data[:value] == true || data[:value] == "true", id: "settings_#{key}", class: "w-5 h-5 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-2", data: { action: "change->settings-form#autoSave" } }, "true", "false" %>
+                        </label>
+                        <% end %>
+                      <% when "integer" %>
+                        <%= form.number_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                      <% when "json" %>
+                        <%= form.text_field "settings[#{key}]", value: data[:value].is_a?(Array) ? data[:value].join(', ') : data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <p class="mt-1 text-xs text-gray-500">For multiple values, use comma-separated format (e.g., en, fr, de)</p>
+                      <% else %>
+                        <% if key.to_s.end_with?("_library_id") && @audiobookshelf_libraries.any? %>
+                          <% library_options = @audiobookshelf_libraries.map { |lib| ["#{lib.name} (#{lib.media_type})", lib.id] } %>
+                          <%= form.select "settings[#{key}]", options_for_select([["Select a library...", ""]] + library_options, data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% elsif key.to_s.end_with?("_library_id") %>
+                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure Audiobookshelf URL and API key first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <p class="mt-1 text-xs text-yellow-500">Enter Audiobookshelf URL and API key above to select from available libraries</p>
+                        <% elsif key.to_s == "oidc_default_role" %>
+                          <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% elsif key.to_s.include?("password") || key.to_s.include?("api_key") || key.to_s.include?("token") || key.to_s.include?("secret") %>
+                          <%= form.password_field "settings[#{key}]", value: data[:value], placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% else %>
+                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% end %>
+                      <% end %>
+                    </div>
+                  </div>
+                <% end %>
+
+                <%# Test connection buttons for services %>
+                <% if category == "anna_archive" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test FlareSolverr</span>
+                      <p class="text-sm text-gray-500">Verify FlareSolverr is reachable (required to bypass DDoS protection)</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test FlareSolverr Connection", test_flaresolverr_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "audiobookshelf" %>
+                  <div class="grid grid-cols-1 gap-2 border-t border-gray-800 pt-4">
+                    <div class="space-y-2">
+                      <p class="text-sm text-gray-300 font-medium">Library Sync</p>
+                      <% if @audiobookshelf_library_items_count.to_i > 0 %>
+                        <p class="text-xs text-gray-500">
+                          Cached items: <%= @audiobookshelf_library_items_count %> ·
+                          Last synced: <%= @audiobookshelf_library_items_last_synced_at ? time_ago_in_words(@audiobookshelf_library_items_last_synced_at) + " ago" : "never" %>
+                        </p>
+                      <% else %>
+                        <p class="text-xs text-gray-500">
+                          No cached items yet. Run a sync to populate.
+                        </p>
+                      <% end %>
+                      <%= link_to "Sync Audiobookshelf Library", sync_audiobookshelf_library_admin_settings_path, data: { turbo_method: :post }, class: "inline-block rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                    <div>
+                      <% if @audiobookshelf_library_items.any? %>
+                        <p class="text-xs text-gray-400 mb-2">Recent cached items:</p>
+                        <ul class="space-y-1 max-h-32 overflow-y-auto">
+                          <% @audiobookshelf_library_items.each do |item| %>
+                            <li class="text-xs text-gray-300 truncate">
+                              <% item_label = [item.title, item.author].compact.join(" · ").truncate(90) %>
+                              <% if item.audiobookshelf_url.present? %>
+                                <%= link_to item_label, item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "text-blue-400 hover:text-blue-300 underline" %>
+                              <% else %>
+                                <%= item_label %>
+                              <% end %>
+                            </li>
+                          <% end %>
+                        </ul>
+                      <% end %>
+                    </div>
+                  </div>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test Connection</span>
+                      <p class="text-sm text-gray-500">Verify Audiobookshelf is reachable</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test Audiobookshelf Connection", test_audiobookshelf_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "hardcover" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test Connection</span>
+                      <p class="text-sm text-gray-500">Verify Hardcover API token is valid</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test Hardcover Connection", test_hardcover_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "webhook" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test Webhook</span>
+                      <p class="text-sm text-gray-500">Send a sample JSON webhook payload using the current settings</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Send Test Webhook", test_webhook_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "oidc" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test Configuration</span>
+                      <p class="text-sm text-gray-500">Verify OIDC provider discovery works</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test OIDC Configuration", test_oidc_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -11,6 +11,10 @@
 
   <% @settings_by_category.each do |category, settings| %>
     <% next if category == "indexer" %>
+    <% if category == "format_preferences" %>
+      <%= render "admin/settings/format_preferences_section", form: form, settings: settings %>
+      <% next %>
+    <% end %>
     <div class="bg-gray-900 rounded-lg border border-gray-800 mb-6">
       <div class="px-6 py-4 border-b border-gray-800">
         <h2 class="font-bold text-xl text-white"><%= SettingsService::CATEGORIES[category] || category.titleize %></h2>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -79,6 +79,9 @@
                       <p class="text-sm text-gray-500"><%= data[:definition][:description] %></p>
                     </div>
                     <div class="md:w-2/3">
+                      <% if key.to_s == "preferred_download_types" %>
+                        <%= render "admin/settings/download_type_preferences_field", form: form, key: key, ordered_types: SettingsService.preferred_download_types %>
+                      <% else %>
                       <% case data[:definition][:type] %>
                       <% when "boolean" %>
                         <% if key.to_s == "auth_disabled" %>
@@ -110,6 +113,7 @@
                         <% else %>
                           <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% end %>
+                      <% end %>
                       <% end %>
                     </div>
                   </div>

--- a/app/views/admin/settings/_format_preferences_section.html.erb
+++ b/app/views/admin/settings/_format_preferences_section.html.erb
@@ -1,7 +1,7 @@
 <% audiobook_settings = settings.select { |key, _| key.to_s.start_with?("audiobook_") } %>
 <% ebook_settings = settings.select { |key, _| key.to_s.start_with?("ebook_") } %>
 
-<div class="bg-gray-900 rounded-lg border border-gray-800 mb-6">
+<div class="bg-gray-900 rounded-lg border border-gray-800">
   <div class="px-6 py-4 border-b border-gray-800">
     <h2 class="font-bold text-xl text-white"><%= SettingsService::CATEGORIES["format_preferences"] %></h2>
     <p class="mt-1 text-sm text-gray-500">Control which formats can be auto-selected and how matching releases should be ranked.</p>

--- a/app/views/admin/settings/_format_preferences_section.html.erb
+++ b/app/views/admin/settings/_format_preferences_section.html.erb
@@ -1,0 +1,49 @@
+<% audiobook_settings = settings.select { |key, _| key.to_s.start_with?("audiobook_") } %>
+<% ebook_settings = settings.select { |key, _| key.to_s.start_with?("ebook_") } %>
+
+<div class="bg-gray-900 rounded-lg border border-gray-800 mb-6">
+  <div class="px-6 py-4 border-b border-gray-800">
+    <h2 class="font-bold text-xl text-white"><%= SettingsService::CATEGORIES["format_preferences"] %></h2>
+    <p class="mt-1 text-sm text-gray-500">Control which formats can be auto-selected and how matching releases should be ranked.</p>
+  </div>
+
+  <div class="p-6 space-y-6">
+    <div class="grid gap-6 lg:grid-cols-2">
+      <% [["Audiobooks", audiobook_settings], ["Ebooks", ebook_settings]].each do |label, group| %>
+        <div class="rounded-xl border border-gray-800 bg-gray-950/70 p-5 space-y-5">
+          <div>
+            <h3 class="text-lg font-semibold text-white"><%= label %></h3>
+            <p class="mt-1 text-sm text-gray-500">
+              <% if label == "Audiobooks" %>
+                Use file extensions plus optional structure and bitrate hints from the release title.
+              <% else %>
+                Use file extensions detected in the release title.
+              <% end %>
+            </p>
+          </div>
+
+          <% group.each do |key, data| %>
+            <div class="space-y-2">
+              <label for="settings_<%= key %>" class="font-medium text-gray-300"><%= key.to_s.humanize %></label>
+              <p class="text-sm text-gray-500"><%= data[:definition][:description] %></p>
+
+              <% if data[:definition][:type] == "boolean" %>
+                <label class="inline-flex items-center cursor-pointer">
+                  <%= form.check_box "settings[#{key}]", { checked: data[:value] == true || data[:value] == "true", id: "settings_#{key}", class: "w-5 h-5 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-2", data: { action: "change->settings-form#autoSave" } }, "true", "false" %>
+                </label>
+              <% else %>
+                <% field_value = data[:value].is_a?(Array) ? data[:value].join(", ") : data[:value] %>
+                <%= form.text_field "settings[#{key}]", value: field_value, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                <p class="text-xs text-gray-500">Use comma-separated extensions such as <%= label == "Audiobooks" ? "m4b, mp3" : "epub, pdf" %>.</p>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="rounded-xl border border-gray-800 bg-gray-950/70 px-4 py-3 text-sm text-gray-400">
+      Auto-selection treats rejected formats as manual-review-only. Preferred formats still remain manually selectable even when they rank lower.
+    </div>
+  </div>
+</div>

--- a/app/views/admin/settings/_indexer_section.html.erb
+++ b/app/views/admin/settings/_indexer_section.html.erb
@@ -1,7 +1,7 @@
 <% selected_provider = SettingsService.active_indexer_provider %>
 <% indexer_provider_value = settings.dig(:indexer_provider, :value).presence || selected_provider %>
 
-<div class="bg-gray-900 rounded-lg border border-gray-800 mb-6">
+<div class="bg-gray-900 rounded-lg border border-gray-800">
   <div class="px-6 py-4 border-b border-gray-800">
     <h2 class="font-bold text-xl text-white">Indexer</h2>
   </div>

--- a/app/views/profiles/link_oidc_redirect.html.erb
+++ b/app/views/profiles/link_oidc_redirect.html.erb
@@ -1,0 +1,23 @@
+<div class="mx-auto max-w-xl">
+  <div class="rounded-2xl border border-gray-800 bg-gray-900 p-8 shadow-sm" data-controller="oidc-redirect">
+    <h1 class="text-3xl font-bold text-white">Link <%= SettingsService.get(:oidc_provider_name, default: "SSO") %> to your account</h1>
+    <p class="mt-3 text-sm text-gray-400">
+      You are about to connect your current Shelfarr account to your OIDC login. Your existing role and profile stay the same.
+    </p>
+
+    <div class="mt-8 space-y-4">
+      <%= button_to "/auth/oidc",
+          method: :post,
+          form: { data: { oidc_redirect_target: "form", turbo: false } },
+          class: "w-full rounded-lg bg-blue-600 px-5 py-3 text-center font-medium text-white transition hover:bg-blue-500" do %>
+        Continue to <%= SettingsService.get(:oidc_provider_name, default: "SSO") %>
+      <% end %>
+
+      <%= link_to "Cancel", profile_path, class: "inline-flex text-sm text-gray-400 transition hover:text-white" %>
+    </div>
+
+    <p class="mt-6 text-xs text-gray-500">
+      If the sign-in fails, you will be returned without changing your current local account.
+    </p>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -55,12 +55,32 @@
             <% end %>
           </dd>
         </div>
+        <% if SettingsService.oidc_configured? %>
+          <div>
+            <dt class="text-gray-500">OIDC Sign-In</dt>
+            <dd class="font-medium">
+              <% if @user.oidc_user? %>
+                <span class="inline-flex items-center text-green-400">
+                  <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                  </svg>
+                  Linked to <%= SettingsService.get(:oidc_provider_name, default: "SSO") %>
+                </span>
+              <% else %>
+                <span class="text-gray-500">Not linked</span>
+              <% end %>
+            </dd>
+          </div>
+        <% end %>
       </dl>
     </div>
 
     <div class="px-6 py-4 bg-gray-800 border-t border-gray-700 flex flex-wrap gap-4">
       <%= link_to "Edit Profile", edit_profile_path, class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition" %>
       <%= link_to "Change Password", password_profile_path, class: "px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 font-medium rounded-lg transition" %>
+      <% if SettingsService.oidc_configured? && !@user.oidc_user? %>
+        <%= button_to "Link OIDC Login", link_oidc_profile_path, method: :post, form: { data: { turbo: false } }, class: "px-4 py-2 bg-indigo-700 hover:bg-indigo-600 text-white font-medium rounded-lg transition cursor-pointer" %>
+      <% end %>
       <%= link_to two_factor_profile_path, class: "px-4 py-2 #{@user.otp_enabled? ? 'bg-green-900/50 text-green-400 hover:bg-green-900/70' : 'bg-yellow-900/50 text-yellow-400 hover:bg-yellow-900/70'} font-medium rounded-lg transition" do %>
         <span class="flex items-center">
           <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -70,5 +90,24 @@
         </span>
       <% end %>
     </div>
+
+    <% if SettingsService.oidc_configured? && @user.oidc_user? %>
+      <div class="border-t border-gray-700 bg-gray-900/40 px-6 py-5">
+        <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div class="max-w-xl">
+            <p class="text-sm font-medium text-gray-200">Linked OIDC account</p>
+            <p class="mt-1 text-sm text-gray-400">
+              This account is linked to <%= SettingsService.get(:oidc_provider_name, default: "SSO") %>.
+              Enter your current local password to remove the link and return to password-only sign-in for this account.
+            </p>
+          </div>
+
+          <%= form_with url: unlink_oidc_profile_path, method: :delete, class: "flex w-full flex-col gap-3 md:w-auto md:min-w-[24rem] md:flex-row" do |form| %>
+            <%= form.password_field :current_password, required: !SettingsService.auth_disabled?, autocomplete: "current-password", placeholder: "Current password", class: "w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+            <%= form.submit "Unlink OIDC Login", class: "rounded-lg bg-red-700 px-4 py-2 font-medium text-white transition hover:bg-red-600 cursor-pointer whitespace-nowrap" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/requests/_search_result_row.html.erb
+++ b/app/views/requests/_search_result_row.html.erb
@@ -21,8 +21,25 @@
           Score: <%= result.confidence_score %>%
         </span>
       <% end %>
+      <% if result.primary_extension.present? %>
+        <span class="text-gray-300"><%= result.primary_extension.upcase %></span>
+      <% end %>
+      <% if result.audiobook_structure.present? %>
+        <span class="text-gray-300"><%= result.audiobook_structure == :single_file ? "Single file" : "Multi-file" %></span>
+      <% end %>
+      <% if result.audio_bitrate_kbps.present? %>
+        <span class="text-gray-300"><%= result.audio_bitrate_kbps %> kbps</span>
+      <% end %>
       <% if result.indexer.present? %>
         <span class="text-gray-500"><%= result.indexer %></span>
+      <% end %>
+      <% if result.preference_adjustment != 0 %>
+        <span class="<%= result.preference_adjustment.positive? ? 'text-blue-400' : 'text-red-400' %>">
+          Pref <%= result.preference_adjustment.positive? ? '+' : '' %><%= result.preference_adjustment %>
+        </span>
+      <% end %>
+      <% unless result.auto_select_allowed_by_preferences? %>
+        <span class="text-red-400 font-medium">Manual review</span>
       <% end %>
     </div>
   </div>
@@ -39,6 +56,8 @@
       <span class="px-2 py-1 text-xs bg-gray-700 text-gray-500 rounded">No link</span>
     <% elsif result.selected? %>
       <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
+    <% elsif result.rejected? %>
+      <span class="px-2 py-1 text-xs bg-gray-700 text-gray-400 rounded">Skipped</span>
     <% end %>
   </div>
 </div>

--- a/app/views/requests/_search_result_row.html.erb
+++ b/app/views/requests/_search_result_row.html.erb
@@ -30,33 +30,33 @@
       <% if result.audio_bitrate_kbps.present? %>
         <span class="text-gray-300"><%= result.audio_bitrate_kbps %> kbps</span>
       <% end %>
-      <% if result.indexer.present? %>
+      <% if Current.user.admin? && result.indexer.present? %>
         <span class="text-gray-500"><%= result.indexer %></span>
       <% end %>
-      <% if result.preference_adjustment != 0 %>
+      <% if Current.user.admin? && result.preference_adjustment != 0 %>
         <span class="<%= result.preference_adjustment.positive? ? 'text-blue-400' : 'text-red-400' %>">
           Pref <%= result.preference_adjustment.positive? ? '+' : '' %><%= result.preference_adjustment %>
         </span>
       <% end %>
-      <% unless result.auto_select_allowed_by_preferences? %>
+      <% if Current.user.admin? && !result.auto_select_allowed_by_preferences? %>
         <span class="text-red-400 font-medium">Manual review</span>
       <% end %>
     </div>
   </div>
   <div class="flex-shrink-0 flex items-center gap-2">
-    <% if result.info_url.present? %>
+    <% if Current.user.admin? && result.info_url.present? %>
       <%= link_to "Info", result.info_url, target: "_blank", rel: "noopener",
           class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
     <% end %>
-    <% if result.pending? && result.downloadable? %>
+    <% if Current.user.admin? && result.pending? && result.downloadable? %>
       <%= button_to "Select", select_admin_request_search_result_path(request, result),
           method: :post,
           class: "px-2 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
-    <% elsif result.pending? %>
+    <% elsif Current.user.admin? && result.pending? %>
       <span class="px-2 py-1 text-xs bg-gray-700 text-gray-500 rounded">No link</span>
-    <% elsif result.selected? %>
+    <% elsif Current.user.admin? && result.selected? %>
       <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
-    <% elsif result.rejected? %>
+    <% elsif Current.user.admin? && result.rejected? %>
       <span class="px-2 py-1 text-xs bg-gray-700 text-gray-400 rounded">Skipped</span>
     <% end %>
   </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -95,52 +95,61 @@
       <% end %>
 
       <% if @request.searching? && @request.search_results.any? %>
-        <div class="mb-6" data-controller="search-results" data-search-results-expanded-value="true">
-          <div class="flex items-center justify-between mb-3">
-            <h3 class="text-sm font-medium text-gray-400">
-              Search Results
-              <span class="text-gray-500">(<%= @request.search_results.count %>)</span>
-            </h3>
-            <div class="flex items-center gap-2">
-              <% if Current.user.admin? %>
+        <% if Current.user.admin? %>
+          <div class="mb-6" data-controller="search-results" data-search-results-expanded-value="true">
+            <div class="flex items-center justify-between mb-3">
+              <h3 class="text-sm font-medium text-gray-400">
+                Search Results
+                <span class="text-gray-500">(<%= @request.search_results.count %>)</span>
+              </h3>
+              <div class="flex items-center gap-2">
                 <%= button_to "Refresh Search", refresh_admin_request_search_results_path(@request),
                     method: :post, class: "px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
+                <button type="button"
+                    data-action="click->search-results#toggle"
+                    data-search-results-target="toggleBtn"
+                    class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition">
+                  Hide Results (<%= @request.search_results.count %>)
+                </button>
+              </div>
+            </div>
+
+            <div data-search-results-target="content" class="space-y-2">
+              <% @request.search_results.best_first.each do |result| %>
+                <%= render "requests/search_result_row", result: result, request: @request %>
               <% end %>
-              <button type="button"
-                  data-action="click->search-results#toggle"
-                  data-search-results-target="toggleBtn"
-                  class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition">
-                Hide Results (<%= @request.search_results.count %>)
-              </button>
+
+              <%# Pagination controls %>
+              <div data-search-results-target="pagination" class="flex items-center justify-center gap-4 pt-2 text-xs">
+                <button type="button"
+                    data-action="click->search-results#prevPage"
+                    data-search-results-target="prevBtn"
+                    class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
+                  Prev
+                </button>
+                <span data-search-results-target="pageInfo" class="text-gray-400">Page 1 of 1</span>
+                <button type="button"
+                    data-action="click->search-results#nextPage"
+                    data-search-results-target="nextBtn"
+                    class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
+                  Next
+                </button>
+              </div>
             </div>
           </div>
-
-          <div data-search-results-target="content" class="space-y-2">
-            <% if !Current.user.admin? %>
-              <p class="text-sm text-gray-500 mb-2">Waiting for admin approval.</p>
-            <% end %>
-            <% @request.search_results.best_first.each do |result| %>
-              <%= render "requests/search_result_row", result: result, request: @request %>
-            <% end %>
-
-            <%# Pagination controls %>
-            <div data-search-results-target="pagination" class="flex items-center justify-center gap-4 pt-2 text-xs">
-              <button type="button"
-                  data-action="click->search-results#prevPage"
-                  data-search-results-target="prevBtn"
-                  class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
-                Prev
-              </button>
-              <span data-search-results-target="pageInfo" class="text-gray-400">Page 1 of 1</span>
-              <button type="button"
-                  data-action="click->search-results#nextPage"
-                  data-search-results-target="nextBtn"
-                  class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
-                Next
-              </button>
+        <% else %>
+          <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
+            <div class="flex items-center">
+              <svg class="w-5 h-5 text-blue-400 mr-2 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
+              </svg>
+              <div>
+                <h3 class="text-sm font-medium text-blue-400">Search Results Available</h3>
+                <p class="text-sm text-blue-400/80 mt-1">Waiting for admin approval.</p>
+              </div>
             </div>
           </div>
-        </div>
+        <% end %>
       <% elsif @request.searching? %>
         <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
           <div class="flex items-center">

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto max-w-2xl">
+<div class="mx-auto max-w-4xl">
   <div class="mb-6">
     <%= link_to "&larr; Back to Requests".html_safe, requests_path, class: "text-blue-400 hover:text-blue-300" %>
   </div>
@@ -95,28 +95,50 @@
       <% end %>
 
       <% if @request.searching? && @request.search_results.any? %>
-        <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
-          <div class="flex items-center justify-between">
-            <div class="flex items-start">
-              <svg class="w-5 h-5 text-blue-400 mr-2 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
-              </svg>
-              <div>
-                <h3 class="text-sm font-medium text-blue-400">Search Results Available</h3>
-                <p class="text-sm text-blue-400/80 mt-1">
-                  <%= @request.search_results.count %> results found.
-                  <% if Current.user.admin? %>
-                    Select a result to begin download.
-                  <% else %>
-                    Waiting for admin approval.
-                  <% end %>
-                </p>
-              </div>
+        <div class="mb-6" data-controller="search-results" data-search-results-expanded-value="true">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium text-gray-400">
+              Search Results
+              <span class="text-gray-500">(<%= @request.search_results.count %>)</span>
+            </h3>
+            <div class="flex items-center gap-2">
+              <% if Current.user.admin? %>
+                <%= button_to "Refresh Search", refresh_admin_request_search_results_path(@request),
+                    method: :post, class: "px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
+              <% end %>
+              <button type="button"
+                  data-action="click->search-results#toggle"
+                  data-search-results-target="toggleBtn"
+                  class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition">
+                Hide Results (<%= @request.search_results.count %>)
+              </button>
             </div>
-            <% if Current.user.admin? %>
-              <%= link_to "View Results", admin_request_search_results_path(@request),
-                  class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition text-sm" %>
+          </div>
+
+          <div data-search-results-target="content" class="space-y-2">
+            <% if !Current.user.admin? %>
+              <p class="text-sm text-gray-500 mb-2">Waiting for admin approval.</p>
             <% end %>
+            <% @request.search_results.best_first.each do |result| %>
+              <%= render "requests/search_result_row", result: result, request: @request %>
+            <% end %>
+
+            <%# Pagination controls %>
+            <div data-search-results-target="pagination" class="flex items-center justify-center gap-4 pt-2 text-xs">
+              <button type="button"
+                  data-action="click->search-results#prevPage"
+                  data-search-results-target="prevBtn"
+                  class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
+                Prev
+              </button>
+              <span data-search-results-target="pageInfo" class="text-gray-400">Page 1 of 1</span>
+              <button type="button"
+                  data-action="click->search-results#nextPage"
+                  data-search-results-target="nextBtn"
+                  class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
+                Next
+              </button>
+            </div>
           </div>
         </div>
       <% elsif @request.searching? %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,12 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl text-white">Sign in</h1>
 
+  <% if params[:local].present? && SettingsService.oidc_auto_redirect? %>
+    <div class="my-4 rounded-lg border border-blue-800 bg-blue-950/40 p-3 text-sm text-blue-200">
+      SSO auto-redirect is enabled. This page is the local login fallback.
+    </div>
+  <% end %>
+
   <% if SettingsService.auth_disabled? %>
     <div class="my-4 p-3 rounded-lg bg-yellow-900/30 border border-yellow-700 text-yellow-400 text-sm">
       Authentication is disabled. Enter your username to continue.
@@ -38,7 +44,7 @@
 
     <%= form_with url: session_url, class: "contents" do |form| %>
       <div class="my-5">
-        <%= form.text_field :username, required: true, autofocus: !SettingsService.oidc_configured?, autocomplete: "username", placeholder: "Enter your username", value: params[:username], class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+        <%= form.text_field :username, required: true, autofocus: params[:local].present? || !SettingsService.oidc_configured?, autocomplete: "username", placeholder: "Enter your username", value: params[:username], class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
       </div>
 
       <div class="my-5">

--- a/app/views/sessions/oidc_redirect.html.erb
+++ b/app/views/sessions/oidc_redirect.html.erb
@@ -1,0 +1,23 @@
+<div class="mx-auto max-w-xl">
+  <div class="rounded-2xl border border-gray-800 bg-gray-900 p-8 shadow-sm" data-controller="oidc-redirect">
+    <h1 class="text-3xl font-bold text-white">Redirecting to <%= SettingsService.get(:oidc_provider_name, default: "SSO") %></h1>
+    <p class="mt-3 text-sm text-gray-400">
+      Shelfarr is configured to use single sign-on for the default login flow.
+    </p>
+
+    <div class="mt-8 space-y-4">
+      <%= button_to "/auth/oidc",
+          method: :post,
+          form: { data: { oidc_redirect_target: "form", turbo: false } },
+          class: "w-full rounded-lg bg-blue-600 px-5 py-3 text-center font-medium text-white transition hover:bg-blue-500" do %>
+        Continue to <%= SettingsService.get(:oidc_provider_name, default: "SSO") %>
+      <% end %>
+
+      <%= link_to "Use local sign-in instead", new_session_path(local: 1), class: "inline-flex text-sm text-gray-400 transition hover:text-white" %>
+    </div>
+
+    <p class="mt-6 text-xs text-gray-500">
+      If your identity provider is unavailable or you need local access, use the local sign-in link.
+    </p>
+  </div>
+</div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,15 +10,25 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  queue:
+    <<: *default
+    database: storage/development_queue.sqlite3
+    migrations_paths: db/queue_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: storage/test.sqlite3
+  primary:
+    <<: *default
+    database: storage/test.sqlite3
+  queue:
+    <<: *default
+    database: storage/test_queue.sqlite3
+    migrations_paths: db/queue_migrate
 
 
 # Store production database in the storage/ directory, which by default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,6 +78,7 @@ Rails.application.configure do
 
   # Use Solid Queue for background jobs in development too
   config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Active Record Encryption - use fixed keys in development for convenience
   config.active_record.encryption.primary_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "dev_primary_key_12345678901234567890123456")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   resource :profile, only: [ :show, :edit, :update ] do
     get :password, on: :member
     patch :update_password, on: :member
+    post :link_oidc, on: :member
+    delete :unlink_oidc, on: :member
     # Two-factor authentication
     get :two_factor, on: :member
     post :enable_two_factor, on: :member

--- a/db/migrate/20260412113500_add_unique_index_to_users_oidc_identity.rb
+++ b/db/migrate/20260412113500_add_unique_index_to_users_oidc_identity.rb
@@ -1,0 +1,10 @@
+class AddUniqueIndexToUsersOidcIdentity < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :users, :oidc_uid if index_exists?(:users, :oidc_uid)
+
+    add_index :users, [ :oidc_provider, :oidc_uid ],
+      unique: true,
+      where: "deleted_at IS NULL AND oidc_provider IS NOT NULL AND oidc_uid IS NOT NULL",
+      name: "index_users_on_oidc_provider_and_uid_unique"
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,123 +1,135 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 1) do
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
     t.string "concurrency_key", null: false
-    t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
-    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    t.datetime "expires_at", null: false
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "job_id", null: false
     t.bigint "process_id"
-    t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.text "error"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    t.text "error"
+    t.bigint "job_id", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
-    t.string "queue_name", null: false
-    t.string "class_name", null: false
-    t.text "arguments"
-    t.integer "priority", default: 0, null: false
     t.string "active_job_id"
-    t.datetime "scheduled_at"
-    t.datetime "finished_at"
+    t.text "arguments"
+    t.string "class_name", null: false
     t.string "concurrency_key"
     t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at"
     t.datetime "updated_at", null: false
-    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
-    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
-    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
-    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
-    t.string "queue_name", null: false
     t.datetime "created_at", null: false
-    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    t.string "queue_name", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "hostname"
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
-    t.bigint "supervisor_id"
-    t.integer "pid", null: false
-    t.string "hostname"
     t.text "metadata"
-    t.datetime "created_at", null: false
     t.string "name", null: false
-    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+    t.integer "pid", null: false
+    t.bigint "supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
-    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "task_key", null: false
-    t.datetime "run_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    t.bigint "job_id", null: false
+    t.datetime "run_at", null: false
+    t.string "task_key", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "schedule", null: false
-    t.string "command", limit: 2048
-    t.string "class_name"
     t.text "arguments"
-    t.string "queue_name"
-    t.integer "priority", default: 0
-    t.boolean "static", default: true, null: false
-    t.text "description"
+    t.string "class_name"
+    t.string "command", limit: 2048
     t.datetime "created_at", null: false
+    t.text "description"
+    t.string "key", null: false
+    t.integer "priority", default: 0
+    t.string "queue_name"
+    t.string "schedule", null: false
+    t.boolean "static", default: true, null: false
     t.datetime "updated_at", null: false
-    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+    t.bigint "job_id", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "queue_name", null: false
+    t.datetime "scheduled_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
-    t.string "key", null: false
-    t.integer "value", default: 1, null: false
-    t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key", null: false
     t.datetime "updated_at", null: false
-    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+    t.integer "value", default: 1, null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_113500) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -258,7 +258,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_120000) do
     t.datetime "updated_at", null: false
     t.string "username", null: false
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
-    t.index ["oidc_uid"], name: "index_users_on_oidc_uid"
+    t.index ["oidc_provider", "oidc_uid"], name: "index_users_on_oidc_provider_and_uid_unique", unique: true, where: "deleted_at IS NULL AND oidc_provider IS NOT NULL AND oidc_uid IS NOT NULL"
     t.index ["role"], name: "index_users_on_role"
     t.index ["username"], name: "index_users_on_username", unique: true, where: "deleted_at IS NULL"
   end

--- a/test/controllers/admin/search_results_controller_test.rb
+++ b/test/controllers/admin/search_results_controller_test.rb
@@ -65,7 +65,7 @@ module Admin
       assert_response :success
 
       assert_match @pending_result.indexer, response.body
-      assert_match(/seeders/, response.body)
+      assert_match(/seeds/, response.body)
     end
 
     # === Select ===

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -64,6 +64,28 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: /Automatically enqueue search immediately for requests created by non-admin users/
   end
 
+  test "index shows ordered download type preferences" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "input[name='settings[preferred_download_types]'][type='hidden']"
+    assert_select "p", text: /Most preferred first/
+    assert_select "p", text: "Torrent"
+    assert_select "p", text: "Usenet"
+    assert_select "p", text: "Direct"
+  end
+
+  test "bulk_update stores ordered download type preferences" do
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        preferred_download_types: %w[direct usenet torrent]
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal %w[direct usenet torrent], SettingsService.preferred_download_types
+  end
+
   test "index shows library picker dropdown when audiobookshelf configured" do
     SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
     SettingsService.set(:audiobookshelf_api_key, "test-api-key")

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -75,6 +75,15 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: "Direct"
   end
 
+  test "index shows OIDC auto redirect setting" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label", text: "Oidc Auto Redirect"
+    assert_select "input[name='settings[oidc_auto_redirect]']"
+    assert_select "p", text: /Use \/session\/new\?local=1/
+  end
+
   test "bulk_update stores ordered download type preferences" do
     patch bulk_update_admin_settings_url, params: {
       settings: {
@@ -84,6 +93,17 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_settings_path
     assert_equal %w[direct usenet torrent], SettingsService.preferred_download_types
+  end
+
+  test "bulk_update stores OIDC auto redirect setting" do
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        oidc_auto_redirect: "true"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal true, SettingsService.get(:oidc_auto_redirect)
   end
 
   test "index shows library picker dropdown when audiobookshelf configured" do
@@ -382,7 +402,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
         .with(headers: { "Authorization" => "Bearer test-api-key" })
         .to_return(
           status: 200,
-          body: { "libraries" => [{ "id" => "lib1", "name" => "Test" }] }.to_json,
+          body: { "libraries" => [ { "id" => "lib1", "name" => "Test" } ] }.to_json,
           headers: { "Content-Type" => "application/json" }
         )
 
@@ -583,7 +603,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
         .with(headers: { "Authorization" => "Bearer test-api-key" })
         .to_return(
           status: 200,
-          body: { "libraries" => [{ "id" => "lib1", "name" => "Test" }] }.to_json,
+          body: { "libraries" => [ { "id" => "lib1", "name" => "Test" } ] }.to_json,
           headers: { "Content-Type" => "application/json" }
         )
 

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -125,11 +125,80 @@ class Auth::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_match(/locked/i, flash[:alert])
   end
 
+  test "OIDC callback links current signed-in user when link flow is pending" do
+    user = users(:one)
+    sign_in_as(user)
+    post link_oidc_profile_path
+    assert_equal user.id, session[:pending_oidc_link_user_id]
+
+    OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new({
+      provider: "oidc",
+      uid: "linked-user-uid",
+      info: {
+        email: "test@example.com",
+        name: "Linked User"
+      }
+    })
+
+    get "/auth/oidc/callback"
+
+    assert_redirected_to profile_path
+    assert_match(/now linked/i, flash[:notice])
+    assert_equal "oidc", user.reload.oidc_provider
+    assert_equal "linked-user-uid", user.oidc_uid
+    assert_nil session[:pending_oidc_link_user_id]
+  end
+
+  test "OIDC callback refuses to link identity that belongs to another user" do
+    user = users(:one)
+    other_user = users(:two)
+    other_user.update!(oidc_provider: "oidc", oidc_uid: "shared-uid")
+
+    sign_in_as(user)
+    post link_oidc_profile_path
+
+    OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new({
+      provider: "oidc",
+      uid: "shared-uid",
+      info: {
+        email: "admin@example.com",
+        name: "Existing OIDC User"
+      }
+    })
+
+    get "/auth/oidc/callback"
+
+    assert_redirected_to profile_path
+    assert_match(/already linked to another/i, flash[:alert])
+    assert_nil user.reload.oidc_uid
+  end
+
   test "failure endpoint handles OIDC errors" do
     get "/auth/failure", params: { message: "invalid_credentials" }
 
     assert_redirected_to new_session_path
     assert_match(/invalid_credentials/i, flash[:alert])
+  end
+
+  test "failure endpoint redirects to local bypass when OIDC auto redirect is enabled" do
+    SettingsService.set(:oidc_auto_redirect, true)
+
+    get "/auth/failure", params: { message: "invalid_credentials" }
+
+    assert_redirected_to new_session_path(local: 1)
+    assert_match(/invalid_credentials/i, flash[:alert])
+  end
+
+  test "failure endpoint returns to profile when OIDC link flow is pending" do
+    user = users(:one)
+    sign_in_as(user)
+    post link_oidc_profile_path
+
+    get "/auth/failure", params: { message: "invalid_credentials" }
+
+    assert_redirected_to profile_path
+    assert_match(/invalid_credentials/i, flash[:alert])
+    assert_nil session[:pending_oidc_link_user_id]
   end
 
   test "OIDC callback without auth hash redirects with error" do
@@ -144,5 +213,24 @@ class Auth::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
 
     # Then our failure handler redirects to login
     assert_redirected_to new_session_path
+  end
+
+  test "OIDC callback user-not-found failure redirects to local bypass when auto redirect is enabled" do
+    SettingsService.set(:oidc_auto_redirect, true)
+    SettingsService.set(:oidc_auto_create_users, false)
+
+    OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new({
+      provider: "oidc",
+      uid: "unknown-uid",
+      info: {
+        email: "newuser@example.com",
+        name: "New User"
+      }
+    })
+
+    get "/auth/oidc/callback"
+
+    assert_redirected_to new_session_path(local: 1)
+    assert_match(/not found/i, flash[:alert])
   end
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -10,6 +10,10 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
     sign_in_as(@user)
+    SettingsService.set(:oidc_enabled, false)
+    SettingsService.set(:oidc_issuer, "")
+    SettingsService.set(:oidc_client_id, "")
+    SettingsService.set(:oidc_client_secret, "")
   end
 
   test "show requires authentication" do
@@ -38,6 +42,35 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     get profile_path
     assert_response :success
     assert_select "dt", "Two-Factor Authentication"
+  end
+
+  test "show displays OIDC link button when OIDC is configured and user is not linked" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+
+    get profile_path
+
+    assert_response :success
+    assert_select "dt", "OIDC Sign-In"
+    assert_select "form[action='#{link_oidc_profile_path}']"
+    assert_select "button", "Link OIDC Login"
+  end
+
+  test "show displays linked OIDC status when account is already linked" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+    @user.update!(oidc_provider: "oidc", oidc_uid: "linked-uid")
+
+    get profile_path
+
+    assert_response :success
+    assert_select "dd", /Linked to/
+    assert_select "form[action='#{link_oidc_profile_path}']", count: 0
+    assert_select "form[action='#{unlink_oidc_profile_path}']"
   end
 
   test "edit displays form" do
@@ -119,6 +152,73 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
       user: { password: "alllowercase123", password_confirmation: "alllowercase123" }
     }
     assert_response :unprocessable_entity
+  end
+
+  test "link_oidc requires configured OIDC" do
+    post link_oidc_profile_path
+
+    assert_redirected_to profile_path
+    assert_match(/must be fully configured/i, flash[:alert])
+  end
+
+  test "link_oidc starts OIDC linking flow for current user" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+
+    post link_oidc_profile_path
+
+    assert_response :success
+    assert_equal @user.id, session[:pending_oidc_link_user_id]
+    assert_select "h1", /Link/
+    assert_select "form[action='/auth/oidc']"
+    assert_select "a[href='#{profile_path}']", text: "Cancel"
+  end
+
+  test "link_oidc returns to profile when account is already linked" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+    @user.update!(oidc_provider: "oidc", oidc_uid: "linked-uid")
+
+    post link_oidc_profile_path
+
+    assert_redirected_to profile_path
+    assert_match(/already linked/i, flash[:notice])
+  end
+
+  test "unlink_oidc requires current password when auth is enabled" do
+    @user.update!(oidc_provider: "oidc", oidc_uid: "linked-uid")
+
+    delete unlink_oidc_profile_path, params: { current_password: "WrongPassword123!" }
+
+    assert_redirected_to profile_path
+    assert_match(/incorrect/i, flash[:alert])
+    assert @user.reload.oidc_user?
+  end
+
+  test "unlink_oidc removes OIDC link with correct current password" do
+    @user.update!(oidc_provider: "oidc", oidc_uid: "linked-uid")
+
+    delete unlink_oidc_profile_path, params: { current_password: FIXTURE_PASSWORD }
+
+    assert_redirected_to profile_path
+    assert_match(/removed from your account/i, flash[:notice])
+    assert_not @user.reload.oidc_user?
+  end
+
+  test "unlink_oidc allows unlinking without password when auth is disabled" do
+    SettingsService.set(:auth_disabled, true)
+    @user.update!(oidc_provider: "oidc", oidc_uid: "linked-uid")
+
+    delete unlink_oidc_profile_path
+
+    assert_redirected_to profile_path
+    assert_not @user.reload.oidc_user?
+  ensure
+    SettingsService.set(:auth_disabled, false)
   end
 
   # Two-factor authentication tests

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -127,6 +127,31 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", @pending_request.book.title
   end
 
+  test "show keeps search results hidden from regular users" do
+    @pending_request.update!(status: :searching)
+
+    get request_path(@pending_request)
+    assert_response :success
+
+    assert_select "h3", text: "Search Results Available"
+    assert_select "p", text: "Waiting for admin approval."
+    assert_select "p", text: /The Pending Ebook - Complete Audiobook/, count: 0
+    assert_select "form[action='#{select_admin_request_search_result_path(@pending_request, search_results(:pending_result))}']", count: 0
+  end
+
+  test "show displays inline search results for admins" do
+    @pending_request.update!(status: :searching)
+    sign_out
+    sign_in_as(@admin)
+
+    get request_path(@pending_request)
+    assert_response :success
+
+    assert_select "h3", text: /Search Results/
+    assert_select "p", text: /The Pending Ebook - Complete Audiobook/
+    assert_select "form[action='#{select_admin_request_search_result_path(@pending_request, search_results(:pending_result))}']"
+  end
+
   test "show displays diagnostics timeline for request activity" do
     sign_out
     sign_in_as(@admin)

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -8,11 +8,64 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     @user = users(:one)
     # Ensure user is not locked
     @user.update!(failed_login_count: 0, locked_until: nil)
+    SettingsService.set(:auth_disabled, false)
+    SettingsService.set(:oidc_enabled, false)
+    SettingsService.set(:oidc_auto_redirect, false)
+    SettingsService.set(:oidc_issuer, "")
+    SettingsService.set(:oidc_client_id, "")
+    SettingsService.set(:oidc_client_secret, "")
   end
 
   test "new" do
     get new_session_path
     assert_response :success
+  end
+
+  test "new renders OIDC auto handoff when auto redirect is enabled" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_auto_redirect, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+
+    get new_session_path
+
+    assert_response :success
+    assert_select "h1", /Redirecting to/
+    assert_select "form[action='/auth/oidc']"
+    assert_select "a[href='#{new_session_path(local: 1)}']", text: /Use local sign-in instead/
+    assert_select "input[name='username']", count: 0
+  end
+
+  test "new shows local login form when local bypass is requested" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_auto_redirect, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+
+    get new_session_path, params: { local: 1 }
+
+    assert_response :success
+    assert_select "h1", "Sign in"
+    assert_select "div", text: /local login fallback/
+    assert_select "input[name='username']"
+    assert_select "input[name='password']"
+  end
+
+  test "new does not auto redirect when auth is disabled" do
+    SettingsService.set(:auth_disabled, true)
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_auto_redirect, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+
+    get new_session_path
+
+    assert_response :success
+    assert_select "div", text: /Authentication is disabled/
+    assert_select "form[action='/auth/oidc']", count: 0
   end
 
   test "create with valid credentials" do
@@ -70,6 +123,20 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     delete session_path
 
     assert_redirected_to new_session_path
+    assert_empty cookies[:session_id]
+  end
+
+  test "destroy redirects to local bypass when OIDC auto redirect is enabled" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_auto_redirect, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+    sign_in_as(@user)
+
+    delete session_path
+
+    assert_redirected_to new_session_path(local: 1)
     assert_empty cookies[:session_id]
   end
 

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -114,4 +114,24 @@ class SearchResultTest < ActiveSupport::TestCase
     result = SearchResult.new
     assert_nil result.size_human
   end
+
+  test "format helper methods read score breakdown metadata" do
+    result = SearchResult.new(
+      score_breakdown: {
+        extension: "m4b",
+        extensions: [ "m4b" ],
+        audiobook_structure: "single_file",
+        audio_bitrate_kbps: 192,
+        auto_select_allowed: false,
+        preference_adjustment: 12
+      }
+    )
+
+    assert_equal "m4b", result.primary_extension
+    assert_equal [ "m4b" ], result.detected_extensions
+    assert_equal :single_file, result.audiobook_structure
+    assert_equal 192, result.audio_bitrate_kbps
+    refute result.auto_select_allowed_by_preferences?
+    assert_equal 12, result.preference_adjustment
+  end
 end

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -7,6 +7,7 @@ class SearchResultTest < ActiveSupport::TestCase
     @pending_result = search_results(:pending_result)
     @selected_result = search_results(:selected_result)
     @no_link_result = search_results(:no_link_result)
+    Setting.where(key: %w[preferred_download_types preferred_download_type]).delete_all
   end
 
   # === Validations ===
@@ -65,6 +66,62 @@ class SearchResultTest < ActiveSupport::TestCase
     assert_equal same_seeders_small, ordered[1]
     assert_equal same_seeders_large, ordered[2]
     assert_equal low_seeders, ordered[3]
+  end
+
+  test "best_first respects ordered download type preferences" do
+    request = requests(:pending_request)
+    request.search_results.destroy_all
+
+    direct_result = request.search_results.create!(
+      guid: "direct",
+      title: "Direct result",
+      source: SearchResult::SOURCE_ANNA_ARCHIVE,
+      confidence_score: 80
+    )
+    usenet_result = request.search_results.create!(
+      guid: "usenet",
+      title: "Usenet result",
+      download_url: "http://example.com/download/test.nzb",
+      confidence_score: 80
+    )
+    torrent_result = request.search_results.create!(
+      guid: "torrent",
+      title: "Torrent result",
+      magnet_url: "magnet:?xt=urn:btih:torrent",
+      confidence_score: 80
+    )
+
+    SettingsService.set(:preferred_download_types, %w[direct usenet torrent])
+
+    assert_equal [direct_result, usenet_result, torrent_result], request.search_results.best_first.to_a
+  end
+
+  test "best_first falls back to legacy preferred download type" do
+    request = requests(:pending_request)
+    request.search_results.destroy_all
+
+    usenet_result = request.search_results.create!(
+      guid: "legacy-usenet",
+      title: "Legacy Usenet result",
+      download_url: "http://example.com/download/test.nzb",
+      confidence_score: 80
+    )
+    torrent_result = request.search_results.create!(
+      guid: "legacy-torrent",
+      title: "Legacy Torrent result",
+      magnet_url: "magnet:?xt=urn:btih:torrent",
+      confidence_score: 80
+    )
+
+    Setting.create!(
+      key: "preferred_download_type",
+      value: "usenet",
+      value_type: "string",
+      category: "download",
+      description: "Legacy preferred download type"
+    )
+
+    assert_equal [usenet_result, torrent_result], request.search_results.best_first.to_a
   end
 
   # === Methods ===

--- a/test/models/user_oidc_test.rb
+++ b/test/models/user_oidc_test.rb
@@ -36,8 +36,7 @@ class UserOidcTest < ActiveSupport::TestCase
     assert_equal user, result
   end
 
-  test "from_oidc links existing user by username derived from email" do
-    # Create user with username matching email prefix
+  test "from_oidc does not implicitly link existing user by email prefix" do
     user = User.create!(
       username: "johndoe",
       name: "John Doe",
@@ -52,9 +51,8 @@ class UserOidcTest < ActiveSupport::TestCase
 
     result = User.from_oidc(auth_hash)
 
-    assert_equal user, result
-    assert_equal "oidc", result.oidc_provider
-    assert_equal "new-uid", result.oidc_uid
+    assert_nil result
+    assert_not user.reload.oidc_user?
   end
 
   test "from_oidc returns nil when user not found and auto-create disabled" do
@@ -171,5 +169,36 @@ class UserOidcTest < ActiveSupport::TestCase
     result = User.from_oidc(auth_hash)
 
     assert_equal "preferred_user", result.username
+  end
+
+  test "link_oidc_identity! links an unlinked user" do
+    user = users(:one)
+
+    user.link_oidc_identity!(provider: "oidc", uid: "linked-uid")
+
+    assert_equal "oidc", user.reload.oidc_provider
+    assert_equal "linked-uid", user.oidc_uid
+  end
+
+  test "link_oidc_identity! rejects identities already linked to another user" do
+    existing = users(:two)
+    existing.update!(oidc_provider: "oidc", oidc_uid: "shared-uid")
+
+    error = assert_raises(User::OidcIdentityAlreadyLinkedError) do
+      users(:one).link_oidc_identity!(provider: "oidc", uid: "shared-uid")
+    end
+
+    assert_match(/already linked/i, error.message)
+  end
+
+  test "link_oidc_identity! rejects replacing a different existing identity" do
+    user = users(:one)
+    user.update!(oidc_provider: "oidc", oidc_uid: "old-uid")
+
+    error = assert_raises(User::OidcIdentityConflictError) do
+      user.link_oidc_identity!(provider: "oidc", uid: "new-uid")
+    end
+
+    assert_match(/different OIDC identity/i, error.message)
   end
 end

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -20,6 +20,10 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
       value_type: "integer",
       category: "auto_select"
     )
+
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
   end
 
   test "selects best downloadable result meeting seeder threshold" do
@@ -135,6 +139,29 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert selected.reload.selected?
     assert other1.reload.rejected?
     assert other2.reload.rejected?
+  end
+
+  test "skips blocked formats and selects next allowed result" do
+    SettingsService.set(:ebook_rejected_formats, [ "mobi" ])
+
+    blocked = create_search_result(
+      title: "Test Result English EPUB MOBI",
+      seeders: 100,
+      magnet_url: "magnet:?blocked",
+      confidence_score: 99
+    )
+    allowed = create_search_result(
+      title: "Test Result English EPUB",
+      seeders: 10,
+      magnet_url: "magnet:?allowed",
+      confidence_score: 95
+    )
+
+    selection = AutoSelectService.call(@request)
+
+    assert selection.success?
+    assert_equal allowed, selection.search_result
+    assert blocked.reload.rejected?
   end
 
   test "selection result error reason works" do

--- a/test/services/format_preference_service_test.rb
+++ b/test/services/format_preference_service_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FormatPreferenceServiceTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    SettingsService.set(:audiobook_approved_formats, [])
+    SettingsService.set(:audiobook_rejected_formats, [])
+    SettingsService.set(:audiobook_preferred_formats, [])
+    SettingsService.set(:audiobook_prefer_single_file, false)
+    SettingsService.set(:audiobook_prefer_higher_bitrate, false)
+  end
+
+  test "rejected formats are excluded from auto selection" do
+    SettingsService.set(:audiobook_rejected_formats, [ "mp3" ])
+
+    result = FormatPreferenceService.evaluate(
+      title: "Book Title Audiobook MP3 128kbps",
+      book_type: :audiobook
+    )
+
+    refute result.auto_select_allowed
+    assert_equal "mp3", result.matched_extension
+    assert_operator result.score_adjustment, :<=, -35
+  end
+
+  test "preferred formats use configured ranking order" do
+    SettingsService.set(:ebook_preferred_formats, [ "epub", "pdf" ])
+
+    result = FormatPreferenceService.evaluate(
+      title: "Book Title PDF EPUB",
+      book_type: :ebook
+    )
+
+    assert result.auto_select_allowed
+    assert_equal "epub", result.matched_extension
+    assert_equal 12, result.score_adjustment
+  end
+
+  test "single file and bitrate preferences add audiobook bonuses" do
+    SettingsService.set(:audiobook_prefer_single_file, true)
+    SettingsService.set(:audiobook_prefer_higher_bitrate, true)
+
+    result = FormatPreferenceService.evaluate(
+      title: "Book Title Audiobook M4B 256kbps",
+      book_type: :audiobook
+    )
+
+    assert result.auto_select_allowed
+    assert_equal :single_file, result.audiobook_structure
+    assert_equal 256, result.audio_bitrate_kbps
+    assert_equal 12, result.score_adjustment
+  end
+end

--- a/test/services/release_parser_service_test.rb
+++ b/test/services/release_parser_service_test.rb
@@ -103,6 +103,9 @@ class ReleaseParserServiceTest < ActiveSupport::TestCase
 
     assert_includes result[:languages], "nl"
     assert_equal :audiobook, result[:format]
+    assert_equal [ "m4b" ], result[:extensions]
+    assert_equal "m4b", result[:primary_extension]
+    assert_equal :single_file, result[:audiobook_structure]
     refute result[:is_multi_language]
     assert_equal "Book.Title.Dutch.Audiobook.M4B", result[:raw_title]
   end
@@ -112,8 +115,28 @@ class ReleaseParserServiceTest < ActiveSupport::TestCase
 
     assert_empty result[:languages]
     assert_nil result[:format]
+    assert_empty result[:extensions]
+    assert_nil result[:primary_extension]
+    assert_nil result[:audio_bitrate_kbps]
+    assert_nil result[:audiobook_structure]
     refute result[:is_multi_language]
     assert_nil result[:raw_title]
+  end
+
+  test "detect_extensions returns all supported extensions found" do
+    assert_equal [ "epub", "pdf" ], ReleaseParserService.detect_extensions("Book Title EPUB PDF")
+  end
+
+  test "detect_primary_extension returns first extension in title order" do
+    assert_equal "pdf", ReleaseParserService.detect_primary_extension("Book Title PDF EPUB")
+  end
+
+  test "detect_audio_bitrate extracts kbps values" do
+    assert_equal 192, ReleaseParserService.detect_audio_bitrate("Book Title Audiobook 192kbps M4B")
+  end
+
+  test "detect_audiobook_structure identifies multi file releases" do
+    assert_equal :multi_file, ReleaseParserService.detect_audiobook_structure("Book Title Audiobook MP3 Chapters")
   end
 
   test "language_info returns correct data for known language" do

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -18,6 +18,12 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       status: :pending,
       language: "en"
     )
+
+    SettingsService.set(:audiobook_approved_formats, [])
+    SettingsService.set(:audiobook_rejected_formats, [])
+    SettingsService.set(:audiobook_preferred_formats, [])
+    SettingsService.set(:audiobook_prefer_single_file, false)
+    SettingsService.set(:audiobook_prefer_higher_bitrate, false)
   end
 
   test "scores high for exact title match with correct language" do
@@ -96,6 +102,43 @@ class ReleaseScorerTest < ActiveSupport::TestCase
 
     assert_equal :ebook, result.detected_format
     assert result.breakdown[:format] == 0
+  end
+
+  test "preferred audiobook format increases score" do
+    SettingsService.set(:audiobook_preferred_formats, [ "m4b", "mp3" ])
+
+    m4b_result = @request.search_results.create!(
+      guid: "test-pref-m4b",
+      title: "The Name of the Wind English Audiobook M4B",
+      seeders: 25
+    )
+    mp3_result = @request.search_results.create!(
+      guid: "test-pref-mp3",
+      title: "The Name of the Wind English Audiobook MP3",
+      seeders: 25
+    )
+
+    m4b_score = ReleaseScorer.score(m4b_result, @request)
+    mp3_score = ReleaseScorer.score(mp3_result, @request)
+
+    assert_operator m4b_score.total, :>, mp3_score.total
+    assert_equal "m4b", m4b_score.breakdown[:extension]
+    assert_equal "mp3", mp3_score.breakdown[:extension]
+  end
+
+  test "rejected audiobook format blocks auto selection" do
+    SettingsService.set(:audiobook_rejected_formats, [ "mp3" ])
+
+    search_result = @request.search_results.create!(
+      guid: "test-rejected-format",
+      title: "The Name of the Wind English Audiobook MP3",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, @request)
+
+    refute result.breakdown[:auto_select_allowed]
+    assert_operator result.breakdown[:preference_adjustment], :<=, -35
   end
 
   test "scores author presence correctly" do

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class SettingsServiceTest < ActiveSupport::TestCase
   setup do
-    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key]).delete_all
+    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -31,5 +31,27 @@ class SettingsServiceTest < ActiveSupport::TestCase
   test "active_indexer_provider returns none when nothing is configured" do
     assert_equal "none", SettingsService.active_indexer_provider
     assert_not SettingsService.active_indexer_configured?
+  end
+
+  test "preferred_download_types defaults to torrent usenet then direct" do
+    assert_equal %w[torrent usenet direct], SettingsService.preferred_download_types
+  end
+
+  test "preferred_download_types falls back to legacy preferred_download_type" do
+    Setting.create!(
+      key: "preferred_download_type",
+      value: "usenet",
+      value_type: "string",
+      category: "download",
+      description: "Legacy preferred download type"
+    )
+
+    assert_equal %w[usenet torrent direct], SettingsService.preferred_download_types
+  end
+
+  test "preferred_download_types preserves stored order and appends missing types" do
+    SettingsService.set(:preferred_download_types, %w[direct torrent])
+
+    assert_equal %w[direct torrent usenet], SettingsService.preferred_download_types
   end
 end


### PR DESCRIPTION
## Summary
- add configurable ebook and audiobook format preferences for release scoring and auto-selection
- add ordered download type preferences across torrent, usenet, and direct results
- surface richer release metadata and preference outcomes in the dark admin search results UI
- reorganize admin settings into tabs, keep the tabbed UI resilient when JavaScript fails, and extend the settings/profile UX for OIDC login management
- add OIDC-first login support with a local bypass, explicit account linking/unlinking, and stricter OIDC identity constraints

## Issues
Closes #214
Closes #220

## Testing
- bundle exec rails test
- bundle exec rubocop app/controllers/auth/omniauth_callbacks_controller.rb app/controllers/profiles_controller.rb app/controllers/sessions_controller.rb app/models/user.rb app/services/settings_service.rb test/controllers/admin/settings_controller_test.rb test/controllers/auth/omniauth_callbacks_controller_test.rb test/controllers/profiles_controller_test.rb test/controllers/sessions_controller_test.rb test/models/user_oidc_test.rb db/migrate/20260412113500_add_unique_index_to_users_oidc_identity.rb
- manual browser smoke test on the local dev instance for the settings UI, request search results, OIDC auto-handoff screen, and profile-based OIDC linking flow
