### PR TITLE
feat: add optional webhook topic field

### DIFF
--- a/app/services/outbound_notifications/webhook_delivery.rb
+++ b/app/services/outbound_notifications/webhook_delivery.rb
@@ -49,11 +49,16 @@ module OutboundNotifications
       end
 
       def test_payload
-        {
+        payload = {
           event: TEST_EVENT,
           title: "Shelfarr Test",
           message: "Test notification from Shelfarr"
         }
+
+        topic = webhook_topic
+        payload[:topic] = topic if topic.present?
+
+        payload
       end
 
       private
@@ -100,6 +105,10 @@ module OutboundNotifications
         headers
       end
 
+      def webhook_topic
+        SettingsService.get(:webhook_topic).to_s.strip
+      end
+
       def build_payload(event:, title:, message:, request:)
         payload = {
           event: event,
@@ -107,6 +116,9 @@ module OutboundNotifications
           message: message,
           occurred_at: Time.current.iso8601
         }
+
+        topic = webhook_topic
+        payload[:topic] = topic if topic.present?
 
         return payload unless request.present?
 

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -113,6 +113,7 @@ class SettingsService
     webhook_url: { type: "string", default: "", category: "webhook", description: "Webhook endpoint URL. Shelfarr sends a JSON payload for each enabled event." },
     webhook_token: { type: "string", default: "", category: "webhook", description: "Optional Bearer token for webhook authentication" },
     webhook_events: { type: "string", default: "request_created,request_completed,request_failed,request_attention", category: "webhook", description: "Comma-separated webhook events to send" },
+    webhook_topic: { type: "string", default: "", category: "webhook", description: "Optional topic field included in webhook JSON payload (required by ntfy when posting to the server base URL)" },
 
     # OIDC/SSO Authentication
     oidc_enabled: { type: "boolean", default: false, category: "oidc", description: "Enable OpenID Connect (OIDC) single sign-on authentication" },

--- a/test/services/outbound_notifications/webhook_delivery_test.rb
+++ b/test/services/outbound_notifications/webhook_delivery_test.rb
@@ -55,6 +55,59 @@ class OutboundNotifications::WebhookDeliveryTest < ActiveSupport::TestCase
     assert_includes error.message, "HTTP 500"
   end
 
+  test "deliver! includes topic in payload when configured" do
+    SettingsService.set(:webhook_topic, "shelfarr")
+
+    stub = stub_request(:post, "http://localhost:4567/webhook")
+      .with do |request|
+        json = JSON.parse(request.body)
+        json["topic"] == "shelfarr" &&
+          json["event"] == "request_completed"
+      end
+      .to_return(status: 200, body: "{\"ok\":true}", headers: { "Content-Type" => "application/json" })
+
+    OutboundNotifications::WebhookDelivery.deliver!(
+      event: "request_completed",
+      title: "Book Ready",
+      message: "test",
+      request: @request
+    )
+
+    assert_requested(stub)
+  end
+
+  test "test_payload includes topic when configured" do
+    SettingsService.set(:webhook_topic, "shelfarr")
+
+    payload = OutboundNotifications::WebhookDelivery.test_payload
+
+    assert_equal "shelfarr", payload[:topic]
+  end
+
+  test "test_payload omits topic when not configured" do
+    payload = OutboundNotifications::WebhookDelivery.test_payload
+
+    assert_not payload.key?(:topic)
+  end
+
+  test "deliver! omits topic from payload when not configured" do
+    stub = stub_request(:post, "http://localhost:4567/webhook")
+      .with do |request|
+        json = JSON.parse(request.body)
+        !json.key?("topic")
+      end
+      .to_return(status: 200, body: "{\"ok\":true}", headers: { "Content-Type" => "application/json" })
+
+    OutboundNotifications::WebhookDelivery.deliver!(
+      event: "request_completed",
+      title: "Book Ready",
+      message: "test",
+      request: @request
+    )
+
+    assert_requested(stub)
+  end
+
   test "deliver! raises a delivery error for invalid webhook URLs" do
     SettingsService.set(:webhook_url, "ht!tp://bad")
 


### PR DESCRIPTION
## Summary
- add optional `webhook_topic` setting to webhook configuration
- when configured, include a `topic` field in the JSON payload for systems that use topic-based message routing (ntfy, Google Cloud Pub/Sub, AWS SNS, MQTT receivers)
- when blank, the payload is unchanged from current behavior
- topic is included in both regular event payloads and the admin test webhook payload

## Testing
- bundle exec rails test test/services/outbound_notifications/webhook_delivery_test.rb