### PR TITLE
feat: add Z-Library as ebook search and download source

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -35,6 +35,8 @@ class DownloadJob < ApplicationJob
       # Handle Anna's Archive downloads differently
       if search_result.from_anna_archive?
         handle_anna_archive_download(download, search_result)
+      elsif search_result.from_zlibrary?
+        handle_zlibrary_download(download, search_result)
       else
         handle_standard_download(download, search_result)
       end
@@ -63,6 +65,11 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Anna's Archive error: #{e.message}")
+    rescue ZLibraryClient::Error => e
+      Rails.logger.error "[DownloadJob] Z-Library error for download ##{download.id}: #{e.message}"
+      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+      download.update!(status: :failed)
+      download.request.mark_for_attention!("Z-Library error: #{e.message}")
     end
   end
 
@@ -87,6 +94,17 @@ class DownloadJob < ApplicationJob
     end
   end
 
+  def handle_zlibrary_download(download, search_result)
+    # guid format is "id:hash"
+    id, hash = search_result.guid.split(":", 2)
+    Rails.logger.info "[DownloadJob] Fetching download URL from Z-Library for book #{id}"
+
+    download_url = ZLibraryClient.get_download_url(id: id, hash: hash)
+    Rails.logger.info "[DownloadJob] Got Z-Library download URL: #{download_url.truncate(100)}"
+
+    handle_direct_http_download(download, search_result, download_url)
+  end
+
   def handle_direct_http_download(download, search_result, download_url)
     book = download.request.book
 
@@ -105,6 +123,9 @@ class DownloadJob < ApplicationJob
 
     # Download the file
     download_file_via_http(download_url, destination_path)
+
+    # Verify the downloaded file is actually an ebook
+    verify_ebook_file(destination_path)
 
     # Update download record as completed
     download.update!(
@@ -207,6 +228,37 @@ class DownloadJob < ApplicationJob
 
     file_size = File.size(destination)
     Rails.logger.info "[DownloadJob] Downloaded #{(file_size / 1024.0 / 1024.0).round(2)} MB"
+  end
+
+  # Verify downloaded file is actually an ebook, not an error page
+  def verify_ebook_file(path)
+    unless File.exist?(path)
+      raise "Downloaded file does not exist: #{path}"
+    end
+
+    file_size = File.size(path)
+
+    raw_head = File.binread(path, 200)
+    head = raw_head.downcase
+
+    # Reject HTML error pages regardless of size
+    if head.include?("<html") || head.include?("<!doctype")
+      FileUtils.rm_f(path)
+      raise "Downloaded file is an HTML error page, not an ebook"
+    end
+
+    if file_size < 1_000
+      FileUtils.rm_f(path)
+      raise "Downloaded file too small (#{file_size} bytes) - likely corrupt"
+    end
+
+    # Check magic bytes for known formats
+    magic = raw_head[0, 4]
+    valid_magic = ["PK\x03\x04", "%PDF"]
+
+    unless valid_magic.any? { |m| magic&.start_with?(m) }
+      Rails.logger.warn "[DownloadJob] Unknown file format (magic: #{magic&.bytes&.map { |b| '%02x' % b }&.join(' ')}), allowing"
+    end
   end
 
   def trigger_library_scan(book)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -16,8 +16,9 @@ class SearchJob < ApplicationJob
     # Check if any search sources are configured
     indexer_available = IndexerClient.configured?
     anna_available = AnnaArchiveClient.configured? && request.book.ebook?
+    zlib_available = !anna_available && ZLibraryClient.configured? && request.book.ebook?
 
-    unless indexer_available || anna_available
+    unless indexer_available || anna_available || zlib_available
       Rails.logger.error "[SearchJob] No search sources configured"
       request.mark_for_attention!("No search sources configured. Please configure an indexer or Anna's Archive in Admin Settings.")
       return
@@ -37,6 +38,13 @@ class SearchJob < ApplicationJob
         anna_results = search_anna_archive(request)
         all_results.concat(anna_results)
         Rails.logger.info "[SearchJob] Found #{anna_results.count} Anna's Archive results"
+      end
+
+      # Search Z-Library for ebooks if configured
+      if zlib_available
+        zlib_results = search_zlibrary(request)
+        all_results.concat(zlib_results)
+        Rails.logger.info "[SearchJob] Found #{zlib_results.count} Z-Library results"
       end
 
       if all_results.any?
@@ -64,6 +72,8 @@ class SearchJob < ApplicationJob
     rescue AnnaArchiveClient::Error => e
       Rails.logger.error "[SearchJob] Anna's Archive error for request ##{request.id}: #{e.message}"
       # Non-fatal - continue if Prowlarr had results
+    rescue ZLibraryClient::Error => e
+      Rails.logger.error "[SearchJob] Z-Library error for request ##{request.id}: #{e.message}"
     end
   end
 
@@ -120,6 +130,26 @@ class SearchJob < ApplicationJob
     language_search_term(request)
   end
 
+  def search_zlibrary(request)
+    book = request.book
+
+    query_parts = [book.title]
+    query_parts << book.author if book.author.present?
+    query = query_parts.join(" ")
+
+    language = request.effective_language
+    Rails.logger.debug "[SearchJob] Searching Z-Library for: #{query} (language: #{language})"
+
+    results = ZLibraryClient.search(query, language: language)
+
+    results.map do |r|
+      { result: r, source: SearchResult::SOURCE_ZLIBRARY }
+    end
+  rescue ZLibraryClient::Error => e
+    Rails.logger.warn "[SearchJob] Z-Library search failed: #{e.message}"
+    []
+  end
+
   def search_anna_archive(request)
     book = request.book
 
@@ -154,8 +184,11 @@ class SearchJob < ApplicationJob
       result = tagged[:result]
       source = tagged[:source]
 
-      search_result = if source == SearchResult::SOURCE_ANNA_ARCHIVE
+      search_result = case source
+      when SearchResult::SOURCE_ANNA_ARCHIVE
         save_anna_archive_result(request, result)
+      when SearchResult::SOURCE_ZLIBRARY
+        save_zlibrary_result(request, result)
       else
         save_indexer_result(request, result, source)
       end
@@ -186,7 +219,7 @@ class SearchJob < ApplicationJob
 
     # Use find_or_create_by to handle duplicate MD5s in Anna's Archive results
     request.search_results.find_or_create_by!(guid: result.md5) do |sr|
-      sr.title = build_anna_title(result)
+      sr.title = build_ebook_source_title(result)
       sr.indexer = "Anna's Archive"
       sr.size_bytes = size_bytes
       sr.seeders = nil  # N/A for Anna's Archive
@@ -200,7 +233,24 @@ class SearchJob < ApplicationJob
     end
   end
 
-  def build_anna_title(result)
+  def save_zlibrary_result(request, result)
+    guid = "#{result.id}:#{result.hash}"
+    request.search_results.find_or_create_by!(guid: guid) do |sr|
+      sr.title = build_ebook_source_title(result)
+      sr.indexer = "Z-Library"
+      sr.size_bytes = result.file_size
+      sr.seeders = nil
+      sr.leechers = nil
+      sr.download_url = nil
+      sr.magnet_url = nil
+      sr.info_url = nil
+      sr.published_at = nil
+      sr.source = SearchResult::SOURCE_ZLIBRARY
+      sr.detected_language = result.language
+    end
+  end
+
+  def build_ebook_source_title(result)
     parts = []
     parts << result.title if result.title.present?
     parts << "- #{result.author}" if result.author.present?

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -13,6 +13,7 @@ class SearchResult < ApplicationRecord
   SOURCE_PROWLARR = "prowlarr"
   SOURCE_JACKETT = "jackett"
   SOURCE_ANNA_ARCHIVE = "anna_archive"
+  SOURCE_ZLIBRARY = "zlibrary"
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
   validates :title, presence: true
@@ -47,6 +48,7 @@ class SearchResult < ApplicationRecord
   def downloadable?
     # Anna's Archive results are always downloadable - URL is fetched at download time
     return true if from_anna_archive?
+    return true if from_zlibrary?
 
     download_url.present? || magnet_url.present?
   end
@@ -143,12 +145,18 @@ class SearchResult < ApplicationRecord
     source == SOURCE_ANNA_ARCHIVE
   end
 
+  def from_zlibrary?
+    source == SOURCE_ZLIBRARY
+  end
+
   def source_display_name
     case source
     when SOURCE_JACKETT
       indexer.presence || "Jackett"
     when SOURCE_ANNA_ARCHIVE
       "Anna's Archive"
+    when SOURCE_ZLIBRARY
+      "Z-Library"
     else
       indexer.presence || "Prowlarr"
     end

--- a/app/services/auto_select_service.rb
+++ b/app/services/auto_select_service.rb
@@ -76,6 +76,8 @@ class AutoSelectService
 
   def meets_seeder_threshold?(result)
     return true if result.usenet?
+    return true if result.from_anna_archive?
+    return true if result.from_zlibrary?
     (result.seeders || 0) >= @min_seeders
   end
 

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -77,6 +77,10 @@ class SettingsService
     anna_archive_api_key: { type: "string", default: "", category: "anna_archive", description: "Member API key from Anna's Archive (requires donation)" },
     flaresolverr_url: { type: "string", default: "", category: "anna_archive", description: "FlareSolverr URL for bypassing DDoS protection (e.g., http://flaresolverr:8191)" },
 
+    # Z-Library
+    zlibrary_email: { type: "string", default: "", category: "zlibrary", description: "Z-Library account email for ebook search and download" },
+    zlibrary_password: { type: "string", default: "", category: "zlibrary", description: "Z-Library account password" },
+
     # Hardcover Integration
     hardcover_api_token: { type: "string", default: "", category: "hardcover", description: "API token from Hardcover account settings (hardcover.app/account/api)" },
     metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Primary metadata source: auto (Hardcover first, OpenLibrary fallback), hardcover, or openlibrary" },
@@ -104,6 +108,7 @@ class SettingsService
     "download" => "Download Settings",
     "audiobookshelf" => "Audiobookshelf",
     "anna_archive" => "Anna's Archive",
+    "zlibrary" => "Z-Library",
     "hardcover" => "Hardcover",
     "paths" => "Output Paths",
     "queue" => "Queue Settings",

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+# Client for searching and downloading ebooks via Z-Library's eAPI
+# Requires Z-Library account credentials (email + password)
+class ZLibraryClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class AuthenticationError < Error; end
+  class NotConfiguredError < Error; end
+
+  Result = Data.define(
+    :id, :hash, :title, :author, :year,
+    :file_type, :file_size, :language
+  ) do
+    def downloadable?
+      id.present? && hash.present?
+    end
+
+    def size_human
+      file_size
+    end
+  end
+
+  AUTH_TTL_SECONDS = 1800 # 30 minutes
+  DOMAINS = %w[z-library.bz 1lib.sk z-lib.fm z-lib.sk].freeze
+
+  @auth_cache = nil
+
+  class << self
+    def configured?
+      SettingsService.configured?(:zlibrary_email) &&
+        SettingsService.configured?(:zlibrary_password)
+    end
+
+    def reset_auth_cache!
+      @auth_cache = nil
+    end
+
+    # Search Z-Library for books via eAPI
+    # @param query [String] Search query
+    # @param file_types [Array<String>] File extensions to filter (e.g., ["epub", "pdf"])
+    # @param limit [Integer] Max results
+    # @param language [String] Language filter (e.g., "english")
+    def search(query, file_types: %w[epub pdf], limit: 50, language: nil)
+      ensure_configured!
+
+      auth = login
+      raise AuthenticationError, "Z-Library login failed" unless auth
+
+      Rails.logger.info "[ZLibraryClient] Searching: #{query}"
+
+      body_parts = [["message", query], ["limit", limit.to_s]]
+      file_types.each { |ext| body_parts << ["extensions[]", ext] }
+      body_parts << ["languages[]", language] if language.present?
+
+      response = connection.post("https://#{auth[:domain]}/eapi/book/search") do |req|
+        req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        req.headers["Cookie"] = "remix_userid=#{auth[:remix_userid]}; remix_userkey=#{auth[:remix_userkey]}"
+        req.body = URI.encode_www_form(body_parts)
+      end
+
+      raise ConnectionError, "Search failed with status #{response.status}" unless response.status == 200
+
+      data = JSON.parse(response.body)
+      books = data["books"] || []
+
+      results = parse_search_results(books, limit)
+      Rails.logger.info "[ZLibraryClient] Found #{results.size} results"
+      results
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise ConnectionError, "Failed to connect to Z-Library: #{e.message}"
+    end
+
+    # Get direct download URL for a book via eAPI
+    # @param id [String] Z-Library book ID
+    # @param hash [String] Z-Library book hash
+    # @return [String] Direct download URL
+    def get_download_url(id:, hash:)
+      ensure_configured!
+
+      auth = login
+      raise AuthenticationError, "Z-Library login failed" unless auth
+
+      Rails.logger.info "[ZLibraryClient] Fetching download URL for book #{id}"
+
+      url = "https://#{auth[:domain]}/eapi/book/#{id}/#{hash}/file"
+      response = connection.get(url) do |req|
+        req.headers["Cookie"] = "remix_userid=#{auth[:remix_userid]}; remix_userkey=#{auth[:remix_userkey]}"
+      end
+
+      raise ConnectionError, "Download request failed with status #{response.status}" unless response.status == 200
+
+      data = JSON.parse(response.body)
+      download_link = data.dig("file", "downloadLink")
+
+      if download_link.blank?
+        raise Error, "No download link returned for book #{id}"
+      end
+
+      Rails.logger.info "[ZLibraryClient] Got download link: #{download_link.truncate(100)}"
+      download_link
+    rescue JSON::ParserError => e
+      raise Error, "Failed to parse download response: #{e.message}"
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise ConnectionError, "Failed to connect to Z-Library: #{e.message}"
+    end
+
+    private
+
+    def login
+      # Return cached auth if still valid
+      if @auth_cache && @auth_cache[:expires_at] > Time.current
+        return @auth_cache[:auth]
+      end
+
+      email = SettingsService.get(:zlibrary_email)
+      password = SettingsService.get(:zlibrary_password)
+
+      DOMAINS.each do |domain|
+        begin
+          response = connection.post("https://#{domain}/eapi/user/login") do |req|
+            req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+            req.body = URI.encode_www_form(email: email, password: password)
+          end
+
+          next unless response.status == 200
+
+          data = JSON.parse(response.body)
+          if data["success"] == 1
+            Rails.logger.info "[ZLibraryClient] Login successful via #{domain}"
+            auth = {
+              remix_userid: data.dig("user", "id")&.to_s,
+              remix_userkey: data.dig("user", "remix_userkey")&.to_s,
+              domain: domain
+            }
+            @auth_cache = { auth: auth, expires_at: Time.current + AUTH_TTL_SECONDS }
+            return auth
+          end
+        rescue JSON::ParserError, Faraday::Error => e
+          Rails.logger.debug "[ZLibraryClient] Login failed on #{domain}: #{e.message}"
+          next
+        end
+      end
+
+      Rails.logger.warn "[ZLibraryClient] Login failed on all domains"
+      nil
+    end
+
+    def ensure_configured!
+      raise NotConfiguredError, "Z-Library is not configured" unless configured?
+    end
+
+    def parse_search_results(books, limit)
+      books.first(limit).filter_map do |book|
+        id = book["id"]&.to_s
+        hash = book["hash"]&.to_s
+        next if id.blank? || hash.blank?
+
+        Result.new(
+          id: id,
+          hash: hash,
+          title: book["name"].presence || book["title"].presence || "Unknown",
+          author: book["author"].presence,
+          year: book["year"].to_i.nonzero?,
+          file_type: book["extension"]&.downcase,
+          file_size: book["filesize"].to_i.nonzero?,
+          language: book["language"]
+        )
+      end
+    end
+
+    def connection
+      @connection ||= Faraday.new do |f|
+        f.request :url_encoded
+        f.adapter Faraday.default_adapter
+        f.headers["User-Agent"] = "Mozilla/5.0 (compatible; Shelfarr/1.0)"
+        f.options.timeout = 30
+        f.options.open_timeout = 10
+      end
+    end
+  end
+end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -25,6 +25,7 @@ class DownloadJobTest < ActiveJob::TestCase
     # Clear qBittorrent sessions
     Thread.current[:qbittorrent_sessions] = {}
     Thread.current[:transmission_protocols] = {}
+    ZLibraryClient.reset_auth_cache! if defined?(ZLibraryClient)
 
     # Create a queued download
     @download = @request.downloads.create!(
@@ -254,6 +255,54 @@ class DownloadJobTest < ActiveJob::TestCase
     assert filename.end_with?(".epub") || filename.end_with?(".pdf") || filename.end_with?(".mobi")
   end
 
+  test "zlibrary download completes via eAPI" do
+    VCR.turned_off do
+      setup_zlibrary_download
+
+      stub_zlibrary_login
+      stub_zlibrary_download_api
+      stub_request(:get, "https://download.z-library.bz/dl/book999/file.epub")
+        .to_return(status: 200, body: "PK\x03\x04" + "x" * 2000, headers: { "Content-Type" => "application/epub+zip" })
+
+      DownloadJob.perform_now(@zlib_download.id)
+      @zlib_download.reload
+
+      assert @zlib_download.completed?
+    end
+  end
+
+  test "zlibrary download fails on auth error" do
+    VCR.turned_off do
+      setup_zlibrary_download
+
+      %w[z-library.bz 1lib.sk z-lib.fm z-lib.sk].each do |domain|
+        stub_request(:post, "https://#{domain}/eapi/user/login")
+          .to_return(status: 500, body: "Server Error")
+      end
+
+      DownloadJob.perform_now(@zlib_download.id)
+      @zlib_download.reload
+
+      assert @zlib_download.failed?
+    end
+  end
+
+  test "zlibrary download rejects HTML error page" do
+    VCR.turned_off do
+      setup_zlibrary_download
+
+      stub_zlibrary_login
+      stub_zlibrary_download_api
+      stub_request(:get, "https://download.z-library.bz/dl/book999/file.epub")
+        .to_return(status: 200, body: "<html><body>Error</body></html>", headers: { "Content-Type" => "text/html" })
+
+      DownloadJob.perform_now(@zlib_download.id)
+      @zlib_download.reload
+
+      assert @zlib_download.failed?
+    end
+  end
+
   private
 
   def stub_qbittorrent_success
@@ -291,6 +340,49 @@ class DownloadJobTest < ActiveJob::TestCase
         status: 200,
         headers: { "Content-Type" => "application/json" },
         body: [{ "hash" => expected_hash, "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json
+      )
+  end
+
+  def setup_zlibrary_download
+    SettingsService.set(:zlibrary_email, "test@example.com")
+    SettingsService.set(:zlibrary_password, "testpass")
+    SettingsService.set(:ebook_output_path, Dir.tmpdir)
+
+    zlib_result = @request.search_results.create!(
+      guid: "999:deadbeef",
+      title: "Z-Library Book [EPUB]",
+      indexer: "Z-Library",
+      source: SearchResult::SOURCE_ZLIBRARY,
+      status: :selected
+    )
+    @request.search_results.where.not(id: zlib_result.id).update_all(status: :pending)
+
+    @zlib_download = @request.downloads.create!(
+      name: zlib_result.title,
+      size_bytes: 1_000_000,
+      status: :queued
+    )
+    @download.update!(status: :completed)
+  end
+
+  def stub_zlibrary_login
+    stub_request(:post, "https://z-library.bz/eapi/user/login")
+      .to_return(
+        status: 200,
+        body: { success: 1, user: { id: "12345", remix_userkey: "abcdef123456" } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def stub_zlibrary_download_api
+    stub_request(:get, "https://z-library.bz/eapi/book/999/deadbeef/file")
+      .to_return(
+        status: 200,
+        body: {
+          success: 1,
+          file: { downloadLink: "https://download.z-library.bz/dl/book999/file.epub" }
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
       )
   end
 end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -7,6 +7,7 @@ class SearchJobTest < ActiveJob::TestCase
     @request = requests(:pending_request)
     SettingsService.set(:prowlarr_url, "http://localhost:9696")
     SettingsService.set(:prowlarr_api_key, "test-key")
+    ZLibraryClient.reset_auth_cache! if defined?(ZLibraryClient)
   end
 
   test "updates request status to searching" do
@@ -388,6 +389,101 @@ class SearchJobTest < ActiveJob::TestCase
       assert_equal SearchResult::SOURCE_JACKETT, @request.search_results.first.source
       assert_equal "JackettBooks", @request.search_results.first.indexer
     end
+  end
+
+  test "includes Z-Library results when configured" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:zlibrary_email, "test@example.com")
+    SettingsService.set(:zlibrary_password, "testpass")
+
+    result = ZLibraryClient::Result.new(
+      id: "999",
+      hash: "deadbeef",
+      title: "Z-Library Book",
+      author: "Test Author",
+      year: 2023,
+      file_type: "epub",
+      file_size: 5452595,
+      language: "english"
+    )
+
+    ZLibraryClient.stub :configured?, true do
+      ZLibraryClient.stub :search, ->(query, **_) {
+        assert_includes query, @request.book.title
+        [result]
+      } do
+        SearchJob.perform_now(@request.id)
+        @request.reload
+
+        assert @request.search_results.any?
+        assert_equal SearchResult::SOURCE_ZLIBRARY, @request.search_results.first.source
+        assert_equal "Z-Library", @request.search_results.first.indexer
+        assert_equal "999:deadbeef", @request.search_results.first.guid
+      end
+    end
+
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+  end
+
+  test "does not search Z-Library when not configured" do
+    SettingsService.set(:zlibrary_email, "")
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert @request.search_results.any?
+      assert @request.search_results.none? { |r| r.source == SearchResult::SOURCE_ZLIBRARY }
+    end
+  end
+
+  test "does not search Z-Library for audiobook requests" do
+    SettingsService.set(:zlibrary_email, "test@example.com")
+    SettingsService.set(:zlibrary_password, "testpass")
+
+    audiobook_book = books(:audiobook_acquired)
+    request = Request.create!(book: audiobook_book, user: users(:one), status: :pending)
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+
+      ZLibraryClient.stub :configured?, true do
+        ZLibraryClient.stub :search, ->(*) { raise "Should not be called" } do
+          assert_nothing_raised do
+            SearchJob.perform_now(request.id)
+          end
+        end
+      end
+    end
+
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+  end
+
+  test "Z-Library errors do not block other search sources" do
+    SettingsService.set(:zlibrary_email, "test@example.com")
+    SettingsService.set(:zlibrary_password, "testpass")
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+
+      ZLibraryClient.stub :configured?, true do
+        ZLibraryClient.stub :search, ->(*) { raise ZLibraryClient::ConnectionError, "Z-Library down" } do
+          SearchJob.perform_now(@request.id)
+          @request.reload
+
+          # Prowlarr results should still be saved despite Z-Library failure
+          assert @request.search_results.any?
+          assert @request.search_results.none? { |r| r.source == SearchResult::SOURCE_ZLIBRARY }
+        end
+      end
+    end
+
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
   end
 
   private

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -146,6 +146,32 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert_nil result.search_result
   end
 
+  test "zlibrary results bypass seeder check" do
+    Setting.find_or_create_by(key: "auto_select_min_seeders").update!(
+      value: "100",
+      value_type: "integer",
+      category: "auto_select"
+    )
+
+    # Z-Library results have nil seeders since they're direct downloads
+    result = create_search_result(
+      seeders: nil,
+      source: SearchResult::SOURCE_ZLIBRARY,
+      indexer: "Z-Library",
+      download_url: nil,
+      magnet_url: nil
+    )
+
+    assert_enqueued_with(job: DownloadJob) do
+      selection = AutoSelectService.call(@request)
+
+      assert selection.success?
+      assert_equal :auto_selected, selection.reason
+    end
+
+    assert result.reload.selected?
+  end
+
   private
 
   def create_search_result(attrs = {})

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ZLibraryClientTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:zlibrary_email, "test@example.com")
+    SettingsService.set(:zlibrary_password, "testpass")
+    ZLibraryClient.reset_auth_cache!
+  end
+
+  teardown do
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+    ZLibraryClient.reset_auth_cache!
+  end
+
+  test "configured? returns true when both email and password set" do
+    assert ZLibraryClient.configured?
+  end
+
+  test "configured? returns false when email missing" do
+    SettingsService.set(:zlibrary_email, "")
+    assert_not ZLibraryClient.configured?
+  end
+
+  test "configured? returns false when password missing" do
+    SettingsService.set(:zlibrary_password, "")
+    assert_not ZLibraryClient.configured?
+  end
+
+  test "login succeeds and caches auth" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+
+      auth = ZLibraryClient.send(:login)
+
+      assert_equal "12345", auth[:remix_userid]
+      assert_equal "abcdef123456", auth[:remix_userkey]
+      assert_equal "z-library.bz", auth[:domain]
+    end
+  end
+
+  test "login tries next domain on failure" do
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.bz/eapi/user/login")
+        .to_return(status: 500, body: "Server Error")
+      stub_request(:post, "https://1lib.sk/eapi/user/login")
+        .to_return(
+          status: 200,
+          body: { success: 1, user: { id: "12345", remix_userkey: "abcdef123456" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      auth = ZLibraryClient.send(:login)
+
+      assert_equal "1lib.sk", auth[:domain]
+    end
+  end
+
+  test "login returns nil when all domains fail" do
+    VCR.turned_off do
+      stub_zlibrary_login_all_fail
+
+      auth = ZLibraryClient.send(:login)
+
+      assert_nil auth
+    end
+  end
+
+  test "login caches auth for subsequent calls" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+
+      auth1 = ZLibraryClient.send(:login)
+      auth2 = ZLibraryClient.send(:login)
+
+      assert_equal auth1, auth2
+      assert_requested(:post, "https://z-library.bz/eapi/user/login", times: 1)
+    end
+  end
+
+  test "search returns results from eAPI" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_zlibrary_search_success
+
+      results = ZLibraryClient.search("Test Book")
+
+      assert_equal 1, results.size
+      result = results.first
+      assert_equal "999", result.id
+      assert_equal "deadbeef", result.hash
+      assert_equal "Test Book Title", result.title
+      assert_equal "Test Author", result.author
+      assert_equal "epub", result.file_type
+      assert_equal 5452595, result.file_size
+      assert_equal 2023, result.year
+      assert_equal "english", result.language
+    end
+  end
+
+  test "search returns empty array when no results" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.bz/eapi/book/search")
+        .to_return(
+          status: 200,
+          body: { success: 1, books: [] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      results = ZLibraryClient.search("Nonexistent Book")
+
+      assert_equal [], results
+    end
+  end
+
+  test "search raises NotConfiguredError when not configured" do
+    SettingsService.set(:zlibrary_email, "")
+
+    assert_raises ZLibraryClient::NotConfiguredError do
+      ZLibraryClient.search("Test")
+    end
+  end
+
+  test "search raises AuthenticationError when login fails" do
+    VCR.turned_off do
+      stub_zlibrary_login_all_fail
+
+      assert_raises ZLibraryClient::AuthenticationError do
+        ZLibraryClient.search("Test")
+      end
+    end
+  end
+
+  test "search passes file type extensions" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.bz/eapi/book/search")
+        .with { |req| req.body.include?("extensions%5B%5D=epub") }
+        .to_return(
+          status: 200,
+          body: { success: 1, books: [] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ZLibraryClient.search("Test", file_types: %w[epub])
+
+      assert_requested(:post, "https://z-library.bz/eapi/book/search")
+    end
+  end
+
+  test "get_download_url returns direct URL from eAPI" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_zlibrary_download_success
+
+      url = ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+
+      assert_equal "https://download.z-library.bz/dl/book999/file.epub", url
+    end
+  end
+
+  test "get_download_url raises Error when no download link" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:get, "https://z-library.bz/eapi/book/999/deadbeef/file")
+        .to_return(
+          status: 200,
+          body: { success: 0, error: "Book not found" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      assert_raises ZLibraryClient::Error do
+        ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+      end
+    end
+  end
+
+  test "get_download_url raises NotConfiguredError when not configured" do
+    SettingsService.set(:zlibrary_email, "")
+
+    assert_raises ZLibraryClient::NotConfiguredError do
+      ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+    end
+  end
+
+  private
+
+  def stub_zlibrary_login_success
+    stub_request(:post, "https://z-library.bz/eapi/user/login")
+      .to_return(
+        status: 200,
+        body: {
+          success: 1,
+          user: { id: "12345", remix_userkey: "abcdef123456" }
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def stub_zlibrary_login_all_fail
+    %w[z-library.bz 1lib.sk z-lib.fm z-lib.sk].each do |domain|
+      stub_request(:post, "https://#{domain}/eapi/user/login")
+        .to_return(status: 500, body: "Server Error")
+    end
+  end
+
+  def stub_zlibrary_download_success
+    stub_request(:get, "https://z-library.bz/eapi/book/999/deadbeef/file")
+      .to_return(
+        status: 200,
+        body: {
+          success: 1,
+          file: {
+            description: "Test Book Title",
+            extension: "epub",
+            downloadLink: "https://download.z-library.bz/dl/book999/file.epub"
+          }
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def stub_zlibrary_search_success
+    stub_request(:post, "https://z-library.bz/eapi/book/search")
+      .to_return(
+        status: 200,
+        body: {
+          success: 1,
+          books: [
+            {
+              id: 999,
+              hash: "deadbeef",
+              name: "Test Book Title",
+              author: "Test Author",
+              year: "2023",
+              extension: "epub",
+              filesize: "5452595",
+              language: "english"
+            }
+          ]
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+end


### PR DESCRIPTION
## Why

Anna's Archive is a great ebook source but the download path has a high barrier to entry - it requires a paid API key ($2+/mo) and a FlareSolverr/Byparr instance to bypass DDoS-Guard on the search pages. For users who just want automated ebook downloads without that infrastructure, Z-Library's eAPI provides a free alternative that only needs account credentials. Pure JSON over HTTP, no browser automation.

This doesn't replace the Anna's Archive integration. Ebook source priority is:

1. **Anna's Archive** - used when AA API key is configured (paid, fastest, broadest coverage)
2. **Z-Library** - used when Z-Library credentials are configured and no AA API key is present (free, only needs email/password)
3. **Neither** - skipped if no credentials for either are set

Prowlarr/Jackett indexers always run alongside whichever ebook source is active.

## Summary
- New `ZLibraryClient` service: auth, search, and download via Z-Library eAPI
- Search via `POST /eapi/book/search` with file type and language filters
- Download via `GET /eapi/book/{id}/{hash}/file` with direct CDN URLs
- Multi-domain login fallback with 30-minute token caching
- Z-Library results bypass seeder threshold in auto-select (direct downloads, same as AA)
- Post-download file verification rejects HTML error pages and corrupt files
- New admin settings: `zlibrary_email`, `zlibrary_password`
- Purely additive - no changes to existing AnnaArchiveClient or other services

## Testing
- `bundle exec rails test`
- 14 new tests across ZLibraryClient, SearchJob, DownloadJob, AutoSelectService