### PR TITLE
feat: add z-library ebook fallback

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -14,6 +14,7 @@ module Admin
 
       validate_path_template!(key, value)
       SettingsService.set(key, value)
+      handle_settings_side_effects([key.to_s])
 
       respond_to do |format|
         format.html { redirect_to admin_settings_path, notice: "Setting updated." }
@@ -35,28 +36,8 @@ module Admin
         end
       end
 
-      # Reset cached connections and trigger health checks when relevant settings change
       changed_keys = params[:settings]&.keys&.map(&:to_s) || []
-
-      if changed_keys.any? { |k| k.start_with?("audiobookshelf") }
-        AudiobookshelfClient.reset_connection!
-        AudiobookshelfLibrarySyncJob.perform_later if AudiobookshelfClient.configured?
-        run_service_health_check("audiobookshelf")
-      end
-      if changed_keys.any? { |k| indexer_setting_key?(k) }
-        IndexerClient.reset_all_connections!
-        run_service_health_check("indexer")
-      end
-      if changed_keys.any? { |k| k == "flaresolverr_url" }
-        FlaresolverrClient.reset_connection!
-      end
-      if changed_keys.any? { |k| k.start_with?("hardcover") }
-        HardcoverClient.reset_connection!
-        run_service_health_check("hardcover")
-      end
-      if changed_keys.any? { |k| k.start_with?("audiobook_output_path") || k.start_with?("ebook_output_path") }
-        run_service_health_check_now("output_paths")
-      end
+      handle_settings_side_effects(changed_keys)
 
       @settings_by_category = SettingsService.all_by_category
       @audiobookshelf_libraries = fetch_audiobookshelf_libraries
@@ -193,6 +174,19 @@ module Admin
       respond_with_flash(alert: "Hardcover error: #{e.message}")
     end
 
+    def test_zlibrary
+      unless ZLibraryClient.configured?
+        respond_with_flash(alert: "Z-Library is not configured. Enable it and enter your account credentials first.")
+        return
+      end
+
+      if ZLibraryClient.test_connection
+        respond_with_flash(notice: "Z-Library connection successful!")
+      else
+        respond_with_flash(alert: "Z-Library connection failed.")
+      end
+    end
+
     def test_oidc
       unless SettingsService.get(:oidc_enabled, default: false)
         respond_with_flash(alert: "OIDC is not enabled. Enable it first.")
@@ -265,6 +259,33 @@ module Admin
       HealthCheckJob.perform_now(service: service_name)
     rescue => e
       Rails.logger.warn "[SettingsController] Failed to run health check for #{service_name}: #{e.message}"
+    end
+
+    def handle_settings_side_effects(changed_keys)
+      return if changed_keys.blank?
+
+      if changed_keys.any? { |k| k.start_with?("audiobookshelf") }
+        AudiobookshelfClient.reset_connection!
+        AudiobookshelfLibrarySyncJob.perform_later if AudiobookshelfClient.configured?
+        run_service_health_check("audiobookshelf")
+      end
+      if changed_keys.any? { |k| indexer_setting_key?(k) }
+        IndexerClient.reset_all_connections!
+        run_service_health_check("indexer")
+      end
+      if changed_keys.any? { |k| k == "flaresolverr_url" }
+        FlaresolverrClient.reset_connection!
+      end
+      if changed_keys.any? { |k| k.start_with?("zlibrary") }
+        ZLibraryClient.reset_connection!
+      end
+      if changed_keys.any? { |k| k.start_with?("hardcover") }
+        HardcoverClient.reset_connection!
+        run_service_health_check("hardcover")
+      end
+      if changed_keys.any? { |k| k.start_with?("audiobook_output_path") || k.start_with?("ebook_output_path") }
+        run_service_health_check_now("output_paths")
+      end
     end
 
     PATH_TEMPLATE_SETTINGS = %w[audiobook_path_template ebook_path_template].freeze

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -121,7 +121,7 @@ class DownloadJob < ApplicationJob
     FileUtils.mkdir_p(destination_dir)
 
     # Download the file
-    download_file_via_http(download_url, destination_path)
+    download_file_via_http(search_result, download_url, destination_path)
     verify_downloaded_ebook!(destination_path)
 
     # Update download record as completed
@@ -212,29 +212,59 @@ class DownloadJob < ApplicationJob
     result
   end
 
-  def download_file_via_http(url, destination)
-    require "open-uri"
-    validate_direct_download_url!(url)
+  def download_file_via_http(search_result, url, destination)
+    uri = validate_direct_download_url!(url, search_result)
 
     Rails.logger.info "[DownloadJob] Starting HTTP download..."
 
-    URI.open(url, "rb", read_timeout: 300, open_timeout: 30) do |source|
-      File.open(destination, "wb") do |dest|
-        IO.copy_stream(source, dest)
-      end
+    response = direct_download_connection(uri).get(uri.request_uri)
+    raise "Direct download failed with status #{response.status}" unless response.success?
+
+    File.open(destination, "wb") do |dest|
+      dest.write(response.body)
     end
 
     file_size = File.size(destination)
     Rails.logger.info "[DownloadJob] Downloaded #{(file_size / 1024.0 / 1024.0).round(2)} MB"
+  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+    raise "Direct download request failed: #{e.message}"
   end
 
-  def validate_direct_download_url!(url)
+  def validate_direct_download_url!(url, search_result = nil)
     uri = URI.parse(url)
-    return if %w[http https].include?(uri.scheme) && uri.host.present?
+    raise "Invalid direct download URL" unless %w[http https].include?(uri.scheme) && uri.host.present?
 
-    raise "Invalid direct download URL"
+    if search_result&.from_zlibrary? && !zlibrary_download_host_allowed?(uri.host)
+      raise "Invalid direct download URL host"
+    end
+
+    uri
   rescue URI::InvalidURIError => e
     raise "Invalid direct download URL: #{e.message}"
+  end
+
+  def direct_download_connection(uri)
+    Faraday.new(url: direct_download_base_url(uri)) do |f|
+      f.adapter Faraday.default_adapter
+      f.headers["User-Agent"] = "Shelfarr/1.0"
+      f.options.timeout = 300
+      f.options.open_timeout = 30
+    end
+  end
+
+  def direct_download_base_url(uri)
+    default_port = (uri.scheme == "https" ? 443 : 80)
+    port_suffix = uri.port == default_port ? "" : ":#{uri.port}"
+    "#{uri.scheme}://#{uri.host}#{port_suffix}"
+  end
+
+  def zlibrary_download_host_allowed?(host)
+    configured_host = URI.parse(SettingsService.get(:zlibrary_url).to_s).host
+    return false if configured_host.blank?
+
+    host == configured_host || host.end_with?(".#{configured_host}")
+  rescue URI::InvalidURIError
+    false
   end
 
   def verify_downloaded_ebook!(path)

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
+require "net/http"
+require "uri"
+
 class DownloadJob < ApplicationJob
   queue_as :default
+
+  MAX_DIRECT_DOWNLOAD_BYTES = 512.megabytes
 
   def perform(download_id)
     download = Download.find_by(id: download_id)
@@ -121,8 +126,9 @@ class DownloadJob < ApplicationJob
     FileUtils.mkdir_p(destination_dir)
 
     # Download the file
+    expected_extension = infer_extension(download_url, search_result)
     download_file_via_http(search_result, download_url, destination_path)
-    verify_downloaded_ebook!(destination_path)
+    verify_downloaded_ebook!(destination_path, expected_extension: expected_extension)
 
     # Update download record as completed
     download.update!(
@@ -217,16 +223,34 @@ class DownloadJob < ApplicationJob
 
     Rails.logger.info "[DownloadJob] Starting HTTP download..."
 
-    response = direct_download_connection(uri).get(uri.request_uri)
-    raise "Direct download failed with status #{response.status}" unless response.success?
+    bytes_written = 0
 
-    File.open(destination, "wb") do |dest|
-      dest.write(response.body)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 30, read_timeout: 300) do |http|
+      request = Net::HTTP::Get.new(uri)
+      request["User-Agent"] = "Shelfarr/1.0"
+
+      http.request(request) do |response|
+        raise "Direct download failed with status #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+        validate_direct_download_response_headers!(
+          content_type: response["Content-Type"],
+          content_length: response["Content-Length"]
+        )
+
+        File.open(destination, "wb") do |dest|
+          response.read_body do |chunk|
+            bytes_written += chunk.bytesize
+            raise "Direct download exceeds size limit of #{MAX_DIRECT_DOWNLOAD_BYTES / 1.megabyte} MB" if bytes_written > MAX_DIRECT_DOWNLOAD_BYTES
+
+            dest.write(chunk)
+          end
+        end
+      end
     end
 
     file_size = File.size(destination)
     Rails.logger.info "[DownloadJob] Downloaded #{(file_size / 1024.0 / 1024.0).round(2)} MB"
-  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+  rescue SocketError, IOError, EOFError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
     raise "Direct download request failed: #{e.message}"
   end
 
@@ -243,21 +267,6 @@ class DownloadJob < ApplicationJob
     raise "Invalid direct download URL: #{e.message}"
   end
 
-  def direct_download_connection(uri)
-    Faraday.new(url: direct_download_base_url(uri)) do |f|
-      f.adapter Faraday.default_adapter
-      f.headers["User-Agent"] = "Shelfarr/1.0"
-      f.options.timeout = 300
-      f.options.open_timeout = 30
-    end
-  end
-
-  def direct_download_base_url(uri)
-    default_port = (uri.scheme == "https" ? 443 : 80)
-    port_suffix = uri.port == default_port ? "" : ":#{uri.port}"
-    "#{uri.scheme}://#{uri.host}#{port_suffix}"
-  end
-
   def zlibrary_download_host_allowed?(host)
     configured_host = URI.parse(SettingsService.get(:zlibrary_url).to_s).host
     return false if configured_host.blank?
@@ -267,17 +276,44 @@ class DownloadJob < ApplicationJob
     false
   end
 
-  def verify_downloaded_ebook!(path)
+  def validate_direct_download_response_headers!(content_type:, content_length:)
+    normalized_content_type = content_type.to_s.split(";").first.to_s.downcase
+
+    if normalized_content_type.present? &&
+        (normalized_content_type.start_with?("text/") ||
+         normalized_content_type.include?("html") ||
+         normalized_content_type.include?("json") ||
+         normalized_content_type.include?("xml"))
+      raise "Direct download returned unexpected content type: #{normalized_content_type}"
+    end
+
+    length = content_length.to_i if content_length.present?
+    if length.present? && length > MAX_DIRECT_DOWNLOAD_BYTES
+      raise "Direct download exceeds size limit of #{MAX_DIRECT_DOWNLOAD_BYTES / 1.megabyte} MB"
+    end
+  end
+
+  def verify_downloaded_ebook!(path, expected_extension: nil)
     raise "Downloaded file does not exist" unless File.exist?(path)
 
     file_size = File.size(path)
     raise "Downloaded file is empty" if file_size.zero?
 
-    head = File.binread(path, 256)
+    head = File.binread(path, [512, file_size].min)
     lowered = head.downcase
     if lowered.include?("<html") || lowered.include?("<!doctype")
       FileUtils.rm_f(path)
       raise "Downloaded file is an HTML page, not an ebook"
+    end
+
+    case expected_extension.to_s.downcase
+    when "epub"
+      raise "Downloaded file is not a valid EPUB" unless head.start_with?("PK\x03\x04")
+    when "pdf"
+      raise "Downloaded file is not a valid PDF" unless head.start_with?("%PDF")
+    when "mobi"
+      mobi_signature = File.binread(path, [68, file_size].min).byteslice(60, 8)
+      raise "Downloaded file is not a valid MOBI" unless mobi_signature == "BOOKMOBI"
     end
   rescue Errno::ENOENT => e
     raise "Downloaded file is missing: #{e.message}"

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -35,6 +35,8 @@ class DownloadJob < ApplicationJob
       # Handle Anna's Archive downloads differently
       if search_result.from_anna_archive?
         handle_anna_archive_download(download, search_result)
+      elsif search_result.from_zlibrary?
+        handle_zlibrary_download(download, search_result)
       else
         handle_standard_download(download, search_result)
       end
@@ -63,6 +65,11 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Anna's Archive error: #{e.message}")
+    rescue ZLibraryClient::Error => e
+      Rails.logger.error "[DownloadJob] Z-Library error for download ##{download.id}: #{e.message}"
+      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+      download.update!(status: :failed)
+      download.request.mark_for_attention!("Z-Library error: #{e.message}")
     end
   end
 
@@ -87,6 +94,16 @@ class DownloadJob < ApplicationJob
     end
   end
 
+  def handle_zlibrary_download(download, search_result)
+    book_id, file_hash = search_result.guid.to_s.split(":", 2)
+    raise ZLibraryClient::Error, "Selected Z-Library result is missing download metadata" if book_id.blank? || file_hash.blank?
+
+    Rails.logger.info "[DownloadJob] Fetching Z-Library download URL for book #{book_id}"
+    download_url = ZLibraryClient.get_download_url(id: book_id, hash: file_hash)
+
+    handle_direct_http_download(download, search_result, download_url)
+  end
+
   def handle_direct_http_download(download, search_result, download_url)
     book = download.request.book
 
@@ -105,6 +122,7 @@ class DownloadJob < ApplicationJob
 
     # Download the file
     download_file_via_http(download_url, destination_path)
+    verify_downloaded_ebook!(destination_path)
 
     # Update download record as completed
     download.update!(
@@ -196,6 +214,7 @@ class DownloadJob < ApplicationJob
 
   def download_file_via_http(url, destination)
     require "open-uri"
+    validate_direct_download_url!(url)
 
     Rails.logger.info "[DownloadJob] Starting HTTP download..."
 
@@ -207,6 +226,31 @@ class DownloadJob < ApplicationJob
 
     file_size = File.size(destination)
     Rails.logger.info "[DownloadJob] Downloaded #{(file_size / 1024.0 / 1024.0).round(2)} MB"
+  end
+
+  def validate_direct_download_url!(url)
+    uri = URI.parse(url)
+    return if %w[http https].include?(uri.scheme) && uri.host.present?
+
+    raise "Invalid direct download URL"
+  rescue URI::InvalidURIError => e
+    raise "Invalid direct download URL: #{e.message}"
+  end
+
+  def verify_downloaded_ebook!(path)
+    raise "Downloaded file does not exist" unless File.exist?(path)
+
+    file_size = File.size(path)
+    raise "Downloaded file is empty" if file_size.zero?
+
+    head = File.binread(path, 256)
+    lowered = head.downcase
+    if lowered.include?("<html") || lowered.include?("<!doctype")
+      FileUtils.rm_f(path)
+      raise "Downloaded file is an HTML page, not an ebook"
+    end
+  rescue Errno::ENOENT => e
+    raise "Downloaded file is missing: #{e.message}"
   end
 
   def trigger_library_scan(book)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -16,58 +16,71 @@ class SearchJob < ApplicationJob
     # Check if any search sources are configured
     indexer_available = IndexerClient.configured?
     anna_available = AnnaArchiveClient.configured? && request.book.ebook?
+    zlibrary_available = !anna_available && ZLibraryClient.configured? && request.book.ebook?
 
-    unless indexer_available || anna_available
+    unless indexer_available || anna_available || zlibrary_available
       Rails.logger.error "[SearchJob] No search sources configured"
-      request.mark_for_attention!("No search sources configured. Please configure an indexer or Anna's Archive in Admin Settings.")
+      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, or Z-Library in Admin Settings.")
       return
     end
 
-    begin
-      all_results = []
+    all_results = []
+    indexer_error = nil
 
-      if indexer_available
-        indexer_results = search_indexer(request)
-        all_results.concat(indexer_results)
-        Rails.logger.info "[SearchJob] Found #{indexer_results.count} #{IndexerClient.display_name} results"
-      end
+    if indexer_available
+      indexer_results, indexer_error = search_indexer_safely(request)
+      all_results.concat(indexer_results)
+      Rails.logger.info "[SearchJob] Found #{indexer_results.count} #{IndexerClient.display_name} results"
+    end
 
-      # Search Anna's Archive for ebooks if configured
-      if anna_available
-        anna_results = search_anna_archive(request)
-        all_results.concat(anna_results)
-        Rails.logger.info "[SearchJob] Found #{anna_results.count} Anna's Archive results"
-      end
+    # Search Anna's Archive for ebooks if configured
+    if anna_available
+      anna_results = search_anna_archive(request)
+      all_results.concat(anna_results)
+      Rails.logger.info "[SearchJob] Found #{anna_results.count} Anna's Archive results"
+    end
 
-      if all_results.any?
-        save_results(request, all_results)
-        Rails.logger.info "[SearchJob] Total #{all_results.count} results for request ##{request.id}"
-        attempt_auto_select(request)
-      else
-        Rails.logger.info "[SearchJob] No results found for request ##{request.id}"
-        # If bot protection was detected and no results from other sources, mark for attention
-        if @anna_archive_bot_protection_error
-          request.mark_for_attention!(@anna_archive_bot_protection_error)
-        else
-          request.schedule_retry!
-        end
-      end
-    rescue IndexerClients::Base::AuthenticationError => e
-      Rails.logger.error "[SearchJob] #{IndexerClient.display_name} authentication failed: #{e.message}"
-      request.mark_for_attention!("#{IndexerClient.display_name} authentication failed. Please check your API key.")
-    rescue IndexerClients::Base::ConnectionError => e
-      Rails.logger.error "[SearchJob] #{IndexerClient.display_name} connection error for request ##{request.id}: #{e.message}"
-      request.schedule_retry!
-    rescue IndexerClients::Base::Error => e
-      Rails.logger.error "[SearchJob] #{IndexerClient.display_name} error for request ##{request.id}: #{e.message}"
-      request.schedule_retry!
-    rescue AnnaArchiveClient::Error => e
-      Rails.logger.error "[SearchJob] Anna's Archive error for request ##{request.id}: #{e.message}"
-      # Non-fatal - continue if Prowlarr had results
+    if zlibrary_available
+      zlibrary_results = search_zlibrary(request)
+      all_results.concat(zlibrary_results)
+      Rails.logger.info "[SearchJob] Found #{zlibrary_results.count} Z-Library results"
+    end
+
+    if all_results.any?
+      save_results(request, all_results)
+      Rails.logger.info "[SearchJob] Total #{all_results.count} results for request ##{request.id}"
+      attempt_auto_select(request)
+    else
+      Rails.logger.info "[SearchJob] No results found for request ##{request.id}"
+      handle_no_results(request, indexer_error)
     end
   end
 
   private
+
+  def search_indexer_safely(request)
+    results = search_indexer(request)
+    [results, nil]
+  rescue IndexerClients::Base::AuthenticationError => e
+    Rails.logger.error "[SearchJob] #{IndexerClient.display_name} authentication failed: #{e.message}"
+    [[], e]
+  rescue IndexerClients::Base::ConnectionError => e
+    Rails.logger.error "[SearchJob] #{IndexerClient.display_name} connection error for request ##{request.id}: #{e.message}"
+    [[], e]
+  rescue IndexerClients::Base::Error => e
+    Rails.logger.error "[SearchJob] #{IndexerClient.display_name} error for request ##{request.id}: #{e.message}"
+    [[], e]
+  end
+
+  def handle_no_results(request, indexer_error)
+    if @anna_archive_bot_protection_error
+      request.mark_for_attention!(@anna_archive_bot_protection_error)
+    elsif indexer_error.is_a?(IndexerClients::Base::AuthenticationError)
+      request.mark_for_attention!("#{IndexerClient.display_name} authentication failed. Please check your API key.")
+    else
+      request.schedule_retry!
+    end
+  end
 
   def search_indexer(request)
     if IndexerClient.provider == SearchResult::SOURCE_PROWLARR
@@ -147,6 +160,20 @@ class SearchJob < ApplicationJob
     []
   end
 
+  def search_zlibrary(request)
+    book = request.book
+    query = [book.title, book.author].compact.join(" ")
+    language = zlibrary_language_filter(request)
+    Rails.logger.debug "[SearchJob] Searching Z-Library for: #{query} (language: #{language || 'any'})"
+
+    ZLibraryClient.search(query, language: language).map do |result|
+      { result: result, source: SearchResult::SOURCE_ZLIBRARY }
+    end
+  rescue ZLibraryClient::Error => e
+    Rails.logger.warn "[SearchJob] Z-Library search failed: #{e.message}"
+    []
+  end
+
   def save_results(request, tagged_results)
     request.search_results.destroy_all
 
@@ -154,8 +181,11 @@ class SearchJob < ApplicationJob
       result = tagged[:result]
       source = tagged[:source]
 
-      search_result = if source == SearchResult::SOURCE_ANNA_ARCHIVE
+      search_result = case source
+      when SearchResult::SOURCE_ANNA_ARCHIVE
         save_anna_archive_result(request, result)
+      when SearchResult::SOURCE_ZLIBRARY
+        save_zlibrary_result(request, result)
       else
         save_indexer_result(request, result, source)
       end
@@ -186,7 +216,7 @@ class SearchJob < ApplicationJob
 
     # Use find_or_create_by to handle duplicate MD5s in Anna's Archive results
     request.search_results.find_or_create_by!(guid: result.md5) do |sr|
-      sr.title = build_anna_title(result)
+      sr.title = build_direct_source_title(result)
       sr.indexer = "Anna's Archive"
       sr.size_bytes = size_bytes
       sr.seeders = nil  # N/A for Anna's Archive
@@ -200,7 +230,23 @@ class SearchJob < ApplicationJob
     end
   end
 
-  def build_anna_title(result)
+  def save_zlibrary_result(request, result)
+    request.search_results.find_or_create_by!(guid: "#{result.id}:#{result.hash}") do |sr|
+      sr.title = build_direct_source_title(result)
+      sr.indexer = "Z-Library"
+      sr.size_bytes = result.file_size
+      sr.seeders = nil
+      sr.leechers = nil
+      sr.download_url = nil
+      sr.magnet_url = nil
+      sr.info_url = nil
+      sr.published_at = nil
+      sr.source = SearchResult::SOURCE_ZLIBRARY
+      sr.detected_language = result.language
+    end
+  end
+
+  def build_direct_source_title(result)
     parts = []
     parts << result.title if result.title.present?
     parts << "- #{result.author}" if result.author.present?
@@ -224,6 +270,11 @@ class SearchJob < ApplicationJob
     when "GB" then (value * 1024 * 1024 * 1024).to_i
     else nil
     end
+  end
+
+  def zlibrary_language_filter(request)
+    info = ReleaseParserService.language_info(request.effective_language)
+    info&.dig(:name)&.downcase
   end
 
   def attempt_auto_select(request)

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -13,6 +13,7 @@ class SearchResult < ApplicationRecord
   SOURCE_PROWLARR = "prowlarr"
   SOURCE_JACKETT = "jackett"
   SOURCE_ANNA_ARCHIVE = "anna_archive"
+  SOURCE_ZLIBRARY = "zlibrary"
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
   validates :title, presence: true
@@ -24,7 +25,7 @@ class SearchResult < ApplicationRecord
     type_order_sql = ordered_types.each_with_index.map { |type, index| "WHEN '#{type}' THEN #{index}" }.join(" ")
     download_type_sql = <<~SQL.squish
       CASE
-        WHEN source = '#{SOURCE_ANNA_ARCHIVE}' THEN 'direct'
+        WHEN source IN ('#{SOURCE_ANNA_ARCHIVE}', '#{SOURCE_ZLIBRARY}') THEN 'direct'
         WHEN download_url IS NOT NULL AND magnet_url IS NULL AND seeders IS NULL THEN 'usenet'
         ELSE 'torrent'
       END
@@ -50,8 +51,7 @@ class SearchResult < ApplicationRecord
   }
 
   def downloadable?
-    # Anna's Archive results are always downloadable - URL is fetched at download time
-    return true if from_anna_archive?
+    return true if direct_download?
 
     download_url.present? || magnet_url.present?
   end
@@ -73,7 +73,7 @@ class SearchResult < ApplicationRecord
   end
 
   def direct_download?
-    from_anna_archive?
+    from_anna_archive? || from_zlibrary?
   end
 
   def download_type
@@ -189,12 +189,18 @@ class SearchResult < ApplicationRecord
     source == SOURCE_ANNA_ARCHIVE
   end
 
+  def from_zlibrary?
+    source == SOURCE_ZLIBRARY
+  end
+
   def source_display_name
     case source
     when SOURCE_JACKETT
       indexer.presence || "Jackett"
     when SOURCE_ANNA_ARCHIVE
       "Anna's Archive"
+    when SOURCE_ZLIBRARY
+      "Z-Library"
     else
       indexer.presence || "Prowlarr"
     end

--- a/app/services/auto_select_service.rb
+++ b/app/services/auto_select_service.rb
@@ -76,7 +76,7 @@ class AutoSelectService
   end
 
   def meets_seeder_threshold?(result)
-    return true if result.usenet?
+    return true if result.usenet? || result.direct_download?
     (result.seeders || 0) >= @min_seeders
   end
 

--- a/app/services/indexer_clients/base.rb
+++ b/app/services/indexer_clients/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module IndexerClients
   class Base
     class Error < StandardError; end
@@ -61,7 +63,17 @@ module IndexerClients
 
       def normalize_base_url(url)
         value = url.to_s.strip
-        value.end_with?("/") ? value : "#{value}/"
+        raise ArgumentError, "#{display_name} URL is blank" if value.blank?
+
+        uri = URI.parse(value)
+        unless %w[http https].include?(uri.scheme) && uri.host.present?
+          raise ArgumentError, "#{display_name} URL must be a valid http or https URL"
+        end
+
+        normalized = uri.to_s
+        normalized.end_with?("/") ? normalized : "#{normalized}/"
+      rescue URI::InvalidURIError => e
+        raise ArgumentError, "Invalid #{display_name} URL: #{e.message}"
       end
     end
   end

--- a/app/services/indexer_clients/base.rb
+++ b/app/services/indexer_clients/base.rb
@@ -55,6 +55,8 @@ module IndexerClients
         yield
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
         raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
+      rescue URI::Error, ArgumentError => e
+        raise ConnectionError, "Invalid #{display_name} URL: #{e.message}"
       end
 
       def normalize_base_url(url)

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -11,7 +11,7 @@ class SettingsService
     },
     "direct" => {
       label: "Direct",
-      description: "Integration downloads such as Anna's Archive"
+      description: "Integration downloads such as Anna's Archive and Z-Library"
     }
   }.freeze
 
@@ -103,6 +103,12 @@ class SettingsService
     anna_archive_api_key: { type: "string", default: "", category: "anna_archive", description: "Member API key from Anna's Archive (requires donation)" },
     flaresolverr_url: { type: "string", default: "", category: "anna_archive", description: "FlareSolverr URL for bypassing DDoS protection (e.g., http://flaresolverr:8191)" },
 
+    # Z-Library
+    zlibrary_enabled: { type: "boolean", default: false, category: "zlibrary", description: "Enable the unofficial Z-Library fallback for ebook search and direct download. This integration may break if the service changes." },
+    zlibrary_url: { type: "string", default: "https://z-library.sk", category: "zlibrary", description: "Base URL for the Z-Library site you can access (for example https://z-library.sk)" },
+    zlibrary_email: { type: "string", default: "", category: "zlibrary", description: "Z-Library account email used for login" },
+    zlibrary_password: { type: "string", default: "", category: "zlibrary", description: "Z-Library account password used for login" },
+
     # Hardcover Integration
     hardcover_api_token: { type: "string", default: "", category: "hardcover", description: "API token from Hardcover account settings (hardcover.app/account/api)" },
     metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Primary metadata source: auto (Hardcover first, OpenLibrary fallback), hardcover, or openlibrary" },
@@ -133,6 +139,7 @@ class SettingsService
     "download" => "Download Settings",
     "audiobookshelf" => "Audiobookshelf",
     "anna_archive" => "Anna's Archive",
+    "zlibrary" => "Z-Library",
     "hardcover" => "Hardcover",
     "paths" => "Output Paths",
     "queue" => "Queue Settings",
@@ -258,6 +265,13 @@ class SettingsService
 
     def anna_archive_configured?
       get(:anna_archive_enabled, default: false) && configured?(:anna_archive_api_key)
+    end
+
+    def zlibrary_configured?
+      get(:zlibrary_enabled, default: false) &&
+        configured?(:zlibrary_url) &&
+        configured?(:zlibrary_email) &&
+        configured?(:zlibrary_password)
     end
 
     def flaresolverr_configured?

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "digest"
+require "uri"
 
 # Client for interacting with Z-Library's internal eAPI.
 # This integration is unofficial and may break if the service changes.
@@ -148,6 +149,10 @@ class ZLibraryClient
     end
 
     def configured_domain
+      configured_uri.host
+    end
+
+    def configured_uri
       raw_url = SettingsService.get(:zlibrary_url).to_s.strip
       raise ConfigurationError, "Z-Library URL is not configured" if raw_url.blank?
 
@@ -156,7 +161,15 @@ class ZLibraryClient
         raise ConfigurationError, "Z-Library URL must be a valid http or https URL"
       end
 
-      uri.host
+      if uri.path.present? && uri.path != "/"
+        raise ConfigurationError, "Z-Library URL must not include a path"
+      end
+
+      if uri.query.present? || uri.fragment.present? || uri.userinfo.present?
+        raise ConfigurationError, "Z-Library URL must only include the site origin"
+      end
+
+      uri
     rescue URI::InvalidURIError => e
       raise ConfigurationError, "Z-Library URL is invalid: #{e.message}"
     end
@@ -203,11 +216,20 @@ class ZLibraryClient
 
     def validate_download_url!(url)
       uri = URI.parse(url)
-      return if ALLOWED_DOWNLOAD_SCHEMES.include?(uri.scheme) && uri.host.present?
+      unless ALLOWED_DOWNLOAD_SCHEMES.include?(uri.scheme) && uri.host.present?
+        raise Error, "Z-Library returned an invalid download URL"
+      end
 
-      raise Error, "Z-Library returned an invalid download URL"
+      return if download_host_allowed?(uri.host)
+
+      raise Error, "Z-Library returned a download URL outside the configured host family"
     rescue URI::InvalidURIError => e
       raise Error, "Z-Library returned an invalid download URL: #{e.message}"
+    end
+
+    def download_host_allowed?(host)
+      configured_host = configured_domain
+      host == configured_host || host.end_with?(".#{configured_host}")
     end
 
     def parse_search_results(books, limit)

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require "digest"
+
+# Client for interacting with Z-Library's internal eAPI.
+# This integration is unofficial and may break if the service changes.
+class ZLibraryClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class AuthenticationError < Error; end
+  class NotConfiguredError < Error; end
+  class RateLimitError < Error; end
+  class ConfigurationError < Error; end
+
+  Result = Data.define(
+    :id, :hash, :title, :author, :year,
+    :file_type, :file_size, :language
+  ) do
+    def downloadable?
+      id.present? && hash.present?
+    end
+  end
+
+  AUTH_TTL_SECONDS = 30.minutes
+  ALLOWED_DOWNLOAD_SCHEMES = %w[http https].freeze
+
+  class << self
+    def configured?
+      SettingsService.zlibrary_configured?
+    end
+
+    def test_connection
+      ensure_configured!
+      login.present?
+    rescue Error => e
+      Rails.logger.error "[ZLibraryClient] Connection test failed: #{e.message}"
+      false
+    end
+
+    def search(query, file_types: %w[epub pdf], limit: 50, language: nil)
+      ensure_configured!
+
+      auth = login
+      Rails.logger.info "[ZLibraryClient] Searching for '#{query}'"
+
+      payload = [["message", query], ["limit", limit.to_s]]
+      Array(file_types).each { |ext| payload << ["extensions[]", ext] }
+      payload << ["languages[]", language] if language.present?
+
+      response = connection.post("https://#{auth[:domain]}/eapi/book/search") do |req|
+        req.headers["Cookie"] = cookie_header(auth)
+        req.body = URI.encode_www_form(payload)
+      end
+
+      data = parse_response(response, context: "search")
+      parse_search_results(data.fetch("books", []), limit)
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise ConnectionError, "Failed to connect to Z-Library: #{e.message}"
+    end
+
+    def get_download_url(id:, hash:)
+      ensure_configured!
+
+      auth = login
+      response = connection.get("https://#{auth[:domain]}/eapi/book/#{id}/#{hash}/file") do |req|
+        req.headers["Cookie"] = cookie_header(auth)
+      end
+
+      data = parse_response(response, context: "download lookup")
+      download_link = data.dig("file", "downloadLink")
+      raise Error, "Z-Library did not return a download link" if download_link.blank?
+
+      validate_download_url!(download_link)
+      download_link
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise ConnectionError, "Failed to connect to Z-Library: #{e.message}"
+    end
+
+    def reset_connection!
+      @auth_cache = nil
+      @connection = nil
+    end
+
+    private
+
+    def login
+      cached = @auth_cache
+      signature = credential_signature
+
+      if cached.present? &&
+          cached[:signature] == signature &&
+          cached[:expires_at] > Time.current
+        return cached[:auth]
+      end
+
+      auth = perform_login(signature)
+      raise AuthenticationError, "Z-Library login failed" unless auth
+
+      auth
+    end
+
+    def perform_login(signature)
+      email = SettingsService.get(:zlibrary_email).to_s.strip
+      password = SettingsService.get(:zlibrary_password).to_s
+      domain = configured_domain
+
+      response = connection.post("https://#{domain}/eapi/user/login") do |req|
+        req.body = URI.encode_www_form(email: email, password: password)
+      end
+
+      return nil unless response.status == 200
+
+      data = parse_json_body(response)
+      return nil unless data["success"] == 1
+
+      auth = {
+        remix_userid: data.dig("user", "id")&.to_s,
+        remix_userkey: data.dig("user", "remix_userkey")&.to_s,
+        domain: domain
+      }
+
+      return nil if auth[:remix_userid].blank? || auth[:remix_userkey].blank?
+
+      Rails.logger.info "[ZLibraryClient] Login succeeded via #{domain}"
+      @auth_cache = {
+        signature: signature,
+        auth: auth,
+        expires_at: Time.current + AUTH_TTL_SECONDS
+      }
+      auth
+    rescue JSON::ParserError, Faraday::Error => e
+      Rails.logger.debug "[ZLibraryClient] Login failed on #{domain}: #{e.message}"
+      nil
+    end
+
+    def ensure_configured!
+      raise NotConfiguredError, "Z-Library is not configured" unless configured?
+      configured_domain
+    end
+
+    def credential_signature
+      Digest::SHA256.hexdigest([
+        SettingsService.get(:zlibrary_enabled, default: false),
+        SettingsService.get(:zlibrary_url).to_s,
+        SettingsService.get(:zlibrary_email).to_s,
+        SettingsService.get(:zlibrary_password).to_s
+      ].join("\0"))
+    end
+
+    def configured_domain
+      raw_url = SettingsService.get(:zlibrary_url).to_s.strip
+      raise ConfigurationError, "Z-Library URL is not configured" if raw_url.blank?
+
+      uri = URI.parse(raw_url)
+      unless ALLOWED_DOWNLOAD_SCHEMES.include?(uri.scheme) && uri.host.present?
+        raise ConfigurationError, "Z-Library URL must be a valid http or https URL"
+      end
+
+      uri.host
+    rescue URI::InvalidURIError => e
+      raise ConfigurationError, "Z-Library URL is invalid: #{e.message}"
+    end
+
+    def connection
+      @connection ||= Faraday.new do |f|
+        f.request :url_encoded
+        f.response :json, parser_options: { symbolize_names: false }, content_type: /\bjson$/
+        f.adapter Faraday.default_adapter
+        f.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        f.headers["User-Agent"] = "Shelfarr/1.0"
+        f.options.timeout = 30
+        f.options.open_timeout = 10
+      end
+    end
+
+    def cookie_header(auth)
+      "remix_userid=#{auth[:remix_userid]}; remix_userkey=#{auth[:remix_userkey]}"
+    end
+
+    def parse_response(response, context:)
+      case response.status
+      when 200
+        data = parse_json_body(response)
+        if data["success"] == 0
+          error_message = data["error"].presence || "unknown Z-Library error"
+          raise Error, "Z-Library #{context} failed: #{error_message}"
+        end
+        data
+      when 401, 403
+        raise AuthenticationError, "Invalid Z-Library credentials"
+      when 429
+        raise RateLimitError, "Z-Library rate limit exceeded"
+      else
+        raise ConnectionError, "Z-Library #{context} failed with status #{response.status}"
+      end
+    end
+
+    def parse_json_body(response)
+      return response.body if response.body.is_a?(Hash)
+
+      JSON.parse(response.body)
+    end
+
+    def validate_download_url!(url)
+      uri = URI.parse(url)
+      return if ALLOWED_DOWNLOAD_SCHEMES.include?(uri.scheme) && uri.host.present?
+
+      raise Error, "Z-Library returned an invalid download URL"
+    rescue URI::InvalidURIError => e
+      raise Error, "Z-Library returned an invalid download URL: #{e.message}"
+    end
+
+    def parse_search_results(books, limit)
+      Array(books).first(limit).filter_map do |book|
+        id = book["id"]&.to_s
+        hash = book["hash"]&.to_s
+        next if id.blank? || hash.blank?
+
+        Result.new(
+          id: id,
+          hash: hash,
+          title: book["name"].presence || book["title"].presence || "Unknown",
+          author: book["author"].presence,
+          year: book["year"]&.to_i&.nonzero?,
+          file_type: book["extension"]&.to_s&.downcase,
+          file_size: book["filesize"]&.to_i&.nonzero?,
+          language: normalize_language(book["language"])
+        )
+      end
+    end
+
+    def normalize_language(language)
+      value = language.to_s.strip
+      return if value.blank?
+
+      direct_match = ReleaseParserService.language_info(value)
+      return value if direct_match
+
+      matched_code, = ReleaseParserService::LANGUAGES.find do |code, info|
+        code.casecmp?(value) || info[:name].casecmp?(value)
+      end
+
+      matched_code || value.downcase
+    end
+  end
+end

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -3,7 +3,7 @@
   tab_groups = {
     "search" => {
       label: "Search",
-      categories: %w[indexer anna_archive language auto_select]
+      categories: %w[indexer anna_archive zlibrary language auto_select]
     },
     "downloads" => {
       label: "Downloads",
@@ -181,6 +181,16 @@
                     </div>
                     <div class="md:w-2/3">
                       <%= link_to "Test Hardcover Connection", test_hardcover_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "zlibrary" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Connection Check</span>
+                      <p class="text-sm text-gray-500">Validate your Z-Library login before using it as an ebook fallback. This integration is unofficial and may break if the service changes.</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test Z-Library Connection", test_zlibrary_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
                     </div>
                   </div>
                 <% elsif category == "webhook" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
         post :sync_audiobookshelf_library
         post :test_audiobookshelf
         post :test_flaresolverr
+        post :test_zlibrary
         post :test_hardcover
         post :test_oidc
         post :test_webhook

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -9,12 +9,14 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     AudiobookshelfClient.reset_connection!
     ProwlarrClient.reset_connection!
     FlaresolverrClient.reset_connection!
+    ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
   end
 
   teardown do
     AudiobookshelfClient.reset_connection!
     ProwlarrClient.reset_connection!
     FlaresolverrClient.reset_connection!
+    ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
   end
 
   test "index requires admin" do
@@ -237,6 +239,18 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Send Test Webhook"
   end
 
+  test "index shows z-library settings and test button" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label", text: "Zlibrary Enabled"
+    assert_select "input[name='settings[zlibrary_enabled]']"
+    assert_select "input[name='settings[zlibrary_url]']"
+    assert_select "input[name='settings[zlibrary_email]']"
+    assert_select "input[name='settings[zlibrary_password]']"
+    assert_select "a", text: "Test Z-Library Connection"
+  end
+
   test "bulk_update validates path templates" do
     patch bulk_update_admin_settings_url, params: {
       settings: {
@@ -400,6 +414,32 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_settings_path
     assert_match /invalid/i, flash[:alert]
+  end
+
+  test "test_zlibrary fails when not configured" do
+    SettingsService.set(:zlibrary_enabled, false)
+    SettingsService.set(:zlibrary_url, "")
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+
+    post test_zlibrary_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match /not configured/i, flash[:alert]
+  end
+
+  test "test_zlibrary succeeds when connection works" do
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+
+    ZLibraryClient.stub :test_connection, true do
+      post test_zlibrary_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /successful/i, flash[:notice]
   end
 
   # Test connection tests for Audiobookshelf

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -10,6 +10,10 @@ class DownloadJobTest < ActiveJob::TestCase
     DownloadClient.destroy_all
     @request = requests(:pending_request)
     @selected_result = search_results(:selected_result)
+    SettingsService.set(:zlibrary_enabled, false)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
 
     # Create a qBittorrent client
     @client = DownloadClient.create!(
@@ -25,6 +29,7 @@ class DownloadJobTest < ActiveJob::TestCase
     # Clear qBittorrent sessions
     Thread.current[:qbittorrent_sessions] = {}
     Thread.current[:transmission_protocols] = {}
+    ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
 
     # Create a queued download
     @download = @request.downloads.create!(
@@ -32,6 +37,14 @@ class DownloadJobTest < ActiveJob::TestCase
       size_bytes: @selected_result.size_bytes,
       status: :queued
     )
+  end
+
+  teardown do
+    SettingsService.set(:zlibrary_enabled, false)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+    ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
   end
 
   test "updates download status to downloading on success" do
@@ -254,7 +267,73 @@ class DownloadJobTest < ActiveJob::TestCase
     assert filename.end_with?(".epub") || filename.end_with?(".pdf") || filename.end_with?(".mobi")
   end
 
+  test "z-library download completes via direct http download" do
+    setup_zlibrary_download
+
+    VCR.turned_off do
+      ZLibraryClient.stub :get_download_url, "https://download.z-library.sk/books/test-book.epub" do
+        stub_request(:get, "https://download.z-library.sk/books/test-book.epub")
+          .to_return(status: 200, body: "PK\x03\x04" + ("x" * 1024), headers: { "Content-Type" => "application/epub+zip" })
+
+        DownloadJob.perform_now(@zlibrary_download.id)
+      end
+    end
+
+    @zlibrary_download.reload
+    assert @zlibrary_download.completed?
+    assert_equal "direct", @zlibrary_download.download_type
+  end
+
+  test "z-library download rejects html error pages" do
+    setup_zlibrary_download
+
+    VCR.turned_off do
+      ZLibraryClient.stub :get_download_url, "https://download.z-library.sk/books/test-book.epub" do
+        stub_request(:get, "https://download.z-library.sk/books/test-book.epub")
+          .to_return(status: 200, body: "<html><body>error</body></html>", headers: { "Content-Type" => "text/html" })
+
+        DownloadJob.perform_now(@zlibrary_download.id)
+      end
+    end
+
+    @zlibrary_download.reload
+    @request.reload
+    assert @zlibrary_download.failed?
+    assert @request.attention_needed?
+  end
+
+  test "validate_direct_download_url rejects non-http schemes" do
+    error = assert_raises RuntimeError do
+      DownloadJob.new.send(:validate_direct_download_url!, "file:///tmp/book.epub")
+    end
+
+    assert_match /Invalid direct download URL/, error.message
+  end
+
   private
+
+  def setup_zlibrary_download
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+    SettingsService.set(:ebook_output_path, Dir.tmpdir)
+
+    zlibrary_result = @request.search_results.create!(
+      guid: "999:deadbeef",
+      title: "Z-Library Result [EPUB]",
+      indexer: "Z-Library",
+      source: SearchResult::SOURCE_ZLIBRARY,
+      status: :selected
+    )
+    @request.search_results.where.not(id: zlibrary_result.id).update_all(status: :rejected)
+
+    @zlibrary_download = @request.downloads.create!(
+      name: zlibrary_result.title,
+      size_bytes: 1_000_000,
+      status: :queued
+    )
+  end
 
   def stub_qbittorrent_success
     # Create a valid torrent file for hash extraction

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -310,6 +310,16 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_match /Invalid direct download URL/, error.message
   end
 
+  test "validate_direct_download_url rejects z-library hosts outside configured family" do
+    setup_zlibrary_download
+
+    error = assert_raises RuntimeError do
+      DownloadJob.new.send(:validate_direct_download_url!, "https://evil.example/book.epub", @request.search_results.selected.first)
+    end
+
+    assert_match /Invalid direct download URL host/, error.message
+  end
+
   private
 
   def setup_zlibrary_download

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -320,6 +320,43 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_match /Invalid direct download URL host/, error.message
   end
 
+  test "validate_direct_download_response_headers rejects html content types" do
+    error = assert_raises RuntimeError do
+      DownloadJob.new.send(
+        :validate_direct_download_response_headers!,
+        content_type: "text/html; charset=utf-8",
+        content_length: "1024"
+      )
+    end
+
+    assert_match /unexpected content type/i, error.message
+  end
+
+  test "validate_direct_download_response_headers rejects oversized downloads" do
+    error = assert_raises RuntimeError do
+      DownloadJob.new.send(
+        :validate_direct_download_response_headers!,
+        content_type: "application/epub+zip",
+        content_length: (DownloadJob::MAX_DIRECT_DOWNLOAD_BYTES + 1).to_s
+      )
+    end
+
+    assert_match /size limit/i, error.message
+  end
+
+  test "verify_downloaded_ebook rejects invalid pdf signature" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "broken.pdf")
+      File.binwrite(path, "not a pdf")
+
+      error = assert_raises RuntimeError do
+        DownloadJob.new.send(:verify_downloaded_ebook!, path, expected_extension: "pdf")
+      end
+
+      assert_match /not a valid PDF/, error.message
+    end
+  end
+
   private
 
   def setup_zlibrary_download

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -7,6 +7,19 @@ class SearchJobTest < ActiveJob::TestCase
     @request = requests(:pending_request)
     SettingsService.set(:prowlarr_url, "http://localhost:9696")
     SettingsService.set(:prowlarr_api_key, "test-key")
+    SettingsService.set(:zlibrary_enabled, false)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+    ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
+  end
+
+  teardown do
+    SettingsService.set(:zlibrary_enabled, false)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+    ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
   end
 
   test "updates request status to searching" do
@@ -353,6 +366,106 @@ class SearchJobTest < ActiveJob::TestCase
         SearchJob.perform_now(@request.id)
       end
     end
+  end
+
+  test "includes z-library results when enabled and anna is unavailable" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+
+    result = ZLibraryClient::Result.new(
+      id: "999",
+      hash: "deadbeef",
+      title: "Z-Library Result",
+      author: @request.book.author,
+      year: 2024,
+      file_type: "epub",
+      file_size: 5_452_595,
+      language: "en"
+    )
+
+    ZLibraryClient.stub :search, ->(query, language: nil, **) {
+      assert_includes query, @request.book.title
+      assert_equal "english", language
+      [result]
+    } do
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    saved_result = @request.search_results.first
+    assert_equal SearchResult::SOURCE_ZLIBRARY, saved_result.source
+    assert_equal "999:deadbeef", saved_result.guid
+    assert_equal "Z-Library", saved_result.indexer
+  end
+
+  test "continues to z-library when indexer URL is invalid" do
+    SettingsService.set(:prowlarr_url, "localhost:9696")
+    SettingsService.set(:prowlarr_api_key, "test-key")
+    SettingsService.set(:anna_archive_enabled, false)
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+
+    result = ZLibraryClient::Result.new(
+      id: "999",
+      hash: "deadbeef",
+      title: "Z-Library Result",
+      author: @request.book.author,
+      year: 2024,
+      file_type: "epub",
+      file_size: 5_452_595,
+      language: "en"
+    )
+
+    ZLibraryClient.stub :search, [result] do
+      assert_nothing_raised do
+        SearchJob.perform_now(@request.id)
+      end
+    end
+
+    @request.reload
+    assert_equal SearchResult::SOURCE_ZLIBRARY, @request.search_results.first.source
+    assert @request.attention_needed?
+  end
+
+  test "skips z-library when anna archive is configured" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:anna_archive_enabled, true)
+    SettingsService.set(:anna_archive_api_key, "aa-key")
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+
+    AnnaArchiveClient.stub :search, [] do
+      ZLibraryClient.stub :search, ->(*) { flunk "Z-Library should not be searched when Anna's Archive is available" } do
+        SearchJob.perform_now(@request.id)
+      end
+    end
+
+    @request.reload
+    assert @request.not_found?
+    assert @request.search_results.none? { |result| result.source == SearchResult::SOURCE_ZLIBRARY }
+  end
+
+  test "marks z-library as a valid configured source" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+
+    ZLibraryClient.stub :search, [] do
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    assert @request.not_found?
+    assert_not @request.attention_needed?
   end
 
   test "uses jackett when explicitly selected as the indexer provider" do

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -95,6 +95,30 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert result.reload.selected?
   end
 
+  test "direct download results bypass seeder check" do
+    Setting.find_or_create_by(key: "auto_select_min_seeders").update!(
+      value: "100",
+      value_type: "integer",
+      category: "auto_select"
+    )
+
+    result = create_search_result(
+      seeders: nil,
+      source: SearchResult::SOURCE_ZLIBRARY,
+      download_url: nil,
+      magnet_url: nil
+    )
+
+    assert_enqueued_with(job: DownloadJob) do
+      selection = AutoSelectService.call(@request)
+
+      assert selection.success?
+      assert_equal :auto_selected, selection.reason
+    end
+
+    assert result.reload.selected?
+  end
+
   test "creates download record and enqueues job on success" do
     result = create_search_result(
       title: "Test Book - Audiobook",

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class SettingsServiceTest < ActiveSupport::TestCase
   setup do
-    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types]).delete_all
+    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -53,5 +53,17 @@ class SettingsServiceTest < ActiveSupport::TestCase
     SettingsService.set(:preferred_download_types, %w[direct torrent])
 
     assert_equal %w[direct torrent usenet], SettingsService.preferred_download_types
+  end
+
+  test "zlibrary_configured? requires enabled flag and credentials" do
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+
+    assert SettingsService.zlibrary_configured?
+
+    SettingsService.set(:zlibrary_enabled, false)
+    assert_not SettingsService.zlibrary_configured?
   end
 end

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ZLibraryClientTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+    ZLibraryClient.reset_connection!
+  end
+
+  teardown do
+    SettingsService.set(:zlibrary_enabled, false)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "")
+    SettingsService.set(:zlibrary_password, "")
+    ZLibraryClient.reset_connection!
+  end
+
+  test "configured? requires enable flag and credentials" do
+    assert ZLibraryClient.configured?
+
+    SettingsService.set(:zlibrary_enabled, false)
+    assert_not ZLibraryClient.configured?
+  end
+
+  test "test_connection returns true when login succeeds" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      assert ZLibraryClient.test_connection
+    end
+  end
+
+  test "search returns parsed results" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .to_return(
+          status: 200,
+          body: {
+            success: 1,
+            books: [
+              {
+                id: 999,
+                hash: "deadbeef",
+                name: "Test Book",
+                author: "Author",
+                year: "2024",
+                extension: "epub",
+                filesize: "12345",
+                language: "English"
+              }
+            ]
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      results = ZLibraryClient.search("Test Book", language: "english")
+
+      assert_equal 1, results.size
+      assert_equal "999", results.first.id
+      assert_equal "en", results.first.language
+    end
+  end
+
+  test "search raises AuthenticationError when login fails" do
+    VCR.turned_off do
+      stub_zlibrary_login_failure
+
+      assert_raises ZLibraryClient::AuthenticationError do
+        ZLibraryClient.search("Test")
+      end
+    end
+  end
+
+  test "search passes language filter through request body" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .with { |request| request.body.include?("languages%5B%5D=english") }
+        .to_return(
+          status: 200,
+          body: { success: 1, books: [] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ZLibraryClient.search("Test", language: "english")
+
+      assert_requested(:post, "https://z-library.sk/eapi/book/search")
+    end
+  end
+
+  test "get_download_url validates returned URL scheme" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:get, "https://z-library.sk/eapi/book/999/deadbeef/file")
+        .to_return(
+          status: 200,
+          body: {
+            success: 1,
+            file: { downloadLink: "file:///tmp/book.epub" }
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      assert_raises ZLibraryClient::Error do
+        ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+      end
+    end
+  end
+
+  test "login cache is invalidated when credentials change" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+
+      first_auth = ZLibraryClient.send(:login)
+      SettingsService.set(:zlibrary_password, "new-secret")
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .with(body: "email=reader%40example.com&password=new-secret")
+        .to_return(
+          status: 200,
+          body: { success: 1, user: { id: "54321", remix_userkey: "updated-key" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      second_auth = ZLibraryClient.send(:login)
+
+      refute_equal first_auth, second_auth
+      assert_equal "54321", second_auth[:remix_userid]
+    end
+  end
+
+  test "configured? requires a valid url" do
+    SettingsService.set(:zlibrary_url, "")
+    assert_not ZLibraryClient.configured?
+  end
+
+  test "test_connection returns false for invalid url" do
+    SettingsService.set(:zlibrary_url, "not-a-url")
+    assert_not ZLibraryClient.test_connection
+  end
+
+  private
+
+  def stub_zlibrary_login_success
+    stub_request(:post, "https://z-library.sk/eapi/user/login")
+      .with(body: "email=reader%40example.com&password=secret")
+      .to_return(
+        status: 200,
+        body: { success: 1, user: { id: "12345", remix_userkey: "abc123" } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def stub_zlibrary_login_failure
+    stub_request(:post, "https://z-library.sk/eapi/user/login")
+      .to_return(status: 500, body: "server error")
+  end
+end

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -111,6 +111,25 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "get_download_url rejects hosts outside configured family" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:get, "https://z-library.sk/eapi/book/999/deadbeef/file")
+        .to_return(
+          status: 200,
+          body: {
+            success: 1,
+            file: { downloadLink: "https://evil.example/book.epub" }
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      assert_raises ZLibraryClient::Error do
+        ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+      end
+    end
+  end
+
   test "login cache is invalidated when credentials change" do
     VCR.turned_off do
       stub_zlibrary_login_success
@@ -139,6 +158,11 @@ class ZLibraryClientTest < ActiveSupport::TestCase
 
   test "test_connection returns false for invalid url" do
     SettingsService.set(:zlibrary_url, "not-a-url")
+    assert_not ZLibraryClient.test_connection
+  end
+
+  test "test_connection returns false when url includes a path" do
+    SettingsService.set(:zlibrary_url, "https://z-library.sk/login")
     assert_not ZLibraryClient.test_connection
   end
 


### PR DESCRIPTION
## Summary
- add a Z-Library ebook fallback with configurable URL, credentials, and admin connection testing
- integrate Z-Library search, direct download handling, and auto-select support for direct sources
- harden search fallback behavior so misconfigured indexers do not block Z-Library results

## Testing
- bundle exec rails test
- manual local validation against a real Z-Library account for login, search, and download URL lookup