### PR TITLE
fix: add optional OIDC user linking

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,6 +190,12 @@ class User < ApplicationRecord
     user = active.find_by(oidc_provider: provider, oidc_uid: uid)
     return user if user
 
+    # Optionally link an existing unlinked local account by username
+    if SettingsService.get(:oidc_link_existing_users, default: false)
+      user = find_linkable_user_for_oidc(info, provider:, uid:)
+      return user if user
+    end
+
     # Auto-create user if enabled
     return nil unless SettingsService.get(:oidc_auto_create_users, default: false)
 
@@ -228,6 +234,31 @@ class User < ApplicationRecord
   end
 
   private
+
+  def self.find_linkable_user_for_oidc(info, provider:, uid:)
+    candidate_usernames_from_oidc(info).each do |candidate|
+      user = active.find_by(username: candidate)
+      next unless user
+      next if user.oidc_user?
+
+      user.link_oidc_identity!(provider: provider, uid: uid)
+      return user
+    rescue OidcIdentityAlreadyLinkedError, OidcIdentityConflictError
+      next
+    end
+
+    nil
+  end
+
+  def self.candidate_usernames_from_oidc(info)
+    email_prefix = info["email"].to_s.strip.downcase.split("@").first
+    preferred_username = info["preferred_username"].to_s.strip.downcase
+
+    [ preferred_username, email_prefix ]
+      .map { |value| value.to_s.gsub(/[^a-z0-9_]/, "_") }
+      .reject(&:blank?)
+      .uniq
+  end
 
   def set_admin_if_first_user
     self.role = :admin if User.active.count.zero?

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -123,6 +123,7 @@ class SettingsService
     oidc_client_id: { type: "string", default: "", category: "oidc", description: "OIDC client ID from your identity provider" },
     oidc_client_secret: { type: "string", default: "", category: "oidc", description: "OIDC client secret from your identity provider" },
     oidc_scopes: { type: "string", default: "openid profile email", category: "oidc", description: "OIDC scopes to request (space-separated)" },
+    oidc_link_existing_users: { type: "boolean", default: false, category: "oidc", description: "When enabled, OIDC sign-in will link an unlinked local user whose username matches the OIDC preferred username or email prefix." },
     oidc_auto_create_users: { type: "boolean", default: false, category: "oidc", description: "Automatically create new users on first OIDC login" },
     oidc_default_role: { type: "string", default: "user", category: "oidc", description: "Default role for auto-created OIDC users (user or admin)" }
   }.freeze

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -84,6 +84,15 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: /Use \/session\/new\?local=1/
   end
 
+  test "index shows OIDC link existing users setting" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label", text: "Oidc Link Existing Users"
+    assert_select "input[name='settings[oidc_link_existing_users]']"
+    assert_select "p", text: /link an unlinked local user/
+  end
+
   test "bulk_update stores ordered download type preferences" do
     patch bulk_update_admin_settings_url, params: {
       settings: {
@@ -104,6 +113,17 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_settings_path
     assert_equal true, SettingsService.get(:oidc_auto_redirect)
+  end
+
+  test "bulk_update stores OIDC link existing users setting" do
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        oidc_link_existing_users: "true"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal true, SettingsService.get(:oidc_link_existing_users)
   end
 
   test "index shows library picker dropdown when audiobookshelf configured" do

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -57,6 +57,32 @@ class Auth::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     assert_match(/not found/i, flash[:alert])
   end
 
+  test "OIDC login links existing local user when linking is enabled" do
+    SettingsService.set(:oidc_link_existing_users, true)
+
+    user = User.create!(
+      username: "existing_user",
+      name: "Existing User",
+      password: "ValidPassword123!"
+    )
+
+    OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new({
+      provider: "oidc",
+      uid: "existing-user-uid",
+      info: {
+        preferred_username: "existing_user",
+        email: "existing_user@example.com",
+        name: "Existing User"
+      }
+    })
+
+    get "/auth/oidc/callback"
+
+    assert_redirected_to root_path
+    assert_equal "oidc", user.reload.oidc_provider
+    assert_equal "existing-user-uid", user.oidc_uid
+  end
+
   test "OIDC login creates user when auto-create enabled" do
     SettingsService.set(:oidc_auto_create_users, true)
     SettingsService.set(:oidc_default_role, "user")

--- a/test/models/user_oidc_test.rb
+++ b/test/models/user_oidc_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class UserOidcTest < ActiveSupport::TestCase
   setup do
     SettingsService.set(:oidc_auto_create_users, false)
+    SettingsService.set(:oidc_link_existing_users, false)
     SettingsService.set(:oidc_default_role, "user")
   end
 
@@ -53,6 +54,50 @@ class UserOidcTest < ActiveSupport::TestCase
 
     assert_nil result
     assert_not user.reload.oidc_user?
+  end
+
+  test "from_oidc links existing user by preferred_username when linking is enabled" do
+    SettingsService.set(:oidc_link_existing_users, true)
+
+    user = User.create!(
+      username: "johndoe",
+      name: "John Doe",
+      password: "ValidPassword123!"
+    )
+
+    auth_hash = {
+      "provider" => "oidc",
+      "uid" => "new-uid",
+      "info" => { "preferred_username" => "johndoe" }
+    }
+
+    result = User.from_oidc(auth_hash)
+
+    assert_equal user, result
+    assert_equal "oidc", user.reload.oidc_provider
+    assert_equal "new-uid", user.oidc_uid
+  end
+
+  test "from_oidc links existing user by email prefix when linking is enabled" do
+    SettingsService.set(:oidc_link_existing_users, true)
+
+    user = User.create!(
+      username: "johndoe",
+      name: "John Doe",
+      password: "ValidPassword123!"
+    )
+
+    auth_hash = {
+      "provider" => "oidc",
+      "uid" => "new-uid",
+      "info" => { "email" => "johndoe@example.com" }
+    }
+
+    result = User.from_oidc(auth_hash)
+
+    assert_equal user, result
+    assert_equal "oidc", user.reload.oidc_provider
+    assert_equal "new-uid", user.oidc_uid
   end
 
   test "from_oidc returns nil when user not found and auto-create disabled" do


### PR DESCRIPTION
## Summary
- add an opt-in OIDC setting to link an existing unlinked local user during OIDC sign-in
- match local users by OIDC preferred username or email prefix when the setting is enabled
- keep the stricter OIDC identity constraints and explicit profile-based linking flow from #217 intact

## Issue
Closes #221

## Testing
- bundle exec rails test
- bundle exec rubocop app/models/user.rb app/services/settings_service.rb test/models/user_oidc_test.rb test/controllers/auth/omniauth_callbacks_controller_test.rb test/controllers/admin/settings_controller_test.rb
