### PR TITLE
feat: send attention webhook for all mark_for_attention events

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -33,6 +33,7 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: "No search result selected for download", level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("No search result selected for download")
+      NotificationService.request_attention(download.request)
       return
     end
 
@@ -50,31 +51,37 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!(e.message)
+      NotificationService.request_attention(download.request)
     rescue DownloadClients::Base::AuthenticationError => e
       Rails.logger.error "[DownloadJob] Download client authentication failed: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Download client authentication failed. Please check credentials.")
+      NotificationService.request_attention(download.request)
     rescue DownloadClients::Base::ConnectionError => e
       Rails.logger.error "[DownloadJob] Download client connection error: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Failed to connect to download client: #{e.message}")
+      NotificationService.request_attention(download.request)
     rescue DownloadClients::Base::Error => e
       Rails.logger.error "[DownloadJob] Download client error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Download client error: #{e.message}")
+      NotificationService.request_attention(download.request)
     rescue AnnaArchiveClient::Error => e
       Rails.logger.error "[DownloadJob] Anna's Archive error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Anna's Archive error: #{e.message}")
+      NotificationService.request_attention(download.request)
     rescue ZLibraryClient::Error => e
       Rails.logger.error "[DownloadJob] Z-Library error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Z-Library error: #{e.message}")
+      NotificationService.request_attention(download.request)
     end
   end
 
@@ -157,6 +164,7 @@ class DownloadJob < ApplicationJob
     track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
     download.update!(status: :failed)
     download.request.mark_for_attention!("Direct download failed: #{e.message}")
+    NotificationService.request_attention(download.request)
   end
 
   def infer_filename_from_url(url, search_result)
@@ -377,6 +385,7 @@ class DownloadJob < ApplicationJob
       )
       download.update!(status: :failed)
       download.request.mark_for_attention!("Failed to add to #{client_record.name}")
+      NotificationService.request_attention(download.request)
       Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
     end
   end
@@ -387,6 +396,7 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: "Selected result has no download link", level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Selected result has no download link")
+      NotificationService.request_attention(download.request)
       return
     end
 
@@ -449,6 +459,7 @@ class DownloadJob < ApplicationJob
       )
       download.update!(status: :failed)
       download.request.mark_for_attention!("Failed to add to #{client_record.name}")
+      NotificationService.request_attention(download.request)
       Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
     end
   end

--- a/app/jobs/download_monitor_job.rb
+++ b/app/jobs/download_monitor_job.rb
@@ -110,6 +110,7 @@ class DownloadMonitorJob < ApplicationJob
     track_request_event(download.request, "failed", download: download, message: "Download failed in client", level: :error)
     download.update!(status: :failed)
     download.request.mark_for_attention!("Download failed in client")
+    NotificationService.request_attention(download.request)
   end
 
   def handle_missing(download)
@@ -129,6 +130,7 @@ class DownloadMonitorJob < ApplicationJob
       )
       download.update!(status: :failed, not_found_count: new_count)
       download.request.mark_for_attention!("Download not found in client '#{client_name}' (hash: #{download.external_id})")
+      NotificationService.request_attention(download.request)
     else
       Rails.logger.warn "[DownloadMonitorJob] Download #{download.id} (hash: #{download.external_id}) not found in client '#{client_name}' (attempt #{new_count}/#{NOT_FOUND_THRESHOLD})"
 
@@ -156,6 +158,7 @@ class DownloadMonitorJob < ApplicationJob
     download.request.mark_for_attention!(
       "Download stayed queued in Shelfarr for more than #{timeout_minutes} minutes and was never sent to the download client. Retry the request and check the job queue/logs."
     )
+    NotificationService.request_attention(download.request)
   end
 
   def schedule_next_run

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -21,6 +21,7 @@ class SearchJob < ApplicationJob
     unless indexer_available || anna_available || zlibrary_available
       Rails.logger.error "[SearchJob] No search sources configured"
       request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, or Z-Library in Admin Settings.")
+      NotificationService.request_attention(request)
       return
     end
 
@@ -75,8 +76,10 @@ class SearchJob < ApplicationJob
   def handle_no_results(request, indexer_error)
     if @anna_archive_bot_protection_error
       request.mark_for_attention!(@anna_archive_bot_protection_error)
+      NotificationService.request_attention(request)
     elsif indexer_error.is_a?(IndexerClients::Base::AuthenticationError)
       request.mark_for_attention!("#{IndexerClient.display_name} authentication failed. Please check your API key.")
+      NotificationService.request_attention(request)
     else
       request.schedule_retry!
     end
@@ -281,6 +284,7 @@ class SearchJob < ApplicationJob
     unless SettingsService.get(:auto_select_enabled, default: false)
       # Auto-select disabled, flag for manual selection
       request.mark_for_attention!("Search results found. Please review and select a result to download.")
+      NotificationService.request_attention(request)
       Rails.logger.info "[SearchJob] Auto-select disabled, flagged for manual selection for request ##{request.id}"
       return
     end
@@ -292,6 +296,7 @@ class SearchJob < ApplicationJob
     else
       # Auto-select failed to find a suitable result, flag for manual selection
       request.mark_for_attention!("Search results found but none matched auto-select criteria. Please review and select a result manually.")
+      NotificationService.request_attention(request)
       Rails.logger.info "[SearchJob] Auto-select failed, flagged for manual selection for request ##{request.id}"
     end
   end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -357,6 +357,53 @@ class DownloadJobTest < ActiveJob::TestCase
     end
   end
 
+  test "sends attention notification when no search result selected" do
+    @request.search_results.update_all(status: :pending)
+
+    attention_requests = []
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    assert_equal 1, attention_requests.size
+    assert_equal @request, attention_requests.first
+  end
+
+  test "sends attention notification when download client unavailable" do
+    DownloadClient.destroy_all
+
+    attention_requests = []
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    assert_equal 1, attention_requests.size
+  end
+
+  test "sends attention notification when selected result has no download link" do
+    @selected_result.update!(download_url: nil, magnet_url: nil, source: "prowlarr")
+
+    attention_requests = []
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    assert_equal 1, attention_requests.size
+  end
+
+  test "download still fails gracefully when outbound dispatch fails" do
+    @request.search_results.update_all(status: :pending)
+
+    OutboundNotifications::Dispatcher.stub :notify, ->(**) { raise "Webhook delivery failed" } do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    @download.reload
+    assert @download.failed?
+    @request.reload
+    assert @request.attention_needed?
+  end
+
   private
 
   def setup_zlibrary_download

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -390,6 +390,75 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     end
   end
 
+  test "sends attention notification when download fails in client" do
+    VCR.turned_off do
+      stub_qbittorrent_auth
+      stub_qbittorrent_torrent_info(progress: 0, state: "error")
+
+      attention_requests = []
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        DownloadMonitorJob.perform_now
+      end
+
+      assert_equal 1, attention_requests.size
+      assert_equal @request, attention_requests.first
+    end
+  end
+
+  test "sends attention notification when download not found after threshold" do
+    @download.update!(not_found_count: DownloadMonitorJob::NOT_FOUND_THRESHOLD - 1)
+
+    VCR.turned_off do
+      stub_qbittorrent_auth
+      stub_qbittorrent_torrent_not_found
+
+      attention_requests = []
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        DownloadMonitorJob.perform_now
+      end
+
+      assert_equal 1, attention_requests.size
+    end
+  end
+
+  test "sends attention notification when download stays queued past timeout" do
+    @download.update_columns(
+      status: Download.statuses[:queued],
+      external_id: nil,
+      download_client_id: nil,
+      created_at: 10.minutes.ago,
+      updated_at: 10.minutes.ago
+    )
+    SettingsService.set(:download_enqueue_timeout_minutes, 5)
+
+    attention_requests = []
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadMonitorJob.perform_now
+    end
+
+    assert_equal 1, attention_requests.size
+  end
+
+  test "download still marked failed when outbound dispatch fails" do
+    @download.update_columns(
+      status: Download.statuses[:queued],
+      external_id: nil,
+      download_client_id: nil,
+      created_at: 10.minutes.ago,
+      updated_at: 10.minutes.ago
+    )
+    SettingsService.set(:download_enqueue_timeout_minutes, 5)
+
+    OutboundNotifications::Dispatcher.stub :notify, ->(**) { raise "Webhook delivery failed" } do
+      DownloadMonitorJob.perform_now
+    end
+
+    @download.reload
+    assert @download.failed?
+    @request.reload
+    assert @request.attention_needed?
+  end
+
   private
 
   def stub_qbittorrent_auth

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -69,6 +69,85 @@ class SearchJobTest < ActiveJob::TestCase
     assert_includes @request.issue_description, "No search sources configured"
   end
 
+  test "sends attention notification when no search sources configured" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:anna_archive_enabled, false)
+
+    attention_requests = []
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    assert @request.attention_needed?
+    assert_equal 1, attention_requests.size
+    assert_equal @request, attention_requests.first
+  end
+
+  test "sends attention notification when auto-select disabled" do
+    SettingsService.set(:auto_select_enabled, false)
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+
+      attention_requests = []
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        SearchJob.perform_now(@request.id)
+      end
+
+      @request.reload
+      assert @request.attention_needed?
+      assert_equal 1, attention_requests.size
+    end
+  end
+
+  test "sends attention notification when auto-select fails" do
+    SettingsService.set(:auto_select_enabled, true)
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+
+      attention_requests = []
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        AutoSelectService.stub :call, OpenStruct.new(success?: false) do
+          SearchJob.perform_now(@request.id)
+        end
+      end
+
+      @request.reload
+      assert @request.attention_needed?
+      assert_equal 1, attention_requests.size
+    end
+  end
+
+  test "sends attention notification on indexer authentication failure" do
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696}).to_raise(IndexerClients::Base::AuthenticationError.new("Invalid API key"))
+
+      attention_requests = []
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        SearchJob.perform_now(@request.id)
+      end
+
+      @request.reload
+      assert @request.attention_needed?
+      assert_equal 1, attention_requests.size
+    end
+  end
+
+  test "attention notification still works when outbound dispatch fails" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:anna_archive_enabled, false)
+
+    OutboundNotifications::Dispatcher.stub :notify, ->(**) { raise "Webhook delivery failed" } do
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    assert @request.attention_needed?
+    assert_includes @request.issue_description, "No search sources configured"
+  end
+
   test "skips non-pending requests" do
     @request.update!(status: :searching)
 


### PR DESCRIPTION
## Summary
- dispatch `request_attention` webhook after every `mark_for_attention!` call across SearchJob, DownloadJob, and DownloadMonitorJob
- only PostProcessingJob previously fired this notification, so 19 other call sites silently flagged requests without sending a webhook
- users with webhook/ntfy integrations now get notified immediately instead of polling the UI

## Motivation

The `request_attention` event type, the webhook delivery pipeline, and the `webhook_events` default all already exist. The gap was that most jobs called `mark_for_attention!` without also dispatching `NotificationService.request_attention`. This matches the pattern PostProcessingJob already uses (lines 40-41).

I considered moving the dispatch into `mark_for_attention!` itself to avoid this gap in the future, but kept it as explicit calls to match the existing PostProcessingJob pattern. Happy to refactor if you prefer it centralized.

## Testing
- `bundle exec rails test`
- 13 new tests: notification dispatch assertions + defensive tests confirming jobs still work when outbound delivery fails