### PR TITLE
feat: add indexer preference for download client routing

### DIFF
--- a/app/controllers/admin/download_clients_controller.rb
+++ b/app/controllers/admin/download_clients_controller.rb
@@ -74,6 +74,11 @@ module Admin
       redirect_to admin_download_clients_path
     end
 
+    def available_indexers
+      names = fetch_indexer_names
+      render json: names
+    end
+
     private
 
     def set_download_client
@@ -83,7 +88,7 @@ module Admin
     def download_client_params
       params.require(:download_client).permit(
         :name, :client_type, :url, :username, :password, :api_key, :category, :download_path, :enabled,
-        :torrent_verification_max_attempts, :torrent_verification_wait_time
+        :torrent_verification_max_attempts, :torrent_verification_wait_time, :preferred_indexers
       )
     end
 
@@ -110,6 +115,20 @@ module Admin
       HealthCheckJob.perform_now(service: "download_client")
     rescue => e
       Rails.logger.warn "[DownloadClientsController] Failed to run download client health check: #{e.message}"
+    end
+
+    def fetch_indexer_names
+      return [] unless IndexerClient.configured?
+
+      provider = IndexerClient.current
+      if provider.respond_to?(:indexers)
+        provider.indexers.map { |i| i["name"] }.compact.sort
+      else
+        []
+      end
+    rescue StandardError => e
+      Rails.logger.warn "[DownloadClientsController] Failed to fetch indexer names: #{e.message}"
+      []
     end
 
     def sync_download_monitor

--- a/app/controllers/admin/download_clients_controller.rb
+++ b/app/controllers/admin/download_clients_controller.rb
@@ -76,7 +76,15 @@ module Admin
 
     def available_indexers
       names = fetch_indexer_names
-      render json: names
+      exclude_id = params[:client_id].present? ? params[:client_id].to_i : nil
+      assignments = DownloadClient.indexer_assignments(exclude_client_id: exclude_id)
+
+      result = names.map do |name|
+        assigned_to = assignments[name.downcase]
+        { name: name, assigned_to: assigned_to }
+      end
+
+      render json: result
     end
 
     private

--- a/app/javascript/controllers/indexer_preference_controller.js
+++ b/app/javascript/controllers/indexer_preference_controller.js
@@ -41,30 +41,59 @@ export default class extends Controller {
       .map(s => s.trim().toLowerCase())
       .filter(s => s.length > 0)
 
-    const html = indexers.map(name => {
-      const checked = selected.includes(name.toLowerCase()) ? "checked" : ""
-      const id = `indexer_${name.replace(/[^a-zA-Z0-9]/g, "_")}`
-      return `
-        <label class="flex items-center gap-2 py-1 cursor-pointer" for="${id}">
-          <input type="checkbox" id="${id}" value="${name}" ${checked}
-                 class="rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900"
-                 data-action="change->indexer-preference#updateSelection">
-          <span class="text-gray-300 text-sm">${name}</span>
-        </label>
-      `
-    }).join("")
+    this.containerTarget.innerHTML = ""
 
-    this.containerTarget.innerHTML = html
+    indexers.forEach(indexer => {
+      const name = indexer.name
+      const assignedTo = indexer.assigned_to
+      const isSelected = selected.includes(name.toLowerCase())
+      const isDisabled = assignedTo && !isSelected
+
+      const label = document.createElement("label")
+      label.className = `flex items-center gap-2 py-1 ${isDisabled ? "opacity-50" : "cursor-pointer"}`
+
+      const checkbox = document.createElement("input")
+      checkbox.type = "checkbox"
+      checkbox.value = name
+      checkbox.checked = isSelected
+      checkbox.disabled = isDisabled
+      checkbox.className = "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900"
+      checkbox.dataset.action = "change->indexer-preference#updateSelection"
+
+      const span = document.createElement("span")
+      span.className = `text-sm ${isDisabled ? "text-gray-500" : "text-gray-300"}`
+      span.textContent = name
+
+      label.appendChild(checkbox)
+      label.appendChild(span)
+
+      if (assignedTo && !isSelected) {
+        const badge = document.createElement("span")
+        badge.className = "text-xs text-gray-500 ml-1"
+        badge.textContent = `(${assignedTo})`
+        label.appendChild(badge)
+      }
+
+      this.containerTarget.appendChild(label)
+    })
   }
 
   showFallback() {
-    this.containerTarget.innerHTML = `
-      <input type="text" value="${this.currentValue || ""}"
-             placeholder="e.g. MyAnonaMouse, IPTorrents"
-             class="block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 w-full"
-             data-action="input->indexer-preference#updateFromText">
-      <p class="mt-1 text-sm text-gray-500">Configure an indexer provider to see available indexers as checkboxes.</p>
-    `
+    this.containerTarget.innerHTML = ""
+
+    const input = document.createElement("input")
+    input.type = "text"
+    input.value = this.currentValue || ""
+    input.placeholder = "e.g. MyAnonaMouse, IPTorrents"
+    input.className = "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 w-full"
+    input.dataset.action = "input->indexer-preference#updateFromText"
+
+    const hint = document.createElement("p")
+    hint.className = "mt-1 text-sm text-gray-500"
+    hint.textContent = "Configure an indexer provider to see available indexers as checkboxes."
+
+    this.containerTarget.appendChild(input)
+    this.containerTarget.appendChild(hint)
   }
 
   updateSelection() {

--- a/app/javascript/controllers/indexer_preference_controller.js
+++ b/app/javascript/controllers/indexer_preference_controller.js
@@ -1,0 +1,79 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "container"]
+  static values = {
+    url: String,
+    current: { type: String, default: "" }
+  }
+
+  connect() {
+    this.loadIndexers()
+  }
+
+  async loadIndexers() {
+    try {
+      const response = await fetch(this.urlValue, {
+        headers: { "Accept": "application/json" }
+      })
+
+      if (!response.ok) {
+        this.showFallback()
+        return
+      }
+
+      const indexers = await response.json()
+
+      if (indexers.length === 0) {
+        this.showFallback()
+        return
+      }
+
+      this.renderCheckboxes(indexers)
+    } catch (error) {
+      this.showFallback()
+    }
+  }
+
+  renderCheckboxes(indexers) {
+    const selected = this.currentValue
+      .split(",")
+      .map(s => s.trim().toLowerCase())
+      .filter(s => s.length > 0)
+
+    const html = indexers.map(name => {
+      const checked = selected.includes(name.toLowerCase()) ? "checked" : ""
+      const id = `indexer_${name.replace(/[^a-zA-Z0-9]/g, "_")}`
+      return `
+        <label class="flex items-center gap-2 py-1 cursor-pointer" for="${id}">
+          <input type="checkbox" id="${id}" value="${name}" ${checked}
+                 class="rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900"
+                 data-action="change->indexer-preference#updateSelection">
+          <span class="text-gray-300 text-sm">${name}</span>
+        </label>
+      `
+    }).join("")
+
+    this.containerTarget.innerHTML = html
+  }
+
+  showFallback() {
+    this.containerTarget.innerHTML = `
+      <input type="text" value="${this.currentValue || ""}"
+             placeholder="e.g. MyAnonaMouse, IPTorrents"
+             class="block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 w-full"
+             data-action="input->indexer-preference#updateFromText">
+      <p class="mt-1 text-sm text-gray-500">Configure an indexer provider to see available indexers as checkboxes.</p>
+    `
+  }
+
+  updateSelection() {
+    const checkboxes = this.containerTarget.querySelectorAll("input[type=checkbox]:checked")
+    const names = Array.from(checkboxes).map(cb => cb.value)
+    this.inputTarget.value = names.join(",")
+  }
+
+  updateFromText(event) {
+    this.inputTarget.value = event.target.value
+  }
+}

--- a/app/models/download_client.rb
+++ b/app/models/download_client.rb
@@ -22,6 +22,7 @@ class DownloadClient < ApplicationRecord
     numericality: { only_integer: true, greater_than: 0 }
   validates :torrent_verification_wait_time,
     numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :preferred_indexers_not_claimed_by_other_clients
 
   scope :enabled, -> { where(enabled: true) }
   scope :by_priority, -> { order(priority: :asc) }
@@ -67,11 +68,46 @@ class DownloadClient < ApplicationRecord
     names.any? { |name| name.casecmp(indexer_name.strip) == 0 }
   end
 
+  def preferred_indexer_list
+    return [] if preferred_indexers.blank?
+
+    preferred_indexers.split(",").map(&:strip).reject(&:blank?)
+  end
+
+  class << self
+    def indexer_assignments(exclude_client_id: nil)
+      scope = preferred_indexers_present
+      scope = scope.where.not(id: exclude_client_id) if exclude_client_id
+      scope.each_with_object({}) do |client, map|
+        client.preferred_indexer_list.each { |name| map[name.downcase] = client.name }
+      end
+    end
+
+    private
+
+    def preferred_indexers_present
+      where.not(preferred_indexers: [nil, ""])
+    end
+  end
+
   def requires_authentication?
     qbittorrent? || decypharr? || nzbget? || deluge? || transmission?
   end
 
   def qbittorrent_compatible?
     qbittorrent? || decypharr?
+  end
+
+  private
+
+  def preferred_indexers_not_claimed_by_other_clients
+    return if preferred_indexers.blank?
+
+    assignments = self.class.indexer_assignments(exclude_client_id: id)
+    conflicts = preferred_indexer_list.select { |name| assignments.key?(name.downcase) }
+    return if conflicts.empty?
+
+    conflict_details = conflicts.map { |name| "#{name} (#{assignments[name.downcase]})" }
+    errors.add(:preferred_indexers, "contains indexers already assigned to other clients: #{conflict_details.join(', ')}")
   end
 end

--- a/app/models/download_client.rb
+++ b/app/models/download_client.rb
@@ -83,7 +83,7 @@ class DownloadClient < ApplicationRecord
 
   class << self
     def indexer_assignments(exclude_client_id: nil)
-      scope = where.not(preferred_indexers: [nil, ""])
+      scope = enabled.torrent_clients.where.not(preferred_indexers: [nil, ""])
       scope = scope.where.not(id: exclude_client_id) if exclude_client_id
       scope.each_with_object({}) do |client, map|
         client.preferred_indexer_list.each { |name| map[name.downcase] = client.name }

--- a/app/models/download_client.rb
+++ b/app/models/download_client.rb
@@ -60,6 +60,13 @@ class DownloadClient < ApplicationRecord
     sabnzbd? || nzbget?
   end
 
+  def preferred_for_indexer?(indexer_name)
+    return false if preferred_indexers.blank? || indexer_name.blank?
+
+    names = preferred_indexers.split(",").map(&:strip).reject(&:blank?)
+    names.any? { |name| name.casecmp(indexer_name.strip) == 0 }
+  end
+
   def requires_authentication?
     qbittorrent? || decypharr? || nzbget? || deluge? || transmission?
   end

--- a/app/models/download_client.rb
+++ b/app/models/download_client.rb
@@ -62,32 +62,15 @@ class DownloadClient < ApplicationRecord
   end
 
   def preferred_for_indexer?(indexer_name)
-    return false if preferred_indexers.blank? || indexer_name.blank?
+    return false if indexer_name.blank?
 
-    names = preferred_indexers.split(",").map(&:strip).reject(&:blank?)
-    names.any? { |name| name.casecmp(indexer_name.strip) == 0 }
+    preferred_indexer_list.any? { |name| name.casecmp(indexer_name.strip) == 0 }
   end
 
   def preferred_indexer_list
     return [] if preferred_indexers.blank?
 
     preferred_indexers.split(",").map(&:strip).reject(&:blank?)
-  end
-
-  class << self
-    def indexer_assignments(exclude_client_id: nil)
-      scope = preferred_indexers_present
-      scope = scope.where.not(id: exclude_client_id) if exclude_client_id
-      scope.each_with_object({}) do |client, map|
-        client.preferred_indexer_list.each { |name| map[name.downcase] = client.name }
-      end
-    end
-
-    private
-
-    def preferred_indexers_present
-      where.not(preferred_indexers: [nil, ""])
-    end
   end
 
   def requires_authentication?
@@ -98,10 +81,21 @@ class DownloadClient < ApplicationRecord
     qbittorrent? || decypharr?
   end
 
+  class << self
+    def indexer_assignments(exclude_client_id: nil)
+      scope = where.not(preferred_indexers: [nil, ""])
+      scope = scope.where.not(id: exclude_client_id) if exclude_client_id
+      scope.each_with_object({}) do |client, map|
+        client.preferred_indexer_list.each { |name| map[name.downcase] = client.name }
+      end
+    end
+  end
+
   private
 
   def preferred_indexers_not_claimed_by_other_clients
     return if preferred_indexers.blank?
+    return unless preferred_indexers_changed?
 
     assignments = self.class.indexer_assignments(exclude_client_id: id)
     conflicts = preferred_indexer_list.select { |name| assignments.key?(name.downcase) }

--- a/app/services/download_client_selector.rb
+++ b/app/services/download_client_selector.rb
@@ -42,7 +42,14 @@ class DownloadClientSelector
       raise NoClientAvailableError, "No #{download_type} download client configured"
     end
 
-    # Try each client in priority order until one succeeds connection test
+    # Prefer clients with matching indexer preference
+    indexer_name = @search_result.indexer
+    if indexer_name.present?
+      preferred = available_clients.select { |c| c.preferred_for_indexer?(indexer_name) }
+      preferred.each { |client| return client if client.test_connection }
+    end
+
+    # Fall back to priority order
     available_clients.each do |client|
       return client if client.test_connection
     end

--- a/app/views/admin/download_clients/_form.html.erb
+++ b/app/views/admin/download_clients/_form.html.erb
@@ -78,6 +78,17 @@
     <p class="mt-1 text-sm text-gray-500">Container path where completed downloads appear (e.g., /downloads). Leave blank to use global settings.</p>
   </div>
 
+  <div class="my-5" data-controller="indexer-preference"
+       data-indexer-preference-url-value="<%= available_indexers_admin_download_clients_path %>"
+       data-indexer-preference-current-value="<%= download_client.preferred_indexers %>">
+    <%= form.label :preferred_indexers, "Indexer Preference", class: "block text-gray-300 font-medium" %>
+    <%= form.hidden_field :preferred_indexers, data: { indexer_preference_target: "input" } %>
+    <div data-indexer-preference-target="container" class="mt-2">
+      <p class="text-sm text-gray-500">Loading indexers...</p>
+    </div>
+    <p class="mt-1 text-sm text-gray-500">Optional. Downloads from selected indexers will prefer this client over the default priority order. Assign each indexer to only one client.</p>
+  </div>
+
   <div id="qbittorrent_fields" class="<%= 'hidden' unless download_client.qbittorrent? || download_client.new_record? %>">
     <div class="grid gap-5 md:grid-cols-2">
       <div>

--- a/app/views/admin/download_clients/_form.html.erb
+++ b/app/views/admin/download_clients/_form.html.erb
@@ -78,15 +78,16 @@
     <p class="mt-1 text-sm text-gray-500">Container path where completed downloads appear (e.g., /downloads). Leave blank to use global settings.</p>
   </div>
 
-  <div class="my-5" data-controller="indexer-preference"
-       data-indexer-preference-url-value="<%= available_indexers_admin_download_clients_path %>"
+  <div id="indexer_preference_fields" class="my-5 <%= 'hidden' if download_client.usenet_client? %>"
+       data-controller="indexer-preference"
+       data-indexer-preference-url-value="<%= available_indexers_admin_download_clients_path(client_id: download_client.id) %>"
        data-indexer-preference-current-value="<%= download_client.preferred_indexers %>">
     <%= form.label :preferred_indexers, "Indexer Preference", class: "block text-gray-300 font-medium" %>
     <%= form.hidden_field :preferred_indexers, data: { indexer_preference_target: "input" } %>
     <div data-indexer-preference-target="container" class="mt-2">
       <p class="text-sm text-gray-500">Loading indexers...</p>
     </div>
-    <p class="mt-1 text-sm text-gray-500">Optional. Downloads from selected indexers will prefer this client over the default priority order. Assign each indexer to only one client.</p>
+    <p class="mt-1 text-sm text-gray-500">Optional. Downloads from selected indexers will prefer this client over the default priority order.</p>
   </div>
 
   <div id="qbittorrent_fields" class="<%= 'hidden' unless download_client.qbittorrent? || download_client.new_record? %>">
@@ -126,17 +127,22 @@
     const authenticationFields = document.getElementById('authentication_fields');
     const sabnzbdFields = document.getElementById('sabnzbd_fields');
     const qbittorrentFields = document.getElementById('qbittorrent_fields');
+    const indexerPreferenceFields = document.getElementById('indexer_preference_fields');
 
     if (!clientTypeSelect || !authenticationFields || !sabnzbdFields || !qbittorrentFields) return;
 
     function toggleFields() {
       const type = clientTypeSelect.value;
+      const isUsenet = ['sabnzbd', 'nzbget'].includes(type);
       authenticationFields.classList.toggle(
         'hidden',
         !['qbittorrent', 'decypharr', 'nzbget', 'deluge', 'transmission'].includes(type)
       );
       sabnzbdFields.classList.toggle('hidden', type !== 'sabnzbd');
       qbittorrentFields.classList.toggle('hidden', type !== 'qbittorrent');
+      if (indexerPreferenceFields) {
+        indexerPreferenceFields.classList.toggle('hidden', isUsenet);
+      }
     }
 
     // Run on load to set initial state

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,9 @@ Rails.application.routes.draw do
         post :move_up
         post :move_down
       end
+      collection do
+        get :available_indexers
+      end
     end
     resources :settings, only: [ :index, :update ] do
       collection do

--- a/db/migrate/20260413120000_add_preferred_indexers_to_download_clients.rb
+++ b/db/migrate/20260413120000_add_preferred_indexers_to_download_clients.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreferredIndexersToDownloadClients < ActiveRecord::Migration[8.1]
+  def change
+    add_column :download_clients, :preferred_indexers, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_110000) do
     t.boolean "enabled", default: true, null: false
     t.string "name", null: false
     t.string "password"
+    t.string "preferred_indexers"
     t.integer "priority", default: 0, null: false
     t.integer "torrent_verification_max_attempts", default: 10, null: false
     t.integer "torrent_verification_wait_time", default: 2, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_113500) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_120000) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -63,6 +63,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_113500) do
     t.boolean "enabled", default: true, null: false
     t.string "name", null: false
     t.string "password"
+    t.string "preferred_indexers"
     t.integer "priority", default: 0, null: false
     t.integer "torrent_verification_max_attempts", default: 10, null: false
     t.integer "torrent_verification_wait_time", default: 2, null: false

--- a/test/controllers/admin/download_clients_controller_test.rb
+++ b/test/controllers/admin/download_clients_controller_test.rb
@@ -112,6 +112,61 @@ class Admin::DownloadClientsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "available_indexers returns empty array when no provider configured" do
+    IndexerClient.stub :configured?, false do
+      get available_indexers_admin_download_clients_url, as: :json
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal [], body
+    end
+  end
+
+  test "create persists preferred_indexers" do
+    VCR.turned_off do
+      stub_qbittorrent_connection("http://localhost:8081")
+
+      assert_enqueued_with(job: DownloadMonitorJob) do
+        post admin_download_clients_url, params: {
+          download_client: {
+            name: "Indexer Routed Client",
+            client_type: "qbittorrent",
+            url: "http://localhost:8081",
+            username: "admin",
+            password: "password",
+            category: "shelfarr",
+            enabled: "1",
+            preferred_indexers: "MyAnonaMouse,IPTorrents"
+          }
+        }
+      end
+
+      assert_redirected_to admin_download_clients_path
+
+      client = DownloadClient.find_by!(name: "Indexer Routed Client")
+      assert_equal "MyAnonaMouse,IPTorrents", client.preferred_indexers
+    end
+  end
+
+  test "update persists preferred_indexers" do
+    client = create_download_client
+
+    VCR.turned_off do
+      stub_qbittorrent_connection(client.url)
+
+      assert_enqueued_with(job: DownloadMonitorJob) do
+        patch admin_download_client_url(client), params: {
+          download_client: {
+            preferred_indexers: "TorrentLeech"
+          }
+        }
+      end
+
+      assert_redirected_to admin_download_clients_path
+      assert_equal "TorrentLeech", client.reload.preferred_indexers
+    end
+  end
+
   private
 
   def create_download_client

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -235,6 +235,84 @@ class DownloadClientTest < ActiveSupport::TestCase
     assert_equal "qBit", assignments["iptorrents"]
   end
 
+  test "indexer_assignments ignores usenet clients" do
+    DownloadClient.create!(
+      name: "SAB",
+      client_type: "sabnzbd",
+      url: "http://localhost:8080",
+      api_key: "key",
+      preferred_indexers: "MyAnonaMouse"
+    )
+    qb = DownloadClient.create!(
+      name: "qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      preferred_indexers: "IPTorrents"
+    )
+
+    assignments = DownloadClient.indexer_assignments
+    assert_nil assignments["myanonamouse"]
+    assert_equal "qBit", assignments["iptorrents"]
+  end
+
+  test "indexer_assignments ignores disabled clients" do
+    DownloadClient.create!(
+      name: "Disabled qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      enabled: false,
+      preferred_indexers: "MyAnonaMouse"
+    )
+    DownloadClient.create!(
+      name: "Enabled qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      enabled: true,
+      preferred_indexers: "IPTorrents"
+    )
+
+    assignments = DownloadClient.indexer_assignments
+    assert_nil assignments["myanonamouse"]
+    assert_equal "Enabled qBit", assignments["iptorrents"]
+  end
+
+  test "disabled client does not block enabled client from claiming same indexer" do
+    DownloadClient.create!(
+      name: "Disabled qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      enabled: false,
+      preferred_indexers: "MyAnonaMouse"
+    )
+    enabled = DownloadClient.new(
+      name: "Enabled qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      enabled: true,
+      preferred_indexers: "MyAnonaMouse"
+    )
+
+    assert enabled.valid?
+  end
+
+  test "usenet client does not block torrent client from claiming same indexer" do
+    DownloadClient.create!(
+      name: "SAB",
+      client_type: "sabnzbd",
+      url: "http://localhost:8080",
+      api_key: "key",
+      preferred_indexers: "MyAnonaMouse"
+    )
+    qb = DownloadClient.new(
+      name: "qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      preferred_indexers: "MyAnonaMouse"
+    )
+
+    assert qb.valid?
+  end
+
   test "indexer_assignments excludes specified client" do
     client = DownloadClient.create!(
       name: "qBit",

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -192,6 +192,61 @@ class DownloadClientTest < ActiveSupport::TestCase
     assert client.preferred_for_indexer?("IPTorrents")
   end
 
+  test "validates preferred_indexers not claimed by other clients" do
+    DownloadClient.create!(
+      name: "Client A",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      preferred_indexers: "MyAnonaMouse"
+    )
+    client_b = DownloadClient.new(
+      name: "Client B",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      preferred_indexers: "MyAnonaMouse"
+    )
+
+    refute client_b.valid?
+    assert_includes client_b.errors[:preferred_indexers].join, "already assigned"
+  end
+
+  test "allows same client to keep its own preferred_indexers on update" do
+    client = DownloadClient.create!(
+      name: "Client A",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      preferred_indexers: "MyAnonaMouse"
+    )
+    client.name = "Client A Renamed"
+
+    assert client.valid?
+  end
+
+  test "indexer_assignments returns map of indexer to client name" do
+    DownloadClient.create!(
+      name: "qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      preferred_indexers: "MyAnonaMouse, IPTorrents"
+    )
+    assignments = DownloadClient.indexer_assignments
+
+    assert_equal "qBit", assignments["myanonamouse"]
+    assert_equal "qBit", assignments["iptorrents"]
+  end
+
+  test "indexer_assignments excludes specified client" do
+    client = DownloadClient.create!(
+      name: "qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      preferred_indexers: "MyAnonaMouse"
+    )
+    assignments = DownloadClient.indexer_assignments(exclude_client_id: client.id)
+
+    assert_empty assignments
+  end
+
   test "encrypts api_key" do
     client = DownloadClient.create!(
       name: "Test",

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -154,6 +154,44 @@ class DownloadClientTest < ActiveSupport::TestCase
     assert_not_equal "secret123", client.password_before_type_cast
   end
 
+  test "preferred_for_indexer? returns true for exact match" do
+    client = DownloadClient.new(preferred_indexers: "MyAnonaMouse")
+    assert client.preferred_for_indexer?("MyAnonaMouse")
+  end
+
+  test "preferred_for_indexer? is case insensitive" do
+    client = DownloadClient.new(preferred_indexers: "MyAnonaMouse")
+    assert client.preferred_for_indexer?("myanonymouse")
+  end
+
+  test "preferred_for_indexer? matches any in comma-separated list" do
+    client = DownloadClient.new(preferred_indexers: "MyAnonaMouse, IPTorrents, TorrentLeech")
+    assert client.preferred_for_indexer?("IPTorrents")
+  end
+
+  test "preferred_for_indexer? returns false for non-matching indexer" do
+    client = DownloadClient.new(preferred_indexers: "MyAnonaMouse")
+    refute client.preferred_for_indexer?("IPTorrents")
+  end
+
+  test "preferred_for_indexer? returns false for blank values" do
+    client = DownloadClient.new(preferred_indexers: nil)
+    refute client.preferred_for_indexer?("MyAnonaMouse")
+
+    client.preferred_indexers = ""
+    refute client.preferred_for_indexer?("MyAnonaMouse")
+
+    client.preferred_indexers = "MyAnonaMouse"
+    refute client.preferred_for_indexer?(nil)
+    refute client.preferred_for_indexer?("")
+  end
+
+  test "preferred_for_indexer? handles whitespace in list" do
+    client = DownloadClient.new(preferred_indexers: " MyAnonaMouse , IPTorrents ")
+    assert client.preferred_for_indexer?("MyAnonaMouse")
+    assert client.preferred_for_indexer?("IPTorrents")
+  end
+
   test "encrypts api_key" do
     client = DownloadClient.create!(
       name: "Test",

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -161,7 +161,7 @@ class DownloadClientTest < ActiveSupport::TestCase
 
   test "preferred_for_indexer? is case insensitive" do
     client = DownloadClient.new(preferred_indexers: "MyAnonaMouse")
-    assert client.preferred_for_indexer?("myanonymouse")
+    assert client.preferred_for_indexer?("myanonamouse")
   end
 
   test "preferred_for_indexer? matches any in comma-separated list" do

--- a/test/services/download_client_selector_test.rb
+++ b/test/services/download_client_selector_test.rb
@@ -26,6 +26,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, false
+      search_result.expect :indexer, nil
 
       selected = DownloadClientSelector.for_download(search_result)
       assert_equal qb, selected
@@ -77,6 +78,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, false
+      search_result.expect :indexer, nil
 
       selected = DownloadClientSelector.for_download(search_result)
       assert_equal high_priority, selected
@@ -110,6 +112,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, false
+      search_result.expect :indexer, nil
 
       selected = DownloadClientSelector.for_download(search_result)
       assert_equal working, selected
@@ -158,6 +161,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, false
+      search_result.expect :indexer, nil
 
       selected = DownloadClientSelector.for_download(search_result)
       assert_equal deluge, selected
@@ -219,6 +223,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, false
+      search_result.expect :indexer, nil
 
       selected = DownloadClientSelector.for_download(search_result)
       assert_equal transmission, selected
@@ -261,6 +266,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, false
+      search_result.expect :indexer, nil
       search_result.expect :usenet?, false  # Called twice (select + download_type)
 
       error = assert_raises(DownloadClientSelector::NoClientAvailableError) do
@@ -287,6 +293,149 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
       DownloadClientSelector.for_download(search_result)
     end
     assert_includes error.message, "No torrent download client configured"
+  end
+
+  test "prefers indexer-matched client over higher priority" do
+    DownloadClient.create!(
+      name: "High Priority",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password",
+      priority: 0
+    )
+    indexer_matched = DownloadClient.create!(
+      name: "Indexer Matched",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      username: "admin",
+      password: "password",
+      priority: 10,
+      preferred_indexers: "MyAnonaMouse"
+    )
+
+    VCR.turned_off do
+      stub_qbittorrent_connection("http://localhost:8080")
+      stub_qbittorrent_connection("http://localhost:9090")
+
+      search_result = Minitest::Mock.new
+      search_result.expect :usenet?, false
+      search_result.expect :indexer, "MyAnonaMouse"
+
+      selected = DownloadClientSelector.for_download(search_result)
+      assert_equal indexer_matched, selected
+    end
+  end
+
+  test "falls back to priority when no client matches indexer" do
+    priority_client = DownloadClient.create!(
+      name: "Priority Client",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password",
+      priority: 0
+    )
+    DownloadClient.create!(
+      name: "Other Indexer",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      username: "admin",
+      password: "password",
+      priority: 10,
+      preferred_indexers: "IPTorrents"
+    )
+
+    VCR.turned_off do
+      stub_qbittorrent_connection("http://localhost:8080")
+      stub_qbittorrent_connection("http://localhost:9090")
+
+      search_result = Minitest::Mock.new
+      search_result.expect :usenet?, false
+      search_result.expect :indexer, "MyAnonaMouse"
+
+      selected = DownloadClientSelector.for_download(search_result)
+      assert_equal priority_client, selected
+    end
+  end
+
+  test "falls back to priority when indexer-matched client fails connection" do
+    DownloadClient.create!(
+      name: "Failing Matched",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password",
+      priority: 10,
+      preferred_indexers: "MyAnonaMouse"
+    )
+    working = DownloadClient.create!(
+      name: "Working",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      username: "admin",
+      password: "password",
+      priority: 0
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(status: 401, body: "Fails.")
+      stub_qbittorrent_connection("http://localhost:9090")
+
+      search_result = Minitest::Mock.new
+      search_result.expect :usenet?, false
+      search_result.expect :indexer, "MyAnonaMouse"
+
+      selected = DownloadClientSelector.for_download(search_result)
+      assert_equal working, selected
+    end
+  end
+
+  test "indexer preference matching is case insensitive" do
+    client = DownloadClient.create!(
+      name: "Case Test",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password",
+      priority: 0,
+      preferred_indexers: "myanonymouse"
+    )
+
+    VCR.turned_off do
+      stub_qbittorrent_connection("http://localhost:8080")
+
+      search_result = Minitest::Mock.new
+      search_result.expect :usenet?, false
+      search_result.expect :indexer, "MyAnonaMouse"
+
+      selected = DownloadClientSelector.for_download(search_result)
+      assert_equal client, selected
+    end
+  end
+
+  test "skips indexer preference when search result has nil indexer" do
+    client = DownloadClient.create!(
+      name: "Priority Client",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password",
+      priority: 0,
+      preferred_indexers: "MyAnonaMouse"
+    )
+
+    VCR.turned_off do
+      stub_qbittorrent_connection("http://localhost:8080")
+
+      search_result = Minitest::Mock.new
+      search_result.expect :usenet?, false
+      search_result.expect :indexer, nil
+
+      selected = DownloadClientSelector.for_download(search_result)
+      assert_equal client, selected
+    end
   end
 
   private

--- a/test/services/download_client_selector_test.rb
+++ b/test/services/download_client_selector_test.rb
@@ -47,6 +47,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, true
+      search_result.expect :indexer, nil
 
       selected = DownloadClientSelector.for_download(search_result)
       assert_equal sab, selected
@@ -400,7 +401,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
       username: "admin",
       password: "password",
       priority: 0,
-      preferred_indexers: "myanonymouse"
+      preferred_indexers: "myanonamouse"
     )
 
     VCR.turned_off do


### PR DESCRIPTION
## Summary
- add optional indexer preference to download clients so users can route downloads from specific indexers to specific clients
- when a search result comes from a preferred indexer, that client is selected regardless of priority order, with automatic fallback to priority-based selection if the preferred client is unavailable
- add a dynamic checkbox picker on the download client form that fetches available indexers from the active indexer provider, with text input fallback when no provider is configured

## Motivation
Users running both a debrid client (Decypharr) and a real torrent client (qBittorrent) currently cannot route private tracker results to qBittorrent while keeping public tracker results on Decypharr. The only routing available is priority-based, which applies the same client to all downloads regardless of source.

## Scope
This is a single feature (indexer-based client routing) that touches backend, UI, and tests together. The 11 files break down as: 1 migration, 3 app changes (model, service, controller), 2 UI (form partial, Stimulus controller), 1 route, 1 schema, 3 test files. Happy to split backend and UI into separate PRs if preferred.

## Changes
- add `preferred_indexers` string column to `download_clients` (comma-separated indexer names)
- add `preferred_for_indexer?` and `preferred_indexer_list` methods to `DownloadClient`
- add cross-client validation preventing the same indexer from being assigned to multiple clients
- update `DownloadClientSelector#select` to check indexer preference before priority fallback
- add `available_indexers` collection endpoint returning indexer names with assignment info
- add Stimulus controller with checkbox UI (DOM construction, no innerHTML) and graceful degradation
- hide indexer preference section for usenet client types
- show which indexers are assigned to other clients (disabled, grayed out with client name)

## Testing
- 5 new selector tests: preference match, fallback on no match, fallback on connection failure, case-insensitive, nil indexer
- 7 new model tests: matching, blank handling, whitespace, validation, self-update, assignments map
- 3 new controller tests: available_indexers endpoint, create/update persistence
- full suite: 926 runs, 0 errors, 2 pre-existing failures (UpdateCheckerServiceTest)