### PR TITLE
Remove tiny truncation of health check messages

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -106,7 +106,7 @@
                 <%= health.status.titleize %>
               </span>
               <% if health.message.present? %>
-                <span class="text-xs text-gray-500 block mt-1"><%= health.message.truncate(40) %></span>
+                <span class="text-xs text-gray-500 block mt-1"><%= health.message %></span>
               <% end %>
             <% else %>
               <span class="px-2 py-1 rounded text-sm bg-gray-700 text-gray-400">Not checked</span>


### PR DESCRIPTION
Remove the truncation here since the messaages do not show up anywhere else in the application or logs that I can see.  Without this messages cannot be fully seen, and they are already truncated to a maximum length of 500 characters as part of the health check anyway.  This affects issue #172 as its hiding critical information on what is going on in the health check.