### PR TITLE
Add setting to disable Z-Library download host validation

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -268,6 +268,8 @@ class DownloadJob < ApplicationJob
   end
 
   def zlibrary_download_host_allowed?(host)
+    return true unless SettingsService.get(:zlibrary_strict_host_check, default: true)
+
     configured_host = URI.parse(SettingsService.get(:zlibrary_url).to_s).host
     return false if configured_host.blank?
 

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -108,6 +108,7 @@ class SettingsService
     zlibrary_url: { type: "string", default: "https://z-library.sk", category: "zlibrary", description: "Base URL for the Z-Library site you can access (for example https://z-library.sk)" },
     zlibrary_email: { type: "string", default: "", category: "zlibrary", description: "Z-Library account email used for login" },
     zlibrary_password: { type: "string", default: "", category: "zlibrary", description: "Z-Library account password used for login" },
+    zlibrary_strict_host_check: { type: "boolean", default: true, category: "zlibrary", description: "Require download URLs to match the configured Z-Library domain. Disable if downloads fail because Z-Library serves files from a different domain (CDN)." },
 
     # Hardcover Integration
     hardcover_api_token: { type: "string", default: "", category: "hardcover", description: "API token from Hardcover account settings (hardcover.app/account/api)" },

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -228,6 +228,8 @@ class ZLibraryClient
     end
 
     def download_host_allowed?(host)
+      return true unless SettingsService.get(:zlibrary_strict_host_check, default: true)
+
       configured_host = configured_domain
       host == configured_host || host.end_with?(".#{configured_host}")
     end


### PR DESCRIPTION
Z-Library frequently serves file downloads from CDN domains that don't match the configured API domain. This causes downloads to fail with 'download URL outside the configured host family' errors.

Add a zlibrary_strict_host_check boolean setting (Admin > Settings > Z-Library) that defaults to true (preserving current behavior). When disabled, the download URL is still validated for scheme and presence of a host, but the domain family check is skipped.

Fixes both validation points: ZLibraryClient#download_host_allowed? and DownloadJob#zlibrary_download_host_allowed?.