### PR TITLE
refactor: centralize request attention notifications

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -38,7 +38,6 @@ class PostProcessingJob < ApplicationJob
       Rails.logger.error "[PostProcessingJob] Failed for download #{download.id}: #{e.message}"
       Rails.logger.error e.backtrace.first(5).join("\n")
       request.mark_for_attention!("Post-processing failed: #{e.message}")
-      NotificationService.request_attention(request)
     end
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -26,9 +26,12 @@ class Request < ApplicationRecord
   scope :processable, -> { pending.order(created_at: :asc) }
   scope :with_issues, -> { where(attention_needed: true).or(where(status: :failed)) }
 
-  def mark_for_attention!(description)
-    update!(attention_needed: true, issue_description: description)
-    track_diagnostic("attention_flagged", message: description, level: :warn)
+  def mark_for_attention!(description, **attributes)
+    self.class.transaction do
+      update!(attributes.merge(attention_needed: true, issue_description: description))
+      track_diagnostic("attention_flagged", message: description, level: :warn)
+    end
+    NotificationService.request_attention(self)
   end
 
   def clear_attention!
@@ -52,7 +55,11 @@ class Request < ApplicationRecord
 
     with_lock do
       if retry_count >= max_retries
-        flag_max_retries_exceeded!
+        mark_for_attention!(
+          "Maximum retry attempts (#{max_retries}) exceeded. Manual intervention required.",
+          status: :not_found,
+          retry_count: retry_count + 1
+        )
         return false
       end
 
@@ -70,16 +77,6 @@ class Request < ApplicationRecord
       )
     end
     true
-  end
-
-  # Flag request when max retries exceeded
-  def flag_max_retries_exceeded!
-    increment!(:retry_count)
-    update!(
-      status: :not_found,
-      attention_needed: true,
-      issue_description: "Maximum retry attempts (#{SettingsService.get(:max_retries)}) exceeded. Manual intervention required."
-    )
   end
 
   # Re-queue a not_found request back to pending

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -357,6 +357,39 @@ class DownloadJobTest < ActiveJob::TestCase
     end
   end
 
+  test "sends attention notification when no search result selected" do
+    @request.search_results.update_all(status: :pending)
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    assert_equal [ @request ], attention_requests
+  end
+
+  test "sends attention notification when no download client is available" do
+    DownloadClient.destroy_all
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    assert_equal [ @request ], attention_requests
+  end
+
+  test "sends attention notification when selected result has no download link" do
+    @selected_result.update!(download_url: nil, magnet_url: nil, source: "prowlarr")
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    assert_equal [ @request ], attention_requests
+  end
+
   private
 
   def setup_zlibrary_download

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -390,6 +390,54 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     end
   end
 
+  test "sends attention notification when download fails in client" do
+    VCR.turned_off do
+      stub_qbittorrent_auth
+      stub_qbittorrent_torrent_info(progress: 0, state: "error")
+      attention_requests = []
+
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        DownloadMonitorJob.perform_now
+      end
+
+      assert_equal [ @request ], attention_requests
+    end
+  end
+
+  test "sends attention notification when download is missing after threshold" do
+    @download.update!(not_found_count: DownloadMonitorJob::NOT_FOUND_THRESHOLD - 1)
+
+    VCR.turned_off do
+      stub_qbittorrent_auth
+      stub_qbittorrent_torrent_not_found
+      attention_requests = []
+
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        DownloadMonitorJob.perform_now
+      end
+
+      assert_equal [ @request ], attention_requests
+    end
+  end
+
+  test "sends attention notification when download stays queued past timeout" do
+    @download.update_columns(
+      status: Download.statuses[:queued],
+      external_id: nil,
+      download_client_id: nil,
+      created_at: 10.minutes.ago,
+      updated_at: 10.minutes.ago
+    )
+    SettingsService.set(:download_enqueue_timeout_minutes, 5)
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      DownloadMonitorJob.perform_now
+    end
+
+    assert_equal [ @request ], attention_requests
+  end
+
   private
 
   def stub_qbittorrent_auth

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -431,6 +431,17 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_match /source path is blank/i, @request.issue_description
   end
 
+  test "sends attention notification when post-processing fails" do
+    @download.update!(download_path: "")
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert_equal [ @request ], attention_requests
+  end
+
   test "marks request for attention when source path does not exist" do
     @download.update!(download_path: "/nonexistent/path/that/does/not/exist")
 

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -69,6 +69,18 @@ class SearchJobTest < ActiveJob::TestCase
     assert_includes @request.issue_description, "No search sources configured"
   end
 
+  test "sends attention notification when no search sources configured" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:anna_archive_enabled, false)
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      SearchJob.perform_now(@request.id)
+    end
+
+    assert_equal [ @request ], attention_requests
+  end
+
   test "skips non-pending requests" do
     @request.update!(status: :searching)
 
@@ -120,6 +132,21 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "sends attention notification when auto-select is disabled" do
+    SettingsService.set(:auto_select_enabled, false)
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+      attention_requests = []
+
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        SearchJob.perform_now(@request.id)
+      end
+
+      assert_equal [ @request ], attention_requests
+    end
+  end
+
   test "marks for attention when auto-select fails to find suitable result" do
     SettingsService.set(:auto_select_enabled, true)
 
@@ -136,6 +163,53 @@ class SearchJobTest < ActiveJob::TestCase
       assert @request.attention_needed?
       assert_includes @request.issue_description, "none matched auto-select criteria"
     end
+  end
+
+  test "sends attention notification when auto-select fails" do
+    SettingsService.set(:auto_select_enabled, true)
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+      attention_requests = []
+
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        AutoSelectService.stub :call, OpenStruct.new(success?: false) do
+          SearchJob.perform_now(@request.id)
+        end
+      end
+
+      assert_equal [ @request ], attention_requests
+    end
+  end
+
+  test "sends attention notification on indexer authentication failure" do
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696}).to_raise(IndexerClients::Base::AuthenticationError.new("Invalid API key"))
+      attention_requests = []
+
+      NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+        SearchJob.perform_now(@request.id)
+      end
+
+      assert_equal [ @request ], attention_requests
+    end
+  end
+
+  test "sends attention notification on Anna's Archive bot protection" do
+    SettingsService.set(:prowlarr_api_key, "")
+    attention_requests = []
+
+    AnnaArchiveClient.stub :configured?, true do
+      AnnaArchiveClient.stub :search, ->(*, **) {
+        raise AnnaArchiveClient::BotProtectionError, "Configure FlareSolverr"
+      } do
+        NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+          SearchJob.perform_now(@request.id)
+        end
+      end
+    end
+
+    assert_equal [ @request ], attention_requests
   end
 
   test "does not mark for attention when auto-select succeeds" do

--- a/test/models/request_retry_test.rb
+++ b/test/models/request_retry_test.rb
@@ -163,6 +163,52 @@ class RequestRetryTest < ActiveSupport::TestCase
     assert_equal "request", event.source
   end
 
+  test "mark_for_attention! sends attention notification" do
+    request = @pending
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      request.mark_for_attention!("Something broke")
+    end
+
+    assert_equal [ request ], attention_requests
+  end
+
+  test "mark_for_attention! still marks request when outbound notification fails" do
+    request = @pending
+
+    OutboundNotifications::Dispatcher.stub :notify, ->(**) { raise "Webhook delivery failed" } do
+      request.mark_for_attention!("Something broke")
+    end
+
+    request.reload
+    assert request.attention_needed?
+    assert_equal "Something broke", request.issue_description
+  end
+
+  test "schedule_retry! sends attention notification when max_retries reached" do
+    max_retries = SettingsService.get(:max_retries)
+    request = Request.create!(
+      book: books(:ebook_pending),
+      user: users(:one),
+      status: :searching,
+      retry_count: max_retries
+    )
+    attention_requests = []
+
+    NotificationService.stub :request_attention, ->(req) { attention_requests << req } do
+      result = request.schedule_retry!
+
+      assert_not result
+    end
+
+    request.reload
+    assert request.not_found?
+    assert request.attention_needed?
+    assert_equal max_retries + 1, request.retry_count
+    assert_equal [ request ], attention_requests
+  end
+
   test "retry_now! retries download when there is a selected result and failed download" do
     book = Book.create!(title: "Test Book", book_type: :ebook, open_library_work_id: "OL_RETRY_DL")
     request = Request.create!(

--- a/test/services/notification_service_test.rb
+++ b/test/services/notification_service_test.rb
@@ -69,6 +69,17 @@ class NotificationServiceTest < ActiveSupport::TestCase
     assert_equal "Attention Needed", notification.title
   end
 
+  test "request_attention enqueues outbound webhook delivery" do
+    assert_enqueued_with(job: OutboundWebhookDeliveryJob) do
+      NotificationService.request_attention(@request)
+    end
+
+    enqueued = enqueued_jobs.find { |job| job[:job] == OutboundWebhookDeliveryJob }
+    args = enqueued[:args].first.with_indifferent_access
+    assert_equal "request_attention", args[:event]
+    assert_equal @request.id, args[:request_id]
+  end
+
   test "request_created only enqueues outbound webhook delivery" do
     assert_no_difference "Notification.count" do
       assert_enqueued_with(job: OutboundWebhookDeliveryJob) do


### PR DESCRIPTION
## Summary
- centralize the request attention flow inside `Request#mark_for_attention!` so the state change, diagnostic event, and notification dispatch live in one place
- cover the PR 224 behavior by making every existing `mark_for_attention!` call automatically create the attention notification/webhook instead of relying on manual `NotificationService.request_attention(...)` calls in jobs
- route max retry exhaustion through the same path and remove the last explicit attention notification call from `PostProcessingJob`

## Motivation

PR #224 fixes the symptom by adding explicit notification calls in each job path, but the underlying architecture problem is that attention is a two-step convention. This branch makes attention a single domain operation so future paths cannot forget the notification side effect.

## Testing
- `PARALLEL_WORKERS=1 bundle exec rails test test/models/request_retry_test.rb test/services/notification_service_test.rb test/jobs/search_job_test.rb test/jobs/download_job_test.rb test/jobs/download_monitor_job_test.rb test/jobs/post_processing_job_test.rb`
- `bundle exec rails test`