### PR TITLE
fix: prevent usenet API key exposure

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -86,7 +86,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.info "[DownloadJob] Fetching download URL from Anna's Archive for MD5: #{md5}"
 
     download_url = AnnaArchiveClient.get_download_url(md5)
-    Rails.logger.info "[DownloadJob] Got download URL: #{download_url.truncate(100)}"
+    Rails.logger.info "[DownloadJob] Got download URL: #{UrlRedactor.redact(download_url).truncate(100)}"
 
     # Check if it's a torrent/magnet link or direct download
     if download_url.start_with?("magnet:") || download_url.end_with?(".torrent")
@@ -399,11 +399,11 @@ class DownloadJob < ApplicationJob
 
     download_link = search_result.download_link
     Rails.logger.info "[DownloadJob] Download link type: #{is_usenet ? 'usenet' : 'torrent'}, length: #{download_link.to_s.length} chars"
-    Rails.logger.debug "[DownloadJob] Full download URL: #{download_link}"
+    Rails.logger.debug "[DownloadJob] Full download URL: #{UrlRedactor.redact(download_link)}"
 
     if is_usenet
       # SABnzbd returns a hash with nzo_ids
-      result = client.add_torrent(download_link)
+      result = client.add_torrent(download_link, nzbname: build_usenet_job_name(search_result))
       external_id = result.is_a?(Hash) ? result["nzo_ids"]&.first : nil
       success = external_id.present?
     else
@@ -467,6 +467,14 @@ class DownloadJob < ApplicationJob
                          "but Download ##{existing.id} (request ##{existing.request_id}) already has this ID. " \
                          "This indicates a potential race condition that should be investigated."
     end
+  end
+
+  def build_usenet_job_name(search_result)
+    book = search_result.request.book
+    parts = [ book.author.to_s.strip.presence, book.title.to_s.strip.presence ].compact
+    return parts.join(" - ") if parts.any?
+
+    search_result.title.to_s.strip.presence
   end
 
   def track_request_event(request, event_type, download: nil, message: nil, level: :info, details: {})

--- a/app/services/download_clients/sabnzbd.rb
+++ b/app/services/download_clients/sabnzbd.rb
@@ -7,11 +7,12 @@ module DownloadClients
     # Add an NZB by URL
     def add_torrent(url, options = {})
       Rails.logger.info "[Sabnzbd] Adding URL to queue (#{url.to_s.length} chars)"
-      Rails.logger.debug "[Sabnzbd] Full URL being sent: #{url}"
+      Rails.logger.debug "[Sabnzbd] Full URL being sent: #{UrlRedactor.redact(url)}"
 
       params = {
         mode: "addurl",
         name: url,
+        nzbname: options[:nzbname].presence,
         apikey: api_key,
         output: "json"
       }

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -174,7 +174,7 @@ module IndexerClients
         url = item["downloadUrl"]
         return nil if url.blank? || url.start_with?("magnet:")
 
-        Rails.logger.debug "[IndexerClients::Prowlarr] Received download URL from indexer '#{item['indexer']}' (#{url.length} chars): #{url.truncate(100)}"
+        Rails.logger.debug "[IndexerClients::Prowlarr] Received download URL from indexer '#{item['indexer']}' (#{url.length} chars): #{UrlRedactor.redact(url).truncate(100)}"
         url
       end
 

--- a/app/services/url_redactor.rb
+++ b/app/services/url_redactor.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "cgi"
+
+class UrlRedactor
+  SENSITIVE_QUERY_KEYS = %w[
+    apikey
+    api_key
+    token
+    access_token
+    refresh_token
+    password
+    pass
+    passkey
+    signature
+    sig
+    auth
+    key
+  ].freeze
+
+  def self.redact(value)
+    url = value.to_s
+    return url if url.blank?
+
+    base, fragment = url.split("#", 2)
+    path, query = base.split("?", 2)
+    return url if query.blank?
+
+    redacted_query = query.split("&").map do |pair|
+      key, = pair.split("=", 2)
+      next pair if key.blank?
+
+      sensitive_query_key?(key) ? "#{key}=[REDACTED]" : pair
+    end.join("&")
+
+    result = "#{path}?#{redacted_query}"
+    fragment.present? ? "#{result}##{fragment}" : result
+  end
+
+  def self.sensitive_query_key?(key)
+    SENSITIVE_QUERY_KEYS.include?(CGI.unescape(key.to_s).downcase)
+  end
+
+  private_class_method :sensitive_query_key?
+end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -200,6 +200,70 @@ class DownloadJobTest < ActiveJob::TestCase
     end
   end
 
+  test "uses book metadata as usenet job name for sabnzbd" do
+    @client.destroy!
+    sabnzbd = DownloadClient.create!(
+      name: "Test SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://localhost:8080",
+      api_key: "test-api-key-12345",
+      priority: 0,
+      enabled: true
+    )
+    @selected_result.update!(
+      magnet_url: nil,
+      download_url: "http://prowlarr:9696/11/download?apikey=secret&file=The+Pending+Ebook",
+      seeders: nil
+    )
+
+    logger = build_test_logger
+
+    Rails.stub(:logger, logger) do
+      VCR.turned_off do
+        stub_request(:get, "http://localhost:8080/api")
+          .with(query: hash_including(
+            "mode" => "version",
+            "apikey" => "test-api-key-12345",
+            "output" => "json"
+          ))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "version" => "4.0.0" }.to_json
+          )
+
+        request_stub = stub_request(:get, "http://localhost:8080/api")
+          .with(query: hash_including(
+            "mode" => "addurl",
+            "name" => "http://prowlarr:9696/11/download?apikey=secret&file=The+Pending+Ebook",
+            "nzbname" => "Another Author - The Pending Ebook",
+            "apikey" => "test-api-key-12345",
+            "output" => "json"
+          ))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "status" => true, "nzo_ids" => ["SABnzbd_nzo_12345"] }.to_json
+          )
+
+        DownloadJob.perform_now(@download.id)
+
+        assert_requested request_stub
+      end
+    end
+
+    @download.reload
+    assert @download.downloading?
+    assert_equal sabnzbd.id.to_s, @download.download_client_id
+    assert_equal "SABnzbd_nzo_12345", @download.external_id
+    assert_equal "usenet", @download.download_type
+
+    log_output = logger.messages.join("\n")
+    assert_includes log_output, "apikey=[REDACTED]"
+    assert_includes log_output, "file=The+Pending+Ebook"
+    assert_not_includes log_output, "apikey=secret"
+  end
+
   test "skips non-existent downloads" do
     assert_nothing_raised do
       DownloadJob.perform_now(999999)
@@ -390,6 +454,16 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_equal [ @request ], attention_requests
   end
 
+  test "build_usenet_job_name falls back to search result title when book metadata is blank" do
+    book = Struct.new(:author, :title).new("", "")
+    request = Struct.new(:book).new(book)
+    search_result = Struct.new(:request, :title).new(request, "Indexer Result Title")
+
+    result = DownloadJob.new.send(:build_usenet_job_name, search_result)
+
+    assert_equal "Indexer Result Title", result
+  end
+
   private
 
   def setup_zlibrary_download
@@ -451,5 +525,31 @@ class DownloadJobTest < ActiveJob::TestCase
         headers: { "Content-Type" => "application/json" },
         body: [{ "hash" => expected_hash, "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json
       )
+  end
+
+  def build_test_logger
+    Class.new do
+      attr_reader :messages
+
+      def initialize
+        @messages = []
+      end
+
+      def debug(message)
+        @messages << message
+      end
+
+      def info(message)
+        @messages << message
+      end
+
+      def warn(message)
+        @messages << message
+      end
+
+      def error(message)
+        @messages << message
+      end
+    end.new
   end
 end

--- a/test/services/download_clients/sabnzbd_test.rb
+++ b/test/services/download_clients/sabnzbd_test.rb
@@ -29,6 +29,29 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_torrent passes nzbname when provided" do
+    VCR.turned_off do
+      request_stub = stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including(
+          "mode" => "addurl",
+          "name" => "http://example.com/test.nzb",
+          "nzbname" => "Another Author - The Pending Ebook",
+          "apikey" => "test-api-key-12345",
+          "output" => "json"
+        ))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => true, "nzo_ids" => ["SABnzbd_nzo_12345"] }.to_json
+        )
+
+      result = @client.add_torrent("http://example.com/test.nzb", nzbname: "Another Author - The Pending Ebook")
+
+      assert result
+      assert_requested request_stub
+    end
+  end
+
   test "list_torrents returns queue and history items" do
     VCR.turned_off do
       stub_request(:get, %r{localhost:8080/api.*mode=queue})

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -180,6 +180,28 @@ class ProwlarrClientTest < ActiveSupport::TestCase
     assert_equal "magnet:?xt=test", result.download_link
   end
 
+  test "extract_download_url redacts sensitive query params in logs" do
+    logger = Struct.new(:messages) do
+      def debug(message)
+        messages << message
+      end
+    end.new([])
+
+    item = {
+      "indexer" => "TestIndexer",
+      "downloadUrl" => "http://prowlarr:9696/11/download?apikey=secret&file=Atomic+Habits"
+    }
+
+    url = Rails.stub(:logger, logger) do
+      ProwlarrClient.send(:extract_download_url, item)
+    end
+
+    assert_equal item["downloadUrl"], url
+    assert_includes logger.messages.first, "apikey=[REDACTED]"
+    assert_includes logger.messages.first, "file=Atomic+Habits"
+    assert_not_includes logger.messages.first, "apikey=secret"
+  end
+
   test "Result.size_human returns formatted size" do
     result = ProwlarrClient::Result.new(
       guid: "test", title: "Test", indexer: "Test", size_bytes: 1073741824,

--- a/test/services/url_redactor_test.rb
+++ b/test/services/url_redactor_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UrlRedactorTest < ActiveSupport::TestCase
+  test "redacts sensitive query parameters while preserving non-sensitive ones" do
+    url = "http://prowlarr:9696/11/download?apikey=secret&file=Atomic+Habits&token=abc123"
+
+    result = UrlRedactor.redact(url)
+
+    assert_equal "http://prowlarr:9696/11/download?apikey=[REDACTED]&file=Atomic+Habits&token=[REDACTED]", result
+  end
+
+  test "leaves urls without query strings unchanged" do
+    url = "http://example.com/download/test.nzb"
+
+    assert_equal url, UrlRedactor.redact(url)
+  end
+end


### PR DESCRIPTION
## Summary
- pass a safe `nzbname` to SABnzbd so queue/history entries use a readable book name instead of the raw Prowlarr URL
- redact sensitive query parameters such as `apikey` from Shelfarr logs while keeping non-sensitive URL context visible
- add coverage for SABnzbd dispatch, URL redaction, and Prowlarr download URL logging

## Testing
- bundle exec rails test

Closes #232