### PR TITLE
fix: batch reported issue fixes

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -14,7 +14,7 @@ class Upload < ApplicationRecord
   enum :book_type, { audiobook: 0, ebook: 1 }
 
   # Supported file extensions
-  AUDIOBOOK_EXTENSIONS = %w[m4b mp3 zip rar].freeze
+  AUDIOBOOK_EXTENSIONS = %w[m4a m4b mp3 zip rar].freeze
   EBOOK_EXTENSIONS = %w[epub pdf mobi azw3].freeze
   SUPPORTED_EXTENSIONS = (AUDIOBOOK_EXTENSIONS + EBOOK_EXTENSIONS).freeze
 

--- a/app/services/download_clients/transmission.rb
+++ b/app/services/download_clients/transmission.rb
@@ -8,7 +8,7 @@ module DownloadClients
   class Transmission < Base
     class LegacyProtocolRequired < StandardError; end
 
-    TORRENT_FIELDS = %w[
+    JSONRPC_TORRENT_FIELDS = %w[
       id
       name
       hash_string
@@ -18,6 +18,18 @@ module DownloadClients
       download_dir
       error
       error_string
+    ].freeze
+
+    LEGACY_TORRENT_FIELDS = %w[
+      id
+      name
+      hashString
+      percentDone
+      status
+      totalSize
+      downloadDir
+      error
+      errorString
     ].freeze
 
     def add_torrent(url, options = {})
@@ -49,7 +61,7 @@ module DownloadClients
     def torrent_info(hash)
       ensure_authenticated!
 
-      response = rpc_request("torrent-get", ids: [hash], fields: TORRENT_FIELDS)
+      response = rpc_request("torrent-get", ids: [hash], fields: torrent_fields)
       return nil unless response && response["torrents"].is_a?(Array)
 
       info = response["torrents"].find { |torrent| transmission_value(torrent, "hash_string", "hashString") == hash.to_s }
@@ -62,7 +74,7 @@ module DownloadClients
       ensure_authenticated!
 
       ids = filter[:ids] || "all"
-      response = rpc_request("torrent-get", ids: ids, fields: TORRENT_FIELDS)
+      response = rpc_request("torrent-get", ids: ids, fields: torrent_fields)
       torrents = response&.fetch("torrents", []) || []
 
       torrents.map { |torrent| parse_torrent(torrent) }
@@ -247,8 +259,16 @@ module DownloadClients
     end
 
     def torrent_ids
-      response = rpc_request("torrent-get", ids: "all", fields: [ "hash_string" ])
+      response = rpc_request("torrent-get", ids: "all", fields: [ torrent_hash_field ])
       response.fetch("torrents", []).map { |torrent| transmission_value(torrent, "hash_string", "hashString") }.compact
+    end
+
+    def torrent_fields
+      protocol_mode.to_sym == :legacy ? LEGACY_TORRENT_FIELDS : JSONRPC_TORRENT_FIELDS
+    end
+
+    def torrent_hash_field
+      protocol_mode.to_sym == :legacy ? "hashString" : "hash_string"
     end
 
     def prepare_torrent_submission(url)

--- a/app/views/uploads/_form.html.erb
+++ b/app/views/uploads/_form.html.erb
@@ -23,13 +23,13 @@
                  class="hidden"
                  data-upload-form-target="input"
                  data-action="change->upload-form#fileSelected"
-                 accept=".m4b,.mp3,.zip,.rar,.epub,.pdf,.mobi,.azw3">
+                 accept=".m4a,.m4b,audio/mp4,.mp3,audio/mpeg,.zip,.rar,.epub,.pdf,.mobi,.azw3">
         </label>
         <span class="text-gray-500"> or drag and drop</span>
       </div>
 
       <p class="text-sm text-gray-500">
-        Audiobooks: m4b, mp3, zip, rar | Ebooks: epub, pdf, mobi, azw3
+        Audiobooks: m4a, m4b, mp3, zip, rar | Ebooks: epub, pdf, mobi, azw3
       </p>
 
       <div data-upload-form-target="filename" class="hidden text-sm font-medium text-gray-300 mt-4">

--- a/test/controllers/admin/uploads_controller_test.rb
+++ b/test/controllers/admin/uploads_controller_test.rb
@@ -49,6 +49,19 @@ class Admin::UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "File uploaded successfully. Processing started.", flash[:notice]
   end
 
+  test "create with m4a audiobook starts processing" do
+    file = fixture_file_upload("test_audiobook.m4a", "audio/mp4")
+
+    assert_difference "Upload.count", 1 do
+      assert_enqueued_with(job: UploadProcessingJob) do
+        post admin_uploads_url, params: { file: file }
+      end
+    end
+
+    assert_redirected_to admin_uploads_path
+    assert_equal "File uploaded successfully. Processing started.", flash[:notice]
+  end
+
   test "create with ebook file starts processing" do
     file = fixture_file_upload("test_ebook.epub", "application/epub+zip")
 

--- a/test/controllers/uploads_controller_test.rb
+++ b/test/controllers/uploads_controller_test.rb
@@ -119,7 +119,23 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Upload Book"
     assert_select "form[action='#{uploads_path}']"
-    assert_select "input[type='file'][name='file']"
+    assert_select "input[type='file'][name='file'][accept='.m4a,.m4b,audio/mp4,.mp3,audio/mpeg,.zip,.rar,.epub,.pdf,.mobi,.azw3']"
+  end
+
+  test "create accepts m4a audiobook uploads for regular users when enabled" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    file = fixture_file_upload("test_audiobook.m4a", "audio/mp4")
+
+    assert_difference "Upload.count", 1 do
+      assert_enqueued_with(job: UploadProcessingJob) do
+        post uploads_url, params: { file: file }
+      end
+    end
+
+    assert_redirected_to uploads_path
+    assert_equal "File uploaded successfully. Processing started.", flash[:notice]
+    assert_equal @user, Upload.order(:created_at).last.user
   end
 
   test "create redirects regular users when uploads are disabled" do

--- a/test/fixtures/files/test_audiobook.m4a
+++ b/test/fixtures/files/test_audiobook.m4a
@@ -1,0 +1,1 @@
+fake m4a audiobook fixture

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -207,7 +207,7 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
             body["method"] == "torrent_get" &&
             body["params"] == {
               "ids" => [ "transmission-hash" ],
-              "fields" => DownloadClients::Transmission::TORRENT_FIELDS
+              "fields" => %w[id name hash_string percent_done status total_size download_dir error error_string]
             } &&
             body["id"] == 1
         end

--- a/test/services/download_clients/transmission_test.rb
+++ b/test/services/download_clients/transmission_test.rb
@@ -5,6 +5,30 @@ require "base64"
 require "bencode"
 
 class DownloadClients::TransmissionTest < ActiveSupport::TestCase
+  JSONRPC_TORRENT_FIELDS = %w[
+    id
+    name
+    hash_string
+    percent_done
+    status
+    total_size
+    download_dir
+    error
+    error_string
+  ].freeze
+
+  LEGACY_TORRENT_FIELDS = %w[
+    id
+    name
+    hashString
+    percentDone
+    status
+    totalSize
+    downloadDir
+    error
+    errorString
+  ].freeze
+
   setup do
     DownloadClient.destroy_all
     @client_record = DownloadClient.create!(
@@ -124,7 +148,7 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
     VCR.turned_off do
       stub_session_handshake("http://localhost:9091/transmission/rpc")
       stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => "all", "fields" => DownloadClients::Transmission::TORRENT_FIELDS }) }
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => "all", "fields" => JSONRPC_TORRENT_FIELDS }) }
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -164,7 +188,7 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
     VCR.turned_off do
       session_stub = stub_session_handshake("http://localhost:9091/transmission/rpc")
       list_stub = stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => "all", "fields" => DownloadClients::Transmission::TORRENT_FIELDS }) }
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => "all", "fields" => JSONRPC_TORRENT_FIELDS }) }
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -183,7 +207,7 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
     VCR.turned_off do
       stub_session_handshake("http://localhost:9091/transmission/rpc")
       stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => [ "missing" ], "fields" => DownloadClients::Transmission::TORRENT_FIELDS }) }
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => [ "missing" ], "fields" => JSONRPC_TORRENT_FIELDS }) }
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -203,7 +227,7 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
     VCR.turned_off do
       stub_session_handshake("http://localhost:9091/transmission/rpc")
       stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => [ "abc123" ], "fields" => DownloadClients::Transmission::TORRENT_FIELDS }) }
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => [ "abc123" ], "fields" => JSONRPC_TORRENT_FIELDS }) }
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -234,13 +258,50 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
     end
   end
 
+  test "torrent_info requests Transmission JSON-RPC snake_case field names" do
+    VCR.turned_off do
+      stub_session_handshake("http://localhost:9091/transmission/rpc")
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => [ "abc123" ], "fields" => JSONRPC_TORRENT_FIELDS }) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "jsonrpc" => "2.0",
+            "result" => {
+              "torrents" => [
+                {
+                  "id" => 7,
+                  "name" => "Transmission Book",
+                  "hash_string" => "abc123",
+                  "percent_done" => 0.5,
+                  "status" => 4,
+                  "total_size" => 1073741824,
+                  "download_dir" => "/downloads/Transmission Book",
+                  "error" => 0,
+                  "error_string" => ""
+                }
+              ]
+            },
+            "id" => 1
+          }.to_json
+        )
+
+      info = @client.torrent_info("abc123")
+
+      assert_equal "abc123", info.hash
+      assert_equal 50, info.progress
+      assert_equal "/downloads/Transmission Book", info.download_path
+    end
+  end
+
   test "list_torrents still parses legacy field names after legacy fallback" do
     VCR.turned_off do
       Thread.current[:transmission_sessions][@client_record.id] = "session-id"
       Thread.current[:transmission_protocols][@client_record.id] = :legacy
 
       stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with { |request| legacy_request?(request, method: "torrent-get", arguments: { "ids" => "all", "fields" => DownloadClients::Transmission::TORRENT_FIELDS }) }
+        .with { |request| legacy_request?(request, method: "torrent-get", arguments: { "ids" => "all", "fields" => LEGACY_TORRENT_FIELDS }) }
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -388,7 +449,7 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
           body: { "result" => "success", "arguments" => {} }.to_json
         )
       legacy_list = stub_request(:post, "http://localhost:9091/transmission/rpc")
-        .with { |request| legacy_request?(request, method: "torrent-get", arguments: { "ids" => "all", "fields" => DownloadClients::Transmission::TORRENT_FIELDS }) }
+        .with { |request| legacy_request?(request, method: "torrent-get", arguments: { "ids" => "all", "fields" => LEGACY_TORRENT_FIELDS }) }
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },


### PR DESCRIPTION
## Summary
- align Transmission RPC field requests with the negotiated protocol so JSON-RPC uses `snake_case` and legacy mode keeps the older camelCase fields, fixing monitored torrent lookups and the resulting false "not found" failures
- allow `.m4a` manual uploads across the shared upload form and server-side upload allowlist so iOS users can select and submit audiobook files that Shelfarr already knows how to process
- add regression coverage for both fixes in the Transmission adapter/job tests and the user/admin upload controller tests

## Motivation

Issue #237 was caused by treating Transmission field names as protocol-agnostic, even though the current JSON-RPC contract and the legacy RPC contract use different field naming schemes.

Issue #238 exposed that manual uploads blocked `.m4a` at the picker and validation layers even though metadata extraction already supported it.

## Testing
- `PARALLEL_WORKERS=1 bundle exec rails test test/services/download_clients/transmission_test.rb test/jobs/download_monitor_job_test.rb`
- `PARALLEL_WORKERS=1 bundle exec rails test test/controllers/uploads_controller_test.rb test/controllers/admin/uploads_controller_test.rb`

Closes #237
Closes #238
