### PR TITLE
feat: enrich Audiobookshelf library inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  quality:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,10 +22,15 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Run tests
+      - name: Prepare test database
         env:
           RAILS_ENV: test
-        run: bin/rails db:test:prepare test
+        run: bin/rails db:test:prepare
+
+      - name: Run quality gate
+        env:
+          RAILS_ENV: test
+        run: bin/quality push
 
   security:
     runs-on: ubuntu-latest
@@ -39,9 +44,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-
-      - name: Scan for security vulnerabilities
-        run: bin/brakeman --no-pager -w2 --ignore-config config/brakeman.ignore || true
 
       - name: Audit gems
         run: bin/bundler-audit --update || true

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 !/tmp/storage/.keep
 
 /public/assets
+/coverage
 
 # Ignore key files for decrypting credentials and more.
 /config/*.key

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,11 @@
+SimpleCov.start "rails" do
+  enable_coverage :branch
+  primary_coverage :branch
+  command_name "rails-test-#{Process.pid}"
+
+  add_filter "/config/"
+  add_filter "/db/"
+  add_filter "/test/"
+
+  minimum_coverage line: 55, branch: 40
+end

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  # Git hooks managed in-repo
+  gem "lefthook", require: false
 end
 
 group :test do
@@ -95,4 +97,9 @@ group :test do
   gem "vcr"
   # Pin minitest to a compatible version with Rails 8.1
   gem "minitest", "~> 5.25"
+  # Coverage reporting for local and CI quality checks
+  gem "simplecov", require: false
+  # Mutation testing for targeted logic-heavy code
+  gem "mutant", require: false
+  gem "mutant-minitest", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    diff-lcs (2.0.0)
+    docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -196,6 +198,7 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    lefthook (2.1.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
@@ -215,6 +218,19 @@ GEM
     minitest (5.27.0)
     msgpack (1.8.0)
     multipart-post (2.4.1)
+    mutant (0.16.2)
+      diff-lcs (>= 1.6, < 3)
+      irb (~> 1.15)
+      parser (~> 3.3.10)
+      regexp_parser (~> 2.10)
+      securerandom (>= 0.3)
+      sorbet-runtime (~> 0.6.0)
+      unparser (>= 0.8.2, < 0.10)
+    mutant-minitest (0.16.2)
+      minitest (>= 5.11, < 7)
+      mutant (= 0.16.2)
+      mutex_m (~> 0.2)
+    mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.2)
@@ -407,6 +423,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -423,6 +445,7 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
+    sorbet-runtime (0.6.13153)
     sqlite3 (2.8.1-aarch64-linux-gnu)
     sqlite3 (2.8.1-aarch64-linux-musl)
     sqlite3 (2.8.1-arm-linux-gnu)
@@ -473,6 +496,10 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    unparser (0.9.0)
+      diff-lcs (>= 1.6, < 3)
+      parser (>= 3.3.0)
+      prism (>= 1.5.1)
     uri (1.1.1)
     useragent (0.16.11)
     validate_url (1.0.15)
@@ -530,7 +557,10 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   kamal
+  lefthook
   minitest (~> 5.25)
+  mutant
+  mutant-minitest
   oj
   omniauth
   omniauth-rails_csrf_protection
@@ -544,6 +574,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubyzip
   selenium-webdriver
+  simplecov
   solid_cable
   solid_cache
   solid_queue

--- a/README.md
+++ b/README.md
@@ -161,6 +161,36 @@ bin/rails db:setup
 bin/dev
 ```
 
+### Local Quality Gate
+
+The repo includes a lightweight local quality gate powered by `lefthook`.
+
+```bash
+# Install hooks
+bundle exec lefthook install
+
+# Quiet staged-file check used by pre-commit
+bin/quality fast --staged
+
+# Quiet full check used by pre-push
+bin/quality push
+
+# Run coverage on demand
+bin/quality coverage
+bin/quality coverage --staged
+
+# Run targeted mutation testing on covered service/model tests
+bin/quality mutant --all
+bin/quality mutant SettingsService*
+
+# Run the full repo sweep
+bin/quality deep
+```
+
+Passing runs stay quiet. On failure, the command prints only the relevant tool output.
+
+Mutation testing is opt-in per test class. Add `cover "YourConstant*"` to logic-heavy Minitest classes you want `mutant` to evaluate.
+
 ## License
 
 [GPL-3.0](LICENSE)

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -322,6 +322,8 @@ module Admin
     def load_audiobookshelf_cache_summary
       @audiobookshelf_library_items = LibraryItem.by_synced_at_desc.limit(50)
       @audiobookshelf_library_items_count = LibraryItem.count
+      @audiobookshelf_available_library_items_count = LibraryItem.available_for_matching.count
+      @audiobookshelf_missing_library_items_count = LibraryItem.where(missing: true).count
       @audiobookshelf_library_items_last_synced_at = @audiobookshelf_library_items.maximum(:synced_at)
     end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
       begin
         @results = MetadataService.search(@query)
         @audiobookshelf_matches = if LibraryItem.exists?
-          AudiobookshelfLibraryMatcherService.matches_for_many(@results, limit_per_result: 2)
+          AudiobookshelfLibraryMatcherService.matches_for_many(@results, limit_per_result: 3)
         else
           Array.new(@results.size) { [] }
         end

--- a/app/models/library_item.rb
+++ b/app/models/library_item.rb
@@ -7,12 +7,41 @@ class LibraryItem < ApplicationRecord
 
   scope :by_synced_at_desc, -> { order(synced_at: :desc, title: :asc) }
   scope :for_libraries, ->(ids) { where(library_id: ids) }
+  scope :available_for_matching, -> { where.not(missing: true) }
 
   def audiobookshelf_url
     base_url = SettingsService.get(:audiobookshelf_url)
     return nil if base_url.blank? || audiobookshelf_id.blank?
 
     "#{base_url.to_s.chomp("/")}/item/#{audiobookshelf_id}"
+  end
+
+  def display_title
+    [ title, subtitle.presence ].compact.join(": ")
+  end
+
+  def series_label
+    return nil if series.blank?
+    return series if series_position.blank?
+
+    "#{series} ##{series_position}"
+  end
+
+  def detail_badges
+    [
+      published_year,
+      series_label,
+      narrator.present? ? "Narrated by #{narrator}" : nil,
+      publisher.presence,
+      language.present? ? language.upcase : nil
+    ].compact
+  end
+
+  def identifier_label
+    return "ISBN #{isbn}" if isbn.present?
+    return "ASIN #{asin}" if asin.present?
+
+    nil
   end
 
   def sync_stale?(threshold:)

--- a/app/services/audiobookshelf_client.rb
+++ b/app/services/audiobookshelf_client.rb
@@ -199,21 +199,51 @@ class AudiobookshelfClient
       raw_items.filter_map do |raw_item|
         next unless raw_item.is_a?(Hash)
 
+        metadata = extract_book_metadata(raw_item)
+
         {
           "audiobookshelf_id" => raw_item["id"] || raw_item.dig("media", "id") || raw_item.dig("item", "id"),
-          "title" => raw_item["title"] ||
-            raw_item.dig("media", "metadata", "title") ||
-            raw_item.dig("media", "title") ||
-            raw_item.dig("metadata", "title") ||
-            raw_item.dig("book", "metadata", "title") ||
-            raw_item.dig("book", "title"),
-          "author" => extract_author(raw_item)
+          "title" => extract_title(raw_item, metadata),
+          "subtitle" => extract_subtitle(raw_item, metadata),
+          "author" => extract_author(raw_item),
+          "narrator" => extract_narrator(raw_item),
+          "series" => extract_series_name(raw_item, metadata),
+          "series_position" => extract_series_position(raw_item, metadata),
+          "publisher" => metadata["publisher"] || raw_item["publisher"],
+          "language" => metadata["language"] || raw_item["language"],
+          "description" => metadata["description"] || raw_item["description"],
+          "isbn" => metadata["isbn"] || raw_item["isbn"],
+          "asin" => metadata["asin"] || raw_item["asin"],
+          "published_year" => extract_published_year(raw_item, metadata),
+          "missing" => raw_item["isMissing"] == true
         }
       end
     end
 
+    def extract_book_metadata(raw_item)
+      raw_item.dig("media", "metadata") ||
+        raw_item["metadata"] ||
+        raw_item.dig("book", "metadata") ||
+        {}
+    end
+
+    def extract_title(raw_item, metadata)
+      raw_item["title"] ||
+        metadata["title"] ||
+        raw_item.dig("media", "title") ||
+        raw_item.dig("book", "title")
+    end
+
+    def extract_subtitle(raw_item, metadata)
+      raw_item["subtitle"] ||
+        metadata["subtitle"] ||
+        raw_item.dig("media", "subtitle") ||
+        raw_item.dig("book", "subtitle")
+    end
+
     def extract_author(raw_item)
       return raw_item["author"] if raw_item["author"].present?
+      return raw_item["authorName"] if raw_item["authorName"].present?
       return raw_item.dig("media", "metadata", "authorName") if raw_item.dig("media", "metadata", "authorName").present?
       return raw_item.dig("media", "author") if raw_item.dig("media", "author").present?
       return raw_item.dig("metadata", "authorName") if raw_item.dig("metadata", "authorName").present?
@@ -239,6 +269,75 @@ class AudiobookshelfClient
       else
         raw_authors.to_s
       end
+    end
+
+    def extract_narrator(raw_item)
+      return raw_item["narrator"] if raw_item["narrator"].present?
+      return raw_item["narratorName"] if raw_item["narratorName"].present?
+      return raw_item.dig("media", "metadata", "narratorName") if raw_item.dig("media", "metadata", "narratorName").present?
+      return raw_item.dig("metadata", "narratorName") if raw_item.dig("metadata", "narratorName").present?
+      return raw_item.dig("book", "metadata", "narratorName") if raw_item.dig("book", "metadata", "narratorName").present?
+
+      raw_narrators = raw_item.dig("media", "metadata", "narrators") ||
+        raw_item.dig("metadata", "narrators") ||
+        raw_item.dig("book", "metadata", "narrators")
+
+      join_people(raw_narrators)
+    end
+
+    def extract_series_name(raw_item, metadata)
+      return raw_item["seriesName"] if raw_item["seriesName"].present?
+      return metadata["seriesName"] if metadata["seriesName"].present?
+
+      first_series = first_series_entry(raw_item, metadata)
+      return first_series["name"] if first_series.is_a?(Hash) && first_series["name"].present?
+      return first_series["series"]["name"] if first_series.is_a?(Hash) && first_series.dig("series", "name").present?
+
+      first_series.to_s if first_series.present?
+    end
+
+    def extract_series_position(raw_item, metadata)
+      return raw_item["seriesSequence"] if raw_item["seriesSequence"].present?
+
+      first_series = first_series_entry(raw_item, metadata)
+      return first_series["sequence"] if first_series.is_a?(Hash) && first_series["sequence"].present?
+
+      nil
+    end
+
+    def first_series_entry(raw_item, metadata)
+      series = metadata["series"] || raw_item["series"] || raw_item.dig("book", "metadata", "series")
+      return series.first if series.is_a?(Array)
+
+      series
+    end
+
+    def extract_published_year(raw_item, metadata)
+      value = metadata["publishedYear"] || raw_item["publishedYear"] || raw_item["year"]
+      return nil if value.blank?
+
+      match = value.to_s.match(/\A\d{4}\z|(\d{4})/)
+      return nil unless match
+
+      (match[0] || match[1]).to_i
+    end
+
+    def join_people(values)
+      return nil if values.blank?
+
+      if values.is_a?(Array)
+        return values.join(", ") if values.all?(String)
+
+        names = values.map do |value|
+          next unless value.is_a?(Hash)
+
+          value["name"] || value["fullName"]
+        end.compact
+
+        return names.join(", ") if names.any?
+      end
+
+      values.to_s
     end
 
     def end_of_items?(page_items, data, page_size, page)

--- a/app/services/audiobookshelf_client.rb
+++ b/app/services/audiobookshelf_client.rb
@@ -212,7 +212,7 @@ class AudiobookshelfClient
           "publisher" => metadata["publisher"] || raw_item["publisher"],
           "language" => metadata["language"] || raw_item["language"],
           "description" => metadata["description"] || raw_item["description"],
-          "isbn" => metadata["isbn"] || raw_item["isbn"],
+          "isbn" => normalize_identifier(metadata["isbn"] || raw_item["isbn"]),
           "asin" => metadata["asin"] || raw_item["asin"],
           "published_year" => extract_published_year(raw_item, metadata),
           "missing" => raw_item["isMissing"] == true
@@ -313,13 +313,24 @@ class AudiobookshelfClient
     end
 
     def extract_published_year(raw_item, metadata)
-      value = metadata["publishedYear"] || raw_item["publishedYear"] || raw_item["year"]
+      value = metadata["publishedYear"] ||
+        metadata["publishedDate"] ||
+        raw_item["publishedYear"] ||
+        raw_item["publishedDate"] ||
+        raw_item["year"]
       return nil if value.blank?
 
       match = value.to_s.match(/\A\d{4}\z|(\d{4})/)
       return nil unless match
 
       (match[0] || match[1]).to_i
+    end
+
+    def normalize_identifier(value)
+      return nil if value.blank?
+      return value.compact_blank.first.to_s if value.is_a?(Array)
+
+      value.to_s
     end
 
     def join_people(values)

--- a/app/services/audiobookshelf_library_matcher_service.rb
+++ b/app/services/audiobookshelf_library_matcher_service.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 class AudiobookshelfLibraryMatcherService
-  Match = Data.define(:item, :score, :match_type)
+  Match = Data.define(:item, :score, :match_type) do
+    def confidence_label
+      likely? ? "Likely match" : "Possible match"
+    end
+
+    def likely?
+      match_type == :likely
+    end
+
+    def possible?
+      match_type == :possible
+    end
+  end
 
   FuzzyThreshold = 85
 
@@ -28,18 +40,19 @@ class AudiobookshelfLibraryMatcherService
 
     matches = library_items.each_with_object([]) do |item, acc|
       item_title = normalize_text(item.title)
+      item_display_title = normalize_text(item.display_title)
       item_author = normalize_text(item.author)
-      next if item_title.blank? && item_author.blank?
+      next if item_title.blank? && item_display_title.blank? && item_author.blank?
 
       score = match_score(
         query_title: query_title,
         query_author: query_author,
-        item_title: item_title,
+        item_titles: [ item_title, item_display_title ].uniq,
         item_author: item_author
       )
       next if score < FuzzyThreshold
 
-      match_type = score == 100 ? :exact : :fuzzy
+      match_type = score == 100 ? :likely : :possible
       acc << Match.new(item: item, score: score, match_type: match_type)
     end
 
@@ -49,13 +62,14 @@ class AudiobookshelfLibraryMatcherService
   private
 
   def library_items
-    @library_items ||= LibraryItem.by_synced_at_desc.to_a
+    @library_items ||= LibraryItem.available_for_matching.by_synced_at_desc.to_a
   end
 
-  def match_score(query_title:, query_author:, item_title:, item_author:)
-    return 100 if query_title == item_title && query_author == item_author
+  def match_score(query_title:, query_author:, item_titles:, item_author:)
+    return 0 if item_titles.blank?
+    return 100 if item_titles.include?(query_title) && query_author == item_author
 
-    title_score = trigram_similarity(query_title, item_title)
+    title_score = item_titles.map { |item_title| trigram_similarity(query_title, item_title) }.max || 0
     return title_score if query_author.blank? || item_author.blank?
 
     author_score = trigram_similarity(query_author, item_author)

--- a/app/services/audiobookshelf_library_sync_service.rb
+++ b/app/services/audiobookshelf_library_sync_service.rb
@@ -73,7 +73,18 @@ class AudiobookshelfLibrarySyncService
 
       cached = LibraryItem.find_or_initialize_by(library_id: library_id, audiobookshelf_id: audiobookshelf_id)
       cached.title = item["title"]
+      cached.subtitle = item["subtitle"]
       cached.author = item["author"]
+      cached.narrator = item["narrator"]
+      cached.series = item["series"]
+      cached.series_position = item["series_position"]
+      cached.publisher = item["publisher"]
+      cached.language = item["language"]
+      cached.description = item["description"]
+      cached.isbn = item["isbn"]
+      cached.asin = item["asin"]
+      cached.published_year = item["published_year"]
+      cached.missing = item["missing"] == true
       cached.synced_at = now
       cached.save!
       item_ids << audiobookshelf_id

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -137,6 +137,8 @@
                       <% if @audiobookshelf_library_items_count.to_i > 0 %>
                         <p class="text-xs text-gray-500">
                           Cached items: <%= @audiobookshelf_library_items_count %> ·
+                          Available: <%= @audiobookshelf_available_library_items_count %> ·
+                          Missing flagged: <%= @audiobookshelf_missing_library_items_count %> ·
                           Last synced: <%= @audiobookshelf_library_items_last_synced_at ? time_ago_in_words(@audiobookshelf_library_items_last_synced_at) + " ago" : "never" %>
                         </p>
                       <% else %>
@@ -149,14 +151,26 @@
                     <div>
                       <% if @audiobookshelf_library_items.any? %>
                         <p class="text-xs text-gray-400 mb-2">Recent cached items:</p>
-                        <ul class="space-y-1 max-h-32 overflow-y-auto">
+                        <ul class="space-y-2 max-h-64 overflow-y-auto pr-1">
                           <% @audiobookshelf_library_items.each do |item| %>
-                            <li class="text-xs text-gray-300 truncate">
-                              <% item_label = [item.title, item.author].compact.join(" · ").truncate(90) %>
-                              <% if item.audiobookshelf_url.present? %>
-                                <%= link_to item_label, item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "text-blue-400 hover:text-blue-300 underline" %>
-                              <% else %>
-                                <%= item_label %>
+                            <li class="rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2">
+                              <div class="flex items-start justify-between gap-2">
+                                <% item_label = item.display_title.truncate(90) %>
+                                <% if item.audiobookshelf_url.present? %>
+                                  <%= link_to item_label, item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "text-xs text-blue-400 hover:text-blue-300 underline font-medium leading-tight" %>
+                                <% else %>
+                                  <span class="text-xs text-gray-200 font-medium leading-tight"><%= item_label %></span>
+                                <% end %>
+                                <% if item.missing? %>
+                                  <span class="shrink-0 rounded-full bg-red-500/10 px-2 py-0.5 text-[10px] font-medium text-red-300">Missing</span>
+                                <% end %>
+                              </div>
+                              <% if item.author.present? %>
+                                <p class="mt-1 text-[11px] text-gray-400"><%= item.author %></p>
+                              <% end %>
+                              <% cache_details = [item.library_id, *item.detail_badges.first(4), item.identifier_label].compact %>
+                              <% if cache_details.any? %>
+                                <p class="mt-1 text-[10px] text-gray-500"><%= cache_details.join(" · ") %></p>
                               <% end %>
                             </li>
                           <% end %>

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -48,7 +48,7 @@
           <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
             <path d="M10 18a1 1 0 100-2H2a1 1 0 100-2h8V8a1 1 0 102 0v6h8a1 1 0 100 2h-8v2h8a1 1 0 100 2H10z"></path>
           </svg>
-          Similar book may already exist
+          Related titles
         </span>
       <% end %>
       <% if audiobook_status == :acquired %>
@@ -147,17 +147,28 @@
     <% end %>
     <% if audiobookshelf_matches.any? %>
       <div class="mt-2 pt-2 border-t border-gray-700">
-        <p class="text-[11px] text-amber-300">A similar book may already exist in your library:</p>
-        <ul class="text-[11px] text-amber-200 space-y-1 mt-1">
+        <p class="text-[11px] text-amber-300">Related titles in your library:</p>
+        <ul class="space-y-2 mt-2">
           <% audiobookshelf_matches.each do |match| %>
-            <li class="truncate">
-              <% label = [match.item.title, match.item.author].compact.join(" · ").truncate(70) %>
-              <% if match.item.audiobookshelf_url.present? %>
-                <%= link_to label, match.item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "hover:text-amber-100 underline" %>
-              <% else %>
-                <%= label %>
+            <li class="rounded-md border border-amber-500/20 bg-amber-500/5 px-2 py-2">
+              <div class="flex items-start justify-between gap-2">
+                <% title_label = match.item.display_title.truncate(60) %>
+                <% if match.item.audiobookshelf_url.present? %>
+                  <%= link_to title_label, match.item.audiobookshelf_url, target: "_blank", rel: "noopener", class: "text-[11px] text-amber-100 hover:text-white underline font-medium leading-tight" %>
+                <% else %>
+                  <span class="text-[11px] text-amber-100 font-medium leading-tight"><%= title_label %></span>
+                <% end %>
+                <span class="shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-300"><%= match.confidence_label %></span>
+              </div>
+              <% if match.item.author.present? %>
+                <p class="mt-1 text-[11px] text-amber-200/90"><%= match.item.author %></p>
               <% end %>
-              <span class="text-amber-400">(<%= match.match_type.to_s.titleize %>)</span>
+              <% detail_badges = match.item.detail_badges.first(3) %>
+              <% if detail_badges.any? || match.item.identifier_label.present? %>
+                <p class="mt-1 text-[10px] text-amber-200/70">
+                  <%= ([ *detail_badges, match.item.identifier_label ].compact).join(" · ") %>
+                </p>
+              <% end %>
             </li>
           <% end %>
         </ul>

--- a/bin/quality
+++ b/bin/quality
@@ -83,7 +83,7 @@ module Quality
     expressions = all_mutant_expressions
     success &&= run_mutant_command(expressions) unless expressions.empty?
 
-    success ? 0 : 1
+    success
   end
 
   def run_push

--- a/bin/quality
+++ b/bin/quality
@@ -1,0 +1,293 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "open3"
+require "set"
+
+ROOT = File.expand_path("..", __dir__)
+APP_BUNDLE_GEMFILE = File.join(ROOT, "Gemfile")
+TEST_ROOT = File.join(ROOT, "test")
+
+module Quality
+  module_function
+
+  MUTANT_NOISE_PATTERNS = [
+    /\Awarning: parser\/current is loading parser\/ruby33,/,
+    %r{\APlease see https://github.com/whitequark/parser#compatibility-with-ruby-mri\.?\z}
+  ].freeze
+
+  SOURCE_TEST_MAPPINGS = {
+    %r{\Aapp/controllers/(.+)_controller\.rb\z} => "test/controllers/%<match>s_controller_test.rb",
+    %r{\Aapp/jobs/(.+)\.rb\z} => "test/jobs/%<match>s_test.rb",
+    %r{\Aapp/mailers/(.+)_mailer\.rb\z} => "test/mailers/%<match>s_mailer_test.rb",
+    %r{\Aapp/models/(.+)\.rb\z} => "test/models/%<match>s_test.rb",
+    %r{\Aapp/services/(.+)\.rb\z} => "test/services/%<match>s_test.rb",
+    %r{\Aapp/helpers/(.+)_helper\.rb\z} => "test/helpers/%<match>s_helper_test.rb",
+    %r{\Aapp/channels/(.+)_channel\.rb\z} => "test/channels/%<match>s_channel_test.rb"
+  }.freeze
+
+  MUTANT_TARGET_MAPPINGS = [
+    %r{\Aapp/models/(.+)\.rb\z},
+    %r{\Aapp/services/(.+)\.rb\z}
+  ].freeze
+
+  def main(argv)
+    Dir.chdir(ROOT)
+
+    command = argv.shift
+
+    case command
+    when "all", "deep"
+      run_deep ? 0 : 1
+    when "fast"
+      run_fast(argv)
+    when "coverage"
+      run_coverage(argv) ? 0 : 1
+    when "mutant"
+      run_mutant(argv)
+    when "push"
+      run_push
+    else
+      warn usage
+      1
+    end
+  end
+
+  def run_fast(argv)
+    files =
+      if argv.delete("--staged")
+        staged_files
+      else
+        argv
+      end
+
+    return 0 if files.empty?
+
+    success = true
+
+    rubocop_files = rubocop_targets(files)
+    success &&= run("RuboCop", "bin/rubocop", "--force-exclusion", "--format", "quiet", "--fail-level", "warning",
+      *rubocop_files) unless rubocop_files.empty?
+
+    tests = related_test_files(files)
+    success &&= run("Tests", "bin/rails", "test", "--fail-fast", *tests) unless tests.empty?
+
+    success ? 0 : 1
+  end
+
+  def run_deep
+    success = true
+    success &&= run_push
+    success &&= run_coverage
+
+    expressions = all_mutant_expressions
+    success &&= run_mutant_command(expressions) unless expressions.empty?
+
+    success ? 0 : 1
+  end
+
+  def run_push
+    success = true
+    success &&= run("RuboCop", "bin/rubocop", "--force-exclusion", "--format", "quiet", "--fail-level", "warning")
+    success &&= run_brakeman
+    success &&= run("Tests", "bin/rails", "test")
+    success ? 0 : 1
+  end
+
+  def run_coverage(argv = [])
+    tests =
+      if argv.delete("--staged")
+        related_test_files(staged_files)
+      else
+        argv
+      end
+
+    command = ["bin/rails", "test"]
+    command.concat(tests) unless tests.empty?
+
+    run("Coverage", *command, env: { "COVERAGE" => "1", "PARALLEL_WORKERS" => "1" })
+  end
+
+  def run_mutant(argv)
+    staged = argv.delete("--staged")
+    expressions =
+      if argv.delete("--all")
+        all_mutant_expressions
+      elsif staged
+        mutant_expressions_from_paths(staged_files)
+      else
+        argv.flat_map { |entry| mutant_expressions_from_argument(entry) }
+      end
+
+    return 0 if staged && expressions.empty?
+
+    if expressions.empty?
+      warn usage
+      return 1
+    end
+
+    success = run_mutant_command(expressions.uniq)
+    success ? 0 : 1
+  end
+
+  def run(label, *command, env: {})
+    output, status = Open3.capture2e(app_bundle_env(env), *command)
+    return true if status.success?
+
+    warn "#{label} failed"
+    warn output unless output.empty?
+    false
+  rescue Errno::ENOENT => e
+    warn "#{label} failed"
+    warn e.message
+    false
+  end
+
+  def run_brakeman
+    output, status = Open3.capture2e(
+      app_bundle_env,
+      "bin/brakeman", "--quiet", "--no-pager", "--exit-on-warn", "--exit-on-error"
+    )
+    return true if status.success?
+
+    filtered_output = strip_brakeman_version_notice(output)
+    return true if filtered_output.empty?
+
+    warn "Brakeman failed"
+    warn filtered_output
+    false
+  rescue Errno::ENOENT => e
+    warn "Brakeman failed"
+    warn e.message
+    false
+  end
+
+  def run_mutant_command(expressions)
+    output, status = Open3.capture2e(
+      app_bundle_env("MUTANT" => "1", "PARALLEL_WORKERS" => "1"),
+      "bundle", "exec", "mutant", "run",
+      "--integration", "minitest",
+      "--usage", "opensource",
+      "--fail-fast",
+      "--include", "app",
+      "--include", "test",
+      *expressions
+    )
+    return true if status.success?
+
+    filtered_output = strip_noise(output, MUTANT_NOISE_PATTERNS)
+
+    warn "Mutant failed"
+    warn filtered_output unless filtered_output.empty?
+    false
+  rescue Errno::ENOENT => e
+    warn "Mutant failed"
+    warn e.message
+    false
+  end
+
+  def app_bundle_env(overrides = {})
+    { "BUNDLE_GEMFILE" => APP_BUNDLE_GEMFILE }.merge(overrides)
+  end
+
+  def staged_files
+    output, status = Open3.capture2("git", "diff", "--cached", "--name-only", "--diff-filter=ACMR")
+    return [] unless status.success?
+
+    output.lines.map(&:strip).reject(&:empty?)
+  end
+
+  def rubocop_targets(files)
+    files.select { |file| rubocop_target?(file) && File.exist?(file) }.uniq
+  end
+
+  def rubocop_target?(file)
+    return true if %w[Gemfile Rakefile].include?(file)
+    return true if file.start_with?("bin/") && File.file?(file)
+
+    [".rb", ".rake"].include?(File.extname(file))
+  end
+
+  def related_test_files(files)
+    files.each_with_object(Set.new) do |file, tests|
+      if file.start_with?("test/") && file.end_with?("_test.rb")
+        tests << file if File.exist?(file)
+        next
+      end
+
+      SOURCE_TEST_MAPPINGS.each do |pattern, template|
+        next unless (match = pattern.match(file))
+
+        candidate = format(template, match: match[1])
+        tests << candidate if File.exist?(candidate)
+        break
+      end
+    end.to_a.sort
+  end
+
+  def mutant_expressions_from_paths(files)
+    files.flat_map { |file| mutant_expressions_from_argument(file) }
+  end
+
+  def all_mutant_expressions
+    test_files = Dir.glob(File.join(TEST_ROOT, "**/*_test.rb")).sort
+
+    test_files.each_with_object(Set.new) do |file, expressions|
+      File.foreach(file) do |line|
+        next unless (match = line.match(/^\s*cover\s+"([^"]+)"/))
+
+        expressions << match[1]
+      end
+    end.to_a.sort
+  end
+
+  def mutant_expressions_from_argument(argument)
+    return [argument] unless argument.end_with?(".rb")
+
+    MUTANT_TARGET_MAPPINGS.each do |pattern|
+      next unless (match = pattern.match(argument))
+
+      return ["#{camelize_path(match[1])}*"]
+    end
+
+    []
+  end
+
+  def camelize_path(path)
+    path
+      .split("/")
+      .map { |segment| segment.split("_").map(&:capitalize).join }
+      .join("::")
+  end
+
+  def strip_brakeman_version_notice(output)
+    strip_noise(output, [/\ABrakeman \S+ is not the latest version \S+\s*\z/])
+  end
+
+  def strip_noise(output, patterns)
+    output
+      .lines
+      .reject { |line| patterns.any? { |pattern| line.match?(pattern) } }
+      .join
+      .strip
+  end
+
+  def usage
+    <<~TEXT
+      Usage:
+        bin/quality fast --staged
+        bin/quality fast path/to/file.rb test/models/example_test.rb
+        bin/quality coverage
+        bin/quality coverage --staged
+        bin/quality coverage test/services/settings_service_test.rb
+        bin/quality mutant --all
+        bin/quality mutant --staged
+        bin/quality mutant SettingsService*
+        bin/quality mutant app/services/settings_service.rb
+        bin/quality push
+        bin/quality deep
+    TEXT
+  end
+end
+
+exit Quality.main(ARGV)

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
+
+if ENV["COVERAGE"]
+  require "simplecov"
+end
+
 require "rails/commands"

--- a/bin/setup
+++ b/bin/setup
@@ -15,6 +15,9 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
+  puts "\n== Installing git hooks =="
+  system! "bundle exec lefthook install"
+
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"

--- a/db/migrate/20260422103000_add_metadata_to_library_items.rb
+++ b/db/migrate/20260422103000_add_metadata_to_library_items.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddMetadataToLibraryItems < ActiveRecord::Migration[8.0]
+  def change
+    change_table :library_items, bulk: true do |t|
+      t.string :subtitle
+      t.string :narrator
+      t.string :series
+      t.string :series_position
+      t.string :publisher
+      t.string :language
+      t.string :isbn
+      t.string :asin
+      t.integer :published_year
+      t.text :description
+      t.boolean :missing, null: false, default: false
+    end
+
+    add_index :library_items, :missing
+    add_index :library_items, :isbn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_110000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_103000) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -96,15 +96,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_110000) do
   end
 
   create_table "library_items", force: :cascade do |t|
+    t.string "asin"
     t.string "audiobookshelf_id", null: false
     t.string "author"
     t.datetime "created_at", null: false
+    t.text "description"
+    t.string "isbn"
+    t.string "language"
     t.string "library_id", null: false
+    t.boolean "missing", default: false, null: false
+    t.string "narrator"
+    t.integer "published_year"
+    t.string "publisher"
+    t.string "series"
+    t.string "series_position"
+    t.string "subtitle"
     t.datetime "synced_at"
     t.string "title"
     t.datetime "updated_at", null: false
+    t.index ["isbn"], name: "index_library_items_on_isbn"
     t.index ["library_id", "audiobookshelf_id"], name: "index_library_items_on_library_id_and_audiobookshelf_id", unique: true
     t.index ["library_id"], name: "index_library_items_on_library_id"
+    t.index ["missing"], name: "index_library_items_on_missing"
     t.index ["synced_at"], name: "index_library_items_on_synced_at"
   end
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  parallel: false
+  commands:
+    quality:
+      run: ./bin/quality fast --staged
+
+pre-push:
+  parallel: false
+  commands:
+    quality:
+      run: ./bin/quality push

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -40,13 +40,18 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "results shows warning when matching audiobookshelf item exists" do
+  test "results shows related titles when matching audiobookshelf items exist" do
     LibraryItem.destroy_all
     LibraryItem.create!(
       library_id: "lib-audio",
       audiobookshelf_id: "ab-1",
       title: "The Hobbit",
+      subtitle: "There and Back Again",
       author: "J.R.R. Tolkien",
+      narrator: "Andy Serkis",
+      series: "Middle-earth",
+      series_position: "0",
+      published_year: 1937,
       synced_at: Time.current
     )
 
@@ -63,10 +68,14 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_match "Similar book may already exist", response.body
+    assert_match "Related titles", response.body
+    assert_match "Related titles in your library", response.body
+    assert_match "Likely match", response.body
+    assert_match "There and Back Again", response.body
+    assert_match "Andy Serkis", response.body
   end
 
-  test "results does not show warning when no similar audiobookshelf item exists" do
+  test "results does not show related titles when no similar audiobookshelf item exists" do
     LibraryItem.destroy_all
     LibraryItem.create!(
       library_id: "lib-audio",
@@ -89,6 +98,33 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_no_match "Similar book may already exist", response.body
+    assert_no_match "Related titles in your library", response.body
+  end
+
+  test "results ignores missing audiobookshelf items" do
+    LibraryItem.destroy_all
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-1",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      missing: true,
+      synced_at: Time.current
+    )
+
+    result = Struct.new(:work_id, :title, :author, :cover_url, :first_publish_year, keyword_init: true)
+    metadata_result = result.new(
+      work_id: "work-hobbit",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      first_publish_year: 1937
+    )
+
+    MetadataService.stub(:search, [metadata_result]) do
+      get search_results_path, params: { q: "hobbit" }
+    end
+
+    assert_response :success
+    assert_no_match "Related titles in your library", response.body
   end
 end

--- a/test/services/audiobookshelf_client_test.rb
+++ b/test/services/audiobookshelf_client_test.rb
@@ -185,10 +185,10 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
                     "series" => [
                       { "series" => { "name" => "Bobiverse-adjacent" }, "sequence" => "1" }
                     ],
-                    "publishedYear" => "2021",
+                    "publishedDate" => "2021-05-04",
                     "publisher" => "Ballantine Books",
                     "description" => "A lone astronaut must save Earth.",
-                    "isbn" => "9780593135204",
+                    "isbn" => [ "9780593135204", "0593135202" ],
                     "asin" => "B08GB58KD5",
                     "language" => "en"
                   }

--- a/test/services/audiobookshelf_client_test.rb
+++ b/test/services/audiobookshelf_client_test.rb
@@ -117,8 +117,19 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
               {
                 "id" => "ab-item-1",
                 "title" => "The Hobbit",
+                "isMissing" => false,
                 "media" => {
-                  "author" => "J.R.R. Tolkien"
+                  "author" => "J.R.R. Tolkien",
+                  "metadata" => {
+                    "subtitle" => "There and Back Again",
+                    "series" => [
+                      { "name" => "Middle-earth Universe", "sequence" => "0" }
+                    ],
+                    "publishedYear" => "1937",
+                    "narratorName" => "Andy Serkis",
+                    "isbn" => "9780261103283",
+                    "language" => "en"
+                  }
                 }
               },
               {
@@ -140,13 +151,21 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
       assert_equal 2, items.size
       assert_equal "ab-item-1", items.first["audiobookshelf_id"]
       assert_equal "The Hobbit", items.first["title"]
+      assert_equal "There and Back Again", items.first["subtitle"]
       assert_equal "J.R.R. Tolkien", items.first["author"]
+      assert_equal "Andy Serkis", items.first["narrator"]
+      assert_equal "Middle-earth Universe", items.first["series"]
+      assert_equal "0", items.first["series_position"]
+      assert_equal 1937, items.first["published_year"]
+      assert_equal "9780261103283", items.first["isbn"]
+      assert_equal "en", items.first["language"]
+      assert_equal false, items.first["missing"]
       assert_equal "Good Omens", items.last["title"]
       assert_equal "Neil Gaiman, Terry Pratchett", items.last["author"]
     end
   end
 
-  test "library_items extracts title and author from media metadata" do
+  test "library_items extracts rich metadata from media metadata" do
     VCR.turned_off do
       stub_request(:get, "http://localhost:13378/api/libraries/lib-123/items?limit=500&page=0")
         .with(headers: { "Authorization" => "Bearer test-api-key-12345" })
@@ -160,7 +179,18 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
                 "media" => {
                   "metadata" => {
                     "title" => "Project Hail Mary",
-                    "authorName" => "Andy Weir"
+                    "subtitle" => "A Novel",
+                    "authorName" => "Andy Weir",
+                    "narrators" => [ "Ray Porter" ],
+                    "series" => [
+                      { "series" => { "name" => "Bobiverse-adjacent" }, "sequence" => "1" }
+                    ],
+                    "publishedYear" => "2021",
+                    "publisher" => "Ballantine Books",
+                    "description" => "A lone astronaut must save Earth.",
+                    "isbn" => "9780593135204",
+                    "asin" => "B08GB58KD5",
+                    "language" => "en"
                   }
                 }
               },
@@ -172,6 +202,9 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
                     "authors" => [
                       { "name" => "Neil Gaiman" },
                       { "name" => "Terry Pratchett" }
+                    ],
+                    "narrators" => [
+                      { "name" => "Martin Jarvis" }
                     ]
                   }
                 }
@@ -185,9 +218,20 @@ class AudiobookshelfClientTest < ActiveSupport::TestCase
 
       assert_equal 2, items.size
       assert_equal "Project Hail Mary", items.first["title"]
+      assert_equal "A Novel", items.first["subtitle"]
       assert_equal "Andy Weir", items.first["author"]
+      assert_equal "Ray Porter", items.first["narrator"]
+      assert_equal "Bobiverse-adjacent", items.first["series"]
+      assert_equal "1", items.first["series_position"]
+      assert_equal 2021, items.first["published_year"]
+      assert_equal "Ballantine Books", items.first["publisher"]
+      assert_equal "A lone astronaut must save Earth.", items.first["description"]
+      assert_equal "9780593135204", items.first["isbn"]
+      assert_equal "B08GB58KD5", items.first["asin"]
+      assert_equal "en", items.first["language"]
       assert_equal "Good Omens", items.last["title"]
       assert_equal "Neil Gaiman, Terry Pratchett", items.last["author"]
+      assert_equal "Martin Jarvis", items.last["narrator"]
     end
   end
 

--- a/test/services/audiobookshelf_library_matcher_service_test.rb
+++ b/test/services/audiobookshelf_library_matcher_service_test.rb
@@ -10,6 +10,7 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
       library_id: "lib-audio",
       audiobookshelf_id: "ab-1",
       title: "The Hobbit",
+      subtitle: "There and Back Again",
       author: "J.R.R. Tolkien",
       synced_at: Time.current
     )
@@ -23,7 +24,7 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
     )
   end
 
-  test "finds exact and fuzzy matches" do
+  test "finds related titles with a likely match label for exact normalized matches" do
     matches = AudiobookshelfLibraryMatcherService.new.matches_for(
       title: "The Hobbit",
       author: "J.R.R. Tolkien",
@@ -32,7 +33,8 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
 
     assert_equal 1, matches.size
     assert_equal "ab-1", matches.first.item.audiobookshelf_id
-    assert_equal :exact, matches.first.match_type
+    assert_equal :likely, matches.first.match_type
+    assert_equal "Likely match", matches.first.confidence_label
   end
 
   test "returns no matches for unrelated titles" do
@@ -56,5 +58,47 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
     assert_equal 2, matches.size
     assert_equal 1, matches.first.size
     assert_empty matches.last
+  end
+
+  test "uses a softer possible match label for fuzzy matches" do
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "The Hobbit",
+      author: "Tolkien",
+      limit: 3
+    )
+
+    assert_equal 1, matches.size
+    assert_equal :possible, matches.first.match_type
+    assert_equal "Possible match", matches.first.confidence_label
+  end
+
+  test "matches against item subtitles when present" do
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "The Hobbit: There and Back Again",
+      author: "J.R.R. Tolkien",
+      limit: 3
+    )
+
+    assert_equal 1, matches.size
+    assert_equal "ab-1", matches.first.item.audiobookshelf_id
+  end
+
+  test "ignores missing library items when suggesting related titles" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-missing",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      missing: true,
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 5
+    )
+
+    assert_equal [ "ab-1" ], matches.map { |match| match.item.audiobookshelf_id }
   end
 end

--- a/test/services/audiobookshelf_library_sync_service_test.rb
+++ b/test/services/audiobookshelf_library_sync_service_test.rb
@@ -25,7 +25,18 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
               {
                 "id" => "ab-1",
                 "title" => "The Hobbit",
-                "author" => "J.R.R. Tolkien"
+                "author" => "J.R.R. Tolkien",
+                "media" => {
+                  "metadata" => {
+                    "subtitle" => "There and Back Again",
+                    "narratorName" => "Andy Serkis",
+                    "series" => [
+                      { "name" => "Middle-earth", "sequence" => "0" }
+                    ],
+                    "publishedYear" => "1937",
+                    "isbn" => "9780261103283"
+                  }
+                }
               }
             ],
             "total" => 1
@@ -56,6 +67,14 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
       assert_empty result.errors
       assert_equal 2, LibraryItem.count
       assert_not LibraryItem.exists?(audiobookshelf_id: "ab-stale")
+
+      item = LibraryItem.find_by!(library_id: "lib-audio", audiobookshelf_id: "ab-1")
+      assert_equal "There and Back Again", item.subtitle
+      assert_equal "Andy Serkis", item.narrator
+      assert_equal "Middle-earth", item.series
+      assert_equal "0", item.series_position
+      assert_equal 1937, item.published_year
+      assert_equal "9780261103283", item.isbn
     end
   end
 
@@ -116,6 +135,38 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
       item = LibraryItem.find_by!(library_id: "lib-ebook", audiobookshelf_id: "ebook-1")
       assert_equal "Project Hail Mary", item.title
       assert_equal "Andy Weir", item.author
+    end
+  end
+
+  test "persists missing items but excludes them from active inventory counts" do
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:13378/api/libraries/lib-audio/items})
+        .with(query: hash_including("limit" => "500", "page" => "0"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "results" => [
+              {
+                "id" => "ab-missing",
+                "title" => "Lost Book",
+                "author" => "Missing Author",
+                "isMissing" => true
+              }
+            ],
+            "total" => 1
+          }.to_json
+        )
+
+      result = AudiobookshelfLibrarySyncService.new.sync!
+
+      assert result.success?
+
+      item = LibraryItem.find_by!(library_id: "lib-audio", audiobookshelf_id: "ab-missing")
+      assert item.missing?
+      assert_equal 0, LibraryItem.available_for_matching.count
     end
   end
 end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class SettingsServiceTest < ActiveSupport::TestCase
+  cover "SettingsService*"
+
   setup do
     Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password]).delete_all
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,13 +2,14 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "minitest/mock"
+require "mutant/minitest/coverage"
 require_relative "test_helpers/session_test_helper"
 require_relative "support/vcr_setup"
 
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers
-    parallelize(workers: :number_of_processors)
+    parallelize(workers: :number_of_processors) unless ENV["COVERAGE"]
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all


### PR DESCRIPTION
## Summary
- sync richer Audiobookshelf library metadata into Shelfarr, including subtitle, narrator, series, publisher, language, identifiers, published year, descriptions, and missing-state flags
- show synced Audiobookshelf items as advisory related titles in search results with likely/possible match labels instead of blocking requests
- improve the admin Audiobookshelf cache summary and recent-item display, including available/missing counts and enriched item details
- add shared local/CI quality gates with lefthook and `bin/quality`

## Motivation

Issue #241 asks for Shelfarr to understand an existing library. Because book metadata and editions are often inconsistent, this implementation treats synced Audiobookshelf records as inventory context and related-title suggestions rather than authoritative duplicate blocks.

## Testing
- `bundle exec rails test test/services/audiobookshelf_client_test.rb test/services/audiobookshelf_library_sync_service_test.rb test/services/audiobookshelf_library_matcher_service_test.rb test/controllers/search_controller_test.rb test/controllers/admin/settings_controller_test.rb`
- `bin/quality push`
- local browser check against `http://127.0.0.1:3000` using a seeded Audiobookshelf item for The Hobbit

Closes #241