### PR TITLE
feat: add download routing rules

### DIFF
--- a/app/controllers/admin/download_routing_rules_controller.rb
+++ b/app/controllers/admin/download_routing_rules_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Admin
+  class DownloadRoutingRulesController < BaseController
+    before_action :set_download_routing_rule, only: [ :edit, :update, :destroy ]
+
+    def index
+      @download_routing_rules = DownloadRoutingRule.includes(:download_client).by_indexer
+    end
+
+    def new
+      @download_routing_rule = DownloadRoutingRule.new(provider: "prowlarr", download_type: "torrent")
+    end
+
+    def create
+      @download_routing_rule = DownloadRoutingRule.new(download_routing_rule_params)
+
+      if @download_routing_rule.save
+        redirect_to admin_download_routing_rules_path, notice: "Download routing rule was successfully created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @download_routing_rule.update(download_routing_rule_params)
+        redirect_to admin_download_routing_rules_path, notice: "Download routing rule was successfully updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @download_routing_rule.destroy
+      redirect_to admin_download_routing_rules_path, notice: "Download routing rule was successfully deleted."
+    end
+
+    private
+
+    def set_download_routing_rule
+      @download_routing_rule = DownloadRoutingRule.find(params[:id])
+    end
+
+    def download_routing_rule_params
+      params.require(:download_routing_rule).permit(
+        :provider, :indexer_name, :download_type, :download_client_id, :enabled
+      )
+    end
+  end
+end

--- a/app/models/download_client.rb
+++ b/app/models/download_client.rb
@@ -13,6 +13,7 @@ class DownloadClient < ApplicationRecord
   }
 
   has_many :downloads, dependent: :nullify
+  has_many :download_routing_rules, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
   validates :client_type, presence: true

--- a/app/models/download_routing_rule.rb
+++ b/app/models/download_routing_rule.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+class DownloadRoutingRule < ApplicationRecord
+  PROVIDERS = {
+    "prowlarr" => "Prowlarr",
+    "jackett" => "Jackett"
+  }.freeze
+  DOWNLOAD_TYPES = %w[torrent usenet].freeze
+
+  belongs_to :download_client
+
+  before_validation :normalize_fields
+
+  validates :provider, presence: true, inclusion: { in: PROVIDERS.keys }
+  validates :indexer_name, presence: true
+  validates :normalized_indexer_name, presence: true
+  validates :download_type, presence: true, inclusion: { in: DOWNLOAD_TYPES }
+  validates :normalized_indexer_name, uniqueness: { scope: [ :provider, :download_type ], case_sensitive: false }
+  validate :download_client_matches_download_type
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :by_indexer, -> { order(provider: :asc, download_type: :asc, normalized_indexer_name: :asc) }
+
+  class << self
+    def for_result(search_result)
+      return unless search_result.respond_to?(:from_indexer?) && search_result.from_indexer?
+
+      indexer = normalize_indexer_name(search_result.indexer)
+      type = search_result.download_type
+      return if indexer.blank? || type.blank? || type == "direct"
+
+      enabled.includes(:download_client).find_by(
+        provider: provider_for_result(search_result),
+        normalized_indexer_name: indexer,
+        download_type: type
+      )
+    end
+
+    def routed_client_for(search_result)
+      rule = for_result(search_result)
+      return unless rule&.download_client&.enabled?
+
+      rule.download_client
+    end
+
+    def normalize_indexer_name(value)
+      value.to_s.squish.downcase
+    end
+
+    private
+
+    def provider_for_result(search_result)
+      search_result.from_jackett? ? "jackett" : "prowlarr"
+    end
+  end
+
+  def provider_name
+    PROVIDERS.fetch(provider, provider.to_s.titleize)
+  end
+
+  private
+
+  def normalize_fields
+    self.provider = provider.to_s.strip.downcase
+    self.download_type = download_type.to_s.strip.downcase
+    self.indexer_name = indexer_name.to_s.squish
+    self.normalized_indexer_name = self.class.normalize_indexer_name(indexer_name)
+  end
+
+  def download_client_matches_download_type
+    return if download_client.blank? || download_type.blank?
+
+    matches = case download_type
+    when "torrent" then download_client.torrent_client?
+    when "usenet" then download_client.usenet_client?
+    else false
+    end
+
+    return if matches
+
+    errors.add(:download_client, "must be a #{download_type} client")
+  end
+end

--- a/app/services/download_client_selector.rb
+++ b/app/services/download_client_selector.rb
@@ -42,8 +42,15 @@ class DownloadClientSelector
       raise NoClientAvailableError, "No #{download_type} download client configured"
     end
 
-    # Try each client in priority order until one succeeds connection test
-    available_clients.each do |client|
+    routed_client = DownloadRoutingRule.routed_client_for(@search_result)
+    ordered_clients = if routed_client && available_clients.include?(routed_client)
+      [ routed_client ] + available_clients.reject { |client| client.id == routed_client.id }
+    else
+      available_clients
+    end
+
+    # Try the routed client first, then fall back to priority order.
+    ordered_clients.each do |client|
       return client if client.test_connection
     end
 

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -128,6 +128,7 @@
         <% end %>
         <%= link_to "Manage Users", admin_users_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Download Clients", admin_download_clients_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
+        <%= link_to "Download Routing", admin_download_routing_rules_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Manual Uploads", admin_uploads_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Settings", admin_settings_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Activity Log", admin_activity_logs_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>

--- a/app/views/admin/download_clients/index.html.erb
+++ b/app/views/admin/download_clients/index.html.erb
@@ -1,7 +1,10 @@
 <div class="mx-auto max-w-5xl">
   <div class="flex justify-between items-center mb-8">
     <h1 class="font-bold text-4xl text-white">Download Clients</h1>
-    <%= link_to "New Client", new_admin_download_client_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
+    <div class="flex items-center gap-3">
+      <%= link_to "Routing Rules", admin_download_routing_rules_path, class: "rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white" %>
+      <%= link_to "New Client", new_admin_download_client_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
+    </div>
   </div>
 
   <% if @download_clients.empty? %>

--- a/app/views/admin/download_routing_rules/_form.html.erb
+++ b/app/views/admin/download_routing_rules/_form.html.erb
@@ -1,0 +1,59 @@
+<%= form_with model: [:admin, download_routing_rule], class: "contents" do |form| %>
+  <% if download_routing_rule.errors.any? %>
+    <div class="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(download_routing_rule.errors.count, "error") %> prohibited this routing rule from being saved:</h2>
+      <ul class="list-disc list-inside mt-2">
+        <% download_routing_rule.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="grid gap-5 md:grid-cols-2">
+    <div>
+      <%= form.label :provider, "Source", class: "block text-gray-300 font-medium" %>
+      <%= form.select :provider,
+        DownloadRoutingRule::PROVIDERS.map { |value, label| [label, value] },
+        {},
+        class: "block rounded-lg border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+    </div>
+
+    <div>
+      <%= form.label :download_type, "Download Type", class: "block text-gray-300 font-medium" %>
+      <%= form.select :download_type,
+        DownloadRoutingRule::DOWNLOAD_TYPES.map { |type| [type.titleize, type] },
+        {},
+        class: "block rounded-lg border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+    </div>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :indexer_name, "Indexer", class: "block text-gray-300 font-medium" %>
+    <%= form.text_field :indexer_name, required: true, placeholder: "e.g., MyAnonaMouse", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+    <p class="mt-1 text-sm text-gray-500">Use the indexer name exactly as it appears on search results.</p>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :download_client_id, "Download Client", class: "block text-gray-300 font-medium" %>
+    <%= form.collection_select :download_client_id,
+      DownloadClient.order(client_type: :asc, priority: :asc),
+      :id,
+      ->(client) { "#{client.name} (#{client.client_type.titleize})" },
+      { prompt: "Select a client" },
+      class: "block rounded-lg border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :enabled, class: "flex items-center gap-2 cursor-pointer" %>
+    <div class="flex items-center">
+      <%= form.check_box :enabled, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+      <span class="ml-2 text-gray-300">Enabled</span>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-4 mt-8">
+    <%= form.submit class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
+    <%= link_to "Cancel", admin_download_routing_rules_path, class: "text-gray-400 hover:text-gray-300" %>
+  </div>
+<% end %>

--- a/app/views/admin/download_routing_rules/edit.html.erb
+++ b/app/views/admin/download_routing_rules/edit.html.erb
@@ -1,0 +1,5 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl text-white mb-8">Edit Routing Rule</h1>
+
+  <%= render "form", download_routing_rule: @download_routing_rule %>
+</div>

--- a/app/views/admin/download_routing_rules/index.html.erb
+++ b/app/views/admin/download_routing_rules/index.html.erb
@@ -1,0 +1,57 @@
+<div class="mx-auto max-w-5xl">
+  <div class="flex justify-between items-center mb-8">
+    <div>
+      <h1 class="font-bold text-4xl text-white">Download Routing</h1>
+      <p class="text-gray-400 mt-2">Route selected search results from specific indexers to specific download clients.</p>
+    </div>
+    <%= link_to "New Rule", new_admin_download_routing_rule_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
+  </div>
+
+  <% if @download_routing_rules.empty? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 text-center">
+      <p class="text-gray-400 mb-4">No download routing rules configured yet.</p>
+      <%= link_to "Add your first rule", new_admin_download_routing_rule_path, class: "text-blue-400 hover:text-blue-300" %>
+    </div>
+  <% else %>
+    <div class="bg-gray-900 rounded-lg border border-gray-800 overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-800">
+        <thead class="bg-gray-800/50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Source</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Indexer</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Type</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Client</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          <% @download_routing_rules.each do |rule| %>
+            <tr class="hover:bg-gray-800/50 transition">
+              <td class="px-6 py-4 whitespace-nowrap text-gray-300"><%= rule.provider_name %></td>
+              <td class="px-6 py-4 whitespace-nowrap font-medium text-white"><%= rule.indexer_name %></td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="px-2 py-1 text-xs rounded <%= rule.download_type == 'torrent' ? 'bg-orange-500/20 text-orange-400' : 'bg-blue-500/20 text-blue-400' %>">
+                  <%= rule.download_type.titleize %>
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-gray-300">
+                <%= rule.download_client.name %>
+                <span class="text-gray-500 text-sm">(<%= rule.download_client.client_type.titleize %>)</span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="px-2 py-1 text-xs rounded <%= rule.enabled? ? 'bg-green-500/20 text-green-400' : 'bg-gray-700 text-gray-400' %>">
+                  <%= rule.enabled? ? "Enabled" : "Disabled" %>
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <%= link_to "Edit", edit_admin_download_routing_rule_path(rule), class: "text-blue-400 hover:text-blue-300 mr-3" %>
+                <%= button_to "Delete", admin_download_routing_rule_path(rule), method: :delete, class: "text-red-400 hover:text-red-300", data: { turbo_confirm: "Are you sure you want to delete this routing rule?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/download_routing_rules/new.html.erb
+++ b/app/views/admin/download_routing_rules/new.html.erb
@@ -1,0 +1,5 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl text-white mb-8">New Routing Rule</h1>
+
+  <%= render "form", download_routing_rule: @download_routing_rule %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
         post :move_down
       end
     end
+    resources :download_routing_rules, except: [ :show ]
     resources :settings, only: [ :index, :update ] do
       collection do
         patch :bulk_update

--- a/db/migrate/20260424120000_create_download_routing_rules.rb
+++ b/db/migrate/20260424120000_create_download_routing_rules.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateDownloadRoutingRules < ActiveRecord::Migration[8.1]
+  def change
+    create_table :download_routing_rules do |t|
+      t.string :provider, null: false
+      t.string :indexer_name, null: false
+      t.string :normalized_indexer_name, null: false
+      t.string :download_type, null: false
+      t.references :download_client, null: false, foreign_key: true
+      t.boolean :enabled, null: false, default: true
+
+      t.timestamps
+    end
+
+    add_index :download_routing_rules,
+      [ :provider, :normalized_indexer_name, :download_type ],
+      unique: true,
+      name: "index_download_routing_rules_on_route"
+    add_index :download_routing_rules, :enabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_103000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_120000) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -74,6 +74,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_103000) do
     t.index ["client_type", "priority"], name: "index_download_clients_on_client_type_and_priority"
     t.index ["enabled"], name: "index_download_clients_on_enabled"
     t.index ["name"], name: "index_download_clients_on_name", unique: true
+  end
+
+  create_table "download_routing_rules", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "download_client_id", null: false
+    t.string "download_type", null: false
+    t.boolean "enabled", default: true, null: false
+    t.string "indexer_name", null: false
+    t.string "normalized_indexer_name", null: false
+    t.string "provider", null: false
+    t.datetime "updated_at", null: false
+    t.index ["download_client_id"], name: "index_download_routing_rules_on_download_client_id"
+    t.index ["enabled"], name: "index_download_routing_rules_on_enabled"
+    t.index ["provider", "normalized_indexer_name", "download_type"], name: "index_download_routing_rules_on_route", unique: true
   end
 
   create_table "downloads", force: :cascade do |t|
@@ -279,6 +293,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_103000) do
   end
 
   add_foreign_key "activity_logs", "users"
+  add_foreign_key "download_routing_rules", "download_clients"
   add_foreign_key "downloads", "requests"
   add_foreign_key "notifications", "users"
   add_foreign_key "request_events", "downloads"

--- a/test/controllers/admin/download_routing_rules_controller_test.rb
+++ b/test/controllers/admin/download_routing_rules_controller_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::DownloadRoutingRulesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:two)
+    sign_in_as(@admin)
+    DownloadRoutingRule.delete_all
+    DownloadClient.delete_all
+    @client = DownloadClient.create!(
+      name: "qBit",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password"
+    )
+  end
+
+  test "index renders routing rules" do
+    DownloadRoutingRule.create!(
+      provider: "prowlarr",
+      indexer_name: "MyAnonaMouse",
+      download_type: "torrent",
+      download_client: @client
+    )
+
+    get admin_download_routing_rules_url
+
+    assert_response :success
+    assert_includes response.body, "MyAnonaMouse"
+  end
+
+  test "create persists routing rule" do
+    assert_difference "DownloadRoutingRule.count", 1 do
+      post admin_download_routing_rules_url, params: {
+        download_routing_rule: {
+          provider: "prowlarr",
+          indexer_name: "MyAnonaMouse",
+          download_type: "torrent",
+          download_client_id: @client.id,
+          enabled: "1"
+        }
+      }
+    end
+
+    assert_redirected_to admin_download_routing_rules_path
+    rule = DownloadRoutingRule.last
+    assert_equal "myanonamouse", rule.normalized_indexer_name
+  end
+
+  test "update changes routing rule" do
+    rule = DownloadRoutingRule.create!(
+      provider: "prowlarr",
+      indexer_name: "MyAnonaMouse",
+      download_type: "torrent",
+      download_client: @client
+    )
+
+    patch admin_download_routing_rule_url(rule), params: {
+      download_routing_rule: {
+        indexer_name: "IPTorrents",
+        enabled: "0"
+      }
+    }
+
+    assert_redirected_to admin_download_routing_rules_path
+    assert_equal "IPTorrents", rule.reload.indexer_name
+    assert_not rule.enabled?
+  end
+
+  test "destroy removes routing rule" do
+    rule = DownloadRoutingRule.create!(
+      provider: "prowlarr",
+      indexer_name: "MyAnonaMouse",
+      download_type: "torrent",
+      download_client: @client
+    )
+
+    assert_difference "DownloadRoutingRule.count", -1 do
+      delete admin_download_routing_rule_url(rule)
+    end
+
+    assert_redirected_to admin_download_routing_rules_path
+  end
+end

--- a/test/models/download_routing_rule_test.rb
+++ b/test/models/download_routing_rule_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DownloadRoutingRuleTest < ActiveSupport::TestCase
+  Result = Struct.new(:source, :indexer, :download_type, keyword_init: true) do
+    def from_indexer?
+      source.in?([SearchResult::SOURCE_PROWLARR, SearchResult::SOURCE_JACKETT]) || source.blank?
+    end
+
+    def from_jackett?
+      source == SearchResult::SOURCE_JACKETT
+    end
+  end
+
+  setup do
+    DownloadRoutingRule.delete_all
+    DownloadClient.delete_all
+  end
+
+  test "normalizes provider indexer and download type" do
+    client = create_client
+    rule = DownloadRoutingRule.create!(
+      provider: " Prowlarr ",
+      indexer_name: "  My   AnonaMouse  ",
+      download_type: " Torrent ",
+      download_client: client
+    )
+
+    assert_equal "prowlarr", rule.provider
+    assert_equal "My AnonaMouse", rule.indexer_name
+    assert_equal "my anonamouse", rule.normalized_indexer_name
+    assert_equal "torrent", rule.download_type
+  end
+
+  test "prevents duplicate routes for same provider indexer and download type" do
+    create_rule(indexer_name: "MyAnonaMouse")
+    duplicate = build_rule(indexer_name: " myanonamouse ")
+
+    refute duplicate.valid?
+    assert_includes duplicate.errors[:normalized_indexer_name].join, "already been taken"
+  end
+
+  test "allows same indexer to route different download types" do
+    create_rule(indexer_name: "Mixed Indexer", download_type: "torrent")
+    usenet_client = create_client(name: "SAB", client_type: "sabnzbd", api_key: "key")
+    rule = build_rule(indexer_name: "Mixed Indexer", download_type: "usenet", download_client: usenet_client)
+
+    assert rule.valid?
+  end
+
+  test "requires a compatible download client" do
+    usenet_client = create_client(name: "SAB", client_type: "sabnzbd", api_key: "key")
+    rule = build_rule(download_type: "torrent", download_client: usenet_client)
+
+    refute rule.valid?
+    assert_includes rule.errors[:download_client].join, "must be a torrent client"
+  end
+
+  test "finds enabled route for matching prowlarr result" do
+    rule = create_rule(provider: "prowlarr", indexer_name: "MyAnonaMouse", download_type: "torrent")
+    result = Result.new(source: SearchResult::SOURCE_PROWLARR, indexer: "myanonamouse", download_type: "torrent")
+
+    assert_equal rule, DownloadRoutingRule.for_result(result)
+  end
+
+  test "finds jackett route separately from prowlarr route" do
+    jackett_rule = create_rule(provider: "jackett", indexer_name: "Books", download_type: "torrent")
+    create_rule(provider: "prowlarr", indexer_name: "Books", download_type: "torrent", download_client: create_client(name: "Other", url: "http://other"))
+    result = Result.new(source: SearchResult::SOURCE_JACKETT, indexer: "Books", download_type: "torrent")
+
+    assert_equal jackett_rule, DownloadRoutingRule.for_result(result)
+  end
+
+  test "ignores disabled routes" do
+    create_rule(indexer_name: "MyAnonaMouse", enabled: false)
+    result = Result.new(source: SearchResult::SOURCE_PROWLARR, indexer: "MyAnonaMouse", download_type: "torrent")
+
+    assert_nil DownloadRoutingRule.for_result(result)
+  end
+
+  test "does not route direct or blank-indexer results" do
+    create_rule(indexer_name: "MyAnonaMouse")
+
+    assert_nil DownloadRoutingRule.for_result(Result.new(source: SearchResult::SOURCE_PROWLARR, indexer: "", download_type: "torrent"))
+    assert_nil DownloadRoutingRule.for_result(Result.new(source: SearchResult::SOURCE_PROWLARR, indexer: "MyAnonaMouse", download_type: "direct"))
+  end
+
+  private
+
+  def create_rule(**attributes)
+    build_rule(**attributes).tap(&:save!)
+  end
+
+  def build_rule(**attributes)
+    defaults = {
+      provider: "prowlarr",
+      indexer_name: "MyAnonaMouse",
+      download_type: "torrent",
+      download_client: create_client
+    }
+    DownloadRoutingRule.new(defaults.merge(attributes))
+  end
+
+  def create_client(name: nil, client_type: "qbittorrent", url: "http://localhost:8080", **attributes)
+    name ||= "qBit #{SecureRandom.hex(4)}"
+    DownloadClient.create!(
+      {
+        name: name,
+        client_type: client_type,
+        url: url
+      }.merge(attributes)
+    )
+  end
+end

--- a/test/services/download_client_selector_test.rb
+++ b/test/services/download_client_selector_test.rb
@@ -3,7 +3,26 @@
 require "test_helper"
 
 class DownloadClientSelectorTest < ActiveSupport::TestCase
+  RoutedResult = Struct.new(:indexer, :usenet, :source, keyword_init: true) do
+    def usenet?
+      usenet
+    end
+
+    def download_type
+      usenet? ? "usenet" : "torrent"
+    end
+
+    def from_indexer?
+      true
+    end
+
+    def from_jackett?
+      source == SearchResult::SOURCE_JACKETT
+    end
+  end
+
   setup do
+    DownloadRoutingRule.delete_all
     DownloadClient.destroy_all
     Thread.current[:qbittorrent_sessions] = {}
     Thread.current[:deluge_sessions] = {}
@@ -287,6 +306,84 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
       DownloadClientSelector.for_download(search_result)
     end
     assert_includes error.message, "No torrent download client configured"
+  end
+
+  test "uses matching routing rule before priority order" do
+    DownloadClient.create!(
+      name: "Priority Client",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password",
+      priority: 0
+    )
+    routed = DownloadClient.create!(
+      name: "Private Tracker Client",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      username: "admin",
+      password: "password",
+      priority: 10
+    )
+    DownloadRoutingRule.create!(
+      provider: "prowlarr",
+      indexer_name: "MyAnonaMouse",
+      download_type: "torrent",
+      download_client: routed
+    )
+
+    VCR.turned_off do
+      stub_qbittorrent_connection("http://localhost:8080")
+      stub_qbittorrent_connection("http://localhost:9090")
+
+      search_result = RoutedResult.new(
+        source: SearchResult::SOURCE_PROWLARR,
+        indexer: "myanonamouse",
+        usenet: false
+      )
+
+      assert_equal routed, DownloadClientSelector.for_download(search_result)
+    end
+  end
+
+  test "falls back to priority when routed client fails without retesting it" do
+    routed = DownloadClient.create!(
+      name: "Routed Client",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      username: "admin",
+      password: "password",
+      priority: 10
+    )
+    fallback = DownloadClient.create!(
+      name: "Fallback Client",
+      client_type: "qbittorrent",
+      url: "http://localhost:9090",
+      username: "admin",
+      password: "password",
+      priority: 0
+    )
+    DownloadRoutingRule.create!(
+      provider: "prowlarr",
+      indexer_name: "MyAnonaMouse",
+      download_type: "torrent",
+      download_client: routed
+    )
+
+    VCR.turned_off do
+      failing_login = stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(status: 401, body: "Fails.")
+      stub_qbittorrent_connection("http://localhost:9090")
+
+      search_result = RoutedResult.new(
+        source: SearchResult::SOURCE_PROWLARR,
+        indexer: "MyAnonaMouse",
+        usenet: false
+      )
+
+      assert_equal fallback, DownloadClientSelector.for_download(search_result)
+      assert_requested failing_login, times: 1
+    end
   end
 
   private


### PR DESCRIPTION
## Summary
- add explicit download routing rules for source provider, indexer name, and download type
- route selected search results to a configured compatible download client before falling back to priority order
- add admin CRUD for managing routing rules

## Validation
- bin/quality fast
- bin/quality push
- bundle exec rails test
- local browser smoke test for create, edit, validation, and runtime routing lookup
