### PR TITLE
fix: retry post-processing source readiness

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -6,7 +6,7 @@
 class PostProcessingJob < ApplicationJob
   queue_as :default
 
-  def perform(download_id)
+  def perform(download_id, source_path_retry_count = 0)
     download = Download.find_by(id: download_id)
     return unless download&.completed?
 
@@ -20,6 +20,10 @@ class PostProcessingJob < ApplicationJob
     begin
       destination = build_destination_path(book, download)
       source_path = remap_download_path(download.download_path, download)
+      if source_path_unavailable?(source_path)
+        return retry_source_path_later(download, request, source_path, source_path_retry_count)
+      end
+
       copy_files(source_path, destination, book: book)
       cleanup_usenet_download(download)
 
@@ -42,6 +46,37 @@ class PostProcessingJob < ApplicationJob
   end
 
   private
+
+  def source_path_unavailable?(source_path)
+    source_path.present? && !File.exist?(source_path)
+  end
+
+  def retry_source_path_later(download, request, source_path, retry_count)
+    retry_limit = SettingsService.get(:post_processing_source_path_retries).to_i
+    if retry_count < retry_limit
+      next_retry_count = retry_count + 1
+      wait_interval = SettingsService.get(:download_check_interval).to_i.seconds
+
+      Rails.logger.warn(
+        "[PostProcessingJob] Source path not visible yet: #{source_path}. " \
+          "Retrying post-processing source check #{next_retry_count}/#{retry_limit} in #{wait_interval.to_i}s."
+      )
+
+      track_request_event(
+        request,
+        "post_processing_waiting",
+        download: download,
+        message: "Source path not visible yet; retrying post-processing",
+        level: :warn,
+        details: { source_path: source_path, retry_count: next_retry_count, retry_limit: retry_limit }
+      )
+
+      self.class.set(wait: wait_interval).perform_later(download.id, next_retry_count)
+      return
+    end
+
+    raise source_path_not_found_message(source_path)
+  end
 
   def cleanup_usenet_download(download)
     return unless SettingsService.get(:remove_completed_usenet_downloads, default: true)
@@ -90,7 +125,7 @@ class PostProcessingJob < ApplicationJob
       Rails.logger.error "[PostProcessingJob] Check path remapping settings:"
       Rails.logger.error "[PostProcessingJob]   - download_remote_path: #{SettingsService.get(:download_remote_path).inspect}"
       Rails.logger.error "[PostProcessingJob]   - download_local_path: #{SettingsService.get(:download_local_path).inspect}"
-      raise "Source path not found: #{source}. Verify path remapping settings (download_remote_path/download_local_path) match your container mount points."
+      raise source_path_not_found_message(source)
     end
 
     Rails.logger.info "[PostProcessingJob] Copying from #{source} to #{destination}"
@@ -149,8 +184,9 @@ class PostProcessingJob < ApplicationJob
     Rails.logger.info "[PostProcessingJob] Path remapping - original path from client: #{path}"
 
     candidates = build_path_candidates(path, download)
+    candidates = deduplicate_path_candidates(candidates)
 
-    # Return the first candidate that actually exists on disk
+    # Return the first candidate that actually exists on disk.
     candidates.each do |candidate|
       next if candidate[:path].blank?
 
@@ -160,7 +196,7 @@ class PostProcessingJob < ApplicationJob
       end
     end
 
-    # None found — log all candidates for debugging
+    # None found - log all candidates for debugging
     Rails.logger.warn "[PostProcessingJob] No remapped path exists on disk. Candidates tried:"
     candidates.each { |c| Rails.logger.warn "[PostProcessingJob]   #{c[:strategy]}: #{c[:path]}" }
 
@@ -211,6 +247,36 @@ class PostProcessingJob < ApplicationJob
     candidates << { strategy: "original_path", path: path }
 
     candidates
+  end
+
+  def deduplicate_path_candidates(candidates)
+    seen = {}
+
+    candidates.select do |candidate|
+      path = candidate[:path]
+      next true if path.blank?
+      next false if seen.key?(path)
+
+      seen[path] = true
+      true
+    end
+  end
+
+  def source_path_not_found_message(source)
+    "Source path not found: #{source}. Verify path remapping settings " \
+      "(download_remote_path/download_local_path) match your container mount points."
+  end
+
+  def track_request_event(request, event_type, download: nil, message: nil, level: :info, details: {})
+    RequestEvent.record!(
+      request: request,
+      download: download,
+      event_type: event_type,
+      source: self.class.name,
+      message: message,
+      level: level,
+      details: details
+    )
   end
 
   def sanitize_filename(name)

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -30,6 +30,7 @@ class SettingsService
     preferred_download_types: { type: "json", default: '["torrent","usenet","direct"]', category: "download", description: "Download types in preference order. Higher-ranked types are preferred when multiple result types are available." },
     download_check_interval: { type: "integer", default: 60, category: "download", description: "Seconds between download status checks" },
     download_enqueue_timeout_minutes: { type: "integer", default: 5, category: "download", description: "Minutes a download may stay queued in Shelfarr before being flagged as never dispatched to the download client" },
+    post_processing_source_path_retries: { type: "integer", default: 10, category: "download", description: "Number of post-processing retries while waiting for completed download files to appear" },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
     # Audiobookshelf Integration

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -421,6 +421,35 @@ class PostProcessingJobTest < ActiveJob::TestCase
       "File should be copied using client download_path + category extraction"
   end
 
+  test "retries later when source path is not visible yet" do
+    FileUtils.rm_rf(@temp_source)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:post_processing_source_path_retries, 2)
+
+    assert_enqueued_with(job: PostProcessingJob, args: [ @download.id, 1 ]) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    @request.reload
+    assert @request.processing?
+    assert_nil @request.issue_description
+  end
+
+  test "copies when source path appears on a later retry" do
+    FileUtils.rm_rf(@temp_source)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    FileUtils.mkdir_p(@temp_source)
+    File.write(File.join(@temp_source, "audiobook.mp3"), "test audio content")
+    PostProcessingJob.perform_now(@download.id, 1)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert @request.reload.completed?
+    assert File.exist?(File.join(expected_dest, "audiobook.mp3"))
+  end
+
   test "marks request for attention when source path is blank" do
     @download.update!(download_path: "")
 
@@ -444,8 +473,10 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "marks request for attention when source path does not exist" do
     @download.update!(download_path: "/nonexistent/path/that/does/not/exist")
+    SettingsService.set(:post_processing_source_path_retries, 1)
 
-    PostProcessingJob.perform_now(@download.id)
+    PostProcessingJob.perform_now(@download.id, 1)
+
     @request.reload
 
     assert @request.attention_needed?

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -57,6 +57,12 @@ class SettingsServiceTest < ActiveSupport::TestCase
     assert_equal %w[direct torrent usenet], SettingsService.preferred_download_types
   end
 
+  test "post processing source path retries has a dedicated default" do
+    Setting.where(key: "post_processing_source_path_retries").delete_all
+
+    assert_equal 10, SettingsService.get(:post_processing_source_path_retries)
+  end
+
   test "zlibrary_configured? requires enabled flag and credentials" do
     SettingsService.set(:zlibrary_enabled, true)
     SettingsService.set(:zlibrary_url, "https://z-library.sk")


### PR DESCRIPTION
## Summary
- retry post-processing when the resolved source path is not visible yet instead of immediately flagging attention
- add a dedicated `post_processing_source_path_retries` setting so import readiness does not reuse queue retry limits
- record a request event while waiting for the source path to appear

Expected to fix #244.

## Root Cause
Some download clients can report completion before the completed file move is visible inside the Shelfarr container. Shelfarr previously resolved candidate paths once and immediately failed when the source path was missing at that exact moment.

## Validation
- `bundle exec rails test test/jobs/post_processing_job_test.rb`
- `bundle exec rails test test/services/settings_service_test.rb`
- `bin/rubocop --force-exclusion --format quiet --fail-level warning app/jobs/post_processing_job.rb app/services/settings_service.rb test/jobs/post_processing_job_test.rb test/services/settings_service_test.rb`
- `bin/quality fast --staged`
- `bin/quality mutant --staged`
- pre-push `bin/quality push`
