### PR TITLE
[codex] Support Z-Library URL rotation

### DIFF
--- a/app/javascript/controllers/settings_form_controller.js
+++ b/app/javascript/controllers/settings_form_controller.js
@@ -1,7 +1,17 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["form", "status", "indexerProvider", "prowlarrFields", "jackettFields"];
+  static targets = [
+    "form",
+    "status",
+    "indexerProvider",
+    "prowlarrFields",
+    "jackettFields",
+    "zlibraryUrlField",
+    "zlibraryUrlInput",
+    "zlibraryUrlList",
+    "zlibraryUrlError"
+  ];
 
   connect() {
     this.saveTimeout = null;
@@ -56,6 +66,47 @@ export default class extends Controller {
     this.autoSave(event);
   }
 
+  addZlibraryUrl(event) {
+    event.preventDefault();
+
+    if (!this.hasZlibraryUrlInputTarget || !this.hasZlibraryUrlFieldTarget) return;
+
+    const result = this.normalizeZlibraryUrl(this.zlibraryUrlInputTarget.value);
+    if (!result.valid) {
+      this.showZlibraryUrlError(result.error);
+      return;
+    }
+
+    const urls = this.zlibraryUrls();
+    if (urls.includes(result.value)) {
+      this.showZlibraryUrlError("This URL is already in the list.");
+      return;
+    }
+
+    urls.push(result.value);
+    this.setZlibraryUrls(urls);
+    this.zlibraryUrlInputTarget.value = "";
+    this.hideZlibraryUrlError();
+  }
+
+  removeZlibraryUrl(event) {
+    event.preventDefault();
+
+    if (!this.hasZlibraryUrlFieldTarget) return;
+
+    const url = event.currentTarget.dataset.zlibraryUrl;
+    const urls = this.zlibraryUrls().filter((existingUrl) => existingUrl !== url);
+
+    this.setZlibraryUrls(urls);
+    this.hideZlibraryUrlError();
+  }
+
+  handleZlibraryUrlKeydown(event) {
+    if (event.key !== "Enter") return;
+
+    this.addZlibraryUrl(event);
+  }
+
   submitForm() {
     if (this.hasFormTarget) {
       this.formTarget.requestSubmit();
@@ -92,5 +143,99 @@ export default class extends Controller {
     if (this.hasJackettFieldsTarget) {
       this.jackettFieldsTarget.classList.toggle("hidden", provider !== "jackett");
     }
+  }
+
+  zlibraryUrls() {
+    return this.zlibraryUrlFieldTarget.value
+      .split(/\s+/)
+      .map((url) => url.trim())
+      .filter((url) => url.length > 0);
+  }
+
+  setZlibraryUrls(urls) {
+    const uniqueUrls = [...new Set(urls)];
+
+    this.zlibraryUrlFieldTarget.value = uniqueUrls.join("\n");
+    this.zlibraryUrlFieldTarget.dispatchEvent(new Event("change", { bubbles: true }));
+    this.renderZlibraryUrlPills(uniqueUrls);
+  }
+
+  renderZlibraryUrlPills(urls) {
+    if (!this.hasZlibraryUrlListTarget) return;
+
+    this.zlibraryUrlListTarget.replaceChildren(...urls.map((url) => this.buildZlibraryUrlPill(url)));
+  }
+
+  buildZlibraryUrlPill(url) {
+    const pill = document.createElement("span");
+    pill.className = "inline-flex items-center gap-2 rounded-full border border-gray-700 bg-gray-800 px-3 py-1 text-sm text-gray-200";
+    pill.dataset.zlibraryUrl = url;
+
+    const label = document.createElement("span");
+    label.className = "break-all";
+    label.textContent = url;
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "rounded-full p-1 text-gray-400 transition hover:bg-gray-700 hover:text-white";
+    button.dataset.action = "click->settings-form#removeZlibraryUrl";
+    button.dataset.zlibraryUrl = url;
+    button.setAttribute("aria-label", `Remove ${url}`);
+
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    icon.setAttribute("class", "h-3 w-3");
+    icon.setAttribute("fill", "none");
+    icon.setAttribute("stroke", "currentColor");
+    icon.setAttribute("viewBox", "0 0 24 24");
+
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("stroke-linecap", "round");
+    path.setAttribute("stroke-linejoin", "round");
+    path.setAttribute("stroke-width", "2");
+    path.setAttribute("d", "M6 18L18 6M6 6l12 12");
+
+    icon.appendChild(path);
+    button.appendChild(icon);
+    pill.append(label, button);
+
+    return pill;
+  }
+
+  normalizeZlibraryUrl(value) {
+    const rawValue = value.trim();
+    if (rawValue.length === 0) {
+      return { valid: false, error: "Enter a URL before adding it." };
+    }
+
+    const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(rawValue) ? rawValue : `https://${rawValue}`;
+
+    try {
+      const url = new URL(candidate);
+      if (!["http:", "https:"].includes(url.protocol) || url.hostname.length === 0) {
+        return { valid: false, error: "Use an http or https URL." };
+      }
+
+      if ((url.pathname && url.pathname !== "/") || url.search || url.hash || url.username || url.password) {
+        return { valid: false, error: "Use only the site origin, without paths, query strings, or credentials." };
+      }
+
+      return { valid: true, value: url.origin };
+    } catch (_error) {
+      return { valid: false, error: "Enter a valid URL." };
+    }
+  }
+
+  showZlibraryUrlError(message) {
+    if (!this.hasZlibraryUrlErrorTarget) return;
+
+    this.zlibraryUrlErrorTarget.textContent = message;
+    this.zlibraryUrlErrorTarget.classList.remove("hidden");
+  }
+
+  hideZlibraryUrlError() {
+    if (!this.hasZlibraryUrlErrorTarget) return;
+
+    this.zlibraryUrlErrorTarget.textContent = "";
+    this.zlibraryUrlErrorTarget.classList.add("hidden");
   }
 }

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -1,4 +1,6 @@
 class SettingsService
+  DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
+
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
   DOWNLOAD_TYPE_OPTIONS = {
     "torrent" => {
@@ -106,7 +108,7 @@ class SettingsService
 
     # Z-Library
     zlibrary_enabled: { type: "boolean", default: false, category: "zlibrary", description: "Enable the unofficial Z-Library fallback for ebook search and direct download. This integration may break if the service changes." },
-    zlibrary_url: { type: "string", default: "https://z-library.sk", category: "zlibrary", description: "Base URL for the Z-Library site you can access (for example https://z-library.sk)" },
+    zlibrary_url: { type: "string", default: DEFAULT_ZLIBRARY_URLS, category: "zlibrary", description: "Z-Library base URLs to try. Shelfarr uses the first URL that accepts your login." },
     zlibrary_email: { type: "string", default: "", category: "zlibrary", description: "Z-Library account email used for login" },
     zlibrary_password: { type: "string", default: "", category: "zlibrary", description: "Z-Library account password used for login" },
 

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -41,40 +41,38 @@ class ZLibraryClient
     def search(query, file_types: %w[epub pdf], limit: 50, language: nil)
       ensure_configured!
 
-      auth = login
-      Rails.logger.info "[ZLibraryClient] Searching for '#{query}'"
+      with_authenticated_retry(context: "search") do |auth|
+        Rails.logger.info "[ZLibraryClient] Searching for '#{query}'"
 
-      payload = [["message", query], ["limit", limit.to_s]]
-      Array(file_types).each { |ext| payload << ["extensions[]", ext] }
-      payload << ["languages[]", language] if language.present?
+        payload = [["message", query], ["limit", limit.to_s]]
+        Array(file_types).each { |ext| payload << ["extensions[]", ext] }
+        payload << ["languages[]", language] if language.present?
 
-      response = connection.post("https://#{auth[:domain]}/eapi/book/search") do |req|
-        req.headers["Cookie"] = cookie_header(auth)
-        req.body = URI.encode_www_form(payload)
+        response = connection.post("#{auth[:base_url]}/eapi/book/search") do |req|
+          req.headers["Cookie"] = cookie_header(auth)
+          req.body = URI.encode_www_form(payload)
+        end
+
+        data = parse_response(response, context: "search")
+        parse_search_results(data.fetch("books", []), limit)
       end
-
-      data = parse_response(response, context: "search")
-      parse_search_results(data.fetch("books", []), limit)
-    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-      raise ConnectionError, "Failed to connect to Z-Library: #{e.message}"
     end
 
     def get_download_url(id:, hash:)
       ensure_configured!
 
-      auth = login
-      response = connection.get("https://#{auth[:domain]}/eapi/book/#{id}/#{hash}/file") do |req|
-        req.headers["Cookie"] = cookie_header(auth)
+      with_authenticated_retry(context: "download lookup") do |auth|
+        response = connection.get("#{auth[:base_url]}/eapi/book/#{id}/#{hash}/file") do |req|
+          req.headers["Cookie"] = cookie_header(auth)
+        end
+
+        data = parse_response(response, context: "download lookup")
+        download_link = data.dig("file", "downloadLink")
+        raise Error, "Z-Library did not return a download link" if download_link.blank?
+
+        validate_download_url!(download_link)
+        download_link
       end
-
-      data = parse_response(response, context: "download lookup")
-      download_link = data.dig("file", "downloadLink")
-      raise Error, "Z-Library did not return a download link" if download_link.blank?
-
-      validate_download_url!(download_link)
-      download_link
-    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-      raise ConnectionError, "Failed to connect to Z-Library: #{e.message}"
     end
 
     def reset_connection!
@@ -91,9 +89,11 @@ class ZLibraryClient
       if cached.present? &&
           cached[:signature] == signature &&
           cached[:expires_at] > Time.current
+        @last_auth_from_cache = true
         return cached[:auth]
       end
 
+      @last_auth_from_cache = false
       auth = perform_login(signature)
       raise AuthenticationError, "Z-Library login failed" unless auth
 
@@ -103,40 +103,46 @@ class ZLibraryClient
     def perform_login(signature)
       email = SettingsService.get(:zlibrary_email).to_s.strip
       password = SettingsService.get(:zlibrary_password).to_s
-      domain = configured_domain
 
-      response = connection.post("https://#{domain}/eapi/user/login") do |req|
-        req.body = URI.encode_www_form(email: email, password: password)
+      configured_uris.each do |uri|
+        base_url = uri.to_s.delete_suffix("/")
+        domain = uri.host
+
+        response = connection.post("#{base_url}/eapi/user/login") do |req|
+          req.body = URI.encode_www_form(email: email, password: password)
+        end
+
+        next unless response.status == 200
+
+        data = parse_json_body(response)
+        next unless data["success"] == 1
+
+        auth = {
+          remix_userid: data.dig("user", "id")&.to_s,
+          remix_userkey: data.dig("user", "remix_userkey")&.to_s,
+          domain: domain,
+          base_url: base_url
+        }
+
+        next if auth[:remix_userid].blank? || auth[:remix_userkey].blank?
+
+        Rails.logger.info "[ZLibraryClient] Login succeeded via #{domain}"
+        @auth_cache = {
+          signature: signature,
+          auth: auth,
+          expires_at: Time.current + AUTH_TTL_SECONDS
+        }
+        return auth
+      rescue JSON::ParserError, Faraday::Error => e
+        Rails.logger.debug "[ZLibraryClient] Login failed on #{domain}: #{e.message}"
       end
 
-      return nil unless response.status == 200
-
-      data = parse_json_body(response)
-      return nil unless data["success"] == 1
-
-      auth = {
-        remix_userid: data.dig("user", "id")&.to_s,
-        remix_userkey: data.dig("user", "remix_userkey")&.to_s,
-        domain: domain
-      }
-
-      return nil if auth[:remix_userid].blank? || auth[:remix_userkey].blank?
-
-      Rails.logger.info "[ZLibraryClient] Login succeeded via #{domain}"
-      @auth_cache = {
-        signature: signature,
-        auth: auth,
-        expires_at: Time.current + AUTH_TTL_SECONDS
-      }
-      auth
-    rescue JSON::ParserError, Faraday::Error => e
-      Rails.logger.debug "[ZLibraryClient] Login failed on #{domain}: #{e.message}"
       nil
     end
 
     def ensure_configured!
       raise NotConfiguredError, "Z-Library is not configured" unless configured?
-      configured_domain
+      configured_uris
     end
 
     def credential_signature
@@ -148,15 +154,21 @@ class ZLibraryClient
       ].join("\0"))
     end
 
-    def configured_domain
-      configured_uri.host
-    end
-
-    def configured_uri
-      raw_url = SettingsService.get(:zlibrary_url).to_s.strip
+    def configured_uris
+      raw_url = SettingsService.get(:zlibrary_url).to_s
       raise ConfigurationError, "Z-Library URL is not configured" if raw_url.blank?
 
-      uri = URI.parse(raw_url)
+      raw_url.split(/[,\s]+/).filter_map do |url|
+        normalized_uri(url.strip)
+      end.uniq { |uri| [uri.scheme, uri.host, uri.port] }.tap do |uris|
+        raise ConfigurationError, "At least one valid Z-Library URL is required" if uris.empty?
+      end
+    end
+
+    def normalized_uri(url)
+      return if url.blank?
+
+      uri = URI.parse(url)
       unless ALLOWED_DOWNLOAD_SCHEMES.include?(uri.scheme) && uri.host.present?
         raise ConfigurationError, "Z-Library URL must be a valid http or https URL"
       end
@@ -172,6 +184,37 @@ class ZLibraryClient
       uri
     rescue URI::InvalidURIError => e
       raise ConfigurationError, "Z-Library URL is invalid: #{e.message}"
+    end
+
+    def with_authenticated_retry(context:)
+      attempted_retry = false
+
+      begin
+        auth = login
+        using_cached_auth = @last_auth_from_cache
+
+        yield auth
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError,
+             JSON::ParserError, Error => e
+        raise ConnectionError, "Failed to connect to Z-Library: #{e.message}" if transport_error?(e) && attempted_retry
+
+        unless using_cached_auth && !attempted_retry
+          raise ConnectionError, "Failed to connect to Z-Library: #{e.message}" if transport_error?(e)
+
+          raise
+        end
+
+        Rails.logger.debug "[ZLibraryClient] #{context} failed on cached domain: #{e.message}"
+        @auth_cache = nil
+        attempted_retry = true
+        retry
+      end
+    end
+
+    def transport_error?(error)
+      error.is_a?(Faraday::ConnectionFailed) ||
+        error.is_a?(Faraday::TimeoutError) ||
+        error.is_a?(Faraday::SSLError)
     end
 
     def connection

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -108,6 +108,51 @@
                           <p class="mt-1 text-xs text-yellow-500">Enter Audiobookshelf URL and API key above to select from available libraries</p>
                         <% elsif key.to_s == "oidc_default_role" %>
                           <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% elsif key.to_s == "zlibrary_url" %>
+                          <% zlibrary_urls = data[:value].to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?).uniq %>
+                          <div class="space-y-3">
+                            <%= form.hidden_field "settings[#{key}]",
+                                value: zlibrary_urls.join("\n"),
+                                id: "settings_#{key}",
+                                data: {
+                                  settings_form_target: "zlibraryUrlField",
+                                  action: "change->settings-form#autoSave"
+                                } %>
+                            <div class="flex flex-wrap gap-2"
+                                 data-settings-form-target="zlibraryUrlList">
+                              <% zlibrary_urls.each do |url| %>
+                                <span class="inline-flex items-center gap-2 rounded-full border border-gray-700 bg-gray-800 px-3 py-1 text-sm text-gray-200"
+                                      data-zlibrary-url="<%= url %>">
+                                  <span class="break-all"><%= url %></span>
+                                  <button type="button"
+                                          class="rounded-full p-1 text-gray-400 transition hover:bg-gray-700 hover:text-white"
+                                          data-action="click->settings-form#removeZlibraryUrl"
+                                          data-zlibrary-url="<%= url %>"
+                                          aria-label="Remove <%= url %>">
+                                    <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                    </svg>
+                                  </button>
+                                </span>
+                              <% end %>
+                            </div>
+                            <div class="flex flex-col gap-2 sm:flex-row">
+                              <input type="url"
+                                     placeholder="https://z-library.example"
+                                     class="min-w-0 flex-grow rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                     data-settings-form-target="zlibraryUrlInput"
+                                     data-action="keydown->settings-form#handleZlibraryUrlKeydown">
+                              <button type="button"
+                                      class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-blue-600 text-white transition hover:bg-blue-500"
+                                      data-action="click->settings-form#addZlibraryUrl"
+                                      aria-label="Add Z-Library URL">
+                                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14M5 12h14" />
+                                </svg>
+                              </button>
+                            </div>
+                            <p class="hidden text-xs text-red-400" data-settings-form-target="zlibraryUrlError"></p>
+                          </div>
                         <% elsif key.to_s.include?("password") || key.to_s.include?("api_key") || key.to_s.include?("token") || key.to_s.include?("secret") %>
                           <%= form.password_field "settings[#{key}]", value: data[:value], placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% else %>

--- a/db/migrate/20260425100000_expand_default_zlibrary_urls.rb
+++ b/db/migrate/20260425100000_expand_default_zlibrary_urls.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ExpandDefaultZlibraryUrls < ActiveRecord::Migration[8.1]
+  DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
+
+  def up
+    return unless table_exists?(:settings)
+
+    execute <<~SQL
+      UPDATE settings
+      SET value = #{quote(DEFAULT_ZLIBRARY_URLS)}
+      WHERE key = 'zlibrary_url'
+        AND value = 'https://z-library.sk'
+    SQL
+  end
+
+  def down
+    return unless table_exists?(:settings)
+
+    execute <<~SQL
+      UPDATE settings
+      SET value = 'https://z-library.sk'
+      WHERE key = 'zlibrary_url'
+        AND value = #{quote(DEFAULT_ZLIBRARY_URLS)}
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_100000) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -245,7 +245,10 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "label", text: "Zlibrary Enabled"
     assert_select "input[name='settings[zlibrary_enabled]']"
-    assert_select "input[name='settings[zlibrary_url]']"
+    assert_select "input[type='hidden'][name='settings[zlibrary_url]']"
+    assert_select "[data-settings-form-target='zlibraryUrlList']"
+    assert_select "input[type='url'][data-settings-form-target='zlibraryUrlInput']"
+    assert_select "button[aria-label='Add Z-Library URL']"
     assert_select "input[name='settings[zlibrary_email]']"
     assert_select "input[name='settings[zlibrary_password]']"
     assert_select "a", text: "Test Z-Library Connection"

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -65,6 +65,73 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "login tries configured urls until one succeeds" do
+    SettingsService.set(:zlibrary_url, "https://offline.example\nhttps://z-library.sk")
+
+    VCR.turned_off do
+      stub_request(:post, "https://offline.example/eapi/user/login")
+        .to_raise(Faraday::SSLError.new("certificate verify failed"))
+      stub_zlibrary_login_success
+
+      auth = ZLibraryClient.send(:login)
+
+      assert_equal "z-library.sk", auth[:domain]
+      assert_requested(:post, "https://offline.example/eapi/user/login")
+      assert_requested(:post, "https://z-library.sk/eapi/user/login")
+    end
+  end
+
+  test "search uses the domain that accepted login" do
+    SettingsService.set(:zlibrary_url, "https://offline.example, https://z-library.sk")
+
+    VCR.turned_off do
+      stub_request(:post, "https://offline.example/eapi/user/login")
+        .to_return(status: 503, body: "unavailable")
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .to_return(
+          status: 200,
+          body: { success: 1, books: [] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      ZLibraryClient.search("Test Book")
+
+      assert_requested(:post, "https://z-library.sk/eapi/book/search")
+      assert_not_requested(:post, "https://offline.example/eapi/book/search")
+    end
+  end
+
+  test "search retries configured urls when cached domain fails" do
+    SettingsService.set(:zlibrary_url, "https://z-library.sk\nhttps://z-library.bz")
+
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .with(body: "email=reader%40example.com&password=secret")
+        .to_return(
+          status: 200,
+          body: { success: 1, user: { id: "12345", remix_userkey: "abc123" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        ).then
+        .to_return(status: 503, body: "unavailable")
+      stub_zlibrary_login_success("z-library.bz")
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .to_return(status: 503, body: "unavailable")
+      stub_request(:post, "https://z-library.bz/eapi/book/search")
+        .to_return(
+          status: 200,
+          body: { success: 1, books: [] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      assert_equal "z-library.sk", ZLibraryClient.send(:login)[:domain]
+      ZLibraryClient.search("Test Book")
+
+      assert_requested(:post, "https://z-library.sk/eapi/book/search")
+      assert_requested(:post, "https://z-library.bz/eapi/book/search")
+    end
+  end
+
   test "search raises AuthenticationError when login fails" do
     VCR.turned_off do
       stub_zlibrary_login_failure
@@ -164,10 +231,16 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     assert_not ZLibraryClient.test_connection
   end
 
+  test "test_connection returns false when any configured url is invalid" do
+    SettingsService.set(:zlibrary_url, "https://z-library.sk\nnot-a-url")
+
+    assert_not ZLibraryClient.test_connection
+  end
+
   private
 
-  def stub_zlibrary_login_success
-    stub_request(:post, "https://z-library.sk/eapi/user/login")
+  def stub_zlibrary_login_success(domain = "z-library.sk")
+    stub_request(:post, "https://#{domain}/eapi/user/login")
       .with(body: "email=reader%40example.com&password=secret")
       .to_return(
         status: 200,


### PR DESCRIPTION
## Summary

- allow the existing Z-Library URL setting to store multiple editable origins
- try configured Z-Library origins in order until login succeeds and cache the working origin
- replace the freeform textarea with a pill-style add/remove UI for Z-Library URLs
- migrate installs using the old stock `https://z-library.sk` value to the new default URL list

## Why

Z-Library domain rotation makes a single configured host a point of failure. This addresses the root issue behind #250 and should help cases like #246 when one known host has TLS/connectivity trouble but another configured host works.

## Validation

- `bundle exec rails test test/services/z_library_client_test.rb test/controllers/admin/settings_controller_test.rb:243 test/services/settings_service_test.rb`
- `bin/quality fast`
- `bin/quality fast --staged`
- pre-commit hook
- pre-push hook
- local browser check of the Admin Settings pill editor: add, duplicate rejection, invalid origin rejection, remove, Enter-to-add, and autosave persistence
