### PR TITLE
Improve Prowlarr fallback search for punctuation-normalized titles

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -109,10 +109,15 @@ class SearchJob < ApplicationJob
 
     return results if results.any?
 
-    fallback_query = generic_indexer_query(request)
-    Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query '#{fallback_query}'"
+    fallback_queries = prowlarr_fallback_queries(request)
 
-    IndexerClient.search(fallback_query, book_type: book.book_type)
+    fallback_queries.each_with_index do |fallback_query, index|
+      Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query #{index + 1}/#{fallback_queries.size}: '#{fallback_query}'"
+      fallback_results = IndexerClient.search(fallback_query, book_type: book.book_type)
+      return fallback_results if fallback_results.any?
+    end
+
+    []
   end
 
   def search_generic_indexer(request)
@@ -125,6 +130,31 @@ class SearchJob < ApplicationJob
 
   def generic_indexer_query(request)
     [ request.book.title, indexer_language_hint(request) ].reject(&:blank?).join(" ")
+  end
+
+  def prowlarr_fallback_queries(request)
+    language_hint = indexer_language_hint(request)
+    title_variants = normalized_query_variants(request.book.title)
+
+    title_variants.map do |title|
+      [ title, language_hint ].reject(&:blank?).join(" ")
+    end.uniq
+  end
+
+  def normalized_query_variants(value)
+    base = value.to_s.squish
+    return [] if base.blank?
+
+    apostrophe_normalized = base.tr("’‘`´", "'").squish
+    apostrophe_removed = apostrophe_normalized.delete("'").squish
+    punctuation_simplified = apostrophe_removed.gsub(/[^\p{Alnum}\s]/, " ").squish
+
+    [
+      base,
+      apostrophe_normalized,
+      apostrophe_removed,
+      punctuation_simplified
+    ].reject(&:blank?).uniq
   end
 
   def indexer_language_hint(request)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -149,12 +149,14 @@ class SearchJob < ApplicationJob
     apostrophe_removed = apostrophe_normalized.delete("'").squish
     punctuation_simplified = apostrophe_removed.gsub(/[^\p{Alnum}\s]/, " ").squish
 
-    [
+    variants = [
       base,
       apostrophe_normalized,
       apostrophe_removed,
       punctuation_simplified
-    ].reject(&:blank?).uniq
+    ].reject(&:blank?)
+
+    (variants + variants.map(&:downcase)).reject(&:blank?).uniq
   end
 
   def indexer_language_hint(request)

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -390,6 +390,71 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "retries with lowercase generic query variant when mixed-case fallbacks miss" do
+    book = Book.create!(
+      title: "CARL’S DOOMSDAY SCENARIO",
+      author: "Matt Dinniman",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "book" &&
+            req.uri.query_values["query"].include?("{title:CARL’S DOOMSDAY SCENARIO}") &&
+            req.uri.query_values["query"].include?("{author:Matt Dinniman}")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      uppercase_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "CARL’S DOOMSDAY SCENARIO"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      apostrophe_removed_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "CARLS DOOMSDAY SCENARIO"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      lowercase_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "carls doomsday scenario"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested structured_stub
+      assert_requested uppercase_stub
+      assert_requested apostrophe_removed_stub
+      assert_requested lowercase_stub
+      assert_equal "Test Result Book", request.search_results.first.title
+    end
+  end
+
   test "sanitizes braces in structured Prowlarr query values" do
     book = Book.create!(
       title: "The {Brace} Book",

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -337,6 +337,59 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "retries with apostrophe-normalized generic query when fallback query has no results" do
+    book = Book.create!(
+      title: "Carl’s Doomsday Scenario",
+      author: "Matt Dinniman",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "book" &&
+            req.uri.query_values["query"].include?("{title:Carl’s Doomsday Scenario}") &&
+            req.uri.query_values["query"].include?("{author:Matt Dinniman}")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Carl’s Doomsday Scenario"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      normalized_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Carls Doomsday Scenario"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested structured_stub
+      assert_requested generic_stub
+      assert_requested normalized_stub
+      assert_equal "Test Result Book", request.search_results.first.title
+    end
+  end
+
   test "sanitizes braces in structured Prowlarr query values" do
     book = Book.create!(
       title: "The {Brace} Book",


### PR DESCRIPTION
## Summary
- keep the existing structured Prowlarr book query as the first attempt
- extend generic fallback search to try multiple normalized title variants
- add a regression test for curly-apostrophe titles (`Carl’s` -> `Carls`)

## Why
Some indexers return no matches for typographic apostrophes and punctuation-heavy titles even when the release exists. This improves resilience by retrying normalized variants before giving up.