### PR TITLE
fix: broaden Prowlarr ebook searches

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -100,19 +100,24 @@ class SearchJob < ApplicationJob
 
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} book query for title='#{book.title}' author='#{book.author}' extra='#{query}' (type: #{book.book_type})"
 
-    results = IndexerClient.search(
+    structured_results = IndexerClient.search(
       query,
       book_type: book.book_type,
       title: book.title,
       author: book.author
     )
 
-    return results if results.any?
+    return structured_results if structured_results.any? && !book.ebook?
 
     fallback_query = generic_indexer_query(request)
-    Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query '#{fallback_query}'"
+    if structured_results.any?
+      Rails.logger.info "[SearchJob] #{IndexerClient.display_name} ebook search found #{structured_results.count} structured results for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
+    else
+      Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query '#{fallback_query}'"
+    end
 
-    IndexerClient.search(fallback_query, book_type: book.book_type)
+    generic_results = IndexerClient.search(fallback_query, book_type: book.book_type)
+    merge_indexer_results(structured_results, generic_results)
   end
 
   def search_generic_indexer(request)
@@ -312,5 +317,17 @@ class SearchJob < ApplicationJob
     language = request.effective_language
     info = ReleaseParserService.language_info(language)
     info[:name]
+  end
+
+  def merge_indexer_results(*result_groups)
+    seen = {}
+
+    result_groups.flatten.each_with_object([]) do |result, merged|
+      key = result.guid.presence || [ result.indexer, result.title, result.download_link ].join("|")
+      next if seen[key]
+
+      seen[key] = true
+      merged << result
+    end
   end
 end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -248,6 +248,7 @@ class SearchJobTest < ActiveJob::TestCase
           headers: { "Content-Type" => "application/json" },
           body: [ prowlarr_result_payload ].to_json
         )
+      stub_prowlarr_generic_search_empty
 
       assert_nothing_raised do
         SearchJob.perform_now(@request.id)
@@ -274,6 +275,7 @@ class SearchJobTest < ActiveJob::TestCase
           headers: { "Content-Type" => "application/json" },
           body: [ prowlarr_result_payload ].to_json
         )
+      stub_prowlarr_generic_search_empty
 
       assert_nothing_raised do
         SearchJob.perform_now(@request.id)
@@ -295,6 +297,7 @@ class SearchJobTest < ActiveJob::TestCase
           headers: { "Content-Type" => "application/json" },
           body: [ prowlarr_result_payload ].to_json
         )
+      stub_prowlarr_generic_search_empty
 
       assert_nothing_raised do
         SearchJob.perform_now(@request.id)
@@ -337,6 +340,62 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "supplements partial Prowlarr ebook results with generic title search" do
+    book = Book.create!(
+      title: "Frieren: Beyond Journey's End, Vol. 1",
+      author: "Kanehito Yamada",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    structured_payload = prowlarr_result_payload.merge(
+      "guid" => "mam-frieren-prelude",
+      "title" => "Frieren: Beyond Journey's End -Prelude-, Vol. 1 by Mei Hachimoku [ENG / EPUB]",
+      "indexer" => "MyAnonaMouse"
+    )
+    generic_payload = prowlarr_result_payload.merge(
+      "guid" => "nyaa-frieren-v01",
+      "title" => "Frieren - Beyond Journey's End v01 (2021) (Digital) (danke-Empire)",
+      "indexer" => "Nyaa.si"
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values["query"]
+          req.uri.query_values["type"] == "book" &&
+            query.include?("{title:Frieren: Beyond Journey's End, Vol. 1}") &&
+            query.include?("{author:Kanehito Yamada}")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ structured_payload ].to_json
+        )
+
+      generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ generic_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested structured_stub
+      assert_requested generic_stub
+      assert_equal [
+        "Frieren - Beyond Journey's End v01 (2021) (Digital) (danke-Empire)",
+        "Frieren: Beyond Journey's End -Prelude-, Vol. 1 by Mei Hachimoku [ENG / EPUB]"
+      ].sort,
+        request.search_results.pluck(:title).sort
+    end
+  end
+
   test "sanitizes braces in structured Prowlarr query values" do
     book = Book.create!(
       title: "The {Brace} Book",
@@ -360,6 +419,7 @@ class SearchJobTest < ActiveJob::TestCase
           headers: { "Content-Type" => "application/json" },
           body: [ prowlarr_result_payload ].to_json
         )
+      stub_prowlarr_generic_search_empty
 
       SearchJob.perform_now(request.id)
       request.reload
@@ -590,6 +650,16 @@ class SearchJobTest < ActiveJob::TestCase
 
   def stub_prowlarr_search_empty
     stub_request(:get, %r{localhost:9696/api/v1/search})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: [].to_json
+      )
+  end
+
+  def stub_prowlarr_generic_search_empty
+    stub_request(:get, %r{localhost:9696/api/v1/search})
+      .with { |req| req.uri.query_values["type"] == "search" }
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },


### PR DESCRIPTION
## Summary
- Keep structured Prowlarr book search for ebooks, but supplement it with a generic title search when structured results are present
- Merge and dedupe Prowlarr result sets so manga/anime-style indexers can contribute title-only matches
- Add regression coverage for the Frieren issue shape where structured search returns only a weak MyAnonaMouse result and generic search returns the Nyaa v01 release

Fixes #268

## Verification
- `bundle exec rails test test/jobs/search_job_test.rb:343`
- `bundle exec rails test test/jobs/search_job_test.rb`
- `bin/quality push`