### PR TITLE
Fix request workflow issues

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -347,6 +347,9 @@ module Admin
       if changed_keys.any? { |k| k == "flaresolverr_url" }
         FlaresolverrClient.reset_connection!
       end
+      if changed_keys.any? { |k| k.start_with?("anna_archive") }
+        AnnaArchiveClient.reset_connection!
+      end
       if changed_keys.any? { |k| k.start_with?("zlibrary") }
         ZLibraryClient.reset_connection!
       end

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -6,17 +6,20 @@ export default class extends Controller {
   static targets = ["input", "results", "spinner"]
   static values = {
     url: String,
-    debounce: { type: Number, default: 300 }
+    debounce: { type: Number, default: 700 }
   }
 
   connect() {
     this.timeout = null
+    this.currentAbortController = null
+    this.requestSequence = 0
   }
 
   disconnect() {
     if (this.timeout) {
       clearTimeout(this.timeout)
     }
+    this.abortCurrentRequest()
   }
 
   search() {
@@ -26,6 +29,7 @@ export default class extends Controller {
     if (this.timeout) {
       clearTimeout(this.timeout)
     }
+    this.abortCurrentRequest()
 
     // If query is empty, clear results
     if (query.length === 0) {
@@ -36,13 +40,10 @@ export default class extends Controller {
 
     // Don't search for very short queries
     if (query.length < 2) {
+      this.hideSpinner()
       return
     }
 
-    // Show spinner
-    this.showSpinner()
-
-    // Debounce the search
     this.timeout = setTimeout(() => {
       this.performSearch(query)
     }, this.debounceValue)
@@ -50,22 +51,42 @@ export default class extends Controller {
 
   async performSearch(query) {
     const url = `${this.urlValue}?q=${encodeURIComponent(query)}`
+    const requestId = ++this.requestSequence
+    const abortController = new AbortController()
+
+    this.currentAbortController = abortController
+    this.showSpinner()
 
     try {
       const response = await fetch(url, {
+        signal: abortController.signal,
         headers: {
           "Accept": "text/vnd.turbo-stream.html"
         }
       })
 
-      if (response.ok) {
+      if (response.ok && requestId === this.requestSequence && this.inputTarget.value.trim() === query) {
         const html = await response.text()
         Turbo.renderStreamMessage(html)
       }
     } catch (error) {
+      if (error.name === "AbortError") {
+        return
+      }
+
       console.error("Search failed:", error)
     } finally {
-      this.hideSpinner()
+      if (this.currentAbortController === abortController) {
+        this.currentAbortController = null
+        this.hideSpinner()
+      }
+    }
+  }
+
+  abortCurrentRequest() {
+    if (this.currentAbortController) {
+      this.currentAbortController.abort()
+      this.currentAbortController = null
     }
   }
 

--- a/app/javascript/controllers/settings_form_controller.js
+++ b/app/javascript/controllers/settings_form_controller.js
@@ -6,11 +6,7 @@ export default class extends Controller {
     "status",
     "indexerProvider",
     "prowlarrFields",
-    "jackettFields",
-    "zlibraryUrlField",
-    "zlibraryUrlInput",
-    "zlibraryUrlList",
-    "zlibraryUrlError"
+    "jackettFields"
   ];
 
   connect() {
@@ -66,45 +62,48 @@ export default class extends Controller {
     this.autoSave(event);
   }
 
-  addZlibraryUrl(event) {
+  addUrl(event) {
     event.preventDefault();
 
-    if (!this.hasZlibraryUrlInputTarget || !this.hasZlibraryUrlFieldTarget) return;
+    const container = this.urlListContainer(event);
+    if (!container) return;
 
-    const result = this.normalizeZlibraryUrl(this.zlibraryUrlInputTarget.value);
+    const input = this.urlListInput(container);
+    const result = this.normalizeUrl(input.value);
     if (!result.valid) {
-      this.showZlibraryUrlError(result.error);
+      this.showUrlListError(container, result.error);
       return;
     }
 
-    const urls = this.zlibraryUrls();
+    const urls = this.urlListUrls(container);
     if (urls.includes(result.value)) {
-      this.showZlibraryUrlError("This URL is already in the list.");
+      this.showUrlListError(container, "This URL is already in the list.");
       return;
     }
 
     urls.push(result.value);
-    this.setZlibraryUrls(urls);
-    this.zlibraryUrlInputTarget.value = "";
-    this.hideZlibraryUrlError();
+    this.setUrlListUrls(container, urls);
+    input.value = "";
+    this.hideUrlListError(container);
   }
 
-  removeZlibraryUrl(event) {
+  removeUrl(event) {
     event.preventDefault();
 
-    if (!this.hasZlibraryUrlFieldTarget) return;
+    const container = this.urlListContainer(event);
+    if (!container) return;
 
-    const url = event.currentTarget.dataset.zlibraryUrl;
-    const urls = this.zlibraryUrls().filter((existingUrl) => existingUrl !== url);
+    const url = event.currentTarget.dataset.urlListValue;
+    const urls = this.urlListUrls(container).filter((existingUrl) => existingUrl !== url);
 
-    this.setZlibraryUrls(urls);
-    this.hideZlibraryUrlError();
+    this.setUrlListUrls(container, urls);
+    this.hideUrlListError(container);
   }
 
-  handleZlibraryUrlKeydown(event) {
+  handleUrlKeydown(event) {
     if (event.key !== "Enter") return;
 
-    this.addZlibraryUrl(event);
+    this.addUrl(event);
   }
 
   submitForm() {
@@ -145,31 +144,53 @@ export default class extends Controller {
     }
   }
 
-  zlibraryUrls() {
-    return this.zlibraryUrlFieldTarget.value
+  urlListContainer(event) {
+    return event.currentTarget.closest("[data-url-list]");
+  }
+
+  urlListField(container) {
+    return container.querySelector("[data-url-list-field]");
+  }
+
+  urlListInput(container) {
+    return container.querySelector("[data-url-list-input]");
+  }
+
+  urlListList(container) {
+    return container.querySelector("[data-url-list-list]");
+  }
+
+  urlListError(container) {
+    return container.querySelector("[data-url-list-error]");
+  }
+
+  urlListUrls(container) {
+    return this.urlListField(container).value
       .split(/\s+/)
       .map((url) => url.trim())
       .filter((url) => url.length > 0);
   }
 
-  setZlibraryUrls(urls) {
+  setUrlListUrls(container, urls) {
     const uniqueUrls = [...new Set(urls)];
+    const field = this.urlListField(container);
 
-    this.zlibraryUrlFieldTarget.value = uniqueUrls.join("\n");
-    this.zlibraryUrlFieldTarget.dispatchEvent(new Event("change", { bubbles: true }));
-    this.renderZlibraryUrlPills(uniqueUrls);
+    field.value = uniqueUrls.join("\n");
+    field.dispatchEvent(new Event("change", { bubbles: true }));
+    this.renderUrlListPills(container, uniqueUrls);
   }
 
-  renderZlibraryUrlPills(urls) {
-    if (!this.hasZlibraryUrlListTarget) return;
+  renderUrlListPills(container, urls) {
+    const list = this.urlListList(container);
+    if (!list) return;
 
-    this.zlibraryUrlListTarget.replaceChildren(...urls.map((url) => this.buildZlibraryUrlPill(url)));
+    list.replaceChildren(...urls.map((url) => this.buildUrlListPill(url)));
   }
 
-  buildZlibraryUrlPill(url) {
+  buildUrlListPill(url) {
     const pill = document.createElement("span");
     pill.className = "inline-flex items-center gap-2 rounded-full border border-gray-700 bg-gray-800 px-3 py-1 text-sm text-gray-200";
-    pill.dataset.zlibraryUrl = url;
+    pill.dataset.urlListValue = url;
 
     const label = document.createElement("span");
     label.className = "break-all";
@@ -178,8 +199,8 @@ export default class extends Controller {
     const button = document.createElement("button");
     button.type = "button";
     button.className = "rounded-full p-1 text-gray-400 transition hover:bg-gray-700 hover:text-white";
-    button.dataset.action = "click->settings-form#removeZlibraryUrl";
-    button.dataset.zlibraryUrl = url;
+    button.dataset.action = "click->settings-form#removeUrl";
+    button.dataset.urlListValue = url;
     button.setAttribute("aria-label", `Remove ${url}`);
 
     const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -201,7 +222,7 @@ export default class extends Controller {
     return pill;
   }
 
-  normalizeZlibraryUrl(value) {
+  normalizeUrl(value) {
     const rawValue = value.trim();
     if (rawValue.length === 0) {
       return { valid: false, error: "Enter a URL before adding it." };
@@ -225,17 +246,19 @@ export default class extends Controller {
     }
   }
 
-  showZlibraryUrlError(message) {
-    if (!this.hasZlibraryUrlErrorTarget) return;
+  showUrlListError(container, message) {
+    const error = this.urlListError(container);
+    if (!error) return;
 
-    this.zlibraryUrlErrorTarget.textContent = message;
-    this.zlibraryUrlErrorTarget.classList.remove("hidden");
+    error.textContent = message;
+    error.classList.remove("hidden");
   }
 
-  hideZlibraryUrlError() {
-    if (!this.hasZlibraryUrlErrorTarget) return;
+  hideUrlListError(container) {
+    const error = this.urlListError(container);
+    if (!error) return;
 
-    this.zlibraryUrlErrorTarget.textContent = "";
-    this.zlibraryUrlErrorTarget.classList.add("hidden");
+    error.textContent = "";
+    error.classList.add("hidden");
   }
 }

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -207,15 +207,16 @@ class PostProcessingJob < ApplicationJob
 
   def build_path_candidates(path, download)
     candidates = []
-    remote_path = SettingsService.get(:download_remote_path)
-    local_path = SettingsService.get(:download_local_path, default: "/downloads")
+    normalized_path = normalize_path_separators(path)
+    remote_path = normalize_path_separators(SettingsService.get(:download_remote_path))
+    local_path = normalize_path_separators(SettingsService.get(:download_local_path, default: "/downloads"))
     category = download.download_client&.category
-    client_download_path = download.download_client&.download_path
-    basename = File.basename(path)
+    client_download_path = normalize_path_separators(download.download_client&.download_path)
+    basename = File.basename(normalized_path)
 
     # 1. Global remote_path → local_path prefix replacement
-    if remote_path.present? && path.start_with?(remote_path)
-      candidates << { strategy: "global_prefix_remap", path: path.sub(remote_path, local_path) }
+    if remote_path.present? && path_prefix_match?(normalized_path, remote_path)
+      candidates << { strategy: "global_prefix_remap", path: replace_path_prefix(normalized_path, remote_path, local_path) }
     end
 
     # 2. local_path/category/basename — most common torrent client layout
@@ -225,10 +226,10 @@ class PostProcessingJob < ApplicationJob
 
     # 3. Category-aware sibling remap — when remote_path points to a sibling folder
     #    e.g., remote=/mnt/Torrents/Completed, path=/mnt/Torrents/shelfarr/File
-    if category.present? && remote_path.present? && path.include?("/#{category}/")
-      category_idx = path.index("/#{category}/")
-      remote_base = path[0...category_idx]
-      relative_after_base = path[(category_idx)..]
+    if category.present? && remote_path.present? && normalized_path.include?("/#{category}/")
+      category_idx = normalized_path.index("/#{category}/")
+      remote_base = normalized_path[0...category_idx]
+      relative_after_base = normalized_path[(category_idx)..]
 
       if remote_base == File.dirname(remote_path)
         candidates << { strategy: "category_sibling_remap", path: File.join(File.dirname(local_path), relative_after_base) }
@@ -247,6 +248,21 @@ class PostProcessingJob < ApplicationJob
     candidates << { strategy: "original_path", path: path }
 
     candidates
+  end
+
+  def normalize_path_separators(path)
+    path.to_s.tr("\\", "/") if path.present?
+  end
+
+  def path_prefix_match?(path, prefix)
+    return false unless path.start_with?(prefix)
+
+    path.length == prefix.length || prefix.end_with?("/") || path[prefix.length] == "/"
+  end
+
+  def replace_path_prefix(path, remote_path, local_path)
+    suffix = path.delete_prefix(remote_path).sub(%r{\A/+}, "")
+    suffix.present? ? File.join(local_path, suffix) : local_path
   end
 
   def deduplicate_path_candidates(candidates)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -228,7 +228,7 @@ class SearchJob < ApplicationJob
       sr.leechers = nil
       sr.download_url = nil  # Will be fetched via API when downloading
       sr.magnet_url = nil
-      sr.info_url = "#{SettingsService.get(:anna_archive_url)}/md5/#{result.md5}"
+      sr.info_url = AnnaArchiveClient.info_url(result.md5)
       sr.published_at = nil
       sr.source = SearchResult::SOURCE_ANNA_ARCHIVE
       sr.detected_language = result.language

--- a/app/services/anna_archive_client.rb
+++ b/app/services/anna_archive_client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 # Client for interacting with Anna's Archive
 # Search via HTML scraping, downloads via member API
 class AnnaArchiveClient
@@ -8,8 +10,10 @@ class AnnaArchiveClient
   class ConnectionError < Error; end
   class AuthenticationError < Error; end
   class NotConfiguredError < Error; end
+  class ConfigurationError < Error; end
   class ScrapingError < Error; end
   class BotProtectionError < Error; end
+  class RetryableError < Error; end
 
   # Data structure for search results
   Result = Data.define(
@@ -24,6 +28,9 @@ class AnnaArchiveClient
       file_size
     end
   end
+
+  DEFAULT_BASE_URL = "https://annas-archive.se"
+  ALLOWED_BASE_URL_SCHEMES = %w[http https].freeze
 
   class << self
     # Check if Anna's Archive is configured (has API key)
@@ -44,13 +51,10 @@ class AnnaArchiveClient
       ensure_configured!
 
       url = build_search_url(query, file_types, language: language)
-      full_url = "#{base_url}#{url}"
       Rails.logger.info "[AnnaArchiveClient] Searching: #{url}"
 
-      html = fetch_with_protection_bypass(full_url)
+      html = fetch_with_rotation(url, context: "search")
       parse_search_results(html, limit)
-    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-      raise ConnectionError, "Failed to connect to Anna's Archive: #{e.message}"
     end
 
     # Get download URL (torrent) via fast_download API
@@ -65,39 +69,76 @@ class AnnaArchiveClient
         domain_index: domain_index
       }
 
-      response = connection.get("/dyn/api/fast_download.json", params)
-      data = JSON.parse(response.body)
+      with_base_url_rotation(context: "download API") do |base_url|
+        response = connection_for(base_url).get("/dyn/api/fast_download.json", params)
+        raise RetryableError, "API request failed with status #{response.status}" unless response.status == 200
 
-      if data["error"]
-        raise Error, "Anna's Archive API error: #{data['error']}"
+        data = JSON.parse(response.body)
+
+        if data["error"]
+          raise Error, "Anna's Archive API error: #{data['error']}"
+        end
+
+        download_url = data["download_url"]
+        raise Error, "No download URL returned" if download_url.blank?
+
+        download_url
+      rescue JSON::ParserError => e
+        raise RetryableError, "Failed to parse Anna's Archive response: #{e.message}"
       end
+    end
 
-      download_url = data["download_url"]
-      raise Error, "No download URL returned" if download_url.blank?
+    def info_url(md5)
+      "#{preferred_base_url}/md5/#{md5}"
+    end
 
-      download_url
-    rescue JSON::ParserError => e
-      raise Error, "Failed to parse Anna's Archive response: #{e.message}"
-    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-      raise ConnectionError, "Failed to connect to Anna's Archive API: #{e.message}"
+    def reset_connection!
+      @connections = nil
+      @working_base_url = nil
     end
 
     # Test connection by fetching search page
     def test_connection
-      response = connection.get("/")
-      response.status == 200
-    rescue Error, Faraday::Error
+      configured_base_urls.any? do |base_url|
+        response = connection_for(base_url).get("/")
+        response.status == 200
+      rescue Faraday::Error
+        false
+      end
+    rescue Error
       false
     end
 
     private
 
-    def fetch_with_protection_bypass(url)
+    def fetch_with_rotation(path, context:)
+      with_base_url_rotation(context: context) do |base_url|
+        fetch_with_protection_bypass(path, base_url: base_url)
+      end
+    end
+
+    def with_base_url_rotation(context:)
+      last_error = nil
+
+      ordered_base_urls.each do |base_url|
+        return yield(base_url).tap { remember_working_base_url(base_url) }
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError,
+             ConnectionError, BotProtectionError, RetryableError => e
+        last_error = e
+        Rails.logger.debug "[AnnaArchiveClient] #{context} failed on #{base_url}: #{e.message}"
+      end
+
+      raise_rotation_error(last_error, context: context)
+    end
+
+    def fetch_with_protection_bypass(path, base_url:)
+      url = "#{base_url}#{path}"
+
       if FlaresolverrClient.configured?
         Rails.logger.info "[AnnaArchiveClient] Using FlareSolverr for request"
         FlaresolverrClient.get(url)
       else
-        response = connection.get(url)
+        response = connection_for(base_url).get(path)
 
         # Detect bot protection
         if response.status == 403 || bot_protection_detected?(response.body)
@@ -105,7 +146,7 @@ class AnnaArchiveClient
                                     "Please configure FlareSolverr URL in settings."
         end
 
-        raise Error, "Search failed with status #{response.status}" unless response.status == 200
+        raise RetryableError, "Search failed with status #{response.status}" unless response.status == 200
         response.body
       end
     rescue FlaresolverrClient::Error => e
@@ -126,10 +167,13 @@ class AnnaArchiveClient
       unless configured?
         raise NotConfiguredError, "Anna's Archive is not configured or enabled"
       end
+
+      configured_base_urls
     end
 
-    def connection
-      @connection ||= Faraday.new(url: base_url) do |f|
+    def connection_for(base_url)
+      @connections ||= {}
+      @connections[base_url] ||= Faraday.new(url: base_url) do |f|
         f.request :url_encoded
         f.adapter Faraday.default_adapter
         f.headers["User-Agent"] = "Shelfarr/1.0"
@@ -138,8 +182,67 @@ class AnnaArchiveClient
       end
     end
 
-    def base_url
-      SettingsService.get(:anna_archive_url, default: "https://annas-archive.org")
+    def configured_base_urls
+      raw_url = SettingsService.get(:anna_archive_url, default: DEFAULT_BASE_URL).to_s
+      raw_url = DEFAULT_BASE_URL if raw_url.blank?
+
+      raw_url.split(/[,\s]+/).filter_map do |url|
+        normalize_base_url(url.strip)
+      end.uniq.tap do |urls|
+        raise ConfigurationError, "At least one valid Anna's Archive URL is required" if urls.empty?
+      end
+    end
+
+    def normalize_base_url(url)
+      return if url.blank?
+
+      uri = URI.parse(url)
+      unless ALLOWED_BASE_URL_SCHEMES.include?(uri.scheme) && uri.host.present?
+        raise ConfigurationError, "Anna's Archive URL must be a valid http or https URL"
+      end
+
+      if uri.path.present? && uri.path != "/"
+        raise ConfigurationError, "Anna's Archive URL must not include a path"
+      end
+
+      if uri.query.present? || uri.fragment.present? || uri.userinfo.present?
+        raise ConfigurationError, "Anna's Archive URL must only include the site origin"
+      end
+
+      uri.to_s.delete_suffix("/")
+    rescue URI::InvalidURIError => e
+      raise ConfigurationError, "Anna's Archive URL is invalid: #{e.message}"
+    end
+
+    def ordered_base_urls
+      urls = configured_base_urls
+      return urls unless @working_base_url && urls.include?(@working_base_url)
+
+      [ @working_base_url, *(urls - [ @working_base_url ]) ]
+    end
+
+    def remember_working_base_url(base_url)
+      @working_base_url = base_url
+    end
+
+    def preferred_base_url
+      urls = configured_base_urls
+      return @working_base_url if @working_base_url && urls.include?(@working_base_url)
+
+      urls.first
+    rescue ConfigurationError
+      DEFAULT_BASE_URL
+    end
+
+    def raise_rotation_error(error, context:)
+      case error
+      when nil
+        raise ConnectionError, "Failed to connect to Anna's Archive #{context}"
+      when Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError
+        raise ConnectionError, "Failed to connect to Anna's Archive #{context}: #{error.message}"
+      else
+        raise error
+      end
     end
 
     def api_key

--- a/app/services/anna_archive_client.rb
+++ b/app/services/anna_archive_client.rb
@@ -119,16 +119,18 @@ class AnnaArchiveClient
 
     def with_base_url_rotation(context:)
       last_error = nil
+      bot_protection_error = nil
 
       ordered_base_urls.each do |base_url|
         return yield(base_url).tap { remember_working_base_url(base_url) }
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError,
              ConnectionError, BotProtectionError, RetryableError => e
         last_error = e
+        bot_protection_error ||= e if e.is_a?(BotProtectionError)
         Rails.logger.debug "[AnnaArchiveClient] #{context} failed on #{base_url}: #{e.message}"
       end
 
-      raise_rotation_error(last_error, context: context)
+      raise_rotation_error(bot_protection_error || last_error, context: context)
     end
 
     def fetch_with_protection_bypass(path, base_url:)

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -57,6 +57,8 @@ module DownloadClients
         # This path is only taken if hash extraction failed
         Rails.logger.warn "[Qbittorrent] Falling back to polling for hash detection (race condition possible)"
         find_newly_added_torrent_hash(existing_hashes, category: category)
+      when 409
+        handle_add_conflict(precomputed_hash)
       when 401, 403
         clear_session!
         raise Base::AuthenticationError, "qBittorrent authentication failed"
@@ -244,8 +246,16 @@ module DownloadClients
     end
 
     def extract_hash_from_magnet(url)
-      match = url.match(/btih:([a-fA-F0-9]+)/i)
-      match[1]&.downcase if match
+      decoded_url = URI.decode_www_form_component(url.to_s)
+      match = decoded_url.match(/btih:([a-fA-F0-9]{40}|[a-zA-Z2-7]{32})/i)
+      return nil unless match
+
+      hash = match[1]
+      return hash.downcase if hash.match?(/\A[a-fA-F0-9]{40}\z/)
+
+      base32_to_hex(hash)
+    rescue ArgumentError
+      nil
     end
 
     # Check if URL points to a .torrent file
@@ -320,6 +330,21 @@ module DownloadClients
     rescue BEncode::DecodeError => e
       Rails.logger.warn "[Qbittorrent] Failed to parse torrent file (not valid bencode): #{e.message}"
       nil
+    end
+
+    def base32_to_hex(value)
+      alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+      bits = value.upcase.each_char.map do |char|
+        index = alphabet.index(char)
+        return nil unless index
+
+        index.to_s(2).rjust(5, "0")
+      end.join
+
+      bytes = bits.scan(/.{8}/).map { |byte| byte.to_i(2) }
+      return nil unless bytes.length == 20
+
+      bytes.pack("C*").unpack1("H*")
     end
 
     def normalized_torrent_url(raw_url)
@@ -417,6 +442,16 @@ module DownloadClients
       end
 
       Rails.logger.warn "[Qbittorrent] No new torrent detected after #{max_wait_seconds} seconds"
+      nil
+    end
+
+    def handle_add_conflict(precomputed_hash)
+      if precomputed_hash.present? && verify_torrent_added(precomputed_hash)
+        Rails.logger.info "[Qbittorrent] Torrent #{precomputed_hash} already exists in #{config.name}; treating 409 as successful add"
+        return precomputed_hash
+      end
+
+      Rails.logger.error "[Qbittorrent] Failed to add torrent: 409 - Conflict"
       nil
     end
 

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -102,7 +102,7 @@ class SettingsService
 
     # Anna's Archive
     anna_archive_enabled: { type: "boolean", default: false, category: "anna_archive", description: "Enable Anna's Archive as an additional search source for ebooks" },
-    anna_archive_url: { type: "string", default: "https://annas-archive.se", category: "anna_archive", description: "Base URL for Anna's Archive (change if domain moves)" },
+    anna_archive_url: { type: "string", default: "https://annas-archive.se", category: "anna_archive", description: "Anna's Archive base URLs to try. Shelfarr uses the first reachable URL." },
     anna_archive_api_key: { type: "string", default: "", category: "anna_archive", description: "Member API key from Anna's Archive (requires donation)" },
     flaresolverr_url: { type: "string", default: "", category: "anna_archive", description: "FlareSolverr URL for bypassing DDoS protection (e.g., http://flaresolverr:8191)" },
 

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "digest"
+require "cgi"
+require "nokogiri"
 require "uri"
 
 # Client for interacting with Z-Library's internal eAPI.
@@ -44,13 +46,18 @@ class ZLibraryClient
       with_authenticated_retry(context: "search") do |auth|
         Rails.logger.info "[ZLibraryClient] Searching for '#{query}'"
 
-        payload = [["message", query], ["limit", limit.to_s]]
-        Array(file_types).each { |ext| payload << ["extensions[]", ext] }
-        payload << ["languages[]", language] if language.present?
+        payload = [ [ "message", query ], [ "limit", limit.to_s ] ]
+        Array(file_types).each { |ext| payload << [ "extensions[]", ext ] }
+        payload << [ "languages[]", language ] if language.present?
 
         response = connection.post("#{auth[:base_url]}/eapi/book/search") do |req|
           req.headers["Cookie"] = cookie_header(auth)
           req.body = URI.encode_www_form(payload)
+        end
+
+        if search_html_fallback_response?(response)
+          Rails.logger.warn "[ZLibraryClient] eAPI search unavailable; falling back to HTML search"
+          return search_html(auth, query, file_types: file_types, limit: limit, language: language)
         end
 
         data = parse_response(response, context: "search")
@@ -64,6 +71,11 @@ class ZLibraryClient
       with_authenticated_retry(context: "download lookup") do |auth|
         response = connection.get("#{auth[:base_url]}/eapi/book/#{id}/#{hash}/file") do |req|
           req.headers["Cookie"] = cookie_header(auth)
+        end
+
+        if download_html_fallback_response?(response)
+          Rails.logger.warn "[ZLibraryClient] eAPI download lookup unavailable; falling back to HTML book page"
+          return get_html_download_url(auth, id: id, hash: hash)
         end
 
         data = parse_response(response, context: "download lookup")
@@ -160,7 +172,7 @@ class ZLibraryClient
 
       raw_url.split(/[,\s]+/).filter_map do |url|
         normalized_uri(url.strip)
-      end.uniq { |uri| [uri.scheme, uri.host, uri.port] }.tap do |uris|
+      end.uniq { |uri| [ uri.scheme, uri.host, uri.port ] }.tap do |uris|
         raise ConfigurationError, "At least one valid Z-Library URL is required" if uris.empty?
       end
     end
@@ -257,6 +269,100 @@ class ZLibraryClient
       JSON.parse(response.body)
     end
 
+    def search_html(auth, query, file_types:, limit:, language:)
+      response = connection.get(html_search_url(auth[:base_url], query, file_types: file_types, language: language)) do |req|
+        req.headers["Cookie"] = cookie_header(auth)
+      end
+
+      unless response.status == 200
+        raise ConnectionError, "Z-Library HTML search failed with status #{response.status}"
+      end
+
+      parse_html_search_results(response.body.to_s, limit)
+    end
+
+    def html_search_url(base_url, query, file_types:, language:)
+      params = []
+      Array(file_types).each { |ext| params << [ "extensions[]", ext.to_s.upcase ] }
+      params << [ "languages[]", language ] if language.present?
+
+      encoded_query = CGI.escape(query.to_s).gsub("+", "%20")
+      query_string = URI.encode_www_form(params)
+
+      [ "#{base_url}/s/#{encoded_query}", query_string.presence ].compact.join("?")
+    end
+
+    def parse_html_search_results(html, limit)
+      doc = Nokogiri::HTML(html)
+      return [] if doc.at_css(".notFound")
+
+      doc.css("z-bookcard").first(limit).filter_map do |card|
+        parse_html_book_card(card)
+      end
+    end
+
+    def parse_html_book_card(card)
+      href = card["href"].to_s
+      id = card["id"].presence || href[%r{/book/(\d+)}, 1]
+      hash = href[%r{/book/\d+/([^/?#]+)}, 1]
+      return if id.blank? || hash.blank?
+
+      Result.new(
+        id: id,
+        hash: hash,
+        title: card.at_css('[slot="title"]')&.text&.strip.presence || "Unknown",
+        author: html_card_author(card),
+        year: card["year"]&.to_i&.nonzero?,
+        file_type: card["extension"]&.to_s&.downcase,
+        file_size: parse_file_size(card["filesize"]),
+        language: normalize_language(card["language"])
+      )
+    end
+
+    def html_card_author(card)
+      card.at_css('[slot="author"]')&.text.to_s.split(";").map(&:strip).reject(&:blank?).join(", ").presence
+    end
+
+    def get_html_download_url(auth, id:, hash:)
+      response = connection.get("#{auth[:base_url]}/book/#{id}/#{hash}") do |req|
+        req.headers["Cookie"] = cookie_header(auth)
+      end
+
+      unless response.status == 200
+        raise ConnectionError, "Z-Library HTML download lookup failed with status #{response.status}"
+      end
+
+      doc = Nokogiri::HTML(response.body.to_s)
+      download_link = doc.at_css("a.addDownloadedBook[href]")&.[]("href").presence ||
+        doc.at_css('a[href^="/dl/"], a[href*="/dl/"]')&.[]("href").presence
+      raise Error, "Z-Library did not return a download link" if download_link.blank?
+
+      absolute_url(auth[:base_url], download_link).tap { |url| validate_download_url!(url) }
+    end
+
+    def absolute_url(base_url, url)
+      URI.join("#{base_url}/", url).to_s
+    rescue URI::InvalidURIError => e
+      raise Error, "Z-Library returned an invalid download URL: #{e.message}"
+    end
+
+    def search_html_fallback_response?(response)
+      response.status == 400 || generic_zlibrary_error?(response)
+    end
+
+    def download_html_fallback_response?(response)
+      response.status == 400 || generic_zlibrary_error?(response)
+    end
+
+    def generic_zlibrary_error?(response)
+      return false unless response.status == 200
+
+      data = parse_json_body(response)
+      data["success"] == 0 && data["error"].to_s.match?(/Some errors? occurr?ed/i)
+    rescue JSON::ParserError
+      false
+    end
+
     def validate_download_url!(url)
       uri = URI.parse(url)
       unless ALLOWED_DOWNLOAD_SCHEMES.include?(uri.scheme) && uri.host.present?
@@ -264,6 +370,24 @@ class ZLibraryClient
       end
     rescue URI::InvalidURIError => e
       raise Error, "Z-Library returned an invalid download URL: #{e.message}"
+    end
+
+    def parse_file_size(value)
+      text = value.to_s.strip
+      return if text.blank?
+
+      number, unit = text.match(/\A([\d.]+)\s*([kmgt]?b)?/i)&.captures
+      return text.to_i if number.blank?
+
+      multiplier = case unit.to_s.downcase
+      when "kb" then 1024
+      when "mb" then 1024**2
+      when "gb" then 1024**3
+      when "tb" then 1024**4
+      else 1
+      end
+
+      (number.to_f * multiplier).round
     end
 
     def parse_search_results(books, limit)

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -420,11 +420,11 @@ class ZLibraryClient
     end
 
     def search_html_fallback_response?(response)
-      response.status == 400 || generic_zlibrary_error?(response)
+      response.status == 400 || eapi_html_response?(response) || generic_zlibrary_error?(response)
     end
 
     def download_html_fallback_response?(response)
-      response.status == 400 || generic_zlibrary_error?(response)
+      response.status == 400 || eapi_html_response?(response) || generic_zlibrary_error?(response)
     end
 
     def generic_zlibrary_error?(response)
@@ -434,6 +434,16 @@ class ZLibraryClient
       data["success"] == 0 && data["error"].to_s.match?(/Some errors? occurr?ed/i)
     rescue JSON::ParserError
       false
+    end
+
+    def eapi_html_response?(response)
+      return false unless response.status == 200
+
+      content_type = response.headers["content-type"].to_s
+      body = response.body.to_s.lstrip
+
+      content_type.match?(%r{text/html|application/xhtml\+xml}i) ||
+        body.start_with?("<!doctype", "<!DOCTYPE", "<html", "<HTML")
     end
 
     def validate_download_url!(url)

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -50,12 +50,12 @@ class ZLibraryClient
         Array(file_types).each { |ext| payload << [ "extensions[]", ext ] }
         payload << [ "languages[]", language ] if language.present?
 
-        response = connection.post("#{auth[:base_url]}/eapi/book/search") do |req|
-          req.headers["Cookie"] = cookie_header(auth)
-          req.body = URI.encode_www_form(payload)
-        end
+        response = post_search(auth, payload)
 
         if search_html_fallback_response?(response)
+          alternate_results = search_eapi_alternate_domains(auth, payload, limit)
+          return alternate_results if alternate_results
+
           Rails.logger.warn "[ZLibraryClient] eAPI search unavailable; falling back to HTML search"
           return search_html(auth, query, file_types: file_types, limit: limit, language: language)
         end
@@ -69,11 +69,12 @@ class ZLibraryClient
       ensure_configured!
 
       with_authenticated_retry(context: "download lookup") do |auth|
-        response = connection.get("#{auth[:base_url]}/eapi/book/#{id}/#{hash}/file") do |req|
-          req.headers["Cookie"] = cookie_header(auth)
-        end
+        response = get_file_response(auth, id: id, hash: hash)
 
         if download_html_fallback_response?(response)
+          alternate_download_url = get_download_url_from_alternate_domains(auth, id: id, hash: hash)
+          return alternate_download_url if alternate_download_url
+
           Rails.logger.warn "[ZLibraryClient] eAPI download lookup unavailable; falling back to HTML book page"
           return get_html_download_url(auth, id: id, hash: hash)
         end
@@ -120,36 +121,49 @@ class ZLibraryClient
         base_url = uri.to_s.delete_suffix("/")
         domain = uri.host
 
-        response = connection.post("#{base_url}/eapi/user/login") do |req|
-          req.body = URI.encode_www_form(email: email, password: password)
-        end
-
-        next unless response.status == 200
-
-        data = parse_json_body(response)
-        next unless data["success"] == 1
-
-        auth = {
-          remix_userid: data.dig("user", "id")&.to_s,
-          remix_userkey: data.dig("user", "remix_userkey")&.to_s,
-          domain: domain,
-          base_url: base_url
-        }
-
-        next if auth[:remix_userid].blank? || auth[:remix_userkey].blank?
+        auth = authenticate_uri(uri)
+        next unless auth
 
         Rails.logger.info "[ZLibraryClient] Login succeeded via #{domain}"
-        @auth_cache = {
-          signature: signature,
-          auth: auth,
-          expires_at: Time.current + AUTH_TTL_SECONDS
-        }
+        cache_auth(signature, auth)
         return auth
       rescue JSON::ParserError, Faraday::Error => e
         Rails.logger.debug "[ZLibraryClient] Login failed on #{domain}: #{e.message}"
       end
 
       nil
+    end
+
+    def authenticate_uri(uri)
+      email = SettingsService.get(:zlibrary_email).to_s.strip
+      password = SettingsService.get(:zlibrary_password).to_s
+      base_url = uri.to_s.delete_suffix("/")
+
+      response = connection.post("#{base_url}/eapi/user/login") do |req|
+        req.body = URI.encode_www_form(email: email, password: password)
+      end
+
+      return unless response.status == 200
+
+      data = parse_json_body(response)
+      return unless data["success"] == 1
+
+      auth = {
+        remix_userid: data.dig("user", "id")&.to_s,
+        remix_userkey: data.dig("user", "remix_userkey")&.to_s,
+        domain: uri.host,
+        base_url: base_url
+      }
+
+      auth if auth[:remix_userid].present? && auth[:remix_userkey].present?
+    end
+
+    def cache_auth(signature, auth)
+      @auth_cache = {
+        signature: signature,
+        auth: auth,
+        expires_at: Time.current + AUTH_TTL_SECONDS
+      }
     end
 
     def ensure_configured!
@@ -245,6 +259,19 @@ class ZLibraryClient
       "remix_userid=#{auth[:remix_userid]}; remix_userkey=#{auth[:remix_userkey]}"
     end
 
+    def post_search(auth, payload)
+      connection.post("#{auth[:base_url]}/eapi/book/search") do |req|
+        req.headers["Cookie"] = cookie_header(auth)
+        req.body = URI.encode_www_form(payload)
+      end
+    end
+
+    def get_file_response(auth, id:, hash:)
+      connection.get("#{auth[:base_url]}/eapi/book/#{id}/#{hash}/file") do |req|
+        req.headers["Cookie"] = cookie_header(auth)
+      end
+    end
+
     def parse_response(response, context:)
       case response.status
       when 200
@@ -267,6 +294,52 @@ class ZLibraryClient
       return response.body if response.body.is_a?(Hash)
 
       JSON.parse(response.body)
+    end
+
+    def search_eapi_alternate_domains(current_auth, payload, limit)
+      each_alternate_auth(current_auth) do |auth|
+        response = post_search(auth, payload)
+        next if search_html_fallback_response?(response)
+
+        data = parse_response(response, context: "search")
+        return parse_search_results(data.fetch("books", []), limit)
+      end
+
+      nil
+    end
+
+    def get_download_url_from_alternate_domains(current_auth, id:, hash:)
+      each_alternate_auth(current_auth) do |auth|
+        response = get_file_response(auth, id: id, hash: hash)
+        next if download_html_fallback_response?(response)
+
+        data = parse_response(response, context: "download lookup")
+        download_link = data.dig("file", "downloadLink")
+        next if download_link.blank?
+
+        validate_download_url!(download_link)
+        return download_link
+      end
+
+      nil
+    end
+
+    def each_alternate_auth(current_auth)
+      signature = credential_signature
+
+      configured_uris.each do |uri|
+        base_url = uri.to_s.delete_suffix("/")
+        next if base_url == current_auth[:base_url]
+
+        auth = authenticate_uri(uri)
+        next unless auth
+
+        Rails.logger.info "[ZLibraryClient] Retrying eAPI via #{auth[:domain]}"
+        cache_auth(signature, auth)
+        yield auth
+      rescue JSON::ParserError, Faraday::Error, Error => e
+        Rails.logger.debug "[ZLibraryClient] eAPI retry failed on #{uri.host}: #{e.message}"
+      end
     end
 
     def search_html(auth, query, file_types:, limit:, language:)

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -110,26 +110,29 @@
                           <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s == "telegram_update_mode" %>
                           <%= form.select "settings[#{key}]", options_for_select([["Polling", "polling"], ["Webhook", "webhook"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                        <% elsif key.to_s == "zlibrary_url" %>
-                          <% zlibrary_urls = data[:value].to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?).uniq %>
-                          <div class="space-y-3">
+                        <% elsif %w[anna_archive_url zlibrary_url].include?(key.to_s) %>
+                          <% url_list_urls = data[:value].to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?).uniq %>
+                          <% url_list_name = key.to_s == "zlibrary_url" ? "Z-Library" : "Anna's Archive" %>
+                          <% url_list_placeholder = key.to_s == "zlibrary_url" ? "https://z-library.example" : "https://annas-archive.example" %>
+                          <div class="space-y-3"
+                               data-url-list
+                               data-url-list-label="<%= url_list_name %>">
                             <%= form.hidden_field "settings[#{key}]",
-                                value: zlibrary_urls.join("\n"),
+                                value: url_list_urls.join("\n"),
                                 id: "settings_#{key}",
                                 data: {
-                                  settings_form_target: "zlibraryUrlField",
+                                  url_list_field: true,
                                   action: "change->settings-form#autoSave"
                                 } %>
-                            <div class="flex flex-wrap gap-2"
-                                 data-settings-form-target="zlibraryUrlList">
-                              <% zlibrary_urls.each do |url| %>
+                            <div class="flex flex-wrap gap-2" data-url-list-list>
+                              <% url_list_urls.each do |url| %>
                                 <span class="inline-flex items-center gap-2 rounded-full border border-gray-700 bg-gray-800 px-3 py-1 text-sm text-gray-200"
-                                      data-zlibrary-url="<%= url %>">
+                                      data-url-list-value="<%= url %>">
                                   <span class="break-all"><%= url %></span>
                                   <button type="button"
                                           class="rounded-full p-1 text-gray-400 transition hover:bg-gray-700 hover:text-white"
-                                          data-action="click->settings-form#removeZlibraryUrl"
-                                          data-zlibrary-url="<%= url %>"
+                                          data-action="click->settings-form#removeUrl"
+                                          data-url-list-value="<%= url %>"
                                           aria-label="Remove <%= url %>">
                                     <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -140,20 +143,20 @@
                             </div>
                             <div class="flex flex-col gap-2 sm:flex-row">
                               <input type="url"
-                                     placeholder="https://z-library.example"
+                                     placeholder="<%= url_list_placeholder %>"
                                      class="min-w-0 flex-grow rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                     data-settings-form-target="zlibraryUrlInput"
-                                     data-action="keydown->settings-form#handleZlibraryUrlKeydown">
+                                     data-url-list-input
+                                     data-action="keydown->settings-form#handleUrlKeydown">
                               <button type="button"
                                       class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-blue-600 text-white transition hover:bg-blue-500"
-                                      data-action="click->settings-form#addZlibraryUrl"
-                                      aria-label="Add Z-Library URL">
+                                      data-action="click->settings-form#addUrl"
+                                      aria-label="Add <%= url_list_name %> URL">
                                 <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14M5 12h14" />
                                 </svg>
                               </button>
                             </div>
-                            <p class="hidden text-xs text-red-400" data-settings-form-target="zlibraryUrlError"></p>
+                            <p class="hidden text-xs text-red-400" data-url-list-error></p>
                           </div>
                         <% elsif key.to_s.include?("password") || key.to_s.include?("api_key") || key.to_s.include?("token") || key.to_s.include?("secret") %>
                           <%= form.password_field "settings[#{key}]", value: data[:value], placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,7 @@
 <div class="mx-auto max-w-6xl">
   <h1 class="font-bold text-3xl mb-6 text-white">Search Books</h1>
 
-  <div data-controller="search" data-search-url-value="<%= search_results_path %>">
+  <div data-controller="search" data-search-url-value="<%= search_results_path %>" data-search-debounce-value="700">
     <div class="relative mb-8">
       <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
         <svg class="h-5 w-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -265,12 +265,21 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "label", text: "Zlibrary Enabled"
     assert_select "input[name='settings[zlibrary_enabled]']"
     assert_select "input[type='hidden'][name='settings[zlibrary_url]']"
-    assert_select "[data-settings-form-target='zlibraryUrlList']"
-    assert_select "input[type='url'][data-settings-form-target='zlibraryUrlInput']"
+    assert_select "[data-url-list] [data-url-list-list]"
+    assert_select "input[type='url'][data-url-list-input]"
     assert_select "button[aria-label='Add Z-Library URL']"
     assert_select "input[name='settings[zlibrary_email]']"
     assert_select "input[name='settings[zlibrary_password]']"
     assert_select "a", text: "Test Z-Library Connection"
+  end
+
+  test "index shows Anna's Archive URL list setting" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label", text: "Anna Archive Url"
+    assert_select "input[type='hidden'][name='settings[anna_archive_url]']"
+    assert_select "button[aria-label=\"Add Anna's Archive URL\"]"
   end
 
   test "bulk_update validates path templates" do

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -18,6 +18,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     get search_path
     assert_response :success
     assert_select "input[type='text']"
+    assert_select "[data-controller='search'][data-search-debounce-value='700']"
   end
 
   test "results returns search results" do
@@ -63,7 +64,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       first_publish_year: 1937
     )
 
-    MetadataService.stub(:search, [metadata_result]) do
+    MetadataService.stub(:search, [ metadata_result ]) do
       get search_results_path, params: { q: "hobbit" }
     end
 
@@ -93,7 +94,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       first_publish_year: 1949
     )
 
-    MetadataService.stub(:search, [metadata_result]) do
+    MetadataService.stub(:search, [ metadata_result ]) do
       get search_results_path, params: { q: "1984" }
     end
 
@@ -120,7 +121,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       first_publish_year: 1937
     )
 
-    MetadataService.stub(:search, [metadata_result]) do
+    MetadataService.stub(:search, [ metadata_result ]) do
       get search_results_path, params: { q: "hobbit" }
     end
 

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -392,6 +392,46 @@ class PostProcessingJobTest < ActiveJob::TestCase
       "File should be copied using category-aware sibling remapping"
   end
 
+  test "remaps Windows download path backslashes after global prefix replacement" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    File.write(File.join(@temp_source, "Windows Book.epub"), "test ebook content")
+
+    @book.update!(book_type: :ebook)
+    @download.update!(download_path: "D:\\QbittorrentMove\\Windows Book.epub")
+
+    SettingsService.set(:download_remote_path, "D:\\QbittorrentMove")
+    SettingsService.set(:download_local_path, @temp_source)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub")),
+      "Windows backslashes should be converted to container path separators"
+  end
+
+  test "remaps Windows download path when remote path uses forward slashes" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    File.write(File.join(@temp_source, "Forward Remote.mobi"), "test ebook content")
+
+    @book.update!(book_type: :ebook)
+    @download.update!(download_path: "D:\\QbittorrentMove\\Forward Remote.mobi")
+
+    SettingsService.set(:download_remote_path, "D:/QbittorrentMove")
+    SettingsService.set(:download_local_path, @temp_source)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.mobi")),
+      "Windows client paths should match normalized remote path mappings"
+  end
+
   test "remaps path using client download_path with category" do
     # Scenario: client has a download_path and category, global remote doesn't match
     category_dir = File.join(@temp_source, "Test Audiobook")

--- a/test/services/anna_archive_client_test.rb
+++ b/test/services/anna_archive_client_test.rb
@@ -7,11 +7,15 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
     SettingsService.set(:anna_archive_enabled, true)
     SettingsService.set(:anna_archive_url, "https://annas-archive.org")
     SettingsService.set(:anna_archive_api_key, "test-api-key")
+    SettingsService.set(:flaresolverr_url, "")
+    AnnaArchiveClient.reset_connection!
   end
 
   teardown do
     SettingsService.set(:anna_archive_enabled, false)
     SettingsService.set(:anna_archive_api_key, "")
+    SettingsService.set(:flaresolverr_url, "")
+    AnnaArchiveClient.reset_connection!
   end
 
   test "configured? returns true when enabled and key is set" do
@@ -58,6 +62,22 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "search tries next configured URL when first URL fails" do
+    VCR.turned_off do
+      SettingsService.set(:anna_archive_url, "https://offline.example\nhttps://annas-archive.org")
+
+      stub_request(:get, /offline\.example\/search/)
+        .to_raise(Faraday::ConnectionFailed.new("Connection failed"))
+      stub_anna_search_with_results
+
+      results = AnnaArchiveClient.search("test book")
+
+      assert_equal "abc123def456", results.first.md5
+      assert_requested :get, /offline\.example\/search/
+      assert_requested :get, /annas-archive\.org\/search/
+    end
+  end
+
   test "search returns empty array on connection error" do
     VCR.turned_off do
       stub_request(:get, /annas-archive\.org\/search/)
@@ -76,6 +96,22 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
       url = AnnaArchiveClient.get_download_url("abc123def456")
 
       assert_equal "magnet:?xt=urn:btih:abc123def456", url
+    end
+  end
+
+  test "get_download_url tries next configured URL when first API URL fails" do
+    VCR.turned_off do
+      SettingsService.set(:anna_archive_url, "https://offline.example, https://annas-archive.org")
+
+      stub_request(:get, /offline\.example\/dyn\/api\/fast_download\.json/)
+        .to_raise(Faraday::ConnectionFailed.new("Connection failed"))
+      stub_anna_download_api
+
+      url = AnnaArchiveClient.get_download_url("abc123def456")
+
+      assert_equal "magnet:?xt=urn:btih:abc123def456", url
+      assert_requested :get, /offline\.example\/dyn\/api\/fast_download\.json/
+      assert_requested :get, /annas-archive\.org\/dyn\/api\/fast_download\.json/
     end
   end
 
@@ -99,6 +135,21 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
         .to_return(status: 200, body: "<html></html>")
 
       assert AnnaArchiveClient.test_connection
+    end
+  end
+
+  test "test_connection tries configured URLs until one is reachable" do
+    VCR.turned_off do
+      SettingsService.set(:anna_archive_url, "https://offline.example\nhttps://annas-archive.org")
+
+      stub_request(:get, "https://offline.example/")
+        .to_raise(Faraday::ConnectionFailed.new("Connection failed"))
+      stub_request(:get, "https://annas-archive.org/")
+        .to_return(status: 200, body: "<html></html>")
+
+      assert AnnaArchiveClient.test_connection
+      assert_requested :get, "https://offline.example/"
+      assert_requested :get, "https://annas-archive.org/"
     end
   end
 
@@ -149,6 +200,20 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
       assert_equal "abc123def456", results.first.md5
 
       SettingsService.set(:flaresolverr_url, "")
+    end
+  end
+
+  test "info_url uses the working Anna Archive URL" do
+    VCR.turned_off do
+      SettingsService.set(:anna_archive_url, "https://offline.example\nhttps://annas-archive.org")
+
+      stub_request(:get, /offline\.example\/search/)
+        .to_raise(Faraday::ConnectionFailed.new("Connection failed"))
+      stub_anna_search_with_results
+
+      AnnaArchiveClient.search("test book")
+
+      assert_equal "https://annas-archive.org/md5/abc123def456", AnnaArchiveClient.info_url("abc123def456")
     end
   end
 

--- a/test/services/anna_archive_client_test.rb
+++ b/test/services/anna_archive_client_test.rb
@@ -188,6 +188,25 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "search preserves BotProtectionError when later configured URLs fail" do
+    VCR.turned_off do
+      SettingsService.set(:anna_archive_url, "https://annas-archive.org\nhttps://offline.example")
+
+      stub_request(:get, /annas-archive\.org\/search/)
+        .to_return(status: 403, body: "Forbidden")
+      stub_request(:get, /offline\.example\/search/)
+        .to_raise(Faraday::ConnectionFailed.new("Connection failed"))
+
+      error = assert_raises AnnaArchiveClient::BotProtectionError do
+        AnnaArchiveClient.search("test query")
+      end
+
+      assert_includes error.message, "FlareSolverr"
+      assert_requested :get, /annas-archive\.org\/search/
+      assert_requested :get, /offline\.example\/search/
+    end
+  end
+
   test "search uses FlareSolverr when configured" do
     VCR.turned_off do
       SettingsService.set(:flaresolverr_url, "http://localhost:8191")

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -994,6 +994,69 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_torrent treats qBittorrent 409 conflict as success when torrent already exists" do
+    @client_record.update!(torrent_verification_max_attempts: 1, torrent_verification_wait_time: 0)
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 409, body: "Conflict")
+
+      stub_request(:get, "http://localhost:8080/api/v2/torrents/info?hashes=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "hash" => "a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "name" => "Already Added", "progress" => 0.1, "state" => "downloading", "size" => 100, "content_path" => "/downloads" } ].to_json
+        )
+
+      result = @client.add_torrent("magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+
+      assert_equal "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", result
+    end
+  end
+
+  test "add_torrent extracts base32 magnet hash for qBittorrent conflict recovery" do
+    @client_record.update!(torrent_verification_max_attempts: 1, torrent_verification_wait_time: 0)
+
+    VCR.turned_off do
+      magnet_url = "magnet:?xt=urn:btih:UGZMHVHF62Q3FQ6U4X3KDMWD2TS7NINS&dn=Test"
+
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .with(body: hash_including("urls" => magnet_url))
+        .to_return(status: 409, body: "Conflict")
+
+      stub_request(:get, "http://localhost:8080/api/v2/torrents/info?hashes=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "hash" => "a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "name" => "Base32 Magnet", "progress" => 0.1, "state" => "downloading", "size" => 100, "content_path" => "/downloads" } ].to_json
+        )
+
+      result = @client.add_torrent(magnet_url)
+
+      assert_equal "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", result
+    end
+  end
+
+  test "magnet hash extraction prefers 40 character hex over base32" do
+    hash = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
+
+    assert_equal hash, @client.send(:extract_hash_from_magnet, "magnet:?xt=urn:btih:#{hash}")
+  end
+
   test "add_torrent retries verification when torrent takes time to appear" do
     VCR.turned_off do
       # Stub authentication

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -159,6 +159,60 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "search falls back to HTML results when eAPI returns 400" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .to_return(
+          status: 400,
+          body: { success: 0, error: "Some errors occured." }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      html_stub = stub_request(:get, "https://z-library.sk/s/Test%20Book?extensions%5B%5D=EPUB&extensions%5B%5D=PDF&languages%5B%5D=english")
+        .with(headers: { "Cookie" => "remix_userid=12345; remix_userkey=abc123" })
+        .to_return(
+          status: 200,
+          body: zlibrary_search_html,
+          headers: { "Content-Type" => "text/html" }
+        )
+
+      results = ZLibraryClient.search("Test Book", language: "english")
+
+      assert_equal 1, results.size
+      assert_equal "999", results.first.id
+      assert_equal "deadbeef", results.first.hash
+      assert_equal "Test Book", results.first.title
+      assert_equal "Author One, Author Two", results.first.author
+      assert_equal 2024, results.first.year
+      assert_equal "epub", results.first.file_type
+      assert_equal 1_572_864, results.first.file_size
+      assert_equal "en", results.first.language
+      assert_requested(html_stub)
+    end
+  end
+
+  test "search falls back to HTML results when eAPI returns generic error payload" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .to_return(
+          status: 200,
+          body: { success: 0, error: "Some errors occured. Error identificator: ." }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      stub_request(:get, "https://z-library.sk/s/Test%20Book?extensions%5B%5D=EPUB&extensions%5B%5D=PDF")
+        .to_return(
+          status: 200,
+          body: zlibrary_search_html,
+          headers: { "Content-Type" => "text/html" }
+        )
+
+      assert_equal "999", ZLibraryClient.search("Test Book").first.id
+    end
+  end
+
   test "get_download_url validates returned URL scheme" do
     VCR.turned_off do
       stub_zlibrary_login_success
@@ -175,6 +229,29 @@ class ZLibraryClientTest < ActiveSupport::TestCase
       assert_raises ZLibraryClient::Error do
         ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
       end
+    end
+  end
+
+  test "get_download_url falls back to HTML book page when eAPI returns 400" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:get, "https://z-library.sk/eapi/book/999/deadbeef/file")
+        .to_return(
+          status: 400,
+          body: { success: 0, error: "Some errors occured." }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      html_stub = stub_request(:get, "https://z-library.sk/book/999/deadbeef")
+        .with(headers: { "Cookie" => "remix_userid=12345; remix_userkey=abc123" })
+        .to_return(
+          status: 200,
+          body: '<html><a class="btn btn-default addDownloadedBook" href="/dl/999/deadbeef/book.epub">Download</a></html>',
+          headers: { "Content-Type" => "text/html" }
+        )
+
+      assert_equal "https://z-library.sk/dl/999/deadbeef/book.epub", ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+      assert_requested(html_stub)
     end
   end
 
@@ -252,5 +329,25 @@ class ZLibraryClientTest < ActiveSupport::TestCase
   def stub_zlibrary_login_failure
     stub_request(:post, "https://z-library.sk/eapi/user/login")
       .to_return(status: 500, body: "server error")
+  end
+
+  def zlibrary_search_html
+    <<~HTML
+      <html>
+        <div id="searchResultBox">
+          <div class="book-item">
+            <z-bookcard id="999"
+                        href="/book/999/deadbeef/test-book"
+                        year="2024"
+                        language="English"
+                        extension="EPUB"
+                        filesize="1.5 MB">
+              <div slot="title">Test Book</div>
+              <div slot="author">Author One; Author Two</div>
+            </z-bookcard>
+          </div>
+        </div>
+      </html>
+    HTML
   end
 end

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -233,6 +233,28 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "search falls back to HTML results when eAPI returns HTML" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .to_return(
+          status: 200,
+          body: "<!doctype html><html><body>Unavailable</body></html>",
+          headers: { "Content-Type" => "text/html" }
+        )
+
+      html_stub = stub_request(:get, "https://z-library.sk/s/Test%20Book?extensions%5B%5D=EPUB&extensions%5B%5D=PDF")
+        .to_return(
+          status: 200,
+          body: zlibrary_search_html,
+          headers: { "Content-Type" => "text/html" }
+        )
+
+      assert_equal "999", ZLibraryClient.search("Test Book").first.id
+      assert_requested(html_stub)
+    end
+  end
+
   test "search falls back to HTML results when eAPI returns generic error payload" do
     VCR.turned_off do
       stub_zlibrary_login_success
@@ -281,6 +303,29 @@ class ZLibraryClientTest < ActiveSupport::TestCase
           status: 400,
           body: { success: 0, error: "Some errors occured." }.to_json,
           headers: { "Content-Type" => "application/json" }
+        )
+
+      html_stub = stub_request(:get, "https://z-library.sk/book/999/deadbeef")
+        .with(headers: { "Cookie" => "remix_userid=12345; remix_userkey=abc123" })
+        .to_return(
+          status: 200,
+          body: '<html><a class="btn btn-default addDownloadedBook" href="/dl/999/deadbeef/book.epub">Download</a></html>',
+          headers: { "Content-Type" => "text/html" }
+        )
+
+      assert_equal "https://z-library.sk/dl/999/deadbeef/book.epub", ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+      assert_requested(html_stub)
+    end
+  end
+
+  test "get_download_url falls back to HTML book page when eAPI returns HTML" do
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_request(:get, "https://z-library.sk/eapi/book/999/deadbeef/file")
+        .to_return(
+          status: 200,
+          body: "<html><body>Unavailable</body></html>",
+          headers: { "Content-Type" => "text/html" }
         )
 
       html_stub = stub_request(:get, "https://z-library.sk/book/999/deadbeef")

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -132,6 +132,47 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "search retries alternate eAPI domain before HTML fallback" do
+    SettingsService.set(:zlibrary_url, "https://z-library.sk\nhttps://z-library.bz")
+
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_zlibrary_login_success("z-library.bz")
+
+      stub_request(:post, "https://z-library.sk/eapi/book/search")
+        .to_return(
+          status: 400,
+          body: { success: 0, error: "Some errors occured." }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      bz_search = stub_request(:post, "https://z-library.bz/eapi/book/search")
+        .to_return(
+          status: 200,
+          body: {
+            success: 1,
+            books: [
+              {
+                id: 123,
+                hash: "feedbeef",
+                name: "Recovered via API",
+                author: "Author",
+                extension: "epub"
+              }
+            ]
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      results = ZLibraryClient.search("Test Book")
+
+      assert_equal "123", results.first.id
+      assert_equal "Recovered via API", results.first.title
+      assert_requested(bz_search)
+      assert_not_requested(:get, %r{https://z-library\.sk/s/})
+    end
+  end
+
   test "search raises AuthenticationError when login fails" do
     VCR.turned_off do
       stub_zlibrary_login_failure
@@ -252,6 +293,36 @@ class ZLibraryClientTest < ActiveSupport::TestCase
 
       assert_equal "https://z-library.sk/dl/999/deadbeef/book.epub", ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
       assert_requested(html_stub)
+    end
+  end
+
+  test "get_download_url retries alternate eAPI domain before HTML fallback" do
+    SettingsService.set(:zlibrary_url, "https://z-library.sk\nhttps://z-library.bz")
+
+    VCR.turned_off do
+      stub_zlibrary_login_success
+      stub_zlibrary_login_success("z-library.bz")
+
+      stub_request(:get, "https://z-library.sk/eapi/book/999/deadbeef/file")
+        .to_return(
+          status: 400,
+          body: { success: 0, error: "Some errors occured." }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      bz_lookup = stub_request(:get, "https://z-library.bz/eapi/book/999/deadbeef/file")
+        .to_return(
+          status: 200,
+          body: {
+            success: 1,
+            file: { downloadLink: "https://download.z-library.bz/books/test-book.epub" }
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      assert_equal "https://download.z-library.bz/books/test-book.epub", ZLibraryClient.get_download_url(id: "999", hash: "deadbeef")
+      assert_requested(bz_lookup)
+      assert_not_requested(:get, "https://z-library.sk/book/999/deadbeef")
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes several request workflow issues across download dispatch, direct-source search/download fallbacks, path remapping, and metadata search behavior.

- Treat qBittorrent duplicate-add `409 Conflict` responses as successful when the expected torrent hash is already present, including base32 magnet hash support.
- Improve Z-Library resilience by retrying eAPI calls across configured mirrors before falling back to HTML parsing, including HTML eAPI responses.
- Normalize Windows-style download path separators before post-processing path remapping.
- Debounce metadata search input and abort stale in-flight searches.
- Add Anna's Archive URL rotation using the same multi-URL settings control pattern as Z-Library.
- Preserve actionable Anna's Archive bot-protection errors when URL rotation exhausts all mirrors.

## Issues

Addresses #271, #272, #273, #274, and #277.

## Validation

- `bundle exec rails test test/services/anna_archive_client_test.rb`
- `bundle exec rails test test/controllers/admin/settings_controller_test.rb`
- `bundle exec rails test test/services/z_library_client_test.rb test/services/anna_archive_client_test.rb`
- `bin/quality fast --staged`
- `bin/quality push`
- pre-commit and pre-push hooks passed
