### PR TITLE
[codex] fix Deluge magnet redirects

### DIFF
--- a/app/services/download_clients/deluge.rb
+++ b/app/services/download_clients/deluge.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "base64"
+require "bencode"
+
 module DownloadClients
   # Deluge Web API client
   class Deluge < Base
@@ -24,11 +27,10 @@ module DownloadClients
       ensure_authenticated!
 
       params = build_add_params(options)
+      prepared = prepare_torrent_submission(url)
       existing_ids = torrent_ids
 
-      # Deluge typically accepts torrent URLs and magnet links via add_torrent_url
-      # Some deployments return no direct ID, so we keep a session-state fallback.
-      result = rpc_call("core.add_torrent_url", [url, params])
+      result = submit_torrent(prepared, params)
 
       return result if result.is_a?(String) && result.present?
 
@@ -237,6 +239,139 @@ module DownloadClients
 
     def clear_session!
       session.delete(:cookie)
+    end
+
+    def prepare_torrent_submission(url)
+      return { url: url } if url.blank?
+      return { url: url } if url.start_with?("magnet:")
+
+      source = resolve_torrent_source(url)
+      return { url: url } if source.blank?
+
+      resolved_url = source[:url].presence || url
+      return { url: resolved_url } if resolved_url.start_with?("magnet:")
+
+      torrent_data = source[:torrent_data]
+      return { url: resolved_url } unless valid_torrent_data?(torrent_data)
+
+      {
+        url: resolved_url,
+        filename: torrent_filename(resolved_url),
+        torrent_data: torrent_data
+      }
+    end
+
+    def submit_torrent(prepared, params)
+      url = prepared[:url].to_s
+
+      if prepared[:torrent_data].present?
+        rpc_call(
+          "core.add_torrent_file",
+          [
+            prepared[:filename],
+            Base64.strict_encode64(prepared[:torrent_data]),
+            params
+          ]
+        )
+      elsif url.start_with?("magnet:")
+        rpc_call("core.add_torrent_magnet", [ url, params ])
+      else
+        rpc_call("core.add_torrent_url", [ url, params ])
+      end
+    end
+
+    def resolve_torrent_source(raw_url)
+      normalized_url = normalized_torrent_url(raw_url)
+      return nil unless normalized_url
+
+      current_url = normalized_url
+      max_redirects = 10
+
+      max_redirects.times do
+        response = torrent_download_connection.get do |req|
+          req.url current_url
+        end
+
+        location = response.headers["location"]
+        if response.status.between?(300, 399) && location.present?
+          redirected_url = absolutize_redirect_url(current_url, location)
+          return { url: current_url } if redirected_url.blank?
+          return { url: redirected_url } if redirected_url.start_with?("magnet:")
+
+          current_url = redirected_url
+          next
+        end
+
+        magnet = extract_magnet_from_body(response.body.to_s)
+        return { url: magnet } if magnet.present?
+        return { url: current_url, torrent_data: response.body } if response.success? && response.body.present?
+
+        return { url: current_url }
+      end
+
+      Rails.logger.warn "[Deluge] Too many redirects while fetching torrent: #{normalized_url.truncate(100)}"
+      { url: current_url }
+    rescue URI::InvalidURIError => e
+      Rails.logger.warn "[Deluge] Invalid torrent URL: #{e.message}"
+      nil
+    rescue Faraday::Error => e
+      Rails.logger.warn "[Deluge] Failed to download torrent file for direct upload: #{e.message}"
+      nil
+    end
+
+    def valid_torrent_data?(torrent_data)
+      return false if torrent_data.blank?
+
+      parsed = BEncode.load(torrent_data.dup)
+      parsed.is_a?(Hash) && parsed["info"].is_a?(Hash)
+    rescue BEncode::DecodeError
+      false
+    end
+
+    def normalized_torrent_url(raw_url)
+      uri = URI.parse(raw_url.to_s.strip)
+      return nil unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+
+      uri.to_s
+    rescue URI::InvalidURIError => e
+      Rails.logger.warn "[Deluge] Invalid torrent URL: #{e.message}"
+      nil
+    end
+
+    def torrent_download_connection
+      Faraday.new do |f|
+        f.adapter Faraday.default_adapter
+        f.options.timeout = 30
+        f.options.open_timeout = 10
+        f.headers["Accept"] = "*/*"
+        f.headers["User-Agent"] = "Shelfarr/1.0"
+      end
+    end
+
+    def absolutize_redirect_url(base_url, location)
+      return location if location.start_with?("magnet:")
+
+      resolved = URI.join(base_url, location).to_s
+      uri = URI.parse(resolved)
+      return nil unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+
+      resolved
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def extract_magnet_from_body(body)
+      body.match(/magnet:\?[^\s"'<>]+/i)&.to_s
+    end
+
+    def torrent_filename(url)
+      path = URI.parse(url).path
+      filename = File.basename(path.to_s)
+      filename = "shelfarr.torrent" if filename.blank? || filename == "/"
+      filename = "#{filename}.torrent" unless filename.end_with?(".torrent")
+      filename
+    rescue URI::InvalidURIError
+      "shelfarr.torrent"
     end
 
     def extract_error_message(error)

--- a/test/services/download_clients/deluge_test.rb
+++ b/test/services/download_clients/deluge_test.rb
@@ -17,7 +17,7 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
     Thread.current[:deluge_sessions] = {}
   end
 
-  test "add_torrent adds torrent and returns id" do
+  test "add_torrent adds magnet and returns id" do
     VCR.turned_off do
       # Login (auth.login)
       stub_request(:post, "http://localhost:8112/json")
@@ -37,9 +37,9 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
           body: { result: [ "known_torrent_id" ], error: nil, id: 1 }.to_json
         )
 
-      # add_torrent_url returns id directly
+      # add_torrent_magnet returns id directly
       stub_request(:post, "http://localhost:8112/json")
-        .with(body: /"core.add_torrent_url"/)
+        .with(body: /"core.add_torrent_magnet"/)
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
@@ -48,6 +48,101 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
 
       result = @client.add_torrent("magnet:?xt=urn:btih:abcdef")
       assert_equal "new_torrent_id", result
+    end
+  end
+
+  test "add_torrent submits resolved magnet when torrent URL redirects to magnet" do
+    VCR.turned_off do
+      magnet_url = "magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"core.get_session_state"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { result: [ "known_torrent_id" ], error: nil, id: 1 }.to_json
+        )
+
+      stub_request(:get, "http://prowlarr:9696/api/v1/indexer/download/123")
+        .to_return(status: 301, headers: { "Location" => magnet_url })
+
+      add_stub = stub_request(:post, "http://localhost:8112/json")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "core.add_torrent_magnet" && body["params"].first == magnet_url
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { result: "magnet_torrent_id", error: nil, id: 1 }.to_json
+        )
+
+      result = @client.add_torrent("http://prowlarr:9696/api/v1/indexer/download/123")
+
+      assert_equal "magnet_torrent_id", result
+      assert_requested(add_stub)
+    end
+  end
+
+  test "add_torrent uploads fetched torrent payload via add_torrent_file" do
+    VCR.turned_off do
+      torrent_data = {
+        "info" => {
+          "name" => "Deluge Book.epub",
+          "piece length" => 16_384,
+          "pieces" => "s" * 20,
+          "length" => 512
+        }
+      }.bencode
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"core.get_session_state"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { result: [ "known_torrent_id" ], error: nil, id: 1 }.to_json
+        )
+
+      stub_request(:get, "http://prowlarr:9696/api/v1/indexer/download/456.torrent")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/x-bittorrent" },
+          body: torrent_data
+        )
+
+      add_stub = stub_request(:post, "http://localhost:8112/json")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "core.add_torrent_file" &&
+            body["params"][0] == "456.torrent" &&
+            body["params"][1] == Base64.strict_encode64(torrent_data)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { result: "file_torrent_id", error: nil, id: 1 }.to_json
+        )
+
+      result = @client.add_torrent("http://prowlarr:9696/api/v1/indexer/download/456.torrent")
+
+      assert_equal "file_torrent_id", result
+      assert_requested(add_stub)
     end
   end
 


### PR DESCRIPTION
## Summary

Fix Deluge dispatch for torrent indexer links that resolve to magnets.

Fixes #275.

## What changed

- Resolve torrent download URLs in Shelfarr before handing them to Deluge.
- Submit resolved magnet links through `core.add_torrent_magnet`.
- Upload valid fetched `.torrent` payloads through `core.add_torrent_file`.
- Preserve `core.add_torrent_url` as the fallback for plain URL submissions.
- Add Deluge tests for magnet redirects and torrent-file upload.

## Why

Prowlarr can return an HTTP redirect from its download proxy to a `magnet:` URI. Deluge's `core.add_torrent_url` tries to follow that redirect as an HTTP fetch and rejects the non-HTTP magnet URI, causing Shelfarr dispatch to fail.

## Validation

- `bundle exec rails test test/services/download_clients/deluge_test.rb`
- `bin/quality fast app/services/download_clients/deluge.rb test/services/download_clients/deluge_test.rb`
- pre-commit `bin/quality fast --staged`
- pre-push `bin/quality push`