### PR TITLE
feat: add Discord notifications

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -239,6 +239,20 @@ module Admin
       respond_with_flash(alert: e.message)
     end
 
+    def test_discord
+      OutboundNotifications::DiscordDelivery.deliver!(
+        event: OutboundNotifications::DiscordDelivery::TEST_EVENT,
+        title: "Shelfarr Test",
+        message: "Test notification from Shelfarr"
+      )
+
+      respond_with_flash(notice: "Discord test sent successfully!")
+    rescue OutboundNotifications::DiscordDelivery::ConfigurationError => e
+      respond_with_flash(alert: e.message)
+    rescue OutboundNotifications::DiscordDelivery::DeliveryError => e
+      respond_with_flash(alert: e.message)
+    end
+
     def test_telegram
       unless Integrations::Telegram::Configuration.configured?
         respond_with_flash(alert: "Telegram is not fully configured. Enable it and enter bot token and webhook secret first.")

--- a/app/jobs/discord_notification_delivery_job.rb
+++ b/app/jobs/discord_notification_delivery_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class DiscordNotificationDeliveryJob < ApplicationJob
+  queue_as :default
+
+  retry_on OutboundNotifications::DiscordDelivery::DeliveryError, wait: 10.seconds, attempts: 3
+  discard_on OutboundNotifications::DiscordDelivery::ConfigurationError
+
+  def perform(event:, title:, message:, request_id: nil)
+    return unless OutboundNotifications::DiscordDelivery.enabled_for?(event)
+
+    request = Request.includes(:book, :user).find_by(id: request_id) if request_id.present?
+
+    OutboundNotifications::DiscordDelivery.deliver!(
+      event: event,
+      title: title,
+      message: message,
+      request: request
+    )
+  end
+end

--- a/app/services/outbound_notifications/discord_delivery.rb
+++ b/app/services/outbound_notifications/discord_delivery.rb
@@ -10,6 +10,7 @@ module OutboundNotifications
     USERNAME = "Shelfarr"
 
     MAX_CONTENT_LENGTH = 2_000
+    MAX_EMBED_TOTAL_LENGTH = 6_000
     MAX_EMBED_TITLE_LENGTH = 256
     MAX_EMBED_DESCRIPTION_LENGTH = 4_096
     MAX_FIELD_NAME_LENGTH = 256
@@ -130,6 +131,31 @@ module OutboundNotifications
         }
 
         embed.delete(:fields) if embed[:fields].empty?
+        enforce_embed_total_limit(embed)
+      end
+
+      def enforce_embed_total_limit(embed)
+        fields = embed[:fields] || []
+        fixed_length = embed[:title].to_s.length +
+          embed[:description].to_s.length +
+          embed.dig(:footer, :text).to_s.length +
+          fields.sum { |field| field[:name].to_s.length }
+        remaining = MAX_EMBED_TOTAL_LENGTH - fixed_length
+
+        if remaining <= 0
+          embed.delete(:fields)
+          embed[:description] = truncate(embed[:description], MAX_EMBED_TOTAL_LENGTH - embed[:title].to_s.length - embed.dig(:footer, :text).to_s.length)
+          return embed
+        end
+
+        embed[:fields] = fields.filter_map do |field|
+          next if remaining <= 0
+
+          value = truncate(field[:value], remaining)
+          remaining -= value.length
+          field.merge(value: value)
+        end
+        embed.delete(:fields) if embed[:fields].empty?
         embed
       end
 
@@ -170,7 +196,12 @@ module OutboundNotifications
       end
 
       def truncate(value, limit)
-        value.to_s.truncate(limit)
+        text = value.to_s
+        return "" if limit <= 0
+        return text if text.length <= limit
+        return text[0, limit] if limit <= 3
+
+        text.truncate(limit)
       end
 
       def response_error_message(response)

--- a/app/services/outbound_notifications/discord_delivery.rb
+++ b/app/services/outbound_notifications/discord_delivery.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+module OutboundNotifications
+  class DiscordDelivery
+    class ConfigurationError < StandardError; end
+    class DeliveryError < StandardError; end
+
+    EVENTS = WebhookDelivery::EVENTS
+    TEST_EVENT = "test"
+    USERNAME = "Shelfarr"
+
+    MAX_CONTENT_LENGTH = 2_000
+    MAX_EMBED_TITLE_LENGTH = 256
+    MAX_EMBED_DESCRIPTION_LENGTH = 4_096
+    MAX_FIELD_NAME_LENGTH = 256
+    MAX_FIELD_VALUE_LENGTH = 1_024
+
+    class << self
+      def enabled?
+        SettingsService.get(:discord_enabled, default: false)
+      end
+
+      def enabled_for?(event)
+        enabled? && configured? && subscribed_events.include?(event)
+      end
+
+      def configured?
+        discord_webhook_url.present?
+      end
+
+      def subscribed_events
+        discord_events_string.split(",").map(&:strip).reject(&:blank?)
+      end
+
+      def deliver!(event:, title:, message:, request: nil)
+        validate_configuration!
+        validate_event!(event)
+
+        response = connection.post(execute_url) do |req|
+          req.headers = headers
+          req.body = build_payload(
+            event: event,
+            title: title,
+            message: message,
+            request: request
+          ).to_json
+        end
+
+        return response if response.success?
+
+        raise DeliveryError, response_error_message(response)
+      rescue URI::InvalidURIError => e
+        raise DeliveryError, "Discord webhook URL is invalid: #{e.message}"
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+        raise DeliveryError, "Discord webhook connection failed: #{e.message}"
+      end
+
+      def test_payload
+        build_payload(
+          event: TEST_EVENT,
+          title: "Shelfarr Test",
+          message: "Test notification from Shelfarr",
+          request: nil
+        )
+      end
+
+      private
+
+      def validate_configuration!
+        raise ConfigurationError, "Discord notifications are not enabled." unless enabled?
+        raise ConfigurationError, "Discord webhook URL is not configured." if discord_webhook_url.blank?
+      end
+
+      def validate_event!(event)
+        return if event == TEST_EVENT || EVENTS.include?(event)
+
+        raise ConfigurationError, "Unsupported Discord notification event: #{event}"
+      end
+
+      def discord_webhook_url
+        SettingsService.get(:discord_webhook_url).to_s.strip
+      end
+
+      def discord_events_string
+        SettingsService.get(:discord_events).to_s
+      end
+
+      def connection
+        Faraday.new do |f|
+          f.options.timeout = 10
+          f.options.open_timeout = 5
+        end
+      end
+
+      def execute_url
+        uri = URI.parse(discord_webhook_url)
+        raise URI::InvalidURIError, "must use HTTP or HTTPS" unless uri.is_a?(URI::HTTP)
+
+        query = Rack::Utils.parse_nested_query(uri.query)
+        query["wait"] ||= "true"
+        uri.query = query.to_query
+        uri.to_s
+      end
+
+      def headers
+        {
+          "Content-Type" => "application/json",
+          "Accept" => "application/json",
+          "User-Agent" => "Shelfarr/1.0"
+        }
+      end
+
+      def build_payload(event:, title:, message:, request:)
+        {
+          content: truncate("#{title}: #{message}", MAX_CONTENT_LENGTH),
+          username: USERNAME,
+          allowed_mentions: { parse: [] },
+          embeds: [ embed_for(event: event, title: title, message: message, request: request) ]
+        }
+      end
+
+      def embed_for(event:, title:, message:, request:)
+        embed = {
+          title: truncate(title, MAX_EMBED_TITLE_LENGTH),
+          description: truncate(message, MAX_EMBED_DESCRIPTION_LENGTH),
+          color: color_for(event),
+          timestamp: Time.current.iso8601,
+          footer: { text: USERNAME },
+          fields: fields_for(event: event, request: request)
+        }
+
+        embed.delete(:fields) if embed[:fields].empty?
+        embed
+      end
+
+      def fields_for(event:, request:)
+        fields = [ field("Event", event) ]
+        return fields unless request.present?
+
+        fields.concat([
+          field("Book", request.book.title),
+          field("Author", request.book.author),
+          field("Type", request.book.book_type),
+          field("Status", request.status),
+          field("Requested By", request.user.username)
+        ])
+      end
+
+      def field(name, value)
+        {
+          name: truncate(name.to_s, MAX_FIELD_NAME_LENGTH),
+          value: truncate(value.to_s.presence || "Unknown", MAX_FIELD_VALUE_LENGTH),
+          inline: true
+        }
+      end
+
+      def color_for(event)
+        case event
+        when "request_created"
+          0x3B82F6
+        when "request_completed"
+          0x22C55E
+        when "request_failed"
+          0xEF4444
+        when "request_attention"
+          0xF59E0B
+        else
+          0x6366F1
+        end
+      end
+
+      def truncate(value, limit)
+        value.to_s.truncate(limit)
+      end
+
+      def response_error_message(response)
+        parsed = parse_json(response.body)
+        if response.status == 429 && parsed["retry_after"].present?
+          return "Discord webhook rate limited; retry after #{parsed['retry_after']} seconds"
+        end
+
+        detail = parsed["message"].presence || response.body.to_s.truncate(200)
+        "Discord webhook returned HTTP #{response.status}: #{detail}"
+      end
+
+      def parse_json(body)
+        JSON.parse(body.to_s.presence || "{}")
+      rescue JSON::ParserError
+        {}
+      end
+    end
+  end
+end

--- a/app/services/outbound_notifications/dispatcher.rb
+++ b/app/services/outbound_notifications/dispatcher.rb
@@ -13,6 +13,15 @@ module OutboundNotifications
           )
         end
 
+        if OutboundNotifications::DiscordDelivery.enabled_for?(event)
+          DiscordNotificationDeliveryJob.perform_later(
+            event: event,
+            request_id: request&.id,
+            title: title,
+            message: message
+          )
+        end
+
         if request&.id && Integrations::Telegram::Configuration.notification_enabled_for?(event)
           TelegramNotificationDeliveryJob.perform_later(event: event, request_id: request.id)
         end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -124,6 +124,11 @@ class SettingsService
     webhook_events: { type: "string", default: "request_created,request_completed,request_failed,request_attention", category: "webhook", description: "Comma-separated webhook events to send" },
     webhook_topic: { type: "string", default: "", category: "webhook", description: "Optional topic field included in webhook JSON payload (required by ntfy when posting to the server base URL)" },
 
+    # Discord Notifications
+    discord_enabled: { type: "boolean", default: false, category: "discord", description: "Send native Discord webhook notifications for request lifecycle events" },
+    discord_webhook_url: { type: "string", default: "", category: "discord", description: "Incoming Discord webhook URL for the channel that should receive notifications" },
+    discord_events: { type: "string", default: "request_created,request_completed,request_failed,request_attention", category: "discord", description: "Comma-separated Discord notification events to send" },
+
     # Telegram Bot
     telegram_enabled: { type: "boolean", default: false, category: "telegram", description: "Enable the Telegram command integration" },
     telegram_update_mode: { type: "string", default: "polling", category: "telegram", description: "How Shelfarr receives Telegram updates. Polling works for local installs; webhook is optional for public HTTPS deployments." },
@@ -164,6 +169,7 @@ class SettingsService
     "updates" => "Updates",
     "security" => "Security",
     "webhook" => "Webhook Notifications",
+    "discord" => "Discord Notifications",
     "telegram" => "Telegram Bot",
     "oidc" => "OIDC/SSO Authentication"
   }.freeze

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -11,7 +11,7 @@
     },
     "integrations" => {
       label: "Integrations",
-      categories: %w[audiobookshelf hardcover open_library telegram]
+      categories: %w[audiobookshelf hardcover open_library discord telegram]
     },
     "system" => {
       label: "Queue & System",
@@ -110,6 +110,8 @@
                           <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s == "telegram_update_mode" %>
                           <%= form.select "settings[#{key}]", options_for_select([["Polling", "polling"], ["Webhook", "webhook"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% elsif key.to_s == "discord_webhook_url" %>
+                          <%= form.password_field "settings[#{key}]", value: data[:value], placeholder: data[:value].present? ? "********" : "https://discord.com/api/webhooks/...", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif %w[anna_archive_url zlibrary_url].include?(key.to_s) %>
                           <% url_list_urls = data[:value].to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?).uniq %>
                           <% url_list_name = key.to_s == "zlibrary_url" ? "Z-Library" : "Anna's Archive" %>
@@ -265,6 +267,16 @@
                     </div>
                     <div class="md:w-2/3">
                       <%= link_to "Send Test Webhook", test_webhook_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "discord" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test Discord</span>
+                      <p class="text-sm text-gray-500">Send a sample Discord webhook notification using the current settings</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Send Test Discord", test_discord_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
                     </div>
                   </div>
                 <% elsif category == "telegram" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
         post :test_hardcover
         post :test_oidc
         post :test_webhook
+        post :test_discord
         post :test_telegram
         post :setup_telegram_webhook
         post :approve_telegram_chat

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -258,6 +258,17 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Send Test Webhook"
   end
 
+  test "index shows Discord notification settings" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label", text: "Discord Enabled"
+    assert_select "input[name='settings[discord_enabled]']"
+    assert_select "input[type='password'][name='settings[discord_webhook_url]']"
+    assert_select "input[name='settings[discord_events]']"
+    assert_select "a", text: "Send Test Discord"
+  end
+
   test "index shows z-library settings and test button" do
     get admin_settings_url
 
@@ -475,6 +486,47 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     SettingsService.set(:webhook_url, "ht!tp://bad")
 
     post test_webhook_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match /invalid/i, flash[:alert]
+  end
+
+  test "test_discord fails when disabled" do
+    SettingsService.set(:discord_enabled, false)
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
+
+    post test_discord_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match /not enabled/i, flash[:alert]
+  end
+
+  test "test_discord succeeds when Discord accepts payload" do
+    SettingsService.set(:discord_enabled, true)
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
+
+    VCR.turned_off do
+      stub_request(:post, "https://discord.com/api/webhooks/123/token?wait=true")
+        .with do |request|
+          json = JSON.parse(request.body)
+          json["username"] == "Shelfarr" &&
+            json["allowed_mentions"] == { "parse" => [] } &&
+            json["embeds"].first["title"] == "Shelfarr Test"
+        end
+        .to_return(status: 200, body: { id: "message-id" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      post test_discord_admin_settings_url
+
+      assert_redirected_to admin_settings_path
+      assert_match /successfully/i, flash[:notice]
+    end
+  end
+
+  test "test_discord handles invalid webhook URL" do
+    SettingsService.set(:discord_enabled, true)
+    SettingsService.set(:discord_webhook_url, "ht!tp://bad")
+
+    post test_discord_admin_settings_url
 
     assert_redirected_to admin_settings_path
     assert_match /invalid/i, flash[:alert]

--- a/test/jobs/discord_notification_delivery_job_test.rb
+++ b/test/jobs/discord_notification_delivery_job_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DiscordNotificationDeliveryJobTest < ActiveJob::TestCase
+  setup do
+    @request = requests(:pending_request)
+    SettingsService.set(:discord_enabled, true)
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
+    SettingsService.set(:discord_events, "request_completed")
+  end
+
+  test "delivers subscribed event" do
+    stub = stub_request(:post, "https://discord.com/api/webhooks/123/token?wait=true")
+      .to_return(status: 200, body: { id: "message-id" }.to_json, headers: { "Content-Type" => "application/json" })
+
+    DiscordNotificationDeliveryJob.perform_now(
+      event: "request_completed",
+      request_id: @request.id,
+      title: "Book Ready",
+      message: "\"#{@request.book.title}\" is now available for download."
+    )
+
+    assert_requested(stub)
+  end
+
+  test "skips unsubscribed event" do
+    SettingsService.set(:discord_events, "request_attention")
+
+    DiscordNotificationDeliveryJob.perform_now(
+      event: "request_completed",
+      request_id: @request.id,
+      title: "Book Ready",
+      message: "\"#{@request.book.title}\" is now available for download."
+    )
+
+    assert_not_requested(:post, "https://discord.com/api/webhooks/123/token?wait=true")
+  end
+end

--- a/test/services/notification_service_test.rb
+++ b/test/services/notification_service_test.rb
@@ -38,6 +38,21 @@ class NotificationServiceTest < ActiveSupport::TestCase
     assert_equal @request.id, args[:request_id]
   end
 
+  test "request_completed enqueues Discord delivery when configured" do
+    SettingsService.set(:discord_enabled, true)
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
+    SettingsService.set(:discord_events, "request_completed")
+
+    assert_enqueued_with(job: DiscordNotificationDeliveryJob) do
+      NotificationService.request_completed(@request)
+    end
+
+    enqueued = enqueued_jobs.find { |job| job[:job] == DiscordNotificationDeliveryJob }
+    args = enqueued[:args].first.with_indifferent_access
+    assert_equal "request_completed", args[:event]
+    assert_equal @request.id, args[:request_id]
+  end
+
   test "request_failed creates notification" do
     assert_difference "Notification.count", 1 do
       NotificationService.request_failed(@request)

--- a/test/services/outbound_notifications/discord_delivery_test.rb
+++ b/test/services/outbound_notifications/discord_delivery_test.rb
@@ -75,6 +75,33 @@ class OutboundNotifications::DiscordDeliveryTest < ActiveSupport::TestCase
     assert_includes error.message, "Cannot send an empty message"
   end
 
+  test "deliver! keeps Discord embed under aggregate character limit" do
+    long_text = "x" * 10_000
+    @request.book.update!(title: long_text, author: long_text)
+    @request.user.update!(username: long_text)
+
+    stub = stub_request(:post, "https://discord.com/api/webhooks/123/token?wait=true")
+      .with do |request|
+        embed = JSON.parse(request.body)["embeds"].first
+        total = embed["title"].to_s.length +
+          embed["description"].to_s.length +
+          embed.dig("footer", "text").to_s.length +
+          embed.fetch("fields", []).sum { |field| field["name"].to_s.length + field["value"].to_s.length }
+
+        total <= 6_000
+      end
+      .to_return(status: 200, body: { id: "message-id" }.to_json, headers: { "Content-Type" => "application/json" })
+
+    OutboundNotifications::DiscordDelivery.deliver!(
+      event: "request_completed",
+      title: long_text,
+      message: long_text,
+      request: @request
+    )
+
+    assert_requested(stub)
+  end
+
   test "deliver! reports Discord rate limits" do
     stub_request(:post, "https://discord.com/api/webhooks/123/token?wait=true")
       .to_return(status: 429, body: { message: "You are being rate limited.", retry_after: 1.5 }.to_json, headers: { "Content-Type" => "application/json" })

--- a/test/services/outbound_notifications/discord_delivery_test.rb
+++ b/test/services/outbound_notifications/discord_delivery_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OutboundNotifications::DiscordDeliveryTest < ActiveSupport::TestCase
+  setup do
+    @request = requests(:pending_request)
+    SettingsService.set(:discord_enabled, true)
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
+    SettingsService.set(:discord_events, "request_completed,request_attention")
+  end
+
+  test "enabled_for? respects subscribed events" do
+    assert OutboundNotifications::DiscordDelivery.enabled_for?("request_completed")
+    assert_not OutboundNotifications::DiscordDelivery.enabled_for?("request_failed")
+  end
+
+  test "deliver! posts Discord webhook payload with embeds and no mentions" do
+    stub = stub_request(:post, "https://discord.com/api/webhooks/123/token?wait=true")
+      .with do |request|
+        json = JSON.parse(request.body)
+        embed = json["embeds"].first
+
+        request.headers["Content-Type"].include?("application/json") &&
+          json["username"] == "Shelfarr" &&
+          json["allowed_mentions"] == { "parse" => [] } &&
+          json["content"].include?("Book Ready") &&
+          embed["title"] == "Book Ready" &&
+          embed["description"].include?(@request.book.title) &&
+          embed["fields"].any? { |field| field["name"] == "Book" && field["value"] == @request.book.title } &&
+          embed["fields"].any? { |field| field["name"] == "Requested By" && field["value"] == @request.user.username }
+      end
+      .to_return(status: 200, body: { id: "message-id" }.to_json, headers: { "Content-Type" => "application/json" })
+
+    OutboundNotifications::DiscordDelivery.deliver!(
+      event: "request_completed",
+      title: "Book Ready",
+      message: "\"#{@request.book.title}\" is now available for download.",
+      request: @request
+    )
+
+    assert_requested(stub)
+  end
+
+  test "deliver! preserves existing query parameters and asks Discord to wait" do
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token?thread_id=456")
+
+    stub = stub_request(:post, "https://discord.com/api/webhooks/123/token?thread_id=456&wait=true")
+      .to_return(status: 204, body: "")
+
+    OutboundNotifications::DiscordDelivery.deliver!(
+      event: "request_completed",
+      title: "Book Ready",
+      message: "test",
+      request: @request
+    )
+
+    assert_requested(stub)
+  end
+
+  test "deliver! raises on non-successful response" do
+    stub_request(:post, "https://discord.com/api/webhooks/123/token?wait=true")
+      .to_return(status: 400, body: { message: "Cannot send an empty message" }.to_json, headers: { "Content-Type" => "application/json" })
+
+    error = assert_raises(OutboundNotifications::DiscordDelivery::DeliveryError) do
+      OutboundNotifications::DiscordDelivery.deliver!(
+        event: "request_completed",
+        title: "Book Ready",
+        message: "failed",
+        request: @request
+      )
+    end
+
+    assert_includes error.message, "HTTP 400"
+    assert_includes error.message, "Cannot send an empty message"
+  end
+
+  test "deliver! reports Discord rate limits" do
+    stub_request(:post, "https://discord.com/api/webhooks/123/token?wait=true")
+      .to_return(status: 429, body: { message: "You are being rate limited.", retry_after: 1.5 }.to_json, headers: { "Content-Type" => "application/json" })
+
+    error = assert_raises(OutboundNotifications::DiscordDelivery::DeliveryError) do
+      OutboundNotifications::DiscordDelivery.deliver!(
+        event: "request_completed",
+        title: "Book Ready",
+        message: "failed",
+        request: @request
+      )
+    end
+
+    assert_includes error.message, "rate limited"
+    assert_includes error.message, "1.5"
+  end
+
+  test "test_payload includes Discord webhook requirements" do
+    payload = OutboundNotifications::DiscordDelivery.test_payload
+
+    assert_equal "Shelfarr", payload[:username]
+    assert_equal({ parse: [] }, payload[:allowed_mentions])
+    assert payload[:content].present?
+    assert_equal "Shelfarr Test", payload[:embeds].first[:title]
+  end
+
+  test "deliver! raises a delivery error for invalid webhook URLs" do
+    SettingsService.set(:discord_webhook_url, "ht!tp://bad")
+
+    error = assert_raises(OutboundNotifications::DiscordDelivery::DeliveryError) do
+      OutboundNotifications::DiscordDelivery.deliver!(
+        event: "request_completed",
+        title: "Book Ready",
+        message: "failed",
+        request: @request
+      )
+    end
+
+    assert_includes error.message.downcase, "invalid"
+  end
+end


### PR DESCRIPTION
Summary
- Add Discord webhook notification settings, delivery job, and admin test action.
- Send Discord-compliant webhook payloads with embeds, disabled mentions, wait=true, and aggregate embed size limits.
- Cover delivery, dispatcher, job, and settings UI behavior with tests.

Test plan
- bundle exec rails test
- bundle exec rails test test/services/outbound_notifications/discord_delivery_test.rb test/jobs/discord_notification_delivery_job_test.rb test/services/notification_service_test.rb test/controllers/admin/settings_controller_test.rb
- bin/quality fast --staged
- pre-push quality hook

Closes #280