### PR TITLE
fix: handle qBittorrent add success responses

### DIFF
--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -35,7 +35,7 @@ module DownloadClients
       end
 
       case response.status
-      when 200
+      when 200, 202
         success_response = parse_add_torrent_success_response(response.body)
         return nil unless success_response
 

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -36,8 +36,10 @@ module DownloadClients
 
       case response.status
       when 200
-        # qBittorrent returns "Ok." on success or empty body
-        return nil unless response.body == "Ok." || response.body.blank?
+        success_response = parse_add_torrent_success_response(response.body)
+        return nil unless success_response
+
+        return success_response[:torrent_id] if success_response[:torrent_id].present?
 
         # Return pre-computed hash if available (eliminates race condition)
         if precomputed_hash.present?
@@ -411,6 +413,34 @@ module DownloadClients
       payload.merge!(build_add_torrent_params(options: options))
 
       upload_conn.post("api/v2/torrents/add", payload)
+    end
+
+    def parse_add_torrent_success_response(body)
+      # qBittorrent < 5 returned "Ok." or an empty body. Newer versions return JSON
+      # with added_torrent_ids, which is the most reliable external ID source.
+      return {} if body.blank?
+      return {} if body.is_a?(String) && body.strip == "Ok."
+
+      data = parse_json_response_body(body)
+      return nil unless data.is_a?(Hash)
+
+      torrent_id = Array(data["added_torrent_ids"]).first.presence
+      success_count = data["success_count"].to_i
+      pending_count = data["pending_count"].to_i
+
+      return { torrent_id: torrent_id } if torrent_id.present?
+      return {} if success_count.positive? || pending_count.positive?
+
+      nil
+    end
+
+    def parse_json_response_body(body)
+      return body if body.is_a?(Hash)
+      return nil unless body.is_a?(String)
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      nil
     end
 
     # Fetch torrent hashes as a Set, optionally filtered by category

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -82,6 +82,74 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_torrent accepts whitespace-padded success response" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(status: 200, body: "Ok.\n")
+
+      stub_request(:get, "http://localhost:8080/api/v2/torrents/info?hashes=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "hash" => "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "name" => "Test", "progress" => 0, "state" => "downloading", "size" => 100, "content_path" => "/downloads" } ].to_json
+        )
+
+      result = @client.add_torrent("magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+
+      assert_equal "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", result
+    end
+  end
+
+  test "add_torrent returns torrent id from qBittorrent JSON success response" do
+    VCR.turned_off do
+      info_dict = {
+        "name" => "JSON Response Book.epub",
+        "piece length" => 16384,
+        "pieces" => "j" * 20,
+        "length" => 512
+      }
+      torrent_data = { "info" => info_dict }.bencode
+      expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      stub_request(:get, "http://prowlarr:9696/api/v1/indexer/download/456")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/x-bittorrent" },
+          body: torrent_data
+        )
+
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "success_count" => 1,
+            "failure_count" => 0,
+            "pending_count" => 0,
+            "added_torrent_ids" => [ expected_hash ]
+          }.to_json
+        )
+
+      result = @client.add_torrent("http://prowlarr:9696/api/v1/indexer/download/456")
+
+      assert_equal expected_hash, result
+    end
+  end
+
   test "add_torrent falls back to polling when torrent file cannot be downloaded" do
     VCR.turned_off do
       # Stub authentication

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -150,6 +150,42 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_torrent accepts qBittorrent async JSON success response" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      stub_request(:get, "http://example.com/file.torrent")
+        .to_timeout
+
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .to_return(
+          status: 202,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "success_count" => 0,
+            "failure_count" => 0,
+            "pending_count" => 1,
+            "added_torrent_ids" => []
+          }.to_json
+        )
+
+      stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
+        .to_return(
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json },
+          { status: 200, headers: { "Content-Type" => "application/json" }, body: [ { "hash" => "async123" } ].to_json }
+        )
+
+      result = @client.add_torrent("http://example.com/file.torrent")
+
+      assert_equal "async123", result
+    end
+  end
+
   test "add_torrent falls back to polling when torrent file cannot be downloaded" do
     VCR.turned_off do
       # Stub authentication


### PR DESCRIPTION
## Summary
- Accept qBittorrent add success responses returned as JSON with added torrent IDs.
- Handle async 202 add responses by continuing existing hash detection flow.
- Preserve support for older Ok./blank success bodies, including whitespace-padded bodies.

Fixes #282

## Test plan
- bundle exec rails test test/services/download_clients/qbittorrent_test.rb
- bundle exec rails test test/jobs/download_job_test.rb
- bin/quality fast --staged
- bin/quality push