### PR TITLE
feat: fulfill requests from manual uploads

### DIFF
--- a/app/controllers/admin/uploads_controller.rb
+++ b/app/controllers/admin/uploads_controller.rb
@@ -2,6 +2,7 @@
 
 module Admin
   class UploadsController < BaseController
+    before_action :set_request_context, only: [:new, :create]
     before_action :set_upload, only: [:show, :destroy, :retry]
 
     def index
@@ -9,16 +10,16 @@ module Admin
     end
 
     def new
-      @upload = Upload.new
+      @upload = Upload.new(request: @request)
     end
 
     def create
-      result = UploadCreator.call(user: Current.user, uploaded_file: params[:file])
+      result = UploadCreator.call(user: Current.user, uploaded_file: params[:file], request: @request)
 
       if result.success?
-        redirect_to admin_uploads_path, notice: result.notice
+        redirect_to upload_success_location, notice: result.notice
       else
-        redirect_to new_admin_upload_path, alert: result.alert
+        redirect_to upload_failure_location, alert: result.alert
       end
     end
 
@@ -51,6 +52,21 @@ module Admin
 
     def set_upload
       @upload = Upload.find(params[:id])
+    end
+
+    def set_request_context
+      return if params[:request_id].blank?
+
+      @request = Request.includes(:book).find(params[:request_id])
+      redirect_to @request, alert: "This request is already completed." if @request.completed?
+    end
+
+    def upload_success_location
+      @request || admin_uploads_path
+    end
+
+    def upload_failure_location
+      @request ? new_admin_upload_path(request_id: @request.id) : new_admin_upload_path
     end
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -2,6 +2,7 @@
 
 class UploadsController < ApplicationController
   before_action :require_upload_access, only: [ :new, :create ]
+  before_action :set_request_context, only: [ :new, :create ]
   before_action :set_upload, only: [ :show ]
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
@@ -13,16 +14,16 @@ class UploadsController < ApplicationController
   end
 
   def new
-    @upload = Upload.new
+    @upload = Upload.new(request: @request)
   end
 
   def create
-    result = UploadCreator.call(user: Current.user, uploaded_file: params[:file])
+    result = UploadCreator.call(user: Current.user, uploaded_file: params[:file], request: @request)
 
     if result.success?
-      redirect_to uploads_path, notice: result.notice
+      redirect_to upload_success_location, notice: result.notice
     else
-      redirect_to new_upload_path, alert: result.alert
+      redirect_to upload_failure_location, alert: result.alert
     end
   end
 
@@ -39,6 +40,26 @@ class UploadsController < ApplicationController
 
   def set_upload
     @upload = policy_scope(Upload).find(params[:id])
+  end
+
+  def set_request_context
+    return if params[:request_id].blank?
+
+    @request = Request.includes(:book).find(params[:request_id])
+    unless Current.user.admin? || @request.user == Current.user
+      redirect_to uploads_path, alert: "You cannot upload files for this request."
+      return
+    end
+
+    redirect_to @request, alert: "This request is already completed." if @request.completed?
+  end
+
+  def upload_success_location
+    @request || uploads_path
+  end
+
+  def upload_failure_location
+    @request ? new_upload_path(request_id: @request.id) : new_upload_path
   end
 
   def record_not_found

--- a/app/jobs/upload_processing_job.rb
+++ b/app/jobs/upload_processing_job.rb
@@ -16,8 +16,13 @@ class UploadProcessingJob < ApplicationJob
     Rails.logger.info "[UploadProcessingJob] Processing upload #{upload.id}: #{upload.original_filename}"
 
     upload.update!(status: :processing)
+    target_request = upload.request
+    target_request_original_status = nil
+    target_request_claimed = false
 
     begin
+      raise "Request is already completed" if target_request&.completed?
+
       # Step 1: Extract metadata from the actual file
       extracted = MetadataExtractorService.extract(upload.file_path)
 
@@ -39,12 +44,12 @@ class UploadProcessingJob < ApplicationJob
         match_confidence: extracted.present? ? 90 : parsed.confidence
       )
 
-      # Step 3: Determine book type from file extension
-      book_type = upload.infer_book_type
+      # Step 3: Determine book type from explicit request or file extension
+      book_type = target_request&.book&.book_type || upload.infer_book_type
       upload.update!(book_type: book_type)
 
       # Step 4: Search metadata sources for enrichment
-      metadata = fetch_metadata(title, author)
+      metadata = target_request ? nil : fetch_metadata(title, author)
 
       if metadata
         Rails.logger.info "[UploadProcessingJob] Found metadata from #{metadata.source}: '#{metadata.title}' by #{metadata.author}"
@@ -55,10 +60,17 @@ class UploadProcessingJob < ApplicationJob
       # Wrap critical operations in transaction for atomicity
       book = nil
       destination = nil
+      completed_request = nil
 
       ActiveRecord::Base.transaction do
+        if target_request
+          target_request_original_status = target_request.reload.status
+          claim_target_request!(target_request)
+          target_request_claimed = true
+        end
+
         # Step 5: Find or create book with metadata
-        book = find_or_create_book_with_metadata(
+        book = target_request&.book || find_or_create_book_with_metadata(
           metadata: metadata,
           extracted: extracted,
           parsed: parsed,
@@ -78,16 +90,20 @@ class UploadProcessingJob < ApplicationJob
           status: :completed,
           processed_at: Time.current
         )
+
+        completed_request = complete_target_request!(target_request, upload) if target_request
       end
 
       # Step 8: Trigger Audiobookshelf scan if configured (outside transaction)
       trigger_library_scan(book) if book && AudiobookshelfClient.configured?
+      NotificationService.request_completed(completed_request) if completed_request
 
       Rails.logger.info "[UploadProcessingJob] Completed processing upload #{upload.id}"
 
     rescue => e
       Rails.logger.error "[UploadProcessingJob] Failed for upload #{upload.id}: #{e.message}"
       Rails.logger.error e.backtrace.first(5).join("\n")
+      restore_target_request_status(target_request, target_request_original_status) if target_request_claimed
 
       upload.update!(
         status: :failed,
@@ -248,6 +264,49 @@ class UploadProcessingJob < ApplicationJob
       book.cover_url.blank? ||
       book.year.blank? ||
       book.description.blank?
+  end
+
+  def complete_target_request!(request, upload)
+    return if request.completed?
+
+    request.downloads.where(status: [ :queued, :downloading, :paused ]).find_each do |download|
+      request.cancel_download(download)
+    end
+    request.complete!
+    RequestEvent.record!(
+      request: request,
+      event_type: "upload_fulfilled",
+      source: "upload",
+      message: "Request fulfilled by manual upload",
+      details: { upload_id: upload.id }
+    )
+    request
+  end
+
+  def claim_target_request!(request)
+    claimable_statuses = Request.statuses.values_at("pending", "searching", "not_found", "downloading", "failed")
+    claimed = Request.where(id: request.id, status: claimable_statuses).update_all(
+      status: Request.statuses[:processing],
+      updated_at: Time.current
+    )
+    request.reload
+
+    return if claimed == 1
+
+    raise "Request is already completed" if request.completed?
+
+    raise "Request is already being completed"
+  end
+
+  def restore_target_request_status(request, original_status)
+    return if request.blank? || original_status.blank?
+
+    request.reload
+    return if request.completed? || !request.processing?
+
+    request.update!(status: original_status)
+  rescue => e
+    Rails.logger.warn "[UploadProcessingJob] Failed to restore request #{request.id} status after upload failure: #{e.message}"
   end
 
   def move_to_library(upload, book)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -6,6 +6,7 @@ class Request < ApplicationRecord
   has_many :request_events, dependent: :destroy
   has_many :downloads, dependent: :destroy
   has_many :search_results, dependent: :destroy
+  has_many :uploads, dependent: :destroy
 
   SHOW_PAGE_BROADCAST_ATTRIBUTES = %w[
     attention_needed

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -3,6 +3,7 @@
 class Upload < ApplicationRecord
   belongs_to :user
   belongs_to :book, optional: true
+  belongs_to :request, optional: true
 
   enum :status, {
     pending: 0,
@@ -20,6 +21,8 @@ class Upload < ApplicationRecord
 
   validates :original_filename, presence: true
   validates :status, presence: true
+
+  before_destroy :remove_unprocessed_file
 
   scope :recent, -> { order(created_at: :desc) }
   scope :pending_or_processing, -> { where(status: [:pending, :processing]) }
@@ -51,5 +54,14 @@ class Upload < ApplicationRecord
     when "completed" then "Completed"
     when "failed" then "Failed: #{error_message}"
     end
+  end
+
+  private
+
+  def remove_unprocessed_file
+    return if completed?
+    return if file_path.blank?
+
+    FileUtils.rm_f(file_path)
   end
 end

--- a/app/services/upload_creator.rb
+++ b/app/services/upload_creator.rb
@@ -5,13 +5,14 @@ class UploadCreator
     end
   end
 
-  def self.call(user:, uploaded_file:)
-    new(user:, uploaded_file:).call
+  def self.call(user:, uploaded_file:, request: nil)
+    new(user:, uploaded_file:, request:).call
   end
 
-  def initialize(user:, uploaded_file:)
+  def initialize(user:, uploaded_file:, request: nil)
     @user = user
     @uploaded_file = uploaded_file
+    @request = request
   end
 
   def call
@@ -24,10 +25,15 @@ class UploadCreator
       )
     end
 
+    if request.present? && inferred_book_type(extension) != request.book.book_type
+      return Result.new(alert: "Uploaded file type does not match this #{request.book.book_type} request")
+    end
+
     temp_path = save_uploaded_file
 
     upload = Upload.new(
       user: user,
+      request: request,
       original_filename: uploaded_file.original_filename,
       file_path: temp_path,
       file_size: uploaded_file.size,
@@ -46,7 +52,11 @@ class UploadCreator
 
   private
 
-  attr_reader :user, :uploaded_file
+  attr_reader :user, :uploaded_file, :request
+
+  def inferred_book_type(extension)
+    Upload::AUDIOBOOK_EXTENSIONS.include?(extension) ? "audiobook" : "ebook"
+  end
 
   def save_uploaded_file
     upload_dir = Rails.root.join("tmp", "uploads")

--- a/app/views/admin/uploads/new.html.erb
+++ b/app/views/admin/uploads/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto max-w-2xl">
   <h1 class="font-bold text-4xl mb-8 text-white">Upload Book</h1>
 
-  <%= render "uploads/form", submit_path: admin_uploads_path, cancel_path: admin_uploads_path %>
+  <%= render "uploads/form", submit_path: admin_uploads_path, cancel_path: (@request || admin_uploads_path), request_context: @request %>
 </div>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -260,6 +260,12 @@
               class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition" %>
         <% end %>
 
+        <% if allowed_to?(:new?, Upload) && !@request.completed? %>
+          <% request_upload_path = Current.user.admin? ? new_admin_upload_path(request_id: @request.id) : new_upload_path(request_id: @request.id) %>
+          <%= link_to "Upload File", request_upload_path,
+              class: "px-4 py-2 bg-green-600 hover:bg-green-500 text-white font-medium rounded-lg transition" %>
+        <% end %>
+
         <% if @request.can_be_cancelled? %>
           <button type="button"
                   class="px-4 py-2 bg-red-600 hover:bg-red-500 text-white font-medium rounded-lg transition"

--- a/app/views/uploads/_form.html.erb
+++ b/app/views/uploads/_form.html.erb
@@ -2,6 +2,18 @@
     multipart: true,
     class: "space-y-6",
     data: { controller: "upload-form" } do |f| %>
+  <% request_context ||= nil %>
+
+  <% if request_context %>
+    <%= hidden_field_tag :request_id, request_context.id %>
+    <div class="rounded-lg border border-blue-500/20 bg-blue-500/10 p-4">
+      <h2 class="text-sm font-medium text-blue-300">Fulfill Request</h2>
+      <p class="mt-1 text-sm text-blue-100/80">
+        This upload will fulfill <strong><%= request_context.book.display_name %></strong>
+        as a <%= request_context.book.book_type %> request after processing succeeds.
+      </p>
+    </div>
+  <% end %>
 
   <div class="border-2 border-dashed border-gray-700 rounded-lg p-8 text-center bg-gray-900"
        data-upload-form-target="dropzone"

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto max-w-2xl">
   <h1 class="font-bold text-4xl mb-8 text-white">Upload Book</h1>
 
-  <%= render "uploads/form", submit_path: uploads_path, cancel_path: uploads_path %>
+  <%= render "uploads/form", submit_path: uploads_path, cancel_path: (@request || uploads_path), request_context: @request %>
 </div>

--- a/db/migrate/20260521120000_add_request_to_uploads.rb
+++ b/db/migrate/20260521120000_add_request_to_uploads.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRequestToUploads < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :uploads, :request, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_101000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -312,12 +312,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_101000) do
     t.string "parsed_author"
     t.string "parsed_title"
     t.datetime "processed_at"
+    t.integer "request_id"
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["book_id"], name: "index_uploads_on_book_id"
     t.index ["book_type"], name: "index_uploads_on_book_type"
     t.index ["processed_at"], name: "index_uploads_on_processed_at"
+    t.index ["request_id"], name: "index_uploads_on_request_id"
     t.index ["status"], name: "index_uploads_on_status"
     t.index ["user_id"], name: "index_uploads_on_user_id"
   end
@@ -364,5 +366,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_101000) do
   add_foreign_key "sessions", "users"
   add_foreign_key "telegram_chat_authorizations", "users", column: "approved_by_id"
   add_foreign_key "uploads", "books"
+  add_foreign_key "uploads", "requests"
   add_foreign_key "uploads", "users"
 end

--- a/test/controllers/admin/uploads_controller_test.rb
+++ b/test/controllers/admin/uploads_controller_test.rb
@@ -36,6 +36,27 @@ class Admin::UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "new shows request upload context" do
+    request = requests(:pending_request)
+
+    get new_admin_upload_url(request_id: request.id)
+
+    assert_response :success
+    assert_select "input[name='request_id'][value='#{request.id}']"
+    assert_select "h2", "Fulfill Request"
+    assert_select "p", text: /#{request.book.display_name}/
+  end
+
+  test "new redirects away from completed request upload context" do
+    request = requests(:pending_request)
+    request.complete!
+
+    get new_admin_upload_url(request_id: request.id)
+
+    assert_redirected_to request_path(request)
+    assert_equal "This request is already completed.", flash[:alert]
+  end
+
   test "create with valid file starts processing" do
     file = fixture_file_upload("test_audiobook.m4b", "audio/mp4")
 
@@ -47,6 +68,33 @@ class Admin::UploadsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_uploads_path
     assert_equal "File uploaded successfully. Processing started.", flash[:notice]
+  end
+
+  test "create with request links upload and redirects to request" do
+    request = requests(:pending_request)
+    file = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+
+    assert_difference "Upload.count", 1 do
+      assert_enqueued_with(job: UploadProcessingJob) do
+        post admin_uploads_url, params: { file: file, request_id: request.id }
+      end
+    end
+
+    upload = Upload.order(:created_at).last
+    assert_equal request, upload.request
+    assert_redirected_to request_path(request)
+  end
+
+  test "create with request rejects mismatched file type" do
+    request = requests(:pending_request)
+    file = fixture_file_upload("test_audiobook.m4b", "audio/mp4")
+
+    assert_no_difference "Upload.count" do
+      post admin_uploads_url, params: { file: file, request_id: request.id }
+    end
+
+    assert_redirected_to new_admin_upload_path(request_id: request.id)
+    assert_includes flash[:alert], "does not match"
   end
 
   test "create with m4a audiobook starts processing" do

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -129,6 +129,45 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-cable-stream-source[channel='Turbo::StreamsChannel']", 1
   end
 
+  test "show links admins to upload a file for an open request" do
+    sign_out
+    sign_in_as(@admin)
+
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "a[href='#{new_admin_upload_path(request_id: @pending_request.id)}']", text: "Upload File"
+  end
+
+  test "show links regular users to request upload when uploads are enabled" do
+    SettingsService.set(:allow_user_uploads, true)
+
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "a[href='#{new_upload_path(request_id: @pending_request.id)}']", text: "Upload File"
+  end
+
+  test "show hides request upload link from regular users when uploads are disabled" do
+    SettingsService.set(:allow_user_uploads, false)
+
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "a[href='#{new_upload_path(request_id: @pending_request.id)}']", count: 0
+  end
+
+  test "show hides request upload link for completed requests" do
+    @pending_request.complete!
+    sign_out
+    sign_in_as(@admin)
+
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "a[href='#{new_admin_upload_path(request_id: @pending_request.id)}']", count: 0
+  end
+
   test "show keeps search results hidden from regular users" do
     @pending_request.update!(status: :searching)
 
@@ -503,6 +542,24 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to requests_path
+  end
+
+  test "destroy removes linked uploads" do
+    upload = Upload.create!(
+      user: @user,
+      request: @pending_request,
+      original_filename: "manual.epub",
+      file_path: "/tmp/manual.epub",
+      status: :pending
+    )
+
+    assert_difference "Request.count", -1 do
+      assert_difference "Upload.count", -1 do
+        delete request_path(@pending_request)
+      end
+    end
+
+    assert_not Upload.exists?(upload.id)
   end
 
   test "destroy does not clean up book with file" do

--- a/test/controllers/uploads_controller_test.rb
+++ b/test/controllers/uploads_controller_test.rb
@@ -122,6 +122,74 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type='file'][name='file'][accept='.m4a,.m4b,audio/mp4,.mp3,audio/mpeg,.zip,.rar,.epub,.pdf,.mobi,.azw3']"
   end
 
+  test "new shows own request upload context when uploads are enabled" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    request = requests(:pending_request)
+
+    get new_upload_url(request_id: request.id)
+
+    assert_response :success
+    assert_select "input[name='request_id'][value='#{request.id}']"
+    assert_select "h2", "Fulfill Request"
+  end
+
+  test "new rejects request upload context for another user's request" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    request = requests(:failed_request)
+    request.update!(user: @admin)
+
+    get new_upload_url(request_id: request.id)
+
+    assert_redirected_to uploads_path
+    assert_equal "You cannot upload files for this request.", flash[:alert]
+  end
+
+  test "new redirects away from completed request upload context" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    request = requests(:pending_request)
+    request.complete!
+
+    get new_upload_url(request_id: request.id)
+
+    assert_redirected_to request_path(request)
+    assert_equal "This request is already completed.", flash[:alert]
+  end
+
+  test "create with own request links upload and redirects to request" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    request = requests(:pending_request)
+    file = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+
+    assert_difference "Upload.count", 1 do
+      assert_enqueued_with(job: UploadProcessingJob) do
+        post uploads_url, params: { file: file, request_id: request.id }
+      end
+    end
+
+    upload = Upload.order(:created_at).last
+    assert_equal request, upload.request
+    assert_redirected_to request_path(request)
+  end
+
+  test "create rejects another user's request upload context" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    request = requests(:failed_request)
+    request.update!(user: @admin)
+    file = fixture_file_upload("test_audiobook.m4b", "audio/mp4")
+
+    assert_no_difference "Upload.count" do
+      post uploads_url, params: { file: file, request_id: request.id }
+    end
+
+    assert_redirected_to uploads_path
+    assert_equal "You cannot upload files for this request.", flash[:alert]
+  end
+
   test "create accepts m4a audiobook uploads for regular users when enabled" do
     SettingsService.set(:allow_user_uploads, true)
     sign_in_as(@user)

--- a/test/jobs/upload_processing_job_test.rb
+++ b/test/jobs/upload_processing_job_test.rb
@@ -119,6 +119,88 @@ class UploadProcessingJobTest < ActiveJob::TestCase
     end
   end
 
+  test "targeted upload completes the existing request" do
+    request = requests(:pending_request)
+    ebook_file = File.join(@temp_source, "Archived Ebook.epub")
+    File.write(ebook_file, "test ebook content")
+    download = request.downloads.create!(name: "Previous download", status: :queued)
+    paused_download = request.downloads.create!(name: "Paused download", status: :paused)
+
+    upload = Upload.create!(
+      user: @user,
+      request: request,
+      original_filename: "Archived Ebook.epub",
+      file_path: ebook_file,
+      file_size: 100,
+      status: :pending
+    )
+
+    assert_no_difference "Book.count" do
+      UploadProcessingJob.perform_now(upload.id)
+    end
+
+    upload.reload
+    request.reload
+
+    assert upload.completed?
+    assert_equal request.book, upload.book
+    assert request.completed?
+    assert request.completed_at.present?
+    assert_not request.attention_needed?
+    assert download.reload.failed?
+    assert paused_download.reload.failed?
+    assert_equal File.join(@temp_ebook_dest, request.book.author, request.book.title), request.book.file_path
+    assert request.request_events.exists?(event_type: "upload_fulfilled")
+  end
+
+  test "targeted upload fails if request completed before processing" do
+    request = requests(:pending_request)
+    ebook_file = File.join(@temp_source, "Late Ebook.epub")
+    File.write(ebook_file, "test ebook content")
+    upload = Upload.create!(
+      user: @user,
+      request: request,
+      original_filename: "Late Ebook.epub",
+      file_path: ebook_file,
+      file_size: 100,
+      status: :pending
+    )
+    request.complete!
+
+    UploadProcessingJob.perform_now(upload.id)
+
+    upload.reload
+    assert upload.failed?
+    assert_equal "Request is already completed", upload.error_message
+    assert_nil upload.book
+    assert_nil request.book.reload.file_path
+    assert File.exist?(ebook_file)
+  end
+
+  test "targeted upload fails if request is already being completed" do
+    request = requests(:pending_request)
+    ebook_file = File.join(@temp_source, "Already Processing.epub")
+    File.write(ebook_file, "test ebook content")
+    upload = Upload.create!(
+      user: @user,
+      request: request,
+      original_filename: "Already Processing.epub",
+      file_path: ebook_file,
+      file_size: 100,
+      status: :pending
+    )
+    request.update!(status: :processing)
+
+    UploadProcessingJob.perform_now(upload.id)
+
+    upload.reload
+    assert upload.failed?
+    assert_equal "Request is already being completed", upload.error_message
+    assert_nil upload.book
+    assert_nil request.book.reload.file_path
+    assert File.exist?(ebook_file)
+  end
+
   test "backfills existing matched book with metadata when needed" do
     original_source = SettingsService.get(:metadata_source)
     original_token = SettingsService.get(:hardcover_api_token)


### PR DESCRIPTION
## Summary
- Add request-linked manual uploads so an upload can explicitly fulfill an open request.
- Reuse the existing upload form with request context and complete the request after successful processing.
- Add safeguards for mismatched file types, stale/completed requests, concurrent targeted uploads, and pending upload cleanup when requests are cancelled.

## Test Plan
- bin/rails test test/controllers/requests_controller_test.rb test/controllers/uploads_controller_test.rb test/controllers/admin/uploads_controller_test.rb test/jobs/upload_processing_job_test.rb
- bin/rails test
- bin/quality fast
- bin/quality push