### PR TITLE
fix: allow admin search result overrides

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -26,7 +26,7 @@ class DownloadJob < ApplicationJob
       details: { request_status: download.request.status }
     )
 
-    search_result = download.request.search_results.selected.first
+    search_result = download.search_result || download.request.search_results.selected.first
 
     unless search_result
       Rails.logger.error "[DownloadJob] No selected search result for download ##{download.id}"

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -1,6 +1,7 @@
 class Download < ApplicationRecord
   belongs_to :request
   belongs_to :download_client, optional: true
+  belongs_to :search_result, optional: true
   has_many :request_events, dependent: :nullify
 
   SHOW_PAGE_BROADCAST_ATTRIBUTES = %w[name progress size_bytes status].freeze

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -112,6 +112,7 @@ class Request < ApplicationRecord
         download = downloads.create!(
           name: selected_result.title,
           size_bytes: selected_result.size_bytes,
+          search_result: selected_result,
           status: :queued
         )
 
@@ -213,12 +214,17 @@ class Request < ApplicationRecord
 
     download = nil
     ActiveRecord::Base.transaction do
+      downloads.where(status: [ :queued, :downloading, :paused ]).find_each do |download|
+        cancel_download(download)
+      end
+
       search_results.where.not(id: search_result.id).update_all(status: :rejected)
       search_result.update!(status: :selected)
 
       download = downloads.create!(
         name: search_result.title,
         size_bytes: search_result.size_bytes,
+        search_result: search_result,
         status: :queued
       )
 

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -2,6 +2,7 @@
 
 class SearchResult < ApplicationRecord
   belongs_to :request
+  has_many :downloads, dependent: :nullify
 
   after_commit :broadcast_request_show_refresh_later
 

--- a/app/views/admin/search_results/index.html.erb
+++ b/app/views/admin/search_results/index.html.erb
@@ -92,18 +92,16 @@
                   <%= link_to "Info", result.info_url, target: "_blank", rel: "noopener",
                       class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
                 <% end %>
-                <% if result.pending? %>
-                  <% if result.downloadable? %>
-                    <%= button_to "Select", select_admin_request_search_result_path(@request, result),
-                        method: :post,
-                        class: "px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
-                  <% else %>
-                    <span class="px-2 py-1 text-xs bg-gray-700 text-gray-500 rounded">No link</span>
-                  <% end %>
-                <% elsif result.selected? %>
+                <% if result.selected? %>
                   <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
+                <% elsif result.downloadable? %>
+                  <%= button_to result.rejected? ? "Select Instead" : "Select", select_admin_request_search_result_path(@request, result),
+                      method: :post,
+                      class: "px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
                 <% elsif result.rejected? %>
                   <span class="px-2 py-1 text-xs bg-gray-700 text-gray-400 rounded">Skipped</span>
+                <% else %>
+                  <span class="px-2 py-1 text-xs bg-gray-700 text-gray-500 rounded">No link</span>
                 <% end %>
               </div>
             </div>

--- a/app/views/requests/_search_result_row.html.erb
+++ b/app/views/requests/_search_result_row.html.erb
@@ -48,16 +48,18 @@
       <%= link_to "Info", result.info_url, target: "_blank", rel: "noopener",
           class: "px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
     <% end %>
-    <% if Current.user.admin? && result.pending? && result.downloadable? %>
-      <%= button_to "Select", select_admin_request_search_result_path(request, result),
-          method: :post,
-          class: "px-2 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
-    <% elsif Current.user.admin? && result.pending? %>
-      <span class="px-2 py-1 text-xs bg-gray-700 text-gray-500 rounded">No link</span>
-    <% elsif Current.user.admin? && result.selected? %>
-      <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
-    <% elsif Current.user.admin? && result.rejected? %>
-      <span class="px-2 py-1 text-xs bg-gray-700 text-gray-400 rounded">Skipped</span>
+    <% if Current.user.admin? %>
+      <% if result.selected? %>
+        <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
+      <% elsif result.downloadable? %>
+        <%= button_to result.rejected? ? "Select Instead" : "Select", select_admin_request_search_result_path(request, result),
+            method: :post,
+            class: "px-2 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
+      <% elsif result.rejected? %>
+        <span class="px-2 py-1 text-xs bg-gray-700 text-gray-400 rounded">Skipped</span>
+      <% else %>
+        <span class="px-2 py-1 text-xs bg-gray-700 text-gray-500 rounded">No link</span>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -73,7 +73,7 @@
   <% else %>
     <div class="space-y-4">
       <% @requests.each do |request| %>
-        <% has_view_results = Current.user.admin? && request.searching? && request.search_results.any? %>
+        <% has_view_results = Current.user.admin? && request.search_results.any? %>
         <div class="bg-gray-900 border border-gray-800 rounded-lg p-4 hover:border-gray-700 transition" <%= "data-controller=search-results" if has_view_results %>>
           <div class="flex gap-4">
             <div class="flex-shrink-0 w-16 aspect-[2/3] bg-gray-800 rounded shadow overflow-hidden">
@@ -134,7 +134,7 @@
 
               <%# Error description and action buttons row %>
               <% if Current.user.admin? %>
-                <% has_retry = request.can_retry? && !has_view_results %>
+                <% has_retry = request.can_retry? %>
                 <% has_cancel = request.can_be_cancelled? %>
                 <% has_issue = request.issue_description.present? %>
                 <% if has_view_results || has_retry || has_cancel || has_issue %>
@@ -155,7 +155,8 @@
                               class="inline-flex items-center px-2 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition whitespace-nowrap">
                             View Results (<%= request.search_results.count %>)
                           </button>
-                        <% elsif has_retry %>
+                        <% end %>
+                        <% if has_retry %>
                           <%= button_to retry_request_path(request), method: :post,
                               class: "inline-flex items-center px-2 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition whitespace-nowrap" do %>
                             Retry

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -97,62 +97,62 @@
         </div>
       <% end %>
 
-      <% if @request.searching? && @request.search_results.any? %>
-        <% if Current.user.admin? %>
-          <div class="mb-6" data-controller="search-results" data-search-results-expanded-value="true">
-            <div class="flex items-center justify-between mb-3">
-              <h3 class="text-sm font-medium text-gray-400">
-                Search Results
-                <span class="text-gray-500">(<%= @request.search_results.count %>)</span>
-              </h3>
-              <div class="flex items-center gap-2">
-                <%= button_to "Refresh Search", refresh_admin_request_search_results_path(@request),
-                    method: :post, class: "px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
-                <button type="button"
-                    data-action="click->search-results#toggle"
-                    data-search-results-target="toggleBtn"
-                    class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition">
-                  Hide Results (<%= @request.search_results.count %>)
-                </button>
-              </div>
-            </div>
-
-            <div data-search-results-target="content" class="space-y-2">
-              <% @request.search_results.best_first.each do |result| %>
-                <%= render "requests/search_result_row", result: result, request: @request %>
-              <% end %>
-
-              <%# Pagination controls %>
-              <div data-search-results-target="pagination" class="flex items-center justify-center gap-4 pt-2 text-xs">
-                <button type="button"
-                    data-action="click->search-results#prevPage"
-                    data-search-results-target="prevBtn"
-                    class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
-                  Prev
-                </button>
-                <span data-search-results-target="pageInfo" class="text-gray-400">Page 1 of 1</span>
-                <button type="button"
-                    data-action="click->search-results#nextPage"
-                    data-search-results-target="nextBtn"
-                    class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
-                  Next
-                </button>
-              </div>
+      <% if Current.user.admin? && @request.search_results.any? %>
+        <div class="mb-6" data-controller="search-results" data-search-results-expanded-value="true">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-medium text-gray-400">
+              Search Results
+              <span class="text-gray-500">(<%= @request.search_results.count %>)</span>
+            </h3>
+            <div class="flex items-center gap-2">
+              <%= button_to "Refresh Search", refresh_admin_request_search_results_path(@request),
+                  method: :post, class: "px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
+              <%= link_to "Manage Results", admin_request_search_results_path(@request),
+                  class: "px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition" %>
+              <button type="button"
+                  data-action="click->search-results#toggle"
+                  data-search-results-target="toggleBtn"
+                  class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded font-medium transition">
+                Hide Results (<%= @request.search_results.count %>)
+              </button>
             </div>
           </div>
-        <% else %>
-          <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
-            <div class="flex items-center">
-              <svg class="w-5 h-5 text-blue-400 mr-2 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
-              </svg>
-              <div>
-                <h3 class="text-sm font-medium text-blue-400">Search Results Available</h3>
-                <p class="text-sm text-blue-400/80 mt-1">Waiting for admin approval.</p>
-              </div>
+
+          <div data-search-results-target="content" class="space-y-2">
+            <% @request.search_results.best_first.each do |result| %>
+              <%= render "requests/search_result_row", result: result, request: @request %>
+            <% end %>
+
+            <%# Pagination controls %>
+            <div data-search-results-target="pagination" class="flex items-center justify-center gap-4 pt-2 text-xs">
+              <button type="button"
+                  data-action="click->search-results#prevPage"
+                  data-search-results-target="prevBtn"
+                  class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
+                Prev
+              </button>
+              <span data-search-results-target="pageInfo" class="text-gray-400">Page 1 of 1</span>
+              <button type="button"
+                  data-action="click->search-results#nextPage"
+                  data-search-results-target="nextBtn"
+                  class="px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded transition">
+                Next
+              </button>
             </div>
           </div>
-        <% end %>
+        </div>
+      <% elsif @request.searching? && @request.search_results.any? %>
+        <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
+          <div class="flex items-start">
+            <svg class="w-5 h-5 text-blue-400 mr-2 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
+            </svg>
+            <div>
+              <h3 class="text-sm font-medium text-blue-400">Search Results Available</h3>
+              <p class="text-sm text-blue-400/80 mt-1">Waiting for admin approval.</p>
+            </div>
+          </div>
+        </div>
       <% elsif @request.searching? %>
         <div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
           <div class="flex items-center">

--- a/db/migrate/20260521000001_add_search_result_to_downloads.rb
+++ b/db/migrate/20260521000001_add_search_result_to_downloads.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSearchResultToDownloads < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :downloads, :search_result, foreign_key: { on_delete: :nullify }, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,12 +117,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
     t.integer "not_found_count", default: 0, null: false
     t.integer "progress", default: 0
     t.integer "request_id", null: false
+    t.integer "search_result_id"
     t.bigint "size_bytes"
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["download_client_id"], name: "index_downloads_on_download_client_id"
     t.index ["external_id"], name: "index_downloads_on_external_id"
     t.index ["request_id"], name: "index_downloads_on_request_id"
+    t.index ["search_result_id"], name: "index_downloads_on_search_result_id"
     t.index ["status"], name: "index_downloads_on_status"
   end
 
@@ -357,6 +359,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
   add_foreign_key "api_tokens", "users"
   add_foreign_key "download_routing_rules", "download_clients"
   add_foreign_key "downloads", "requests"
+  add_foreign_key "downloads", "search_results", on_delete: :nullify
   add_foreign_key "notifications", "users"
   add_foreign_key "request_events", "downloads"
   add_foreign_key "request_events", "requests"

--- a/test/controllers/admin/search_results_controller_test.rb
+++ b/test/controllers/admin/search_results_controller_test.rb
@@ -68,6 +68,17 @@ module Admin
       assert_match(/seeds/, response.body)
     end
 
+    test "index allows selecting rejected downloadable results" do
+      @pending_result.update!(status: :rejected)
+
+      get admin_request_search_results_path(@request_record)
+      assert_response :success
+
+      assert_select "form[action='#{select_admin_request_search_result_path(@request_record, @pending_result)}']" do
+        assert_select "button", text: "Select Instead"
+      end
+    end
+
     # === Select ===
 
     test "select creates download and updates statuses" do
@@ -77,11 +88,24 @@ module Admin
 
       @pending_result.reload
       @request_record.reload
+      download = @request_record.downloads.order(:created_at).last
 
       assert @pending_result.selected?
       assert @request_record.downloading?
+      assert_equal @pending_result, download.search_result
       # Uses redirect_back with fallback to requests_path
       assert_redirected_to requests_path
+    end
+
+    test "select can override a rejected result" do
+      @pending_result.update!(status: :rejected)
+
+      assert_difference -> { Download.count }, 1 do
+        post select_admin_request_search_result_path(@request_record, @pending_result)
+      end
+
+      assert @pending_result.reload.selected?
+      assert @selected_result.reload.rejected?
     end
 
     test "select marks other results as rejected" do

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -249,6 +249,44 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show links admins to search results after auto selection" do
+    @pending_request.update!(status: :downloading)
+    sign_out
+    sign_in_as(@admin)
+
+    get request_path(@pending_request)
+    assert_response :success
+
+    assert_select "a[href='#{admin_request_search_results_path(@pending_request)}']", text: "Manage Results"
+  end
+
+  test "show hides completed search result controls from regular users" do
+    @pending_request.update!(status: :downloading)
+
+    get request_path(@pending_request)
+    assert_response :success
+
+    assert_select "a[href='#{admin_request_search_results_path(@pending_request)}']", count: 0
+    assert_select "h3", text: "Search Results Available", count: 0
+  end
+
+  test "index shows results and retry actions independently" do
+    @failed_request.search_results.create!(
+      guid: "failed-result-guid",
+      title: "Failed Result",
+      download_url: "http://example.com/failed.torrent",
+      status: :rejected
+    )
+    sign_out
+    sign_in_as(@admin)
+
+    get requests_path
+    assert_response :success
+
+    assert_select "button", text: /View Results/
+    assert_select "form[action='#{retry_request_path(@failed_request)}']"
+  end
+
   test "new requires work_id and title" do
     get new_request_path
     assert_redirected_to search_path

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -35,6 +35,7 @@ class DownloadJobTest < ActiveJob::TestCase
     @download = @request.downloads.create!(
       name: @selected_result.title,
       size_bytes: @selected_result.size_bytes,
+      search_result: @selected_result,
       status: :queued
     )
   end
@@ -64,6 +65,7 @@ class DownloadJobTest < ActiveJob::TestCase
 
   test "marks for attention when no search result selected" do
     # Remove the selected result
+    @download.update!(search_result: nil)
     @request.search_results.selected.destroy_all
 
     DownloadJob.perform_now(@download.id)
@@ -76,10 +78,8 @@ class DownloadJobTest < ActiveJob::TestCase
   end
 
   test "marks for attention when result has no download link" do
-    # Replace selected with no-link result
-    @request.search_results.selected.destroy_all
     no_link = search_results(:no_link_result)
-    no_link.update!(status: :selected)
+    @download.update!(search_result: no_link)
 
     DownloadJob.perform_now(@download.id)
     @download.reload
@@ -88,6 +88,29 @@ class DownloadJobTest < ActiveJob::TestCase
     assert @download.failed?
     assert @request.attention_needed?
     assert_includes @request.issue_description, "no download link"
+  end
+
+  test "uses the download search result instead of the current selected result" do
+    no_link = search_results(:no_link_result)
+    @download.update!(search_result: no_link)
+
+    DownloadJob.perform_now(@download.id)
+    @download.reload
+
+    assert @download.failed?
+  end
+
+  test "falls back to selected result for existing downloads without association" do
+    @download.update!(search_result: nil)
+
+    VCR.turned_off do
+      stub_qbittorrent_success
+
+      DownloadJob.perform_now(@download.id)
+      @download.reload
+
+      assert @download.downloading?
+    end
   end
 
   test "marks for attention when no download client configured" do

--- a/test/models/request_retry_test.rb
+++ b/test/models/request_retry_test.rb
@@ -524,6 +524,33 @@ class RequestRetryTest < ActiveSupport::TestCase
     assert_not completed.can_be_cancelled?
   end
 
+  test "select_result! associates the download with the selected result" do
+    request = requests(:pending_request)
+    result = search_results(:pending_result)
+
+    download = request.select_result!(result)
+
+    assert_equal result, download.search_result
+  end
+
+  test "select_result! cancels active downloads before queueing override" do
+    request = requests(:pending_request)
+    original_result = search_results(:selected_result)
+    replacement_result = search_results(:pending_result)
+    active_download = request.downloads.create!(
+      name: original_result.title,
+      search_result: original_result,
+      status: :queued
+    )
+
+    assert_difference -> { request.downloads.count }, 1 do
+      request.select_result!(replacement_result)
+    end
+
+    assert active_download.reload.failed?
+    assert_equal replacement_result, request.downloads.order(:created_at).last.search_result
+  end
+
   test "cancel! removes active downloads from download client" do
     book = Book.create!(title: "Cancel Test Book", book_type: :ebook, open_library_work_id: "OL_CANCEL_TEST")
     request = Request.create!(


### PR DESCRIPTION
## Summary
- allow admins to select a rejected downloadable search result as an override
- tie queued downloads to the exact search result that created them
- expose/manage search results for admins after auto-selection and keep retry actions independent

Fixes #263

## Validation
- bundle exec rails test
- bin/quality fast --staged
- bin/quality push
- local browser test on http://127.0.0.1:3000/requests/9