### PR TITLE
feat: support bulk folder uploads

### DIFF
--- a/app/controllers/admin/uploads_controller.rb
+++ b/app/controllers/admin/uploads_controller.rb
@@ -2,8 +2,8 @@
 
 module Admin
   class UploadsController < BaseController
-    before_action :set_request_context, only: [:new, :create]
-    before_action :set_upload, only: [:show, :destroy, :retry]
+    before_action :set_request_context, only: [ :new, :create ]
+    before_action :set_upload, only: [ :show, :destroy, :retry ]
 
     def index
       @uploads = Upload.includes(:user, :book).recent
@@ -14,10 +14,17 @@ module Admin
     end
 
     def create
-      result = UploadCreator.call(user: Current.user, uploaded_file: params[:file], request: @request)
+      result = UploadCreator.call_many(
+        user: Current.user,
+        uploaded_files: upload_files,
+        request: @request,
+        skip_unsupported: folder_upload?
+      )
 
       if result.success?
-        redirect_to upload_success_location, notice: result.notice
+        flash[:notice] = result.notice if result.notice.present?
+        flash[:alert] = result.alert if result.alert.present?
+        redirect_to upload_success_location
       else
         redirect_to upload_failure_location, alert: result.alert
       end
@@ -67,6 +74,14 @@ module Admin
 
     def upload_failure_location
       @request ? new_admin_upload_path(request_id: @request.id) : new_admin_upload_path
+    end
+
+    def upload_files
+      params[:files].presence || params[:file]
+    end
+
+    def folder_upload?
+      params[:upload_mode] == "folder"
     end
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -18,10 +18,17 @@ class UploadsController < ApplicationController
   end
 
   def create
-    result = UploadCreator.call(user: Current.user, uploaded_file: params[:file], request: @request)
+    result = UploadCreator.call_many(
+      user: Current.user,
+      uploaded_files: upload_files,
+      request: @request,
+      skip_unsupported: folder_upload?
+    )
 
     if result.success?
-      redirect_to upload_success_location, notice: result.notice
+      flash[:notice] = result.notice if result.notice.present?
+      flash[:alert] = result.alert if result.alert.present?
+      redirect_to upload_success_location
     else
       redirect_to upload_failure_location, alert: result.alert
     end
@@ -60,6 +67,14 @@ class UploadsController < ApplicationController
 
   def upload_failure_location
     @request ? new_upload_path(request_id: @request.id) : new_upload_path
+  end
+
+  def upload_files
+    params[:files].presence || params[:file]
+  end
+
+  def folder_upload?
+    params[:upload_mode] == "folder"
   end
 
   def record_not_found

--- a/app/javascript/controllers/upload_form_controller.js
+++ b/app/javascript/controllers/upload_form_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["dropzone", "input", "filename", "submit"]
+  static targets = ["dropzone", "input", "folderInput", "filename", "mode", "submit"]
+  static values = { bulk: Boolean }
+
+  supportedExtensions = ["m4a", "m4b", "mp3", "zip", "rar", "epub", "pdf", "mobi", "azw3"]
 
   dragover(event) {
     event.preventDefault()
@@ -13,26 +16,167 @@ export default class extends Controller {
     this.dropzoneTarget.classList.remove("border-blue-500", "bg-blue-50")
   }
 
-  drop(event) {
+  async drop(event) {
     event.preventDefault()
     this.dropzoneTarget.classList.remove("border-blue-500", "bg-blue-50")
 
+    const entries = this.droppedEntries(event.dataTransfer)
+    if (entries.some((entry) => entry.isDirectory)) {
+      await this.folderDropped(entries)
+      return
+    }
+
     const files = event.dataTransfer.files
     if (files.length > 0) {
+      if (!this.bulkValue && files.length > 1) {
+        this.showFilename("Please choose one file for this request")
+        return
+      }
+
+      this.setMode("files")
+      this.clearFolderInput()
       this.inputTarget.files = files
-      this.showFilename(files[0].name)
+      this.showSelection(files)
     }
+  }
+
+  async folderDropped(entries) {
+    if (!this.bulkValue) {
+      this.showFilename("Please choose one file for this request")
+      return
+    }
+
+    if (!window.DataTransfer) {
+      this.showFilename("Folder drag and drop is not supported by this browser")
+      return
+    }
+
+    this.showFilename("Scanning folder...")
+
+    const files = await this.filesFromEntries(entries)
+    const supportedFiles = files.filter((file) => this.supportedFile(file))
+
+    this.setMode("folder")
+    this.clearFileInput()
+
+    if (supportedFiles.length === 0) {
+      this.clearFolderInput()
+      this.showFilename("No supported book files found in folder")
+      return
+    }
+
+    this.keepSupportedFolderFiles(supportedFiles)
+    this.showFolderSelection(supportedFiles)
   }
 
   fileSelected(event) {
     const files = event.target.files
     if (files.length > 0) {
-      this.showFilename(files[0].name)
+      this.setMode("files")
+      this.clearFolderInput()
+      this.showSelection(files)
     }
+  }
+
+  folderSelected(event) {
+    const files = event.target.files
+    const supportedFiles = Array.from(files).filter((file) => this.supportedFile(file))
+
+    this.setMode("folder")
+    this.clearFileInput()
+
+    if (supportedFiles.length === 0) {
+      event.target.value = ""
+      this.showFilename("No supported book files found in folder")
+      return
+    }
+
+    this.keepSupportedFolderFiles(supportedFiles)
+    this.showFolderSelection(supportedFiles)
+  }
+
+  showFolderSelection(files) {
+    const fileLabel = files.length === 1 ? "file" : "files"
+    this.showFilename(`${files.length} supported ${fileLabel} selected from folder`)
+  }
+
+  showSelection(files) {
+    if (files.length === 1) {
+      this.showFilename(files[0].name)
+      return
+    }
+
+    this.showFilename(`${files.length} files selected`)
   }
 
   showFilename(name) {
     this.filenameTarget.classList.remove("hidden")
     this.filenameTarget.querySelector("span").textContent = name
+  }
+
+  supportedFile(file) {
+    const extension = file.name.split(".").pop()?.toLowerCase()
+    return this.supportedExtensions.includes(extension)
+  }
+
+  keepSupportedFolderFiles(files) {
+    if (!window.DataTransfer) return
+
+    const transfer = new DataTransfer()
+    files.forEach((file) => transfer.items.add(file))
+    this.folderInputTarget.files = transfer.files
+  }
+
+  droppedEntries(dataTransfer) {
+    return Array.from(dataTransfer.items || [])
+      .map((item) => item.webkitGetAsEntry?.())
+      .filter(Boolean)
+  }
+
+  async filesFromEntries(entries) {
+    const nestedFiles = await Promise.all(entries.map((entry) => this.filesFromEntry(entry)))
+    return nestedFiles.reduce((files, entryFiles) => files.concat(entryFiles), [])
+  }
+
+  async filesFromEntry(entry) {
+    if (entry.isFile) {
+      return new Promise((resolve) => {
+        entry.file((file) => resolve([file]), () => resolve([]))
+      })
+    }
+
+    if (entry.isDirectory) {
+      const entries = await this.readDirectoryEntries(entry)
+      return this.filesFromEntries(entries)
+    }
+
+    return []
+  }
+
+  async readDirectoryEntries(directoryEntry) {
+    const reader = directoryEntry.createReader()
+    const entries = []
+
+    while (true) {
+      const batch = await new Promise((resolve) => {
+        reader.readEntries(resolve, () => resolve([]))
+      })
+
+      if (batch.length === 0) return entries
+
+      entries.push(...batch)
+    }
+  }
+
+  setMode(mode) {
+    if (this.hasModeTarget) this.modeTarget.value = mode
+  }
+
+  clearFileInput() {
+    this.inputTarget.value = ""
+  }
+
+  clearFolderInput() {
+    if (this.hasFolderInputTarget) this.folderInputTarget.value = ""
   }
 }

--- a/app/services/upload_creator.rb
+++ b/app/services/upload_creator.rb
@@ -1,12 +1,64 @@
 class UploadCreator
-  Result = Struct.new(:upload, :notice, :alert, keyword_init: true) do
+  Result = Struct.new(:upload, :uploads, :notice, :alert, :success, keyword_init: true) do
     def success?
-      alert.blank?
+      success.nil? ? alert.blank? : success
     end
   end
 
   def self.call(user:, uploaded_file:, request: nil)
     new(user:, uploaded_file:, request:).call
+  end
+
+  def self.call_many(user:, uploaded_files:, request: nil, skip_unsupported: false)
+    submitted_files = Array(uploaded_files).compact_blank
+    return Result.new(alert: "Please select a file to upload", success: false) if submitted_files.empty?
+
+    files = submitted_files
+    files = files.select { |file| supported_file?(file) } if skip_unsupported
+    if skip_unsupported && files.empty?
+      return Result.new(alert: "No supported ebook or audiobook files found in the selected folder", success: false)
+    end
+
+    if request.present? && files.many?
+      return Result.new(alert: "Please upload one file when fulfilling a request", success: false)
+    end
+
+    return call(user:, uploaded_file: files.first, request:) if files.one? && !skip_unsupported
+
+    uploads = []
+    failures = []
+
+    files.each do |file|
+      result = call(user:, uploaded_file: file, request:)
+      if result.success?
+        uploads << result.upload
+      else
+        failures << [ file.original_filename, result.alert ]
+      end
+    end
+
+    if uploads.empty?
+      return Result.new(alert: bulk_failure_message(failures), success: false)
+    end
+
+    Result.new(
+      uploads: uploads,
+      notice: "#{uploads.size} #{'file'.pluralize(uploads.size)} uploaded successfully. Processing started.",
+      alert: bulk_failure_message(failures),
+      success: true
+    )
+  end
+
+  def self.bulk_failure_message(failures)
+    return if failures.empty?
+
+    failed_files = failures.map { |filename, alert| "#{filename}: #{alert}" }.join("; ")
+    "#{failures.size} #{'file'.pluralize(failures.size)} failed to upload: #{failed_files}"
+  end
+
+  def self.supported_file?(uploaded_file)
+    extension = File.extname(uploaded_file.original_filename).delete(".").downcase
+    Upload::SUPPORTED_EXTENSIONS.include?(extension)
   end
 
   def initialize(user:, uploaded_file:, request: nil)

--- a/app/views/uploads/_form.html.erb
+++ b/app/views/uploads/_form.html.erb
@@ -33,7 +33,7 @@
       <div>
         <label class="cursor-pointer">
           <span class="text-blue-400 hover:text-blue-300 font-medium">
-            <%= bulk_upload ? "Choose files" : "Choose a file" %>
+            <%= bulk_upload ? "Choose files," : "Choose a file" %>
           </span>
           <input type="file"
                  name="<%= bulk_upload ? 'files[]' : 'file' %>"
@@ -44,9 +44,8 @@
                  accept=".m4a,.m4b,audio/mp4,.mp3,audio/mpeg,.zip,.rar,.epub,.pdf,.mobi,.azw3">
         </label>
         <% if bulk_upload %>
-          <span class="text-gray-500">, </span>
           <label class="cursor-pointer">
-            <span class="text-blue-400 hover:text-blue-300 font-medium">choose a folder</span>
+            <span class="text-blue-400 hover:text-blue-300 font-medium">a folder</span>
             <input type="file"
                    name="files[]"
                    class="hidden"
@@ -57,7 +56,7 @@
                    data-action="change->upload-form#folderSelected">
           </label>
         <% end %>
-        <span class="text-gray-500"> or drag and drop <%= bulk_upload ? "files/folders" : "a file" %></span>
+        <span class="text-gray-500"> or drag and drop <%= bulk_upload ? "files or folders" : "a file" %></span>
       </div>
 
       <p class="text-sm text-gray-500">

--- a/app/views/uploads/_form.html.erb
+++ b/app/views/uploads/_form.html.erb
@@ -1,8 +1,11 @@
+<% request_context ||= nil %>
+<% bulk_upload = request_context.blank? %>
+
 <%= form_with url: submit_path, method: :post,
     multipart: true,
     class: "space-y-6",
-    data: { controller: "upload-form" } do |f| %>
-  <% request_context ||= nil %>
+    data: { controller: "upload-form", upload_form_bulk_value: bulk_upload } do |f| %>
+  <%= hidden_field_tag :upload_mode, "files", data: { upload_form_target: "mode" } if bulk_upload %>
 
   <% if request_context %>
     <%= hidden_field_tag :request_id, request_context.id %>
@@ -29,20 +32,42 @@
 
       <div>
         <label class="cursor-pointer">
-          <span class="text-blue-400 hover:text-blue-300 font-medium">Choose a file</span>
+          <span class="text-blue-400 hover:text-blue-300 font-medium">
+            <%= bulk_upload ? "Choose files" : "Choose a file" %>
+          </span>
           <input type="file"
-                 name="file"
+                 name="<%= bulk_upload ? 'files[]' : 'file' %>"
                  class="hidden"
+                 <%= "multiple" if bulk_upload %>
                  data-upload-form-target="input"
                  data-action="change->upload-form#fileSelected"
                  accept=".m4a,.m4b,audio/mp4,.mp3,audio/mpeg,.zip,.rar,.epub,.pdf,.mobi,.azw3">
         </label>
-        <span class="text-gray-500"> or drag and drop</span>
+        <% if bulk_upload %>
+          <span class="text-gray-500">, </span>
+          <label class="cursor-pointer">
+            <span class="text-blue-400 hover:text-blue-300 font-medium">choose a folder</span>
+            <input type="file"
+                   name="files[]"
+                   class="hidden"
+                   multiple
+                   webkitdirectory
+                   directory
+                   data-upload-form-target="folderInput"
+                   data-action="change->upload-form#folderSelected">
+          </label>
+        <% end %>
+        <span class="text-gray-500"> or drag and drop <%= bulk_upload ? "files/folders" : "a file" %></span>
       </div>
 
       <p class="text-sm text-gray-500">
         Audiobooks: m4a, m4b, mp3, zip, rar | Ebooks: epub, pdf, mobi, azw3
       </p>
+      <% if bulk_upload %>
+        <p class="text-sm text-gray-500">
+          Select multiple files, choose a folder, or drag a folder to queue supported book files found inside it.
+        </p>
+      <% end %>
 
       <div data-upload-form-target="filename" class="hidden text-sm font-medium text-gray-300 mt-4">
         Selected: <span class="text-blue-400"></span>

--- a/test/controllers/admin/uploads_controller_test.rb
+++ b/test/controllers/admin/uploads_controller_test.rb
@@ -34,6 +34,7 @@ class Admin::UploadsControllerTest < ActionDispatch::IntegrationTest
   test "new shows upload form" do
     get new_admin_upload_url
     assert_response :success
+    assert_select "input[type='file'][name='files[]'][multiple]"
   end
 
   test "new shows request upload context" do
@@ -43,6 +44,7 @@ class Admin::UploadsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "input[name='request_id'][value='#{request.id}']"
+    assert_select "input[type='file'][name='file']"
     assert_select "h2", "Fulfill Request"
     assert_select "p", text: /#{request.book.display_name}/
   end
@@ -68,6 +70,48 @@ class Admin::UploadsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_uploads_path
     assert_equal "File uploaded successfully. Processing started.", flash[:notice]
+  end
+
+  test "create with multiple files starts processing each file" do
+    audiobook = fixture_file_upload("test_audiobook.m4b", "audio/mp4")
+    ebook = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+
+    assert_difference "Upload.count", 2 do
+      assert_enqueued_jobs 2, only: UploadProcessingJob do
+        post admin_uploads_url, params: { files: [ audiobook, ebook ] }
+      end
+    end
+
+    assert_redirected_to admin_uploads_path
+    assert_equal "2 files uploaded successfully. Processing started.", flash[:notice]
+  end
+
+  test "create from folder skips unsupported files" do
+    audiobook = fixture_file_upload("test_audiobook.m4b", "audio/mp4")
+    text = fixture_file_upload("test.txt", "text/plain")
+
+    assert_difference "Upload.count", 1 do
+      assert_enqueued_jobs 1, only: UploadProcessingJob do
+        post admin_uploads_url, params: { files: [ audiobook, text ], upload_mode: "folder" }
+      end
+    end
+
+    assert_redirected_to admin_uploads_path
+    assert_equal "1 file uploaded successfully. Processing started.", flash[:notice]
+    assert_nil flash[:alert]
+  end
+
+  test "create with request rejects multiple files" do
+    request = requests(:pending_request)
+    first_file = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+    second_file = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+
+    assert_no_difference "Upload.count" do
+      post admin_uploads_url, params: { files: [ first_file, second_file ], request_id: request.id }
+    end
+
+    assert_redirected_to new_admin_upload_path(request_id: request.id)
+    assert_equal "Please upload one file when fulfilling a request", flash[:alert]
   end
 
   test "create with request links upload and redirects to request" do

--- a/test/controllers/uploads_controller_test.rb
+++ b/test/controllers/uploads_controller_test.rb
@@ -119,7 +119,7 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Upload Book"
     assert_select "form[action='#{uploads_path}']"
-    assert_select "input[type='file'][name='file'][accept='.m4a,.m4b,audio/mp4,.mp3,audio/mpeg,.zip,.rar,.epub,.pdf,.mobi,.azw3']"
+    assert_select "input[type='file'][name='files[]'][multiple][accept='.m4a,.m4b,audio/mp4,.mp3,audio/mpeg,.zip,.rar,.epub,.pdf,.mobi,.azw3']"
   end
 
   test "new shows own request upload context when uploads are enabled" do
@@ -131,6 +131,7 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "input[name='request_id'][value='#{request.id}']"
+    assert_select "input[type='file'][name='file']"
     assert_select "h2", "Fulfill Request"
   end
 
@@ -173,6 +174,85 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
     upload = Upload.order(:created_at).last
     assert_equal request, upload.request
     assert_redirected_to request_path(request)
+  end
+
+  test "create accepts multiple files for regular users when enabled" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    audiobook = fixture_file_upload("test_audiobook.m4b", "audio/mp4")
+    ebook = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+
+    assert_difference "Upload.count", 2 do
+      assert_enqueued_jobs 2, only: UploadProcessingJob do
+        post uploads_url, params: { files: [ audiobook, ebook ] }
+      end
+    end
+
+    assert_redirected_to uploads_path
+    assert_equal "2 files uploaded successfully. Processing started.", flash[:notice]
+  end
+
+  test "create partially accepts multiple files for regular users when enabled" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    ebook = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+    text = fixture_file_upload("test.txt", "text/plain")
+
+    assert_difference "Upload.count", 1 do
+      assert_enqueued_jobs 1, only: UploadProcessingJob do
+        post uploads_url, params: { files: [ ebook, text ] }
+      end
+    end
+
+    assert_redirected_to uploads_path
+    assert_equal "1 file uploaded successfully. Processing started.", flash[:notice]
+    assert_includes flash[:alert], "test.txt"
+    assert_includes flash[:alert], "Unsupported file type"
+  end
+
+  test "create from folder skips unsupported files for regular users when enabled" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    ebook = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+    text = fixture_file_upload("test.txt", "text/plain")
+
+    assert_difference "Upload.count", 1 do
+      assert_enqueued_jobs 1, only: UploadProcessingJob do
+        post uploads_url, params: { files: [ ebook, text ], upload_mode: "folder" }
+      end
+    end
+
+    assert_redirected_to uploads_path
+    assert_equal "1 file uploaded successfully. Processing started.", flash[:notice]
+    assert_nil flash[:alert]
+  end
+
+  test "create from folder rejects folders without supported files" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    text = fixture_file_upload("test.txt", "text/plain")
+
+    assert_no_difference "Upload.count" do
+      post uploads_url, params: { files: [ text ], upload_mode: "folder" }
+    end
+
+    assert_redirected_to new_upload_path
+    assert_equal "No supported ebook or audiobook files found in the selected folder", flash[:alert]
+  end
+
+  test "create rejects multiple files for request upload context" do
+    SettingsService.set(:allow_user_uploads, true)
+    sign_in_as(@user)
+    request = requests(:pending_request)
+    first_file = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+    second_file = fixture_file_upload("test_ebook.epub", "application/epub+zip")
+
+    assert_no_difference "Upload.count" do
+      post uploads_url, params: { files: [ first_file, second_file ], request_id: request.id }
+    end
+
+    assert_redirected_to new_upload_path(request_id: request.id)
+    assert_equal "Please upload one file when fulfilling a request", flash[:alert]
   end
 
   test "create rejects another user's request upload context" do


### PR DESCRIPTION
## Summary
- add multi-file upload support for regular and admin upload flows
- add browser folder selection and folder drag-and-drop handling for bulk uploads
- keep request fulfillment constrained to a single uploaded file
- skip unsupported files when importing from a selected folder and report partial failures for direct multi-file uploads

## Notes
This addresses the browser bulk-upload portion of #286. Server-side watched folder import is intentionally not included in this branch and can be discussed separately.

## Verification
- `bundle exec rails test test/controllers/uploads_controller_test.rb test/controllers/admin/uploads_controller_test.rb`
- `bundle exec rails test`
- `bin/quality push`
- browser-tested admin bulk upload selection and submission flow