### PR TITLE
feat: add LibriVox source

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -190,6 +190,19 @@ module Admin
       end
     end
 
+    def test_librivox
+      unless LibrivoxClient.configured?
+        respond_with_flash(alert: "LibriVox is not enabled.")
+        return
+      end
+
+      if LibrivoxClient.test_connection
+        respond_with_flash(notice: "LibriVox connection successful!")
+      else
+        respond_with_flash(alert: "LibriVox connection failed.")
+      end
+    end
+
     def test_oidc
       unless SettingsService.get(:oidc_enabled, default: false)
         respond_with_flash(alert: "OIDC is not enabled. Enable it first.")
@@ -366,6 +379,9 @@ module Admin
       end
       if changed_keys.any? { |k| k.start_with?("zlibrary") }
         ZLibraryClient.reset_connection!
+      end
+      if changed_keys.any? { |k| k.start_with?("librivox") }
+        LibrivoxClient.reset_connection!
       end
       if changed_keys.any? { |k| k.start_with?("hardcover") }
         HardcoverClient.reset_connection!

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -2,11 +2,14 @@
 
 require "net/http"
 require "uri"
+require "tempfile"
 
 class DownloadJob < ApplicationJob
   queue_as :default
 
   MAX_DIRECT_DOWNLOAD_BYTES = 512.megabytes
+  MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES = 2.gigabytes
+  MAX_DIRECT_DOWNLOAD_REDIRECTS = 5
 
   def perform(download_id)
     download = Download.find_by(id: download_id)
@@ -42,6 +45,8 @@ class DownloadJob < ApplicationJob
         handle_anna_archive_download(download, search_result)
       elsif search_result.from_zlibrary?
         handle_zlibrary_download(download, search_result)
+      elsif search_result.from_librivox?
+        handle_librivox_download(download, search_result)
       else
         handle_standard_download(download, search_result)
       end
@@ -75,6 +80,11 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Z-Library error: #{e.message}")
+    rescue LibrivoxClient::Error => e
+      Rails.logger.error "[DownloadJob] LibriVox error for download ##{download.id}: #{e.message}"
+      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+      download.update!(status: :failed)
+      download.request.mark_for_attention!("LibriVox error: #{e.message}")
     end
   end
 
@@ -107,6 +117,49 @@ class DownloadJob < ApplicationJob
     download_url = ZLibraryClient.get_download_url(id: book_id, hash: file_hash)
 
     handle_direct_http_download(download, search_result, download_url)
+  end
+
+  def handle_librivox_download(download, search_result)
+    raise LibrivoxClient::Error, "Selected LibriVox result is missing a download URL" if search_result.download_url.blank?
+
+    book = download.request.book
+    base_path = SettingsService.get(:audiobook_output_path, default: "/audiobooks")
+    destination_dir = PathTemplateService.build_destination(book, base_path: base_path)
+
+    Rails.logger.info "[DownloadJob] Downloading LibriVox audiobook to: #{destination_dir}"
+    FileUtils.mkdir_p(destination_dir)
+
+    Tempfile.create([ "shelfarr-librivox-", ".zip" ]) do |archive|
+      archive.binmode
+      download_file_via_http(
+        search_result,
+        search_result.download_url,
+        archive.path,
+        max_bytes: MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES
+      )
+      verify_downloaded_zip!(archive.path)
+      extract_zip_to_directory(archive.path, destination_dir)
+    end
+
+    download.update!(
+      status: :completed,
+      download_path: destination_dir,
+      download_type: "direct"
+    )
+
+    book.update!(file_path: destination_dir)
+    download.request.complete!
+    trigger_library_scan(book) if AudiobookshelfClient.configured?
+    NotificationService.request_completed(download.request)
+    track_request_event(download.request, "completed", download: download, message: "LibriVox download completed")
+
+    Rails.logger.info "[DownloadJob] LibriVox download completed: #{destination_dir}"
+  rescue => e
+    Rails.logger.error "[DownloadJob] LibriVox download failed: #{e.message}"
+    Rails.logger.error e.backtrace.first(5).join("\n")
+    track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
+    download.update!(status: :failed)
+    download.request.mark_for_attention!("LibriVox download failed: #{e.message}")
   end
 
   def handle_direct_http_download(download, search_result, download_url)
@@ -218,34 +271,62 @@ class DownloadJob < ApplicationJob
     result
   end
 
-  def download_file_via_http(search_result, url, destination)
+  def download_file_via_http(search_result, url, destination, max_bytes: MAX_DIRECT_DOWNLOAD_BYTES)
     uri = validate_direct_download_url!(url, search_result)
 
     Rails.logger.info "[DownloadJob] Starting HTTP download..."
 
     bytes_written = 0
+    redirects_followed = 0
+    download_complete = false
 
-    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 30, read_timeout: 300) do |http|
-      request = Net::HTTP::Get.new(uri)
-      request["User-Agent"] = "Shelfarr/1.0"
+    loop do
+      response_handled = false
 
-      http.request(request) do |response|
-        raise "Direct download failed with status #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 30, read_timeout: 300) do |http|
+        request = Net::HTTP::Get.new(uri)
+        request["User-Agent"] = "Shelfarr/1.0"
 
-        validate_direct_download_response_headers!(
-          content_type: response["Content-Type"],
-          content_length: response["Content-Length"]
-        )
+        http.request(request) do |response|
+          if response.is_a?(Net::HTTPRedirection)
+            redirects_followed += 1
+            raise "Direct download exceeded redirect limit" if redirects_followed > MAX_DIRECT_DOWNLOAD_REDIRECTS
 
-        File.open(destination, "wb") do |dest|
-          response.read_body do |chunk|
-            bytes_written += chunk.bytesize
-            raise "Direct download exceeds size limit of #{MAX_DIRECT_DOWNLOAD_BYTES / 1.megabyte} MB" if bytes_written > MAX_DIRECT_DOWNLOAD_BYTES
+            location = response["Location"]
+            raise "Direct download redirect missing Location" if location.blank?
 
-            dest.write(chunk)
+            uri = validate_direct_download_url!(URI.join(uri, normalize_direct_download_url(location)).to_s, search_result)
+            Rails.logger.info "[DownloadJob] Following HTTP redirect to #{uri.host}"
+            response_handled = true
+            next
           end
+
+          raise "Direct download failed with status #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+          validate_direct_download_response_headers!(
+            content_type: response["Content-Type"],
+            content_length: response["Content-Length"],
+            max_bytes: max_bytes
+          )
+
+          File.open(destination, "wb") do |dest|
+            response.read_body do |chunk|
+              bytes_written += chunk.bytesize
+              raise "Direct download exceeds size limit of #{max_bytes / 1.megabyte} MB" if bytes_written > max_bytes
+
+              dest.write(chunk)
+            end
+          end
+
+          response_handled = true
+          download_complete = true
         end
       end
+
+      break if download_complete
+      next if response_handled
+
+      raise "Direct download failed without a response"
     end
 
     file_size = File.size(destination)
@@ -255,7 +336,7 @@ class DownloadJob < ApplicationJob
   end
 
   def validate_direct_download_url!(url, search_result = nil)
-    uri = URI.parse(url)
+    uri = URI.parse(normalize_direct_download_url(url))
     raise "Invalid direct download URL" unless %w[http https].include?(uri.scheme) && uri.host.present?
 
     uri
@@ -263,7 +344,11 @@ class DownloadJob < ApplicationJob
     raise "Invalid direct download URL: #{e.message}"
   end
 
-  def validate_direct_download_response_headers!(content_type:, content_length:)
+  def normalize_direct_download_url(url)
+    url.to_s.strip.gsub(" ", "%20")
+  end
+
+  def validate_direct_download_response_headers!(content_type:, content_length:, max_bytes: MAX_DIRECT_DOWNLOAD_BYTES)
     normalized_content_type = content_type.to_s.split(";").first.to_s.downcase
 
     if normalized_content_type.present? &&
@@ -275,8 +360,8 @@ class DownloadJob < ApplicationJob
     end
 
     length = content_length.to_i if content_length.present?
-    if length.present? && length > MAX_DIRECT_DOWNLOAD_BYTES
-      raise "Direct download exceeds size limit of #{MAX_DIRECT_DOWNLOAD_BYTES / 1.megabyte} MB"
+    if length.present? && length > max_bytes
+      raise "Direct download exceeds size limit of #{max_bytes / 1.megabyte} MB"
     end
   end
 
@@ -304,6 +389,52 @@ class DownloadJob < ApplicationJob
     end
   rescue Errno::ENOENT => e
     raise "Downloaded file is missing: #{e.message}"
+  end
+
+  def verify_downloaded_zip!(path)
+    raise "Downloaded file does not exist" unless File.exist?(path)
+
+    file_size = File.size(path)
+    raise "Downloaded file is empty" if file_size.zero?
+
+    head = File.binread(path, [ 512, file_size ].min)
+    lowered = head.downcase
+    if lowered.include?("<html") || lowered.include?("<!doctype")
+      FileUtils.rm_f(path)
+      raise "Downloaded file is an HTML page, not an audiobook archive"
+    end
+
+    raise "Downloaded file is not a valid ZIP archive" unless head.start_with?("PK\x03\x04")
+  rescue Errno::ENOENT => e
+    raise "Downloaded file is missing: #{e.message}"
+  end
+
+  def extract_zip_to_directory(zip_path, destination_dir)
+    require "zip"
+
+    destination_root = File.expand_path(destination_dir)
+    extracted_files = 0
+
+    Zip::File.open(zip_path) do |zipfile|
+      zipfile.each do |entry|
+        next if entry.directory?
+
+        target = File.expand_path(File.join(destination_root, entry.name))
+        unless target.start_with?("#{destination_root}#{File::SEPARATOR}")
+          raise "ZIP archive contains an unsafe path: #{entry.name}"
+        end
+
+        FileUtils.mkdir_p(File.dirname(target))
+        entry.get_input_stream do |input|
+          File.open(target, "wb") { |output| IO.copy_stream(input, output) }
+        end
+        extracted_files += 1
+      end
+    end
+
+    raise "ZIP archive did not contain any files" if extracted_files.zero?
+  rescue Zip::Error => e
+    raise "Failed to extract audiobook archive: #{e.message}"
   end
 
   def trigger_library_scan(book)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -17,10 +17,11 @@ class SearchJob < ApplicationJob
     indexer_available = IndexerClient.configured?
     anna_available = AnnaArchiveClient.configured? && request.book.ebook?
     zlibrary_available = !anna_available && ZLibraryClient.configured? && request.book.ebook?
+    librivox_available = LibrivoxClient.configured? && request.book.audiobook?
 
-    unless indexer_available || anna_available || zlibrary_available
+    unless indexer_available || anna_available || zlibrary_available || librivox_available
       Rails.logger.error "[SearchJob] No search sources configured"
-      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, or Z-Library in Admin Settings.")
+      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, Z-Library, or LibriVox in Admin Settings.")
       return
     end
 
@@ -44,6 +45,12 @@ class SearchJob < ApplicationJob
       zlibrary_results = search_zlibrary(request)
       all_results.concat(zlibrary_results)
       Rails.logger.info "[SearchJob] Found #{zlibrary_results.count} Z-Library results"
+    end
+
+    if librivox_available
+      librivox_results = search_librivox(request)
+      all_results.concat(librivox_results)
+      Rails.logger.info "[SearchJob] Found #{librivox_results.count} LibriVox results"
     end
 
     if all_results.any?
@@ -179,6 +186,19 @@ class SearchJob < ApplicationJob
     []
   end
 
+  def search_librivox(request)
+    book = request.book
+    language = request.effective_language
+    Rails.logger.debug "[SearchJob] Searching LibriVox for title='#{book.title}' author='#{book.author}' (language: #{language})"
+
+    LibrivoxClient.search(title: book.title, author: book.author, language: language).map do |result|
+      { result: result, source: SearchResult::SOURCE_LIBRIVOX }
+    end
+  rescue LibrivoxClient::Error => e
+    Rails.logger.warn "[SearchJob] LibriVox search failed: #{e.message}"
+    []
+  end
+
   def save_results(request, tagged_results)
     request.search_results.destroy_all
 
@@ -191,6 +211,8 @@ class SearchJob < ApplicationJob
         save_anna_archive_result(request, result)
       when SearchResult::SOURCE_ZLIBRARY
         save_zlibrary_result(request, result)
+      when SearchResult::SOURCE_LIBRIVOX
+        save_librivox_result(request, result)
       else
         save_indexer_result(request, result, source)
       end
@@ -249,6 +271,32 @@ class SearchJob < ApplicationJob
       sr.source = SearchResult::SOURCE_ZLIBRARY
       sr.detected_language = result.language
     end
+  end
+
+  def save_librivox_result(request, result)
+    request.search_results.find_or_create_by!(guid: "librivox:#{result.id}") do |sr|
+      sr.title = build_librivox_title(result)
+      sr.indexer = "LibriVox"
+      sr.size_bytes = nil
+      sr.seeders = nil
+      sr.leechers = nil
+      sr.download_url = result.download_url
+      sr.magnet_url = nil
+      sr.info_url = result.info_url
+      sr.published_at = nil
+      sr.source = SearchResult::SOURCE_LIBRIVOX
+      sr.detected_language = result.language
+    end
+  end
+
+  def build_librivox_title(result)
+    parts = []
+    parts << result.title if result.title.present?
+    parts << "- #{result.author}" if result.author.present?
+    parts << "[AUDIOBOOK ZIP]"
+    parts << "[#{result.language_display_name}]" if result.respond_to?(:language_display_name) && result.language_display_name.present?
+    parts << "(#{result.year})" if result.year.present?
+    parts.join(" ")
   end
 
   def build_direct_source_title(result)

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -17,6 +17,7 @@ class SearchResult < ApplicationRecord
   SOURCE_JACKETT = "jackett"
   SOURCE_ANNA_ARCHIVE = "anna_archive"
   SOURCE_ZLIBRARY = "zlibrary"
+  SOURCE_LIBRIVOX = "librivox"
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
   validates :title, presence: true
@@ -28,7 +29,7 @@ class SearchResult < ApplicationRecord
     type_order_sql = ordered_types.each_with_index.map { |type, index| "WHEN '#{type}' THEN #{index}" }.join(" ")
     download_type_sql = <<~SQL.squish
       CASE
-        WHEN source IN ('#{SOURCE_ANNA_ARCHIVE}', '#{SOURCE_ZLIBRARY}') THEN 'direct'
+        WHEN source IN ('#{SOURCE_ANNA_ARCHIVE}', '#{SOURCE_ZLIBRARY}', '#{SOURCE_LIBRIVOX}') THEN 'direct'
         WHEN download_url IS NOT NULL AND magnet_url IS NULL AND seeders IS NULL THEN 'usenet'
         ELSE 'torrent'
       END
@@ -76,7 +77,7 @@ class SearchResult < ApplicationRecord
   end
 
   def direct_download?
-    from_anna_archive? || from_zlibrary?
+    from_anna_archive? || from_zlibrary? || from_librivox?
   end
 
   def download_type
@@ -196,6 +197,10 @@ class SearchResult < ApplicationRecord
     source == SOURCE_ZLIBRARY
   end
 
+  def from_librivox?
+    source == SOURCE_LIBRIVOX
+  end
+
   def source_display_name
     case source
     when SOURCE_JACKETT
@@ -204,6 +209,8 @@ class SearchResult < ApplicationRecord
       "Anna's Archive"
     when SOURCE_ZLIBRARY
       "Z-Library"
+    when SOURCE_LIBRIVOX
+      "LibriVox"
     else
       indexer.presence || "Prowlarr"
     end

--- a/app/services/librivox_client.rb
+++ b/app/services/librivox_client.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "uri"
+
+class LibrivoxClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class NotConfiguredError < Error; end
+  class ConfigurationError < Error; end
+
+  Result = Data.define(
+    :id, :title, :author, :language, :year,
+    :file_type, :download_url, :info_url, :duration
+  ) do
+    def downloadable?
+      download_url.present?
+    end
+
+    def language_display_name
+      return nil if language.blank?
+
+      ReleaseParserService.language_info(language)&.dig(:name) || language
+    end
+  end
+
+  DEFAULT_BASE_URL = "https://librivox.org"
+  ALLOWED_BASE_URL_SCHEMES = %w[http https].freeze
+
+  class << self
+    def configured?
+      SettingsService.librivox_configured?
+    end
+
+    def test_connection
+      search(title: nil, limit: 1)
+      true
+    rescue Error => e
+      Rails.logger.error "[LibrivoxClient] Connection test failed: #{e.message}"
+      false
+    end
+
+    def search(title:, author: nil, language: nil, limit: nil)
+      ensure_configured!
+
+      response = request do
+        connection.get("/api/feed/audiobooks/") do |req|
+          req.params["format"] = "json"
+          req.params["extended"] = "1"
+          req.params["coverart"] = "1"
+          req.params["limit"] = limit || SettingsService.get(:librivox_search_limit, default: 20)
+          req.params["title"] = title if title.present?
+          req.params["author"] = author_last_name(author) if title.blank? && author.present?
+        end
+      end
+
+      return [] if response.status == 404
+
+      raise ConnectionError, "LibriVox search failed with status #{response.status}" unless response.status == 200
+
+      parse_results(response.body, language: language)
+    rescue JSON::ParserError => e
+      raise ConnectionError, "Failed to parse LibriVox response: #{e.message}"
+    end
+
+    def reset_connection!
+      @connection = nil
+    end
+
+    private
+
+    def ensure_configured!
+      raise NotConfiguredError, "LibriVox is not enabled" unless configured?
+      base_url
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: base_url) do |f|
+        f.request :url_encoded
+        f.response :json, parser_options: { symbolize_names: false }, content_type: /\bjson$/
+        f.adapter Faraday.default_adapter
+        f.headers["User-Agent"] = "Shelfarr/1.0"
+        f.options.timeout = 30
+        f.options.open_timeout = 10
+      end
+    end
+
+    def request
+      yield
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise ConnectionError, "Failed to connect to LibriVox: #{e.message}"
+    rescue URI::Error, ArgumentError => e
+      raise ConnectionError, "Invalid LibriVox URL: #{e.message}"
+    end
+
+    def base_url
+      normalize_base_url(SettingsService.get(:librivox_url, default: DEFAULT_BASE_URL))
+    end
+
+    def normalize_base_url(url)
+      value = url.to_s.strip.presence || DEFAULT_BASE_URL
+      uri = URI.parse(value)
+
+      unless ALLOWED_BASE_URL_SCHEMES.include?(uri.scheme) && uri.host.present?
+        raise ConfigurationError, "LibriVox URL must be a valid http or https URL"
+      end
+
+      if uri.path.present? && uri.path != "/"
+        raise ConfigurationError, "LibriVox URL must not include a path"
+      end
+
+      if uri.query.present? || uri.fragment.present? || uri.userinfo.present?
+        raise ConfigurationError, "LibriVox URL must only include the site origin"
+      end
+
+      uri.to_s.delete_suffix("/")
+    rescue URI::InvalidURIError => e
+      raise ConfigurationError, "LibriVox URL is invalid: #{e.message}"
+    end
+
+    def parse_results(body, language:)
+      data = body.is_a?(Hash) ? body : JSON.parse(body)
+      books = Array(data["books"])
+      requested_language = language.to_s.presence
+
+      books.filter_map do |book|
+        result = parse_book(book)
+        next unless result&.downloadable?
+        next if requested_language.present? && result.language.present? && result.language != requested_language
+
+        result
+      end
+    end
+
+    def parse_book(book)
+      id = book["id"].to_s
+      title = book["title"].to_s.strip
+      download_url = normalize_download_url(book["url_zip_file"])
+      return if id.blank? || title.blank? || download_url.blank?
+
+      Result.new(
+        id: id,
+        title: title,
+        author: author_name(book["authors"]),
+        language: language_code(book["language"]),
+        year: book["copyright_year"].presence,
+        file_type: "audiobook zip",
+        download_url: download_url,
+        info_url: book["url_librivox"].presence || book["url_project"].presence,
+        duration: book["totaltime"].presence
+      )
+    end
+
+    def author_name(authors)
+      first = Array(authors).first
+      return if first.blank?
+
+      [ first["first_name"], first["last_name"] ].compact_blank.join(" ").presence
+    end
+
+    def author_last_name(author)
+      value = author.to_s.strip
+      return value.split(",", 2).first.strip if value.include?(",")
+
+      value.split(/\s+/).last
+    end
+
+    def normalize_download_url(url)
+      url.to_s.strip.gsub(" ", "%20")
+    end
+
+    def language_code(value)
+      normalized = value.to_s.strip.downcase
+      return if normalized.blank?
+
+      ReleaseParserService::LANGUAGES.find do |_, info|
+        info[:name].downcase == normalized
+      end&.first
+    end
+  end
+end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -13,7 +13,7 @@ class SettingsService
     },
     "direct" => {
       label: "Direct",
-      description: "Integration downloads such as Anna's Archive and Z-Library"
+      description: "Integration downloads such as Anna's Archive, Z-Library, and LibriVox"
     }
   }.freeze
 
@@ -112,6 +112,11 @@ class SettingsService
     zlibrary_email: { type: "string", default: "", category: "zlibrary", description: "Z-Library account email used for login" },
     zlibrary_password: { type: "string", default: "", category: "zlibrary", description: "Z-Library account password used for login" },
 
+    # LibriVox
+    librivox_enabled: { type: "boolean", default: false, category: "librivox", description: "Enable LibriVox as a free public-domain audiobook source" },
+    librivox_url: { type: "string", default: "https://librivox.org", category: "librivox", description: "LibriVox base URL" },
+    librivox_search_limit: { type: "integer", default: 20, category: "librivox", description: "Maximum number of LibriVox audiobook results to return" },
+
     # Hardcover Integration
     hardcover_api_token: { type: "string", default: "", category: "hardcover", description: "API token from Hardcover account settings (hardcover.app/account/api)" },
     metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Primary metadata source: auto (Hardcover first, OpenLibrary fallback), hardcover, or openlibrary" },
@@ -158,6 +163,7 @@ class SettingsService
     "audiobookshelf" => "Audiobookshelf",
     "anna_archive" => "Anna's Archive",
     "zlibrary" => "Z-Library",
+    "librivox" => "LibriVox",
     "hardcover" => "Hardcover",
     "paths" => "Output Paths",
     "queue" => "Queue Settings",
@@ -292,6 +298,10 @@ class SettingsService
         configured?(:zlibrary_url) &&
         configured?(:zlibrary_email) &&
         configured?(:zlibrary_password)
+    end
+
+    def librivox_configured?
+      get(:librivox_enabled, default: false) && configured?(:librivox_url)
     end
 
     def flaresolverr_configured?

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -3,7 +3,7 @@
   tab_groups = {
     "search" => {
       label: "Search",
-      categories: %w[indexer anna_archive zlibrary language auto_select]
+      categories: %w[indexer anna_archive zlibrary librivox language auto_select]
     },
     "downloads" => {
       label: "Downloads",
@@ -257,6 +257,16 @@
                     </div>
                     <div class="md:w-2/3">
                       <%= link_to "Test Z-Library Connection", test_zlibrary_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "librivox" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Connection Check</span>
+                      <p class="text-sm text-gray-500">Verify the LibriVox catalog API is reachable.</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test LibriVox Connection", test_librivox_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
                     </div>
                   </div>
                 <% elsif category == "webhook" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
         post :test_audiobookshelf
         post :test_flaresolverr
         post :test_zlibrary
+        post :test_librivox
         post :test_hardcover
         post :test_oidc
         post :test_webhook

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -284,6 +284,17 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Test Z-Library Connection"
   end
 
+  test "index shows LibriVox settings and test button" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label", text: "Librivox Enabled"
+    assert_select "input[name='settings[librivox_enabled]']"
+    assert_select "input[name='settings[librivox_url]']"
+    assert_select "input[name='settings[librivox_search_limit]']"
+    assert_select "a", text: "Test LibriVox Connection"
+  end
+
   test "index shows Anna's Archive URL list setting" do
     get admin_settings_url
 
@@ -732,6 +743,37 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     ZLibraryClient.stub :test_connection, false do
       post test_zlibrary_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /failed/i, flash[:alert]
+  end
+
+  test "test_librivox fails when disabled" do
+    SettingsService.set(:librivox_enabled, false)
+
+    post test_librivox_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match /not enabled/i, flash[:alert]
+  end
+
+  test "test_librivox succeeds when connection works" do
+    SettingsService.set(:librivox_enabled, true)
+
+    LibrivoxClient.stub :test_connection, true do
+      post test_librivox_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /successful/i, flash[:notice]
+  end
+
+  test "test_librivox fails when connection fails" do
+    SettingsService.set(:librivox_enabled, true)
+
+    LibrivoxClient.stub :test_connection, false do
+      post test_librivox_admin_settings_url
     end
 
     assert_redirected_to admin_settings_path

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 require "base64"
 require "bencode"
 require "digest/sha1"
+require "tempfile"
 
 class DownloadJobTest < ActiveJob::TestCase
   setup do
@@ -428,6 +429,55 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_equal "direct", @zlibrary_download.download_type
   end
 
+  test "librivox download extracts audiobook zip into audiobook output path" do
+    Dir.mktmpdir do |dir|
+      setup_librivox_download(output_path: dir)
+      zip_body = build_zip_archive("chapter_01.mp3" => "audio-data")
+
+      VCR.turned_off do
+        stub_request(:get, "https://archive.org/compress/test_librivox/formats=64KBPS%20MP3")
+          .to_return(
+            status: 302,
+            headers: {
+              "Location" => "https://ia801600.us.archive.org/zip_dir.php?path=/35/items/test_librivox.zip&formats=64KBPS MP3"
+            }
+          )
+        stub_request(:get, "https://ia801600.us.archive.org/zip_dir.php?path=/35/items/test_librivox.zip&formats=64KBPS%20MP3")
+          .to_return(status: 200, body: zip_body, headers: { "Content-Type" => "application/zip" })
+
+        DownloadJob.perform_now(@librivox_download.id)
+      end
+
+      @librivox_download.reload
+      @librivox_request.reload
+      assert @librivox_download.completed?
+      assert_equal "direct", @librivox_download.download_type
+      assert @librivox_request.completed?
+      assert_equal @librivox_request.book.file_path, @librivox_download.download_path
+      assert File.exist?(File.join(@librivox_download.download_path, "chapter_01.mp3"))
+    end
+  end
+
+  test "librivox download rejects unsafe zip paths" do
+    Dir.mktmpdir do |dir|
+      setup_librivox_download(output_path: dir)
+      zip_body = build_zip_archive("../escape.mp3" => "audio-data")
+
+      VCR.turned_off do
+        stub_request(:get, "https://archive.org/compress/test_librivox/formats=64KBPS%20MP3")
+          .to_return(status: 200, body: zip_body, headers: { "Content-Type" => "application/zip" })
+
+        DownloadJob.perform_now(@librivox_download.id)
+      end
+
+      @librivox_download.reload
+      @librivox_request.reload
+      assert @librivox_download.failed?
+      assert @librivox_request.attention_needed?
+      assert_not File.exist?(File.join(dir, "escape.mp3"))
+    end
+  end
+
   test "z-library download rejects html error pages" do
     setup_zlibrary_download
 
@@ -620,6 +670,45 @@ class DownloadJobTest < ActiveJob::TestCase
       size_bytes: 1_000_000,
       status: :queued
     )
+  end
+
+  def setup_librivox_download(output_path:)
+    SettingsService.set(:librivox_enabled, true)
+    SettingsService.set(:audiobook_output_path, output_path)
+
+    book = Book.create!(
+      title: "Test LibriVox Book",
+      author: "Jane Austen",
+      book_type: :audiobook
+    )
+    @librivox_request = Request.create!(book: book, user: users(:one), status: :downloading)
+    librivox_result = @librivox_request.search_results.create!(
+      guid: "librivox:253",
+      title: "Test LibriVox Book - Jane Austen [AUDIOBOOK ZIP] [English]",
+      indexer: "LibriVox",
+      source: SearchResult::SOURCE_LIBRIVOX,
+      download_url: "https://archive.org/compress/test_librivox/formats=64KBPS%20MP3",
+      status: :selected
+    )
+    @librivox_download = @librivox_request.downloads.create!(
+      name: librivox_result.title,
+      search_result: librivox_result,
+      status: :queued
+    )
+  end
+
+  def build_zip_archive(entries)
+    require "zip"
+
+    Tempfile.create([ "shelfarr-test-", ".zip" ]) do |file|
+      file.close
+      Zip::File.open(file.path, create: true) do |zipfile|
+        entries.each do |name, content|
+          zipfile.get_output_stream(name) { |stream| stream.write(content) }
+        end
+      end
+      File.binread(file.path)
+    end
   end
 
   def stub_qbittorrent_success

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -11,7 +11,10 @@ class SearchJobTest < ActiveJob::TestCase
     SettingsService.set(:zlibrary_url, "https://z-library.sk")
     SettingsService.set(:zlibrary_email, "")
     SettingsService.set(:zlibrary_password, "")
+    SettingsService.set(:librivox_enabled, false)
+    SettingsService.set(:librivox_url, "https://librivox.org")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
+    LibrivoxClient.reset_connection! if defined?(LibrivoxClient)
   end
 
   teardown do
@@ -19,7 +22,10 @@ class SearchJobTest < ActiveJob::TestCase
     SettingsService.set(:zlibrary_url, "https://z-library.sk")
     SettingsService.set(:zlibrary_email, "")
     SettingsService.set(:zlibrary_password, "")
+    SettingsService.set(:librivox_enabled, false)
+    SettingsService.set(:librivox_url, "https://librivox.org")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
+    LibrivoxClient.reset_connection! if defined?(LibrivoxClient)
   end
 
   test "updates request status to searching" do
@@ -600,6 +606,54 @@ class SearchJobTest < ActiveJob::TestCase
     @request.reload
     assert @request.not_found?
     assert_not @request.attention_needed?
+  end
+
+  test "includes librivox results for audiobook requests" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:librivox_enabled, true)
+    book = books(:audiobook_acquired)
+    request = Request.create!(book: book, user: users(:one), status: :pending, language: "en")
+    result = LibrivoxClient::Result.new(
+      id: "253",
+      title: "Pride and Prejudice",
+      author: "Jane Austen",
+      language: "en",
+      year: "1813",
+      file_type: "audiobook zip",
+      download_url: "https://archive.org/compress/pride_and_prejudice_librivox/formats=64KBPS%20MP3",
+      info_url: "https://librivox.org/pride-and-prejudice-by-jane-austen/",
+      duration: "13:06:44"
+    )
+
+    LibrivoxClient.stub :search, ->(title:, author:, language: nil, **) {
+      assert_equal book.title, title
+      assert_equal book.author, author
+      assert_equal "en", language
+      [ result ]
+    } do
+      SearchJob.perform_now(request.id)
+    end
+
+    request.reload
+    saved_result = request.search_results.first
+    assert_equal SearchResult::SOURCE_LIBRIVOX, saved_result.source
+    assert_equal "librivox:253", saved_result.guid
+    assert_equal "LibriVox", saved_result.indexer
+    assert_equal result.download_url, saved_result.download_url
+    assert_includes saved_result.title, "[AUDIOBOOK ZIP]"
+  end
+
+  test "skips librivox for ebook requests" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:librivox_enabled, true)
+
+    LibrivoxClient.stub :search, ->(*) { flunk "LibriVox should only be searched for audiobooks" } do
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    assert @request.attention_needed?
+    assert_includes @request.issue_description, "No search sources configured"
   end
 
   test "uses jackett when explicitly selected as the indexer provider" do

--- a/test/services/librivox_client_test.rb
+++ b/test/services/librivox_client_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LibrivoxClientTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:librivox_enabled, true)
+    SettingsService.set(:librivox_url, "https://librivox.org")
+    SettingsService.set(:librivox_search_limit, 10)
+    LibrivoxClient.reset_connection!
+  end
+
+  teardown do
+    SettingsService.set(:librivox_enabled, false)
+    SettingsService.set(:librivox_url, "https://librivox.org")
+    SettingsService.set(:librivox_search_limit, 20)
+    LibrivoxClient.reset_connection!
+  end
+
+  test "search raises when disabled" do
+    SettingsService.set(:librivox_enabled, false)
+
+    assert_raises LibrivoxClient::NotConfiguredError do
+      LibrivoxClient.search(title: "Pride and Prejudice")
+    end
+  end
+
+  test "search returns audiobook results" do
+    stub_request(:get, "https://librivox.org/api/feed/audiobooks/")
+      .with(query: hash_including(
+        "format" => "json",
+        "extended" => "1",
+        "coverart" => "1",
+        "limit" => "10",
+        "title" => "Pride and Prejudice"
+      ))
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          books: [
+            {
+              id: "253",
+              title: "Pride and Prejudice",
+              language: "English",
+              copyright_year: "1813",
+              url_zip_file: "https://archive.org/compress/pride_and_prejudice_librivox/formats=64KBPS MP3",
+              url_librivox: "https://librivox.org/pride-and-prejudice-by-jane-austen/",
+              totaltime: "13:06:44",
+              authors: [
+                { first_name: "Jane", last_name: "Austen" }
+              ]
+            }
+          ]
+        }.to_json
+      )
+
+    results = LibrivoxClient.search(title: "Pride and Prejudice", author: "Jane Austen", language: "en")
+
+    assert_equal 1, results.size
+    result = results.first
+    assert_equal "253", result.id
+    assert_equal "Pride and Prejudice", result.title
+    assert_equal "Jane Austen", result.author
+    assert_equal "en", result.language
+    assert_equal "audiobook zip", result.file_type
+    assert_equal "https://archive.org/compress/pride_and_prejudice_librivox/formats=64KBPS%20MP3", result.download_url
+    assert result.downloadable?
+  end
+
+  test "search filters mismatched languages" do
+    stub_request(:get, "https://librivox.org/api/feed/audiobooks/")
+      .with(query: hash_including(
+        "format" => "json",
+        "extended" => "1",
+        "coverart" => "1",
+        "limit" => "10",
+        "title" => "Le Livre"
+      ))
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          books: [
+            {
+              id: "1",
+              title: "Le Livre",
+              language: "French",
+              url_zip_file: "https://archive.org/compress/le_livre/formats=64KBPS%20MP3"
+            }
+          ]
+        }.to_json
+      )
+
+    assert_empty LibrivoxClient.search(title: "Le Livre", language: "en")
+  end
+
+  test "test_connection returns false on connection failure" do
+    stub_request(:get, "https://librivox.org/api/feed/audiobooks/")
+      .with(query: hash_including(
+        "format" => "json",
+        "extended" => "1",
+        "coverart" => "1",
+        "limit" => "1"
+      ))
+      .to_raise(Faraday::ConnectionFailed.new("offline"))
+
+    assert_not LibrivoxClient.test_connection
+  end
+
+  test "search returns empty array when LibriVox reports no audiobooks" do
+    stub_request(:get, "https://librivox.org/api/feed/audiobooks/")
+      .with(query: hash_including(
+        "format" => "json",
+        "extended" => "1",
+        "coverart" => "1",
+        "limit" => "10",
+        "title" => "Not A Real Book"
+      ))
+      .to_return(
+        status: 404,
+        headers: { "Content-Type" => "application/json" },
+        body: { error: "Audiobooks could not be found" }.to_json
+      )
+
+    assert_empty LibrivoxClient.search(title: "Not A Real Book")
+  end
+
+  test "configured URL must be an origin" do
+    SettingsService.set(:librivox_url, "https://librivox.org/api/feed")
+
+    assert_raises LibrivoxClient::ConfigurationError do
+      LibrivoxClient.search(title: "test")
+    end
+  end
+end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password]).delete_all
+    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password librivox_enabled librivox_url]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -73,5 +73,15 @@ class SettingsServiceTest < ActiveSupport::TestCase
 
     SettingsService.set(:zlibrary_enabled, false)
     assert_not SettingsService.zlibrary_configured?
+  end
+
+  test "librivox_configured? requires enabled flag and URL" do
+    SettingsService.set(:librivox_enabled, true)
+    SettingsService.set(:librivox_url, "https://librivox.org")
+
+    assert SettingsService.librivox_configured?
+
+    SettingsService.set(:librivox_enabled, false)
+    assert_not SettingsService.librivox_configured?
   end
 end


### PR DESCRIPTION
## Summary

Adds LibriVox as a public-domain audiobook source for Shelfarr.

## Changes

- Add `LibrivoxClient` for catalog API search and connection testing.
- Add LibriVox admin settings and a connection test action.
- Include LibriVox in audiobook searches and persist results as direct-download search results.
- Download LibriVox audiobook ZIPs directly, follow bounded Archive.org redirects, validate the ZIP response, and extract safely into the audiobook output path.
- Add targeted service, job, settings, and controller tests for the new source.

## Validation

- `bundle exec rails test test/jobs/download_job_test.rb test/services/librivox_client_test.rb test/jobs/search_job_test.rb test/controllers/admin/settings_controller_test.rb test/services/settings_service_test.rb`
- `bin/quality fast --staged`
- pre-commit `lefthook` quality gate
- pre-push `lefthook` quality gate
