### PR TITLE
fix(website): point hero Get Started button at the docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -718,7 +718,10 @@
                         audiobooks. Search, request, enjoy.
                     </p>
                     <div class="hero-buttons">
-                        <a href="#install" class="btn btn-primary">
+                        <a
+                            href="getting-started.html"
+                            class="btn btn-primary"
+                        >
                             Get Started
                         </a>
                         <a


### PR DESCRIPTION
## Summary
The landing page's hero **Get Started** button only scrolled to the on-page `#install` snippet, while the footer CTA (also labelled *Get Started*) already linked to the documentation. New users clicking the most prominent button never reached the setup guide.

Both *Get Started* buttons now link to `getting-started.html`, so the primary call-to-action lands on the full install + setup walkthrough.

The on-page *Quick Start with Docker* section is unchanged and still reachable by scrolling.