### PR TITLE
feat: add Project Gutenberg source

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -203,6 +203,19 @@ module Admin
       end
     end
 
+    def test_gutenberg
+      unless GutenbergClient.configured?
+        respond_with_flash(alert: "Project Gutenberg is not enabled.")
+        return
+      end
+
+      if GutenbergClient.test_connection
+        respond_with_flash(notice: "Project Gutenberg connection successful!")
+      else
+        respond_with_flash(alert: "Project Gutenberg connection failed.")
+      end
+    end
+
     def test_oidc
       unless SettingsService.get(:oidc_enabled, default: false)
         respond_with_flash(alert: "OIDC is not enabled. Enable it first.")
@@ -379,6 +392,9 @@ module Admin
       end
       if changed_keys.any? { |k| k.start_with?("zlibrary") }
         ZLibraryClient.reset_connection!
+      end
+      if changed_keys.any? { |k| k.start_with?("gutenberg") }
+        GutenbergClient.reset_connection!
       end
       if changed_keys.any? { |k| k.start_with?("librivox") }
         LibrivoxClient.reset_connection!

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -10,6 +10,7 @@ class DownloadJob < ApplicationJob
   MAX_DIRECT_DOWNLOAD_BYTES = 512.megabytes
   MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES = 2.gigabytes
   MAX_DIRECT_DOWNLOAD_REDIRECTS = 5
+  DIRECT_EBOOK_EXTENSIONS = %w[epub pdf mobi azw3].freeze
 
   def perform(download_id)
     download = Download.find_by(id: download_id)
@@ -233,36 +234,68 @@ class DownloadJob < ApplicationJob
     # URL-decode the filename (converts %20 to space, %3A to colon, etc.)
     filename_from_url = URI.decode_www_form_component(filename_from_url) if filename_from_url.present?
 
-    # If URL has a valid filename with extension, use it
-    if filename_from_url.present? && filename_from_url.include?(".")
-      return sanitize_filename(filename_from_url)
-    end
+    # If URL has a valid filename, use it after normalizing source-specific suffixes.
+    inferred_extension = infer_extension(url, search_result)
+    normalized_filename = normalize_url_filename(filename_from_url, inferred_extension)
+    return normalized_filename if normalized_filename.present?
 
     # Fall back to constructing from search result
     book = search_result.request.book
     title = book.title.presence || "Unknown"
     author = book.author.presence || "Unknown"
 
-    # Infer extension from search result or URL
-    extension = infer_extension(url, search_result)
-
-    sanitize_filename("#{author} - #{title}.#{extension}")
+    sanitize_filename("#{author} - #{title}.#{inferred_extension}")
   end
 
   def infer_extension(url, search_result)
+    normalized_url = url.to_s.downcase
+
     # Check URL for extension hints
-    return "epub" if url.include?("epub")
-    return "pdf" if url.include?("pdf")
-    return "mobi" if url.include?("mobi")
+    return "epub" if normalized_url.include?("epub")
+    return "pdf" if normalized_url.include?("pdf")
+    if normalized_url.include?("mobi") || normalized_url.include?("kf8") || normalized_url.match?(/\.kindle(\.|[?#]|\z)/)
+      return "mobi"
+    end
+    return "azw3" if normalized_url.include?("azw3")
 
     # Check search result title
     title = search_result.title.to_s.downcase
     return "epub" if title.include?("epub")
     return "pdf" if title.include?("pdf")
     return "mobi" if title.include?("mobi")
+    return "azw3" if title.include?("azw3")
 
     # Default to epub
     "epub"
+  end
+
+  def normalize_url_filename(filename, inferred_extension)
+    return nil if filename.blank?
+
+    current_extension = File.extname(filename).delete(".").downcase
+    return sanitize_filename(filename) if DIRECT_EBOOK_EXTENSIONS.include?(current_extension)
+    return nil unless filename.include?(".") && DIRECT_EBOOK_EXTENSIONS.include?(inferred_extension)
+    return nil unless url_filename_extension_hint?(filename, inferred_extension)
+
+    base = File.basename(filename, ".*")
+    base = base.sub(/\.epub3\z/i, "") if inferred_extension == "epub"
+    base = base.sub(/\.kf8\z/i, "") if inferred_extension == "mobi"
+    base = base.sub(/\.kindle\z/i, "") if inferred_extension == "mobi"
+    base = base.sub(/\.#{Regexp.escape(inferred_extension)}\z/i, "")
+    return nil if base.blank?
+
+    sanitize_filename("#{base}.#{inferred_extension}")
+  end
+
+  def url_filename_extension_hint?(filename, inferred_extension)
+    normalized = filename.to_s.downcase
+    extension = Regexp.escape(inferred_extension)
+
+    return true if normalized.match?(/\.#{extension}(\.|\z)/)
+    return true if inferred_extension == "epub" && normalized.match?(/\.epub3(\.|\z)/)
+    return true if inferred_extension == "mobi" && normalized.match?(/\.(kf8|kindle)(\.|\z)/)
+
+    false
   end
 
   def sanitize_filename(name)

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -45,6 +45,8 @@ class DownloadJob < ApplicationJob
         handle_anna_archive_download(download, search_result)
       elsif search_result.from_zlibrary?
         handle_zlibrary_download(download, search_result)
+      elsif search_result.from_gutenberg?
+        handle_gutenberg_download(download, search_result)
       elsif search_result.from_librivox?
         handle_librivox_download(download, search_result)
       else
@@ -85,6 +87,11 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("LibriVox error: #{e.message}")
+    rescue GutenbergClient::Error => e
+      Rails.logger.error "[DownloadJob] Project Gutenberg error for download ##{download.id}: #{e.message}"
+      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+      download.update!(status: :failed)
+      download.request.mark_for_attention!("Project Gutenberg error: #{e.message}")
     end
   end
 
@@ -117,6 +124,12 @@ class DownloadJob < ApplicationJob
     download_url = ZLibraryClient.get_download_url(id: book_id, hash: file_hash)
 
     handle_direct_http_download(download, search_result, download_url)
+  end
+
+  def handle_gutenberg_download(download, search_result)
+    raise GutenbergClient::Error, "Selected Project Gutenberg result is missing a download URL" if search_result.download_url.blank?
+
+    handle_direct_http_download(download, search_result, search_result.download_url)
   end
 
   def handle_librivox_download(download, search_result)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -17,11 +17,12 @@ class SearchJob < ApplicationJob
     indexer_available = IndexerClient.configured?
     anna_available = AnnaArchiveClient.configured? && request.book.ebook?
     zlibrary_available = !anna_available && ZLibraryClient.configured? && request.book.ebook?
+    gutenberg_available = GutenbergClient.configured? && request.book.ebook?
     librivox_available = LibrivoxClient.configured? && request.book.audiobook?
 
-    unless indexer_available || anna_available || zlibrary_available || librivox_available
+    unless indexer_available || anna_available || zlibrary_available || gutenberg_available || librivox_available
       Rails.logger.error "[SearchJob] No search sources configured"
-      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, Z-Library, or LibriVox in Admin Settings.")
+      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, Z-Library, Project Gutenberg, or LibriVox in Admin Settings.")
       return
     end
 
@@ -45,6 +46,12 @@ class SearchJob < ApplicationJob
       zlibrary_results = search_zlibrary(request)
       all_results.concat(zlibrary_results)
       Rails.logger.info "[SearchJob] Found #{zlibrary_results.count} Z-Library results"
+    end
+
+    if gutenberg_available
+      gutenberg_results = search_gutenberg(request)
+      all_results.concat(gutenberg_results)
+      Rails.logger.info "[SearchJob] Found #{gutenberg_results.count} Project Gutenberg results"
     end
 
     if librivox_available
@@ -199,6 +206,19 @@ class SearchJob < ApplicationJob
     []
   end
 
+  def search_gutenberg(request)
+    book = request.book
+    language = request.effective_language
+    Rails.logger.debug "[SearchJob] Searching Project Gutenberg for title='#{book.title}' author='#{book.author}' (language: #{language})"
+
+    GutenbergClient.search(title: book.title, author: book.author, language: language).map do |result|
+      { result: result, source: SearchResult::SOURCE_GUTENBERG }
+    end
+  rescue GutenbergClient::Error => e
+    Rails.logger.warn "[SearchJob] Project Gutenberg search failed: #{e.message}"
+    []
+  end
+
   def save_results(request, tagged_results)
     request.search_results.destroy_all
 
@@ -211,6 +231,8 @@ class SearchJob < ApplicationJob
         save_anna_archive_result(request, result)
       when SearchResult::SOURCE_ZLIBRARY
         save_zlibrary_result(request, result)
+      when SearchResult::SOURCE_GUTENBERG
+        save_gutenberg_result(request, result)
       when SearchResult::SOURCE_LIBRIVOX
         save_librivox_result(request, result)
       else
@@ -289,6 +311,22 @@ class SearchJob < ApplicationJob
     end
   end
 
+  def save_gutenberg_result(request, result)
+    request.search_results.find_or_create_by!(guid: "gutenberg:#{result.id}") do |sr|
+      sr.title = build_direct_source_title(result)
+      sr.indexer = "Project Gutenberg"
+      sr.size_bytes = nil
+      sr.seeders = nil
+      sr.leechers = nil
+      sr.download_url = result.download_url
+      sr.magnet_url = nil
+      sr.info_url = result.info_url
+      sr.published_at = nil
+      sr.source = SearchResult::SOURCE_GUTENBERG
+      sr.detected_language = result.language
+    end
+  end
+
   def build_librivox_title(result)
     parts = []
     parts << result.title if result.title.present?
@@ -304,6 +342,7 @@ class SearchJob < ApplicationJob
     parts << result.title if result.title.present?
     parts << "- #{result.author}" if result.author.present?
     parts << "[#{result.file_type.upcase}]" if result.file_type.present?
+    parts << "[#{result.language_display_name}]" if result.respond_to?(:language_display_name) && result.language_display_name.present?
     parts << "(#{result.year})" if result.year.present?
     parts.join(" ")
   end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -17,6 +17,7 @@ class SearchResult < ApplicationRecord
   SOURCE_JACKETT = "jackett"
   SOURCE_ANNA_ARCHIVE = "anna_archive"
   SOURCE_ZLIBRARY = "zlibrary"
+  SOURCE_GUTENBERG = "gutenberg"
   SOURCE_LIBRIVOX = "librivox"
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
@@ -29,7 +30,7 @@ class SearchResult < ApplicationRecord
     type_order_sql = ordered_types.each_with_index.map { |type, index| "WHEN '#{type}' THEN #{index}" }.join(" ")
     download_type_sql = <<~SQL.squish
       CASE
-        WHEN source IN ('#{SOURCE_ANNA_ARCHIVE}', '#{SOURCE_ZLIBRARY}', '#{SOURCE_LIBRIVOX}') THEN 'direct'
+        WHEN source IN ('#{SOURCE_ANNA_ARCHIVE}', '#{SOURCE_ZLIBRARY}', '#{SOURCE_GUTENBERG}', '#{SOURCE_LIBRIVOX}') THEN 'direct'
         WHEN download_url IS NOT NULL AND magnet_url IS NULL AND seeders IS NULL THEN 'usenet'
         ELSE 'torrent'
       END
@@ -77,7 +78,7 @@ class SearchResult < ApplicationRecord
   end
 
   def direct_download?
-    from_anna_archive? || from_zlibrary? || from_librivox?
+    from_anna_archive? || from_zlibrary? || from_gutenberg? || from_librivox?
   end
 
   def download_type
@@ -197,6 +198,10 @@ class SearchResult < ApplicationRecord
     source == SOURCE_ZLIBRARY
   end
 
+  def from_gutenberg?
+    source == SOURCE_GUTENBERG
+  end
+
   def from_librivox?
     source == SOURCE_LIBRIVOX
   end
@@ -209,6 +214,8 @@ class SearchResult < ApplicationRecord
       "Anna's Archive"
     when SOURCE_ZLIBRARY
       "Z-Library"
+    when SOURCE_GUTENBERG
+      "Project Gutenberg"
     when SOURCE_LIBRIVOX
       "LibriVox"
     else

--- a/app/services/gutenberg_client.rb
+++ b/app/services/gutenberg_client.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "nokogiri"
+require "uri"
+
+class GutenbergClient
+  class Error < StandardError; end
+  class ConfigurationError < Error; end
+  class ConnectionError < Error; end
+  class NotConfiguredError < Error; end
+
+  Result = Data.define(
+    :id, :title, :author, :language, :year,
+    :file_type, :download_url, :info_url
+  ) do
+    def downloadable?
+      download_url.present?
+    end
+
+    def language_display_name
+      return nil if language.blank?
+
+      ReleaseParserService.language_info(language)&.dig(:name) || language
+    end
+  end
+
+  DEFAULT_BASE_URL = "https://www.gutenberg.org"
+  USER_AGENT = "Shelfarr/1.0 (+https://github.com/Pedro-Revez-Silva/shelfarr)"
+
+  class << self
+    def configured?
+      SettingsService.gutenberg_configured?
+    end
+
+    def search(title:, author: nil, language: nil, limit: nil)
+      raise NotConfiguredError, "Project Gutenberg is not enabled" unless configured?
+
+      query = [ title, author ].compact_blank.join(" ")
+      return [] if query.blank?
+
+      response = connection.get("/ebooks/search.opds/") do |req|
+        req.params["query"] = query
+      end
+
+      return [] if response.status == 404
+      raise ConnectionError, "Project Gutenberg search failed with status #{response.status}" unless response.status == 200
+
+      search_entries = parse_search_entries(response.body)
+      search_entries.first(search_limit(limit)).filter_map do |entry|
+        fetch_book_result(entry, requested_language: language)
+      end
+    rescue Nokogiri::XML::SyntaxError => e
+      raise ConnectionError, "Failed to parse Project Gutenberg response: #{e.message}"
+    rescue Faraday::Error => e
+      raise ConnectionError, "Project Gutenberg request failed: #{e.message}"
+    end
+
+    def test_connection
+      raise NotConfiguredError, "Project Gutenberg is not enabled" unless configured?
+
+      search(title: "pride prejudice", language: "en", limit: 1)
+      true
+    rescue Error
+      false
+    end
+
+    def reset_connection!
+      @connection = nil
+      @base_url = nil
+    end
+
+    def base_url
+      @base_url ||= normalize_base_url(SettingsService.get(:gutenberg_url, default: DEFAULT_BASE_URL))
+    end
+
+    private
+
+    def connection
+      @connection ||= Faraday.new(url: base_url) do |faraday|
+        faraday.headers["User-Agent"] = USER_AGENT
+        faraday.options.timeout = 30
+        faraday.options.open_timeout = 10
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
+    def normalize_base_url(url)
+      uri = URI.parse(url.to_s.strip)
+      raise ConfigurationError, "Project Gutenberg URL must be a valid http or https URL" unless %w[http https].include?(uri.scheme)
+      raise ConfigurationError, "Project Gutenberg URL must include a host" if uri.host.blank?
+      raise ConfigurationError, "Project Gutenberg URL must only include the site origin" if uri.path.present? && uri.path != "/"
+      raise ConfigurationError, "Project Gutenberg URL must only include the site origin" if uri.query.present? || uri.fragment.present?
+
+      "#{uri.scheme}://#{uri.host}#{uri.port == uri.default_port ? '' : ":#{uri.port}"}"
+    rescue URI::InvalidURIError => e
+      raise ConfigurationError, "Project Gutenberg URL is invalid: #{e.message}"
+    end
+
+    def search_limit(limit)
+      requested = limit || SettingsService.get(:gutenberg_search_limit, default: 10)
+      requested.to_i.clamp(1, 25)
+    end
+
+    def parse_search_entries(body)
+      doc = parse_xml(body)
+      doc.xpath("//entry").filter_map do |entry|
+        href = entry.at_xpath("./link[@rel='subsection']/@href")&.value.presence || entry.at_xpath("./id")&.text
+        id = extract_book_id(href)
+        next if id.blank?
+
+        { id: id, path: book_opds_path(href, id) }
+      end.uniq { |entry| entry[:id] }
+    end
+
+    def fetch_book_result(entry, requested_language:)
+      response = connection.get(entry[:path])
+      return nil if response.status == 404
+      raise ConnectionError, "Project Gutenberg detail lookup failed with status #{response.status}" unless response.status == 200
+
+      parse_book_result(response.body, fallback_id: entry[:id], requested_language: requested_language)
+    end
+
+    def parse_book_result(body, fallback_id:, requested_language:)
+      entries = parse_xml(body).xpath("//entry")
+      candidates = entries.filter_map do |entry|
+        language = language_code(entry.at_xpath("./language")&.text)
+        next if requested_language.present? && language.present? && language != requested_language
+
+        format = preferred_download_format(entry.xpath("./link[contains(@rel, 'opds-spec.org/acquisition')]"))
+        next unless format
+
+        {
+          entry: entry,
+          format: format,
+          language: language
+        }
+      end
+
+      best = candidates.max_by { |candidate| candidate[:format][:score] }
+      return nil unless best
+
+      build_result(best[:entry], best[:format], fallback_id: fallback_id, language: best[:language])
+    end
+
+    def parse_xml(body)
+      Nokogiri::XML(body) { |config| config.nonet }.tap(&:remove_namespaces!)
+    end
+
+    def build_result(entry, format, fallback_id:, language:)
+      id = extract_book_id(entry.at_xpath("./id")&.text) || fallback_id
+      Result.new(
+        id: id,
+        title: entry.at_xpath("./title")&.text.to_s.strip,
+        author: entry.at_xpath("./author/name")&.text.to_s.strip.presence,
+        language: language,
+        year: nil,
+        file_type: format[:file_type],
+        download_url: normalize_download_url(format[:url]),
+        info_url: id.present? ? "https://www.gutenberg.org/ebooks/#{id}" : nil
+      )
+    end
+
+    def preferred_download_format(links)
+      links.filter_map do |link|
+        download_candidate(link)
+      end.max_by { |candidate| candidate[:score] }
+    end
+
+    def download_candidate(link)
+      mime_type = link["type"].to_s.split(";").first
+      href = link["href"].to_s.strip
+      return nil if href.blank?
+
+      title = link["title"].to_s
+      score = case mime_type
+      when "application/epub+zip"
+        300
+      when "application/x-mobipocket-ebook"
+        200
+      when "application/pdf"
+        100
+      end
+      return nil unless score
+
+      score += 40 if title.match?(/EPUB3/i)
+      score += 30 if title.match?(/images/i) && !title.match?(/no images/i)
+      score += 10 if title.match?(/\AKindle\z/i)
+
+      {
+        file_type: file_type_for_mime_type(mime_type),
+        url: href,
+        score: score
+      }
+    end
+
+    def file_type_for_mime_type(mime_type)
+      case mime_type
+      when "application/epub+zip"
+        "epub"
+      when "application/x-mobipocket-ebook"
+        "mobi"
+      when "application/pdf"
+        "pdf"
+      end
+    end
+
+    def extract_book_id(value)
+      value.to_s[/ebooks\/(\d+)/, 1] || value.to_s[/urn:gutenberg:(\d+)/, 1]
+    end
+
+    def book_opds_path(href, id)
+      uri = URI.join(base_url, href.to_s.presence || "/ebooks/#{id}.opds")
+      uri.request_uri
+    end
+
+    def language_code(language)
+      code = language.to_s.strip.downcase
+      return nil if code.blank?
+
+      code
+    end
+
+    def normalize_download_url(url)
+      URI.join(base_url, url.to_s.strip.gsub(" ", "%20")).to_s
+    end
+  end
+end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -13,7 +13,7 @@ class SettingsService
     },
     "direct" => {
       label: "Direct",
-      description: "Integration downloads such as Anna's Archive, Z-Library, and LibriVox"
+      description: "Integration downloads such as Anna's Archive, Z-Library, Project Gutenberg, and LibriVox"
     }
   }.freeze
 
@@ -117,6 +117,11 @@ class SettingsService
     librivox_url: { type: "string", default: "https://librivox.org", category: "librivox", description: "LibriVox base URL" },
     librivox_search_limit: { type: "integer", default: 20, category: "librivox", description: "Maximum number of LibriVox audiobook results to return" },
 
+    # Project Gutenberg
+    gutenberg_enabled: { type: "boolean", default: false, category: "gutenberg", description: "Enable Project Gutenberg as a free public-domain ebook source" },
+    gutenberg_url: { type: "string", default: "https://www.gutenberg.org", category: "gutenberg", description: "Project Gutenberg OPDS catalog base URL" },
+    gutenberg_search_limit: { type: "integer", default: 10, category: "gutenberg", description: "Maximum number of Project Gutenberg ebook results to return" },
+
     # Hardcover Integration
     hardcover_api_token: { type: "string", default: "", category: "hardcover", description: "API token from Hardcover account settings (hardcover.app/account/api)" },
     metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Primary metadata source: auto (Hardcover first, OpenLibrary fallback), hardcover, or openlibrary" },
@@ -163,6 +168,7 @@ class SettingsService
     "audiobookshelf" => "Audiobookshelf",
     "anna_archive" => "Anna's Archive",
     "zlibrary" => "Z-Library",
+    "gutenberg" => "Project Gutenberg",
     "librivox" => "LibriVox",
     "hardcover" => "Hardcover",
     "paths" => "Output Paths",
@@ -302,6 +308,10 @@ class SettingsService
 
     def librivox_configured?
       get(:librivox_enabled, default: false) && configured?(:librivox_url)
+    end
+
+    def gutenberg_configured?
+      get(:gutenberg_enabled, default: false) && configured?(:gutenberg_url)
     end
 
     def flaresolverr_configured?

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -3,7 +3,7 @@
   tab_groups = {
     "search" => {
       label: "Search",
-      categories: %w[indexer anna_archive zlibrary librivox language auto_select]
+      categories: %w[indexer anna_archive zlibrary gutenberg librivox language auto_select]
     },
     "downloads" => {
       label: "Downloads",
@@ -257,6 +257,16 @@
                     </div>
                     <div class="md:w-2/3">
                       <%= link_to "Test Z-Library Connection", test_zlibrary_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "gutenberg" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Connection Check</span>
+                      <p class="text-sm text-gray-500">Verify the Project Gutenberg OPDS catalog is reachable.</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test Project Gutenberg Connection", test_gutenberg_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
                     </div>
                   </div>
                 <% elsif category == "librivox" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
         post :test_audiobookshelf
         post :test_flaresolverr
         post :test_zlibrary
+        post :test_gutenberg
         post :test_librivox
         post :test_hardcover
         post :test_oidc

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -295,6 +295,17 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Test LibriVox Connection"
   end
 
+  test "index shows Project Gutenberg settings and test button" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label", text: "Gutenberg Enabled"
+    assert_select "input[name='settings[gutenberg_enabled]']"
+    assert_select "input[name='settings[gutenberg_url]']"
+    assert_select "input[name='settings[gutenberg_search_limit]']"
+    assert_select "a", text: "Test Project Gutenberg Connection"
+  end
+
   test "index shows Anna's Archive URL list setting" do
     get admin_settings_url
 
@@ -774,6 +785,37 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     LibrivoxClient.stub :test_connection, false do
       post test_librivox_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /failed/i, flash[:alert]
+  end
+
+  test "test_gutenberg fails when disabled" do
+    SettingsService.set(:gutenberg_enabled, false)
+
+    post test_gutenberg_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match /not enabled/i, flash[:alert]
+  end
+
+  test "test_gutenberg succeeds when connection works" do
+    SettingsService.set(:gutenberg_enabled, true)
+
+    GutenbergClient.stub :test_connection, true do
+      post test_gutenberg_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /successful/i, flash[:notice]
+  end
+
+  test "test_gutenberg fails when connection fails" do
+    SettingsService.set(:gutenberg_enabled, true)
+
+    GutenbergClient.stub :test_connection, false do
+      post test_gutenberg_admin_settings_url
     end
 
     assert_redirected_to admin_settings_path

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -418,6 +418,23 @@ class DownloadJobTest < ActiveJob::TestCase
     assert filename.end_with?(".epub") || filename.end_with?(".pdf") || filename.end_with?(".mobi")
   end
 
+  test "infer_filename_from_url normalizes Gutenberg pseudo extensions" do
+    job = DownloadJob.new
+
+    assert_equal "1342.epub", job.send(:infer_filename_from_url, "https://www.gutenberg.org/ebooks/1342.epub3.images?download=1", @selected_result)
+    assert_equal "2.mobi", job.send(:infer_filename_from_url, "https://www.gutenberg.org/ebooks/2.kf8.images", @selected_result)
+    assert_equal "3.mobi", job.send(:infer_filename_from_url, "https://www.gutenberg.org/ebooks/3.kindle.noimages", @selected_result)
+  end
+
+  test "infer_filename_from_url ignores unsupported URL extensions without ebook hints" do
+    job = DownloadJob.new
+    filename = job.send(:infer_filename_from_url, "https://example.com/download/release.v1", @selected_result)
+
+    assert_not_equal "release.epub", filename
+    assert_includes filename, @selected_result.request.book.author
+    assert_includes filename, @selected_result.request.book.title
+  end
+
   test "z-library download completes via direct http download" do
     setup_zlibrary_download
 
@@ -453,6 +470,7 @@ class DownloadJobTest < ActiveJob::TestCase
       assert_equal "direct", @gutenberg_download.download_type
       assert @gutenberg_request.completed?
       assert File.exist?(@gutenberg_download.download_path)
+      assert_equal "1342.epub", File.basename(@gutenberg_download.download_path)
       assert_equal File.dirname(@gutenberg_download.download_path), @gutenberg_request.book.file_path
     end
   end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -15,6 +15,8 @@ class DownloadJobTest < ActiveJob::TestCase
     SettingsService.set(:zlibrary_url, "https://z-library.sk")
     SettingsService.set(:zlibrary_email, "")
     SettingsService.set(:zlibrary_password, "")
+    SettingsService.set(:gutenberg_enabled, false)
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
 
     # Create a qBittorrent client
     @client = DownloadClient.create!(
@@ -31,6 +33,7 @@ class DownloadJobTest < ActiveJob::TestCase
     Thread.current[:qbittorrent_sessions] = {}
     Thread.current[:transmission_protocols] = {}
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
+    GutenbergClient.reset_connection! if defined?(GutenbergClient)
 
     # Create a queued download
     @download = @request.downloads.create!(
@@ -46,7 +49,10 @@ class DownloadJobTest < ActiveJob::TestCase
     SettingsService.set(:zlibrary_url, "https://z-library.sk")
     SettingsService.set(:zlibrary_email, "")
     SettingsService.set(:zlibrary_password, "")
+    SettingsService.set(:gutenberg_enabled, false)
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
+    GutenbergClient.reset_connection! if defined?(GutenbergClient)
   end
 
   test "updates download status to downloading on success" do
@@ -429,6 +435,28 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_equal "direct", @zlibrary_download.download_type
   end
 
+  test "Project Gutenberg download completes via direct http download" do
+    Dir.mktmpdir do |dir|
+      setup_gutenberg_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:get, "https://www.gutenberg.org/ebooks/1342.epub3.images")
+          .with(query: hash_including("download" => "1"))
+          .to_return(status: 200, body: "PK\x03\x04" + ("x" * 1024), headers: { "Content-Type" => "application/epub+zip" })
+
+        DownloadJob.perform_now(@gutenberg_download.id)
+      end
+
+      @gutenberg_download.reload
+      @gutenberg_request.reload
+      assert @gutenberg_download.completed?
+      assert_equal "direct", @gutenberg_download.download_type
+      assert @gutenberg_request.completed?
+      assert File.exist?(@gutenberg_download.download_path)
+      assert_equal File.dirname(@gutenberg_download.download_path), @gutenberg_request.book.file_path
+    end
+  end
+
   test "librivox download extracts audiobook zip into audiobook output path" do
     Dir.mktmpdir do |dir|
       setup_librivox_download(output_path: dir)
@@ -693,6 +721,31 @@ class DownloadJobTest < ActiveJob::TestCase
     @librivox_download = @librivox_request.downloads.create!(
       name: librivox_result.title,
       search_result: librivox_result,
+      status: :queued
+    )
+  end
+
+  def setup_gutenberg_download(output_path:)
+    SettingsService.set(:gutenberg_enabled, true)
+    SettingsService.set(:ebook_output_path, output_path)
+
+    book = Book.create!(
+      title: "Pride and Prejudice",
+      author: "Austen, Jane",
+      book_type: :ebook
+    )
+    @gutenberg_request = Request.create!(book: book, user: users(:one), status: :downloading)
+    gutenberg_result = @gutenberg_request.search_results.create!(
+      guid: "gutenberg:1342",
+      title: "Pride and Prejudice - Austen, Jane [EPUB]",
+      indexer: "Project Gutenberg",
+      source: SearchResult::SOURCE_GUTENBERG,
+      download_url: "https://www.gutenberg.org/ebooks/1342.epub3.images?download=1",
+      status: :selected
+    )
+    @gutenberg_download = @gutenberg_request.downloads.create!(
+      name: gutenberg_result.title,
+      search_result: gutenberg_result,
       status: :queued
     )
   end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -13,8 +13,11 @@ class SearchJobTest < ActiveJob::TestCase
     SettingsService.set(:zlibrary_password, "")
     SettingsService.set(:librivox_enabled, false)
     SettingsService.set(:librivox_url, "https://librivox.org")
+    SettingsService.set(:gutenberg_enabled, false)
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
     LibrivoxClient.reset_connection! if defined?(LibrivoxClient)
+    GutenbergClient.reset_connection! if defined?(GutenbergClient)
   end
 
   teardown do
@@ -24,8 +27,11 @@ class SearchJobTest < ActiveJob::TestCase
     SettingsService.set(:zlibrary_password, "")
     SettingsService.set(:librivox_enabled, false)
     SettingsService.set(:librivox_url, "https://librivox.org")
+    SettingsService.set(:gutenberg_enabled, false)
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
     LibrivoxClient.reset_connection! if defined?(LibrivoxClient)
+    GutenbergClient.reset_connection! if defined?(GutenbergClient)
   end
 
   test "updates request status to searching" do
@@ -641,6 +647,54 @@ class SearchJobTest < ActiveJob::TestCase
     assert_equal "LibriVox", saved_result.indexer
     assert_equal result.download_url, saved_result.download_url
     assert_includes saved_result.title, "[AUDIOBOOK ZIP]"
+  end
+
+  test "includes Project Gutenberg results for ebook requests" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:gutenberg_enabled, true)
+    result = GutenbergClient::Result.new(
+      id: "1342",
+      title: "Pride and Prejudice",
+      author: "Austen, Jane",
+      language: "en",
+      year: nil,
+      file_type: "epub",
+      download_url: "https://www.gutenberg.org/ebooks/1342.epub3.images?download=1",
+      info_url: "https://www.gutenberg.org/ebooks/1342"
+    )
+
+    GutenbergClient.stub :search, ->(title:, author:, language: nil, **) {
+      assert_equal @request.book.title, title
+      assert_equal @request.book.author, author
+      assert_equal "en", language
+      [ result ]
+    } do
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    saved_result = @request.search_results.first
+    assert_equal SearchResult::SOURCE_GUTENBERG, saved_result.source
+    assert_equal "gutenberg:1342", saved_result.guid
+    assert_equal "Project Gutenberg", saved_result.indexer
+    assert_equal result.download_url, saved_result.download_url
+    assert_equal "en", saved_result.detected_language
+    assert_includes saved_result.title, "[EPUB]"
+  end
+
+  test "skips Project Gutenberg for audiobook requests" do
+    SettingsService.set(:prowlarr_api_key, "")
+    SettingsService.set(:gutenberg_enabled, true)
+    book = books(:audiobook_acquired)
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    GutenbergClient.stub :search, ->(*) { flunk "Project Gutenberg should only be searched for ebooks" } do
+      SearchJob.perform_now(request.id)
+    end
+
+    request.reload
+    assert request.attention_needed?
+    assert_includes request.issue_description, "No search sources configured"
   end
 
   test "skips librivox for ebook requests" do

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -150,6 +150,19 @@ class SearchResultTest < ActiveSupport::TestCase
     assert anna_result.downloadable?, "Anna's Archive results should always be downloadable via API"
   end
 
+  test "downloadable? returns true for Project Gutenberg direct results" do
+    result = SearchResult.new(
+      request: requests(:pending_request),
+      guid: "gutenberg-1342",
+      title: "Project Gutenberg Book",
+      source: SearchResult::SOURCE_GUTENBERG,
+      download_url: "https://www.gutenberg.org/ebooks/1342.epub3.images"
+    )
+
+    assert result.downloadable?
+    assert_equal "direct", result.download_type
+  end
+
   test "download_link prefers magnet_url over download_url" do
     result = SearchResult.new(
       magnet_url: "magnet:?xt=test",
@@ -249,10 +262,12 @@ class SearchResultTest < ActiveSupport::TestCase
     assert SearchResult.new(source: SearchResult::SOURCE_JACKETT).from_indexer?
     assert SearchResult.new(source: SearchResult::SOURCE_ANNA_ARCHIVE).from_anna_archive?
     assert SearchResult.new(source: SearchResult::SOURCE_ZLIBRARY).from_zlibrary?
+    assert SearchResult.new(source: SearchResult::SOURCE_GUTENBERG).from_gutenberg?
 
     assert_equal "Custom Jackett", SearchResult.new(source: SearchResult::SOURCE_JACKETT, indexer: "Custom Jackett").source_display_name
     assert_equal "Anna's Archive", SearchResult.new(source: SearchResult::SOURCE_ANNA_ARCHIVE).source_display_name
     assert_equal "Z-Library", SearchResult.new(source: SearchResult::SOURCE_ZLIBRARY).source_display_name
+    assert_equal "Project Gutenberg", SearchResult.new(source: SearchResult::SOURCE_GUTENBERG).source_display_name
     assert_equal "Prowlarr", SearchResult.new.source_display_name
   end
 end

--- a/test/services/gutenberg_client_test.rb
+++ b/test/services/gutenberg_client_test.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GutenbergClientTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:gutenberg_enabled, true)
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
+    SettingsService.set(:gutenberg_search_limit, 10)
+    GutenbergClient.reset_connection!
+  end
+
+  teardown do
+    SettingsService.set(:gutenberg_enabled, false)
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
+    SettingsService.set(:gutenberg_search_limit, 10)
+    GutenbergClient.reset_connection!
+  end
+
+  test "search raises when disabled" do
+    SettingsService.set(:gutenberg_enabled, false)
+
+    assert_raises GutenbergClient::NotConfiguredError do
+      GutenbergClient.search(title: "Pride and Prejudice")
+    end
+  end
+
+  test "search returns ebook results from Project Gutenberg OPDS" do
+    stub_search_feed(query: "Pride and Prejudice Jane Austen", ids: [ 1342 ])
+    stub_detail_feed(
+      1342,
+      title: "Pride and Prejudice",
+      author: "Austen, Jane",
+      language: "en",
+      links: [
+        { type: "application/epub+zip", title: "EPUB (no images, older E-readers)", href: "https://www.gutenberg.org/ebooks/1342.epub.noimages" },
+        { type: "application/epub+zip", title: "EPUB3 (E-readers incl. Send-to-Kindle)", href: "https://www.gutenberg.org/ebooks/1342.epub3.images" }
+      ]
+    )
+
+    results = GutenbergClient.search(title: "Pride and Prejudice", author: "Jane Austen", language: "en")
+
+    assert_equal 1, results.size
+    result = results.first
+    assert_equal "1342", result.id
+    assert_equal "Pride and Prejudice", result.title
+    assert_equal "Austen, Jane", result.author
+    assert_equal "en", result.language
+    assert_equal "epub", result.file_type
+    assert_equal "https://www.gutenberg.org/ebooks/1342.epub3.images", result.download_url
+    assert_equal "https://www.gutenberg.org/ebooks/1342", result.info_url
+    assert result.downloadable?
+  end
+
+  test "search filters mismatched languages from detail feed" do
+    stub_search_feed(query: "Le Livre", ids: [ 123 ])
+    stub_detail_feed(
+      123,
+      title: "Le Livre",
+      author: "Auteur, Exemple",
+      language: "fr",
+      links: [
+        { type: "application/epub+zip", title: "EPUB3", href: "https://www.gutenberg.org/ebooks/123.epub3.images" }
+      ]
+    )
+
+    assert_empty GutenbergClient.search(title: "Le Livre", language: "en")
+  end
+
+  test "search filters results without supported ebook acquisition links" do
+    stub_search_feed(query: "Plain Text Only", ids: [ 1 ])
+    stub_detail_feed(
+      1,
+      title: "Plain Text Only",
+      author: "Writer, Test",
+      language: "en",
+      links: [
+        { type: "text/plain", title: "Plain Text UTF-8", href: "https://www.gutenberg.org/files/1/1-0.txt" }
+      ]
+    )
+
+    assert_empty GutenbergClient.search(title: "Plain Text Only")
+  end
+
+  test "search falls back to mobi when epub is unavailable" do
+    stub_search_feed(query: "Kindle Book", ids: [ 2 ])
+    stub_detail_feed(
+      2,
+      title: "Kindle Book",
+      author: "Writer, Test",
+      language: "en",
+      links: [
+        { type: "application/x-mobipocket-ebook", title: "Kindle", href: "/ebooks/2.kf8.images" }
+      ]
+    )
+
+    result = GutenbergClient.search(title: "Kindle Book").first
+
+    assert_equal "mobi", result.file_type
+    assert_equal "https://www.gutenberg.org/ebooks/2.kf8.images", result.download_url
+  end
+
+  test "search limits Project Gutenberg detail lookups" do
+    SettingsService.set(:gutenberg_search_limit, 1)
+    stub_search_feed(query: "Common Title", ids: [ 10, 11 ])
+    stub_detail_feed(
+      10,
+      title: "Common Title One",
+      author: "Writer, One",
+      language: "en",
+      links: [
+        { type: "application/epub+zip", title: "EPUB3", href: "/ebooks/10.epub3.images" }
+      ]
+    )
+
+    results = GutenbergClient.search(title: "Common Title")
+
+    assert_equal [ "10" ], results.map(&:id)
+    assert_not_requested :get, "https://www.gutenberg.org/ebooks/11.opds"
+  end
+
+  test "test_connection returns false on connection failure" do
+    stub_request(:get, "https://www.gutenberg.org/ebooks/search.opds/")
+      .with(query: hash_including(
+        "query" => "pride prejudice"
+      ))
+      .to_raise(Faraday::ConnectionFailed.new("offline"))
+
+    assert_not GutenbergClient.test_connection
+  end
+
+  test "configured URL must be an origin" do
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org/ebooks")
+
+    assert_raises GutenbergClient::ConfigurationError do
+      GutenbergClient.search(title: "test")
+    end
+  end
+
+  private
+
+  def stub_search_feed(query:, ids:)
+    entries = ids.map do |id|
+      <<~XML
+        <entry>
+          <id>https://www.gutenberg.org/ebooks/#{id}.opds</id>
+          <title>Book #{id}</title>
+          <content type="text">Author #{id}</content>
+          <link type="application/atom+xml;profile=opds-catalog" rel="subsection" href="/ebooks/#{id}.opds"/>
+        </entry>
+      XML
+    end.join
+
+    stub_request(:get, "https://www.gutenberg.org/ebooks/search.opds/")
+      .with(query: hash_including("query" => query))
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/atom+xml; charset=UTF-8" },
+        body: opds_feed(entries)
+      )
+  end
+
+  def stub_detail_feed(id, title:, author:, language:, links:)
+    link_xml = links.map do |link|
+      attrs = link.map { |key, value| %(#{key}="#{ERB::Util.html_escape(value)}") }.join(" ")
+      %(<link rel="http://opds-spec.org/acquisition" #{attrs}/>)
+    end.join("\n")
+
+    entry = <<~XML
+      <entry>
+        <id>urn:gutenberg:#{id}:3</id>
+        <title>#{ERB::Util.html_escape(title)}</title>
+        <author><name>#{ERB::Util.html_escape(author)}</name></author>
+        <dcterms:language>#{language}</dcterms:language>
+        #{link_xml}
+      </entry>
+    XML
+
+    stub_request(:get, "https://www.gutenberg.org/ebooks/#{id}.opds")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/atom+xml; charset=UTF-8" },
+        body: opds_feed(entry)
+      )
+  end
+
+  def opds_feed(entries)
+    <<~XML
+      <?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom"
+            xmlns:opds="http://opds-spec.org/2010/catalog"
+            xmlns:dcterms="http://purl.org/dc/terms/">
+        <id>https://www.gutenberg.org/ebooks/search.opds/</id>
+        <title>Project Gutenberg</title>
+        #{entries}
+      </feed>
+    XML
+  end
+end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password librivox_enabled librivox_url]).delete_all
+    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -83,5 +83,15 @@ class SettingsServiceTest < ActiveSupport::TestCase
 
     SettingsService.set(:librivox_enabled, false)
     assert_not SettingsService.librivox_configured?
+  end
+
+  test "gutenberg_configured? requires enabled flag and URL" do
+    SettingsService.set(:gutenberg_enabled, true)
+    SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
+
+    assert SettingsService.gutenberg_configured?
+
+    SettingsService.set(:gutenberg_enabled, false)
+    assert_not SettingsService.gutenberg_configured?
   end
 end


### PR DESCRIPTION
## Summary

- add Project Gutenberg as a direct ebook source using the official OPDS catalog
- surface Gutenberg settings and a connection test in Admin Settings
- save Gutenberg results as direct downloads and route them through the existing verified HTTP ebook download path
- cover OPDS parsing, source routing, settings, search, and download behavior with tests

## Testing

- `~/.rbenv/shims/bundle exec rails test test/services/gutenberg_client_test.rb test/services/settings_service_test.rb test/models/search_result_test.rb test/jobs/search_job_test.rb test/jobs/download_job_test.rb test/controllers/admin/settings_controller_test.rb`
- `~/.rbenv/shims/ruby bin/quality push`
- pre-commit hook: `bin/quality commit` via lefthook
- pre-push hook: `bin/quality push` via lefthook
- live OPDS smoke: searched Project Gutenberg for Pride and Prejudice and received EPUB result `1342`
- live direct download smoke: downloaded and verified the Gutenberg EPUB signature
- local Rails UI smoke: rendered Admin Settings, verified Gutenberg OPDS fields/button, toggled and restored Gutenberg settings

Completes the Gutenberg source portion of #288.
