### PR TITLE
feat: add configurable indexer search scope

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -67,16 +67,16 @@ class SearchJob < ApplicationJob
 
   def search_indexer_safely(request)
     results = search_indexer(request)
-    [results, nil]
+    [ results, nil ]
   rescue IndexerClients::Base::AuthenticationError => e
     Rails.logger.error "[SearchJob] #{IndexerClient.display_name} authentication failed: #{e.message}"
-    [[], e]
+    [ [], e ]
   rescue IndexerClients::Base::ConnectionError => e
     Rails.logger.error "[SearchJob] #{IndexerClient.display_name} connection error for request ##{request.id}: #{e.message}"
-    [[], e]
+    [ [], e ]
   rescue IndexerClients::Base::Error => e
     Rails.logger.error "[SearchJob] #{IndexerClient.display_name} error for request ##{request.id}: #{e.message}"
-    [[], e]
+    [ [], e ]
   end
 
   def handle_no_results(request, indexer_error)
@@ -114,17 +114,21 @@ class SearchJob < ApplicationJob
       author: book.author
     )
 
-    return structured_results if structured_results.any? && !book.ebook?
-
     fallback_query = generic_indexer_query(request)
-    if structured_results.any?
-      Rails.logger.info "[SearchJob] #{IndexerClient.display_name} ebook search found #{structured_results.count} structured results for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
-    else
+    results = structured_results
+
+    if structured_results.empty?
       Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query '#{fallback_query}'"
+      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type))
+    elsif book.ebook?
+      Rails.logger.info "[SearchJob] #{IndexerClient.display_name} ebook search found #{structured_results.count} structured results for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
+      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type))
+    elsif !strong_indexer_match?(results, request)
+      Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search found no strong match for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
+      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type))
     end
 
-    generic_results = IndexerClient.search(fallback_query, book_type: book.book_type)
-    merge_indexer_results(structured_results, generic_results)
+    supplement_with_broad_search(request, results)
   end
 
   def search_generic_indexer(request)
@@ -132,11 +136,12 @@ class SearchJob < ApplicationJob
     query = generic_indexer_query(request)
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} for: #{query} (type: #{book.book_type})"
 
-    IndexerClient.search(query, book_type: book.book_type)
+    results = IndexerClient.search(query, book_type: book.book_type)
+    supplement_with_broad_search(request, results)
   end
 
   def generic_indexer_query(request)
-    [ request.book.title, indexer_language_hint(request) ].reject(&:blank?).join(" ")
+    [ request.book.title, request.book.author, indexer_language_hint(request) ].reject(&:blank?).join(" ")
   end
 
   def indexer_language_hint(request)
@@ -174,7 +179,7 @@ class SearchJob < ApplicationJob
 
   def search_zlibrary(request)
     book = request.book
-    query = [book.title, book.author].compact.join(" ")
+    query = [ book.title, book.author ].compact.join(" ")
     language = zlibrary_language_filter(request)
     Rails.logger.debug "[SearchJob] Searching Z-Library for: #{query} (language: #{language || 'any'})"
 
@@ -376,6 +381,61 @@ class SearchJob < ApplicationJob
 
       seen[key] = true
       merged << result
+    end
+  end
+
+  def supplement_with_broad_search(request, results)
+    query = generic_indexer_query(request)
+    Rails.logger.info "[SearchJob] Supplementing #{IndexerClient.display_name} search for request ##{request.id} without category restrictions using '#{query}'"
+
+    broad_results = IndexerClient.search(query, categories: [])
+    merge_indexer_results(results, filter_broad_results(broad_results, request))
+  rescue IndexerClients::Base::Error => e
+    Rails.logger.warn "[SearchJob] #{IndexerClient.display_name} broad search failed for request ##{request.id}: #{e.message}"
+    results
+  end
+
+  def strong_indexer_match?(results, request)
+    threshold = SettingsService.get(:min_match_confidence)
+
+    Array(results).any? do |result|
+      score_result = ReleaseScorer.score(search_result_for_scoring(result), request)
+      score_result.total >= threshold
+    end
+  end
+
+  def search_result_for_scoring(result)
+    SearchResult.new(
+      title: result.title,
+      seeders: result.seeders,
+      download_url: result.download_url,
+      magnet_url: result.magnet_url
+    )
+  end
+
+  def filter_broad_results(results, request)
+    threshold = SettingsService.get(:min_match_confidence)
+
+    Array(results).select do |result|
+      compatible_result_categories?(result, request.book.book_type) &&
+        ReleaseScorer.score(search_result_for_scoring(result), request).total >= threshold
+    end
+  end
+
+  def compatible_result_categories?(result, book_type)
+    category_ids = Array(result.category_ids).map(&:to_i)
+    known_category_ids = category_ids.reject { |id| id.zero? || id.between?(8000, 8999) }
+    return true if known_category_ids.empty?
+
+    case book_type&.to_sym
+    when :audiobook
+      specific_audio_ids = known_category_ids.reject { |id| (id % 1000).zero? }
+      ids_to_check = specific_audio_ids.presence || known_category_ids
+      ids_to_check.any? { |id| [ 3000, 3030, 3050 ].include?(id) }
+    when :ebook
+      known_category_ids.any? { |id| id.between?(7000, 7999) }
+    else
+      true
     end
   end
 end

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -111,12 +111,14 @@ class SearchJob < ApplicationJob
   def search_prowlarr(request)
     book = request.book
     query = indexer_language_hint(request)
+    categories = primary_indexer_categories(request)
 
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} book query for title='#{book.title}' author='#{book.author}' extra='#{query}' (type: #{book.book_type})"
 
     structured_results = IndexerClient.search(
       query,
       book_type: book.book_type,
+      categories: categories,
       title: book.title,
       author: book.author
     )
@@ -126,29 +128,30 @@ class SearchJob < ApplicationJob
 
     if structured_results.empty?
       Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query '#{fallback_query}'"
-      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type))
+      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type, categories: categories))
     elsif book.ebook?
       Rails.logger.info "[SearchJob] #{IndexerClient.display_name} ebook search found #{structured_results.count} structured results for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
-      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type))
+      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type, categories: categories))
     elsif !strong_indexer_match?(results, request)
       Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search found no strong match for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
-      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type))
+      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type, categories: categories))
     end
 
-    supplement_with_broad_search(request, results)
+    finalize_indexer_results(request, results)
   end
 
   def search_generic_indexer(request)
     book = request.book
     query = generic_indexer_query(request)
+    categories = primary_indexer_categories(request)
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} for: #{query} (type: #{book.book_type})"
 
-    results = IndexerClient.search(query, book_type: book.book_type)
-    supplement_with_broad_search(request, results)
+    results = IndexerClient.search(query, book_type: book.book_type, categories: categories)
+    finalize_indexer_results(request, results)
   end
 
   def generic_indexer_query(request)
-    [ request.book.title, request.book.author, indexer_language_hint(request) ].reject(&:blank?).join(" ")
+    [ request.book.title, indexer_language_hint(request) ].reject(&:blank?).join(" ")
   end
 
   def indexer_language_hint(request)
@@ -423,7 +426,14 @@ class SearchJob < ApplicationJob
     end
   end
 
+  def finalize_indexer_results(request, results)
+    results = filter_broad_results(results, request) if SettingsService.unrestricted_indexer_search_scope?
+    supplement_with_broad_search(request, results)
+  end
+
   def supplement_with_broad_search(request, results)
+    return results unless SettingsService.broad_indexer_search_scope?
+
     query = generic_indexer_query(request)
     Rails.logger.info "[SearchJob] Supplementing #{IndexerClient.display_name} search for request ##{request.id} without category restrictions using '#{query}'"
 
@@ -434,10 +444,17 @@ class SearchJob < ApplicationJob
     results
   end
 
+  def primary_indexer_categories(request)
+    SettingsService.indexer_category_ids_for(request.book.book_type)
+  end
+
   def strong_indexer_match?(results, request)
     threshold = SettingsService.get(:min_match_confidence)
 
     Array(results).any? do |result|
+      next false if SettingsService.unrestricted_indexer_search_scope? &&
+        !compatible_result_categories?(result, request.book.book_type)
+
       score_result = ReleaseScorer.score(search_result_for_scoring(result), request)
       score_result.total >= threshold
     end
@@ -463,16 +480,14 @@ class SearchJob < ApplicationJob
 
   def compatible_result_categories?(result, book_type)
     category_ids = Array(result.category_ids).map(&:to_i)
-    known_category_ids = category_ids.reject { |id| id.zero? || id.between?(8000, 8999) }
-    return true if known_category_ids.empty?
+    standard_category_ids = category_ids.select { |id| id.between?(1000, 7999) }
+    return true if standard_category_ids.empty?
 
     case book_type&.to_sym
     when :audiobook
-      specific_audio_ids = known_category_ids.reject { |id| (id % 1000).zero? }
-      ids_to_check = specific_audio_ids.presence || known_category_ids
-      ids_to_check.any? { |id| [ 3000, 3030, 3050 ].include?(id) }
+      standard_category_ids.any? { |id| id.between?(3000, 3999) }
     when :ebook
-      known_category_ids.any? { |id| id.between?(7000, 7999) }
+      standard_category_ids.any? { |id| id.between?(7000, 7999) }
     else
       true
     end

--- a/app/services/indexer_clients/base.rb
+++ b/app/services/indexer_clients/base.rb
@@ -9,12 +9,6 @@ module IndexerClients
     class AuthenticationError < Error; end
     class NotConfiguredError < Error; end
 
-    CATEGORIES = {
-      audiobook: [3030],
-      ebook: [7020, 7000],
-      all_books: [3030, 7020, 7000]
-    }.freeze
-
     class << self
       def search(...)
         raise NotImplementedError
@@ -39,14 +33,7 @@ module IndexerClients
       private
 
       def categories_for_type(book_type)
-        case book_type&.to_sym
-        when :audiobook
-          CATEGORIES[:audiobook]
-        when :ebook
-          CATEGORIES[:ebook]
-        else
-          CATEGORIES[:all_books]
-        end
+        SettingsService.indexer_category_ids_for(book_type)
       end
 
       def ensure_configured!

--- a/app/services/indexer_clients/jackett.rb
+++ b/app/services/indexer_clients/jackett.rb
@@ -3,6 +3,14 @@
 module IndexerClients
   class Jackett < Base
     DEFAULT_INDEXER_FILTER = "all"
+    CATEGORY_NAME_IDS = {
+      "audio" => 3000,
+      "audio/audiobook" => 3030,
+      "audio/other" => 3050,
+      "books" => 7000,
+      "books/ebook" => 7020,
+      "books/other" => 7050
+    }.freeze
 
     class << self
       def search(query, categories: nil, book_type: nil, limit: 100, **)
@@ -112,8 +120,19 @@ module IndexerClients
           download_url: extract_download_url(enclosure_url),
           magnet_url: extract_magnet_url(enclosure_url),
           info_url: link,
-          published_at: parse_date(item.at_xpath("pubDate")&.text)
+          published_at: parse_date(item.at_xpath("pubDate")&.text),
+          category_ids: extract_category_ids(item)
         )
+      end
+
+      def extract_category_ids(item)
+        attr_categories = item.xpath("attr[@name='category']").map { |attr| attr["value"] }
+        rss_categories = item.xpath("category").map(&:text)
+
+        (attr_categories + rss_categories).filter_map do |category|
+          value = category.to_s.strip
+          Integer(value, exception: false) || CATEGORY_NAME_IDS[value.downcase]
+        end.uniq
       end
 
       def integer_attr(value)

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -113,7 +113,7 @@ module IndexerClients
         tags.to_a.flat_map do |tag|
           case tag
           when Hash
-            [tag["id"], tag["label"], tag["name"]]
+            [ tag["id"], tag["label"], tag["name"] ]
           else
             tag
           end
@@ -166,8 +166,16 @@ module IndexerClients
           download_url: extract_download_url(item),
           magnet_url: extract_magnet_url(item),
           info_url: item["infoUrl"],
-          published_at: parse_date(item["publishDate"])
+          published_at: parse_date(item["publishDate"]),
+          category_ids: extract_category_ids(item)
         )
+      end
+
+      def extract_category_ids(item)
+        Array(item["categories"]).filter_map do |category|
+          value = category.is_a?(Hash) ? category["id"] || category["Id"] || category["ID"] : category
+          Integer(value, exception: false)
+        end.uniq
       end
 
       def extract_download_url(item)

--- a/app/services/indexer_clients/result.rb
+++ b/app/services/indexer_clients/result.rb
@@ -3,8 +3,19 @@
 module IndexerClients
   Result = Data.define(
     :guid, :title, :indexer, :size_bytes, :seeders, :leechers,
-    :download_url, :magnet_url, :info_url, :published_at
+    :download_url, :magnet_url, :info_url, :published_at, :category_ids
   ) do
+    def initialize(
+      guid:, title:, indexer:, size_bytes:, seeders:, leechers:,
+      download_url:, magnet_url:, info_url:, published_at:, category_ids: []
+    )
+      super(
+        guid:, title:, indexer:, size_bytes:, seeders:, leechers:,
+        download_url:, magnet_url:, info_url:, published_at:,
+        category_ids: Array(category_ids).filter_map { |id| Integer(id, exception: false) }.uniq
+      )
+    end
+
     def downloadable?
       download_url.present? || magnet_url.present?
     end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -2,6 +2,30 @@ class SettingsService
   DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
 
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
+  INDEXER_SEARCH_SCOPES = %w[broad strict unrestricted custom].freeze
+  INDEXER_SEARCH_SCOPE_OPTIONS = {
+    "broad" => {
+      label: "Broad (recommended)",
+      description: "Search Shelfarr's book categories, then supplement with an unrestricted search filtered by match quality."
+    },
+    "strict" => {
+      label: "Strict",
+      description: "Search only Shelfarr's default book categories."
+    },
+    "unrestricted" => {
+      label: "Unrestricted",
+      description: "Search without category filters and rely on match quality filtering."
+    },
+    "custom" => {
+      label: "Custom",
+      description: "Search only the custom category IDs configured below."
+    }
+  }.freeze
+  DEFAULT_INDEXER_CATEGORY_IDS = {
+    audiobook: [ 3030 ],
+    ebook: [ 7020, 7000 ],
+    all_books: [ 3030, 7020, 7000 ]
+  }.freeze
   DOWNLOAD_TYPE_OPTIONS = {
     "torrent" => {
       label: "Torrent",
@@ -21,6 +45,9 @@ class SettingsService
   DEFINITIONS = {
     # Indexer Integration
     indexer_provider: { type: "string", default: "", category: "indexer", description: "Active indexer provider. Leave unset on upgrades to keep legacy Prowlarr configuration." },
+    indexer_search_scope: { type: "string", default: "broad", category: "indexer", description: "How broadly Shelfarr should search indexer categories." },
+    indexer_custom_audiobook_categories: { type: "string", default: "", category: "indexer", description: "Comma-separated audiobook category IDs used when search scope is Custom. Leave blank to use Shelfarr defaults." },
+    indexer_custom_ebook_categories: { type: "string", default: "", category: "indexer", description: "Comma-separated ebook category IDs used when search scope is Custom. Leave blank to use Shelfarr defaults." },
     prowlarr_url: { type: "string", default: "", category: "indexer", description: "Base URL for Prowlarr instance (e.g., http://localhost:9696)" },
     prowlarr_api_key: { type: "string", default: "", category: "indexer", description: "API key from Prowlarr Settings > General" },
     prowlarr_tags: { type: "string", default: "", category: "indexer", description: "Comma-separated tag IDs or names to filter Prowlarr indexers (leave empty for all indexers)" },
@@ -287,6 +314,31 @@ class SettingsService
       end
     end
 
+    def active_indexer_search_scope
+      scope = get(:indexer_search_scope).to_s.strip.downcase
+      INDEXER_SEARCH_SCOPES.include?(scope) ? scope : "broad"
+    end
+
+    def broad_indexer_search_scope?
+      active_indexer_search_scope == "broad"
+    end
+
+    def unrestricted_indexer_search_scope?
+      active_indexer_search_scope == "unrestricted"
+    end
+
+    def indexer_category_ids_for(book_type)
+      return [] if unrestricted_indexer_search_scope?
+
+      ids = if active_indexer_search_scope == "custom"
+        custom_indexer_category_ids_for(book_type)
+      else
+        []
+      end
+
+      ids.presence || default_indexer_category_ids_for(book_type)
+    end
+
     def download_client_configured?
       DownloadClient.enabled.exists?
     end
@@ -377,6 +429,13 @@ class SettingsService
       end
     end
 
+    def indexer_search_scope_options
+      INDEXER_SEARCH_SCOPES.map do |scope|
+        INDEXER_SEARCH_SCOPE_OPTIONS.fetch(scope)
+          .merge(value: scope)
+      end
+    end
+
     def format_preferences_for(book_type)
       type = book_type.to_s
       return default_format_preferences unless %w[audiobook ebook].include?(type)
@@ -404,6 +463,41 @@ class SettingsService
         normalized = value.to_s.strip.downcase
         normalized if DOWNLOAD_TYPES.include?(normalized)
       end.uniq
+    end
+
+    def custom_indexer_category_ids_for(book_type)
+      key = case book_type&.to_sym
+      when :audiobook
+        :indexer_custom_audiobook_categories
+      when :ebook
+        :indexer_custom_ebook_categories
+      else
+        nil
+      end
+
+      if key
+        normalize_category_ids(get(key))
+      else
+        (normalize_category_ids(get(:indexer_custom_audiobook_categories)) +
+          normalize_category_ids(get(:indexer_custom_ebook_categories))).uniq
+      end
+    end
+
+    def default_indexer_category_ids_for(book_type)
+      case book_type&.to_sym
+      when :audiobook
+        DEFAULT_INDEXER_CATEGORY_IDS[:audiobook]
+      when :ebook
+        DEFAULT_INDEXER_CATEGORY_IDS[:ebook]
+      else
+        DEFAULT_INDEXER_CATEGORY_IDS[:all_books]
+      end
+    end
+
+    def normalize_category_ids(values)
+      Array(values).flat_map { |value| value.to_s.split(/[,\s]+/) }.filter_map do |value|
+        Integer(value.strip, exception: false)
+      end.reject(&:zero?).uniq
     end
 
     def normalized_list_setting(key)

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -46,8 +46,8 @@ class SettingsService
     # Indexer Integration
     indexer_provider: { type: "string", default: "", category: "indexer", description: "Active indexer provider. Leave unset on upgrades to keep legacy Prowlarr configuration." },
     indexer_search_scope: { type: "string", default: "broad", category: "indexer", description: "How broadly Shelfarr should search indexer categories." },
-    indexer_custom_audiobook_categories: { type: "string", default: "", category: "indexer", description: "Comma-separated audiobook category IDs used when search scope is Custom. Leave blank to use Shelfarr defaults." },
-    indexer_custom_ebook_categories: { type: "string", default: "", category: "indexer", description: "Comma-separated ebook category IDs used when search scope is Custom. Leave blank to use Shelfarr defaults." },
+    indexer_custom_audiobook_categories: { type: "string", default: "", category: "indexer", description: "Audiobook category IDs separated by commas, spaces, or new lines. Used when search scope is Custom. Leave blank to use Shelfarr defaults." },
+    indexer_custom_ebook_categories: { type: "string", default: "", category: "indexer", description: "Ebook category IDs separated by commas, spaces, or new lines. Used when search scope is Custom. Leave blank to use Shelfarr defaults." },
     prowlarr_url: { type: "string", default: "", category: "indexer", description: "Base URL for Prowlarr instance (e.g., http://localhost:9696)" },
     prowlarr_api_key: { type: "string", default: "", category: "indexer", description: "API key from Prowlarr Settings > General" },
     prowlarr_tags: { type: "string", default: "", category: "indexer", description: "Comma-separated tag IDs or names to filter Prowlarr indexers (leave empty for all indexers)" },

--- a/app/views/admin/settings/_indexer_section.html.erb
+++ b/app/views/admin/settings/_indexer_section.html.erb
@@ -22,6 +22,42 @@
       </div>
     </div>
 
+    <div class="flex flex-col md:flex-row md:items-start gap-4">
+      <div class="md:w-1/3">
+        <label for="settings_indexer_search_scope" class="font-medium text-gray-300">Search Scope</label>
+        <p class="text-sm text-gray-500"><%= settings.dig(:indexer_search_scope, :definition, :description) %></p>
+      </div>
+      <div class="md:w-2/3">
+        <%= form.select "settings[indexer_search_scope]",
+          options_for_select(SettingsService.indexer_search_scope_options.map { |option| [option[:label], option[:value]] }, settings.dig(:indexer_search_scope, :value)),
+          {},
+          id: "settings_indexer_search_scope",
+          class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2",
+          data: { action: "change->settings-form#autoSave" } %>
+        <p class="mt-1 text-xs text-gray-500">Broad mode best matches manual Prowlarr searches by adding an unrestricted search, then filtering obvious non-book results locally.</p>
+      </div>
+    </div>
+
+    <div class="flex flex-col md:flex-row md:items-start gap-4">
+      <div class="md:w-1/3">
+        <label for="settings_indexer_custom_audiobook_categories" class="font-medium text-gray-300">Custom Audiobook Categories</label>
+        <p class="text-sm text-gray-500"><%= settings.dig(:indexer_custom_audiobook_categories, :definition, :description) %></p>
+      </div>
+      <div class="md:w-2/3">
+        <%= form.text_field "settings[indexer_custom_audiobook_categories]", value: settings.dig(:indexer_custom_audiobook_categories, :value), id: "settings_indexer_custom_audiobook_categories", placeholder: "3030, 3010, 3040", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+      </div>
+    </div>
+
+    <div class="flex flex-col md:flex-row md:items-start gap-4">
+      <div class="md:w-1/3">
+        <label for="settings_indexer_custom_ebook_categories" class="font-medium text-gray-300">Custom Ebook Categories</label>
+        <p class="text-sm text-gray-500"><%= settings.dig(:indexer_custom_ebook_categories, :definition, :description) %></p>
+      </div>
+      <div class="md:w-2/3">
+        <%= form.text_field "settings[indexer_custom_ebook_categories]", value: settings.dig(:indexer_custom_ebook_categories, :value), id: "settings_indexer_custom_ebook_categories", placeholder: "7020, 7000, 7050", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+      </div>
+    </div>
+
     <div data-settings-form-target="prowlarrFields" class="<%= 'hidden' unless selected_provider == 'prowlarr' %> space-y-6">
       <div class="flex flex-col md:flex-row md:items-start gap-4">
         <div class="md:w-1/3">

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -15,6 +15,9 @@ class SearchJobTest < ActiveJob::TestCase
     SettingsService.set(:librivox_url, "https://librivox.org")
     SettingsService.set(:gutenberg_enabled, false)
     SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
+    SettingsService.set(:indexer_search_scope, "broad")
+    SettingsService.set(:indexer_custom_audiobook_categories, "")
+    SettingsService.set(:indexer_custom_ebook_categories, "")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
     LibrivoxClient.reset_connection! if defined?(LibrivoxClient)
     GutenbergClient.reset_connection! if defined?(GutenbergClient)
@@ -29,6 +32,9 @@ class SearchJobTest < ActiveJob::TestCase
     SettingsService.set(:librivox_url, "https://librivox.org")
     SettingsService.set(:gutenberg_enabled, false)
     SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
+    SettingsService.set(:indexer_search_scope, "broad")
+    SettingsService.set(:indexer_custom_audiobook_categories, "")
+    SettingsService.set(:indexer_custom_ebook_categories, "")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
     LibrivoxClient.reset_connection! if defined?(LibrivoxClient)
     GutenbergClient.reset_connection! if defined?(GutenbergClient)
@@ -340,7 +346,7 @@ class SearchJobTest < ActiveJob::TestCase
       fallback_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            req.uri.query_values["query"] == @request.book.title &&
             category_query_param?(req)
         end
         .to_return(
@@ -352,7 +358,7 @@ class SearchJobTest < ActiveJob::TestCase
       broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            req.uri.query_values["query"] == @request.book.title &&
             !category_query_param?(req)
         end
         .to_return(
@@ -405,7 +411,7 @@ class SearchJobTest < ActiveJob::TestCase
       broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            req.uri.query_values["query"] == @request.book.title &&
             !category_query_param?(req)
         end
         .to_return(
@@ -439,7 +445,7 @@ class SearchJobTest < ActiveJob::TestCase
     broad_payload = prowlarr_result_payload.merge(
       "guid" => "broad-audiobook-match",
       "title" => "Strong Audio Narrator Author Audiobook Complete",
-      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+      "categories" => [ { "id" => 3010, "name" => "Audio/MP3" } ]
     )
     movie_payload = prowlarr_result_payload.merge(
       "guid" => "broad-audiobook-movie",
@@ -459,7 +465,7 @@ class SearchJobTest < ActiveJob::TestCase
       broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "Strong Audio Narrator Author" &&
+            req.uri.query_values["query"] == "Strong Audio" &&
             !category_query_param?(req)
         end
         .to_return(
@@ -496,7 +502,7 @@ class SearchJobTest < ActiveJob::TestCase
       categorized_generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            req.uri.query_values["query"] == @request.book.title &&
             category_query_param?(req)
         end
         .to_return(
@@ -508,7 +514,7 @@ class SearchJobTest < ActiveJob::TestCase
       broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            req.uri.query_values["query"] == @request.book.title &&
             !category_query_param?(req)
         end
         .to_raise(Faraday::TimeoutError.new("timeout"))
@@ -520,6 +526,172 @@ class SearchJobTest < ActiveJob::TestCase
       assert_requested categorized_generic_stub
       assert_requested broad_stub
       assert_equal [ payload["title"] ], @request.search_results.pluck(:title)
+    end
+  end
+
+  test "does not use categoryless Prowlarr complement in strict scope" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    payload = prowlarr_result_payload.merge(
+      "guid" => "strict-categorized-match",
+      "title" => "#{@request.book.title} #{@request.book.author} EPUB"
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" && category_query_param?(req) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ payload ].to_json
+        )
+
+      categorized_generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == @request.book.title &&
+            category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "search" && !category_query_param?(req) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested structured_stub
+      assert_requested categorized_generic_stub
+      assert_not_requested broad_stub
+      assert_equal [ payload["title"] ], @request.search_results.pluck(:title)
+    end
+  end
+
+  test "uses custom category IDs for Prowlarr scope" do
+    SettingsService.set(:indexer_search_scope, "custom")
+    SettingsService.set(:indexer_custom_ebook_categories, "7050")
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "book" &&
+            req.uri.query.to_s.include?("categories=7050")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      stub_prowlarr_generic_search_empty
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested structured_stub
+      assert @request.search_results.any?
+    end
+  end
+
+  test "uses no category parameter for unrestricted Prowlarr scope" do
+    SettingsService.set(:indexer_search_scope, "unrestricted")
+    ebook_payload = prowlarr_result_payload.merge(
+      "guid" => "unrestricted-ebook",
+      "title" => "#{@request.book.title} #{@request.book.author} EPUB",
+      "categories" => [ { "id" => 7020, "name" => "Books/EBook" } ]
+    )
+    movie_payload = prowlarr_result_payload.merge(
+      "guid" => "unrestricted-movie",
+      "title" => "#{@request.book.title} #{@request.book.author} Movie",
+      "categories" => [ { "id" => 2000, "name" => "Movies" } ]
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "book" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ ebook_payload, movie_payload ].to_json
+        )
+
+      generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "search" && !category_query_param?(req) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested structured_stub
+      assert_requested generic_stub
+      assert_equal [ ebook_payload["title"] ], @request.search_results.pluck(:title)
+    end
+  end
+
+  test "unrestricted Prowlarr audiobook search falls back when strong structured results have incompatible categories" do
+    SettingsService.set(:indexer_search_scope, "unrestricted")
+    book = Book.create!(
+      title: "Audio Scope",
+      author: "Narrator Author",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    movie_payload = prowlarr_result_payload.merge(
+      "guid" => "unrestricted-audio-movie",
+      "title" => "Audio Scope Narrator Author Audiobook M4B",
+      "categories" => [ { "id" => 2000, "name" => "Movies" } ]
+    )
+    audiobook_payload = prowlarr_result_payload.merge(
+      "guid" => "unrestricted-audio-generic",
+      "title" => "Audio Scope Narrator Author Audiobook M4B",
+      "categories" => [ { "id" => 3010, "name" => "Audio/MP3" } ]
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "book" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ movie_payload ].to_json
+        )
+
+      generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Audio Scope" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ audiobook_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested structured_stub
+      assert_requested generic_stub
+      assert_equal [ audiobook_payload["title"] ], request.search_results.pluck(:title)
     end
   end
 
@@ -558,7 +730,7 @@ class SearchJobTest < ActiveJob::TestCase
       generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1 Kanehito Yamada" &&
+            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1" &&
             category_query_param?(req)
         end
         .to_return(
@@ -570,7 +742,7 @@ class SearchJobTest < ActiveJob::TestCase
       stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1 Kanehito Yamada" &&
+            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1" &&
             !category_query_param?(req)
         end
         .to_return(
@@ -624,7 +796,7 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
-  test "uses title and author for Jackett text search" do
+  test "uses title-only generic text search for Jackett" do
     SettingsService.set(:indexer_provider, "jackett")
     SettingsService.set(:jackett_url, "http://localhost:9117")
     SettingsService.set(:jackett_api_key, "jackett-key")
@@ -642,7 +814,7 @@ class SearchJobTest < ActiveJob::TestCase
           query = req.uri.query_values["q"]
           req.uri.query_values["t"] == "search" &&
             query.include?(@request.book.title) &&
-            query.include?(@request.book.author)
+            !query.include?(@request.book.author)
         end
         .to_return(status: 200, body: body, headers: { "Content-Type" => "application/xml" })
 
@@ -678,7 +850,7 @@ class SearchJobTest < ActiveJob::TestCase
       broad_stub = stub_request(:get, %r{localhost:9117/api/v2\.0/indexers/all/results/torznab/api})
         .with do |req|
           req.uri.query_values["t"] == "search" &&
-            req.uri.query_values["q"] == "#{@request.book.title} #{@request.book.author}" &&
+            req.uri.query_values["q"] == @request.book.title &&
             !category_query_param?(req)
         end
         .to_return(status: 200, body: result_body, headers: { "Content-Type" => "application/xml" })

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -312,6 +312,11 @@ class SearchJobTest < ActiveJob::TestCase
   end
 
   test "falls back to generic Prowlarr search when book search returns no results" do
+    generic_payload = prowlarr_result_payload.merge(
+      "guid" => "generic-strong-match",
+      "title" => "#{@request.book.title} #{@request.book.author} EPUB"
+    )
+
     VCR.turned_off do
       structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
@@ -329,12 +334,25 @@ class SearchJobTest < ActiveJob::TestCase
       fallback_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == @request.book.title
+            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            category_query_param?(req)
         end
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: [ prowlarr_result_payload ].to_json
+          body: [ generic_payload ].to_json
+        )
+
+      broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
         )
 
       SearchJob.perform_now(@request.id)
@@ -342,7 +360,160 @@ class SearchJobTest < ActiveJob::TestCase
 
       assert_requested structured_stub
       assert_requested fallback_stub
-      assert_equal "Test Result Book", @request.search_results.first.title
+      assert_requested broad_stub
+      assert_equal generic_payload["title"], @request.search_results.first.title
+    end
+  end
+
+  test "uses categoryless Prowlarr fallback when categorized results are weak" do
+    broad_payload = prowlarr_result_payload.merge(
+      "guid" => "broad-strong-match",
+      "title" => "#{@request.book.title} #{@request.book.author} EPUB",
+      "categories" => [ { "id" => 7020, "name" => "Books/EBook" } ]
+    )
+    movie_payload = prowlarr_result_payload.merge(
+      "guid" => "broad-movie-match",
+      "title" => "#{@request.book.title} #{@request.book.author} Movie",
+      "categories" => [ { "id" => 2000, "name" => "Movies" } ]
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+
+      categorized_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" && category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ broad_payload, movie_payload ].to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested structured_stub
+      assert_requested categorized_stub
+      assert_requested broad_stub
+      assert_includes @request.search_results.pluck(:title), broad_payload["title"]
+      assert_not_includes @request.search_results.pluck(:title), movie_payload["title"]
+    end
+  end
+
+  test "uses categoryless Prowlarr complement even when categorized audiobook result is strong" do
+    book = Book.create!(
+      title: "Strong Audio",
+      author: "Narrator Author",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    payload = prowlarr_result_payload.merge(
+      "guid" => "strong-audiobook-match",
+      "title" => "Strong Audio Narrator Author Audiobook M4B"
+    )
+    broad_payload = prowlarr_result_payload.merge(
+      "guid" => "broad-audiobook-match",
+      "title" => "Strong Audio Narrator Author Audiobook Complete",
+      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+    )
+    movie_payload = prowlarr_result_payload.merge(
+      "guid" => "broad-audiobook-movie",
+      "title" => "Strong Audio Narrator Author Movie",
+      "categories" => [ { "id" => 2000, "name" => "Movies" } ]
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ payload ].to_json
+        )
+
+      broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Strong Audio Narrator Author" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ broad_payload, movie_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested structured_stub
+      assert_requested broad_stub
+      assert_equal [ broad_payload["title"], payload["title"] ].sort, request.search_results.pluck(:title).sort
+      assert_not_includes request.search_results.pluck(:title), movie_payload["title"]
+    end
+  end
+
+  test "keeps categorized results when categoryless Prowlarr complement fails" do
+    payload = prowlarr_result_payload.merge(
+      "guid" => "categorized-strong-match",
+      "title" => "#{@request.book.title} #{@request.book.author} EPUB"
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ payload ].to_json
+        )
+
+      categorized_generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      broad_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "#{@request.book.title} #{@request.book.author}" &&
+            !category_query_param?(req)
+        end
+        .to_raise(Faraday::TimeoutError.new("timeout"))
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested structured_stub
+      assert_requested categorized_generic_stub
+      assert_requested broad_stub
+      assert_equal [ payload["title"] ], @request.search_results.pluck(:title)
     end
   end
 
@@ -381,12 +552,25 @@ class SearchJobTest < ActiveJob::TestCase
       generic_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
-            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1"
+            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1 Kanehito Yamada" &&
+            category_query_param?(req)
         end
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
           body: [ generic_payload ].to_json
+        )
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1 Kanehito Yamada" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
         )
 
       SearchJob.perform_now(request.id)
@@ -434,7 +618,7 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
-  test "keeps Jackett on title-only generic search" do
+  test "uses title and author for Jackett text search" do
     SettingsService.set(:indexer_provider, "jackett")
     SettingsService.set(:jackett_url, "http://localhost:9117")
     SettingsService.set(:jackett_api_key, "jackett-key")
@@ -452,13 +636,53 @@ class SearchJobTest < ActiveJob::TestCase
           query = req.uri.query_values["q"]
           req.uri.query_values["t"] == "search" &&
             query.include?(@request.book.title) &&
-            !query.include?(@request.book.author)
+            query.include?(@request.book.author)
         end
         .to_return(status: 200, body: body, headers: { "Content-Type" => "application/xml" })
 
       assert_nothing_raised do
         SearchJob.perform_now(@request.id)
       end
+    end
+  end
+
+  test "uses categoryless Jackett fallback when categorized search is weak" do
+    SettingsService.set(:indexer_provider, "jackett")
+    SettingsService.set(:jackett_url, "http://localhost:9117")
+    SettingsService.set(:jackett_api_key, "jackett-key")
+
+    empty_body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+        <channel></channel>
+      </rss>
+    XML
+    result_body = jackett_result_xml(
+      title: "#{@request.book.title} #{@request.book.author} EPUB",
+      guid: "jackett-broad-guid"
+    )
+
+    VCR.turned_off do
+      categorized_stub = stub_request(:get, %r{localhost:9117/api/v2\.0/indexers/all/results/torznab/api})
+        .with do |req|
+          req.uri.query_values["t"] == "search" && category_query_param?(req)
+        end
+        .to_return(status: 200, body: empty_body, headers: { "Content-Type" => "application/xml" })
+
+      broad_stub = stub_request(:get, %r{localhost:9117/api/v2\.0/indexers/all/results/torznab/api})
+        .with do |req|
+          req.uri.query_values["t"] == "search" &&
+            req.uri.query_values["q"] == "#{@request.book.title} #{@request.book.author}" &&
+            !category_query_param?(req)
+        end
+        .to_return(status: 200, body: result_body, headers: { "Content-Type" => "application/xml" })
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested categorized_stub
+      assert_requested broad_stub
+      assert_equal "#{@request.book.title} #{@request.book.author} EPUB", @request.search_results.first.title
     end
   end
 
@@ -529,7 +753,7 @@ class SearchJobTest < ActiveJob::TestCase
     ZLibraryClient.stub :search, ->(query, language: nil, **) {
       assert_includes query, @request.book.title
       assert_equal "english", language
-      [result]
+      [ result ]
     } do
       SearchJob.perform_now(@request.id)
     end
@@ -561,7 +785,7 @@ class SearchJobTest < ActiveJob::TestCase
       language: "en"
     )
 
-    ZLibraryClient.stub :search, [result] do
+    ZLibraryClient.stub :search, [ result ] do
       assert_nothing_raised do
         SearchJob.perform_now(@request.id)
       end
@@ -734,5 +958,27 @@ class SearchJobTest < ActiveJob::TestCase
       "infoUrl" => "http://example.com/info",
       "publishDate" => "2024-01-15T10:00:00Z"
     }
+  end
+
+  def category_query_param?(request)
+    request.uri.query.to_s.match?(/(?:^|&)(?:categories(?:%5B%5D)?|cat)=/)
+  end
+
+  def jackett_result_xml(title:, guid:)
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+        <channel>
+          <item>
+            <title>#{title}</title>
+            <guid>#{guid}</guid>
+            <link>https://example.com/details/#{guid}</link>
+            <jackettindexer>JackettBooks</jackettindexer>
+            <enclosure url="magnet:?xt=urn:btih:#{guid}" length="12345" type="application/x-bittorrent" />
+            <torznab:attr name="seeders" value="12" />
+          </item>
+        </channel>
+      </rss>
+    XML
   end
 end

--- a/test/services/indexer_clients/jackett_test.rb
+++ b/test/services/indexer_clients/jackett_test.rb
@@ -29,6 +29,7 @@ class IndexerClients::JackettTest < ActiveSupport::TestCase
             <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
             <jackettindexer>Books</jackettindexer>
             <enclosure url="magnet:?xt=urn:btih:123" length="1048576" type="application/x-bittorrent" />
+            <torznab:attr name="category" value="3030" />
             <torznab:attr name="seeders" value="42" />
             <torznab:attr name="peers" value="7" />
             <torznab:attr name="size" value="1048576" />
@@ -54,6 +55,7 @@ class IndexerClients::JackettTest < ActiveSupport::TestCase
       assert_equal 1_048_576, result.size_bytes
       assert_equal "magnet:?xt=urn:btih:123", result.magnet_url
       assert_equal "magnet:?xt=urn:btih:123", result.download_link
+      assert_equal [ 3030 ], result.category_ids
     end
   end
 

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -53,7 +53,8 @@ class ProwlarrClientTest < ActiveSupport::TestCase
               "downloadUrl" => "http://example.com/download/abc123",
               "magnetUrl" => "magnet:?xt=urn:btih:abc123",
               "infoUrl" => "http://example.com/info/abc123",
-              "publishDate" => "2024-01-15T10:00:00Z"
+              "publishDate" => "2024-01-15T10:00:00Z",
+              "categories" => [ { "id" => 7020, "name" => "Books/EBook" } ]
             }
           ].to_json
         )
@@ -70,6 +71,7 @@ class ProwlarrClientTest < ActiveSupport::TestCase
       assert_equal "TestIndexer", result.indexer
       assert_equal 50, result.seeders
       assert_equal "magnet:?xt=urn:btih:abc123", result.download_link
+      assert_equal [ 7020 ], result.category_ids
     end
   end
 

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url]).delete_all
+    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -55,6 +55,38 @@ class SettingsServiceTest < ActiveSupport::TestCase
     SettingsService.set(:preferred_download_types, %w[direct torrent])
 
     assert_equal %w[direct torrent usenet], SettingsService.preferred_download_types
+  end
+
+  test "indexer search scope defaults to broad" do
+    assert_equal "broad", SettingsService.active_indexer_search_scope
+    assert SettingsService.broad_indexer_search_scope?
+  end
+
+  test "indexer search scope ignores invalid values" do
+    SettingsService.set(:indexer_search_scope, "unknown")
+
+    assert_equal "broad", SettingsService.active_indexer_search_scope
+  end
+
+  test "indexer category ids use default categories" do
+    assert_equal [ 3030 ], SettingsService.indexer_category_ids_for(:audiobook)
+    assert_equal [ 7020, 7000 ], SettingsService.indexer_category_ids_for(:ebook)
+  end
+
+  test "indexer category ids use custom categories when configured" do
+    SettingsService.set(:indexer_search_scope, "custom")
+    SettingsService.set(:indexer_custom_audiobook_categories, "3030, 3010\n3040")
+    SettingsService.set(:indexer_custom_ebook_categories, "7020 7050")
+
+    assert_equal [ 3030, 3010, 3040 ], SettingsService.indexer_category_ids_for(:audiobook)
+    assert_equal [ 7020, 7050 ], SettingsService.indexer_category_ids_for(:ebook)
+  end
+
+  test "unrestricted indexer search scope sends no categories" do
+    SettingsService.set(:indexer_search_scope, "unrestricted")
+
+    assert_equal [], SettingsService.indexer_category_ids_for(:audiobook)
+    assert SettingsService.unrestricted_indexer_search_scope?
   end
 
   test "post processing source path retries has a dedicated default" do


### PR DESCRIPTION
## Summary
- add configurable indexer search scope modes for strict, broad, unrestricted, and custom category searches
- keep broad mode as the default by combining categorized search with a categoryless supplement filtered by Shelfarr relevance/category checks
- add admin settings for custom audiobook and ebook category IDs
- make unrestricted searches categoryless but still locally filtered before saving

Closes #294

## Quality gates
- bin/quality deep
- pre-commit quality hook
- pre-push quality hook