### PR TITLE
fix: collapse navigation into a hamburger menu on mobile

### DIFF
--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Toggles the mobile navigation menu and its open/close icons
+export default class extends Controller {
+  static targets = ["menu", "openIcon", "closeIcon"]
+
+  toggle() {
+    const isHidden = this.menuTarget.classList.toggle("hidden")
+    this.openIconTarget.classList.toggle("hidden", !isHidden)
+    this.closeIconTarget.classList.toggle("hidden", isHidden)
+  }
+
+  close() {
+    this.menuTarget.classList.add("hidden")
+    this.openIconTarget.classList.remove("hidden")
+    this.closeIconTarget.classList.add("hidden")
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,40 +24,44 @@
   </head>
 
   <body class="bg-gray-950 min-h-screen">
-    <nav class="bg-gray-900 border-b border-gray-800">
+    <nav class="bg-gray-900 border-b border-gray-800" data-controller="mobile-menu">
+      <% if authenticated? %>
+        <% attention_count = Current.user&.admin? ? Request.needs_attention.count : Request.for_user(Current.user).needs_attention.count %>
+        <% unread_count = Current.user&.notifications&.unread&.count || 0 %>
+      <% end %>
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-          <div class="flex items-center gap-6">
-            <%= link_to root_path, class: "flex items-center gap-2 text-xl font-bold text-white" do %>
+        <div class="flex justify-between items-center h-16 gap-4">
+          <div class="flex items-center gap-6 min-w-0">
+            <%= link_to root_path, class: "flex items-center gap-2 text-xl font-bold text-white shrink-0" do %>
               <img src="<%= public_asset_path('icon.png') %>" alt="Shelfarr" class="w-8 h-8 rounded-md">
               <span>Shelfarr</span>
             <% end %>
             <% if authenticated? %>
-              <%= link_to "Search", search_path, class: "text-gray-400 hover:text-white font-medium transition" %>
-              <% attention_count = Current.user&.admin? ? Request.needs_attention.count : Request.for_user(Current.user).needs_attention.count %>
-              <div class="inline-flex items-center gap-2">
-                <%= link_to "Requests", requests_path, class: "text-gray-400 hover:text-white font-medium transition" %>
-                <% if attention_count > 0 %>
-                  <%= link_to requests_path(attention: "true"), class: "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold bg-red-500 hover:bg-red-400 text-white transition" do %>
-                    <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-                      <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                    </svg>
-                    <%= attention_count %>
+              <div class="hidden lg:flex items-center gap-6">
+                <%= link_to "Search", search_path, class: "text-gray-400 hover:text-white font-medium transition" %>
+                <div class="inline-flex items-center gap-2">
+                  <%= link_to "Requests", requests_path, class: "text-gray-400 hover:text-white font-medium transition" %>
+                  <% if attention_count > 0 %>
+                    <%= link_to requests_path(attention: "true"), class: "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold bg-red-500 hover:bg-red-400 text-white transition" do %>
+                      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                      </svg>
+                      <%= attention_count %>
+                    <% end %>
                   <% end %>
+                </div>
+                <%= link_to "Library", library_index_path, class: "text-gray-400 hover:text-white font-medium transition" %>
+                <% if allowed_to?(:index?, Upload) %>
+                  <%= link_to "Uploads", uploads_path, class: "text-gray-400 hover:text-white font-medium transition" %>
                 <% end %>
               </div>
-              <%= link_to "Library", library_index_path, class: "text-gray-400 hover:text-white font-medium transition" %>
-              <% if allowed_to?(:index?, Upload) %>
-                <%= link_to "Uploads", uploads_path, class: "text-gray-400 hover:text-white font-medium transition" %>
-              <% end %>
             <% end %>
           </div>
-          <div class="flex items-center gap-4">
+          <div class="hidden lg:flex items-center gap-4">
             <% if authenticated? %>
               <% if Current.user&.admin? %>
                 <%= link_to "Admin", admin_root_path, class: "text-gray-400 hover:text-white transition" %>
               <% end %>
-              <% unread_count = Current.user&.notifications&.unread&.count || 0 %>
               <%= link_to notifications_path, class: "relative text-gray-400 hover:text-white transition", title: "Notifications" do %>
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
@@ -82,8 +86,70 @@
               <% end %>
             <% end %>
           </div>
+          <div class="flex lg:hidden items-center gap-2 shrink-0">
+            <% if authenticated? %>
+              <%= link_to notifications_path, class: "relative text-gray-400 hover:text-white transition p-1", title: "Notifications" do %>
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                </svg>
+                <% if unread_count > 0 %>
+                  <span class="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold w-5 h-5 flex items-center justify-center rounded-full">
+                    <%= unread_count > 9 ? '9+' : unread_count %>
+                  </span>
+                <% end %>
+              <% end %>
+              <button type="button" class="text-gray-400 hover:text-white transition p-1" data-action="mobile-menu#toggle" aria-label="Toggle navigation menu">
+                <svg data-mobile-menu-target="openIcon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+                <svg data-mobile-menu-target="closeIcon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            <% else %>
+              <%= link_to "Sign in", new_session_path, class: "text-gray-400 hover:text-white transition" %>
+              <% if User.active.none? %>
+                <%= link_to "Sign up", sign_up_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
+              <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
+
+      <% if authenticated? %>
+        <div data-mobile-menu-target="menu" class="hidden lg:hidden border-t border-gray-800">
+          <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex flex-col">
+            <%= link_to "Search", search_path, class: "py-2 text-gray-300 hover:text-white font-medium transition", data: { action: "mobile-menu#close" } %>
+            <div class="inline-flex items-center gap-2 py-2">
+              <%= link_to "Requests", requests_path, class: "text-gray-300 hover:text-white font-medium transition", data: { action: "mobile-menu#close" } %>
+              <% if attention_count > 0 %>
+                <%= link_to requests_path(attention: "true"), class: "inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold bg-red-500 hover:bg-red-400 text-white transition", data: { action: "mobile-menu#close" } do %>
+                  <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+                  </svg>
+                  <%= attention_count %>
+                <% end %>
+              <% end %>
+            </div>
+            <%= link_to "Library", library_index_path, class: "py-2 text-gray-300 hover:text-white font-medium transition", data: { action: "mobile-menu#close" } %>
+            <% if allowed_to?(:index?, Upload) %>
+              <%= link_to "Uploads", uploads_path, class: "py-2 text-gray-300 hover:text-white font-medium transition", data: { action: "mobile-menu#close" } %>
+            <% end %>
+            <% if Current.user&.admin? %>
+              <%= link_to "Admin", admin_root_path, class: "py-2 text-gray-300 hover:text-white font-medium transition", data: { action: "mobile-menu#close" } %>
+            <% end %>
+            <div class="border-t border-gray-800 mt-2 pt-2 flex flex-col">
+              <%= link_to profile_path, class: "py-2 text-gray-300 hover:text-white flex items-center gap-2 transition", data: { action: "mobile-menu#close" } do %>
+                <span><%= Current.user&.name %></span>
+                <% if Current.user&.admin? %>
+                  <span class="text-xs bg-purple-500/20 text-purple-400 px-2 py-1 rounded">Admin</span>
+                <% end %>
+              <% end %>
+              <%= button_to "Sign out", session_path, method: :delete, class: "py-2 text-left text-gray-300 hover:text-white font-medium transition" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
     </nav>
 
     <main class="max-w-7xl mx-auto mt-8 px-4 sm:px-6 lg:px-8 pb-12">


### PR DESCRIPTION
## Summary

Fixes #300. On narrow screens the top navigation laid all its links out inline with no responsive handling, so they overflowed horizontally — overlapping the logo and running off the right edge.

Below Tailwind's `lg` breakpoint, the inline nav links now collapse into a toggleable hamburger menu:

- The logo and notification bell stay in the top bar for quick access.
- Tapping the hamburger reveals a stacked dropdown with all nav items (Search, Requests + attention badge, Library, Uploads, Admin) and the profile / Sign out below a divider.
- The button icon toggles between the hamburger and an ✕, and tapping any link auto-closes the menu.
- The desktop (`lg+`) layout is unchanged.

A small Stimulus controller (`mobile_menu_controller.js`) handles the toggle, following the project's existing controller conventions.

## Test plan

- [x] Verified at a 390px mobile viewport: nav no longer overflows; hamburger opens/closes the menu; icon swaps correctly; links close the menu on tap.
- [x] Verified the desktop layout is visually unchanged.
- [x] Authorization guards preserved (`allowed_to?(:index?, Upload)`, admin-only Admin link).