### PR TITLE
feat: add custom acquisition providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Think Jellyseerr, but for books. Your users request ebooks and audiobooks; Shelf
 - **Notifications** — In-app, Discord, Telegram and webhook notifications for request events
 - **Download Routing** — Route specific indexers to specific clients, with priority ordering
 - **REST API** — Scoped, per-user API tokens under `/api/v1`
+- **Custom Acquisition Providers** — Trusted HTTP providers can contribute search results and resolve selected items into direct, torrent or usenet artifacts
 
 ## Quick Start
 
@@ -183,7 +184,7 @@ bundle exec lefthook install
 # Quiet staged-file check plus the 90% coverage gate used by pre-commit
 bin/quality commit --staged
 
-# Quiet full check used by pre-push
+# Quiet full check plus coverage gate used by pre-push
 bin/quality push
 
 # Run coverage on demand

--- a/app/controllers/admin/acquisition_providers_controller.rb
+++ b/app/controllers/admin/acquisition_providers_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Admin
+  class AcquisitionProvidersController < BaseController
+    before_action :set_provider, only: [ :show, :edit, :update, :destroy, :test ]
+
+    def index
+      @providers = AcquisitionProvider.by_priority
+    end
+
+    def show
+    end
+
+    def new
+      @provider = AcquisitionProvider.new(timeout_seconds: 30, supports_ebooks: true, supports_audiobooks: true)
+    end
+
+    def create
+      @provider = AcquisitionProvider.new(provider_params)
+      @provider.priority = next_priority
+
+      if @provider.save
+        redirect_to admin_acquisition_providers_path, notice: "Acquisition provider was successfully created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      attributes = provider_params
+      attributes = attributes.except(:api_key) if attributes[:api_key].blank?
+
+      if @provider.update(attributes)
+        redirect_to admin_acquisition_providers_path, notice: "Acquisition provider was successfully updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @provider.destroy
+      redirect_to admin_acquisition_providers_path, notice: "Acquisition provider was successfully deleted."
+    end
+
+    def test
+      if @provider.test_connection
+        redirect_to admin_acquisition_providers_path, notice: "Connection to '#{@provider.name}' successful."
+      else
+        redirect_to admin_acquisition_providers_path, alert: "Connection to '#{@provider.name}' failed."
+      end
+    end
+
+    private
+
+    def set_provider
+      @provider = AcquisitionProvider.find(params[:id])
+    end
+
+    def provider_params
+      params.require(:acquisition_provider).permit(
+        :name, :url, :api_key, :enabled, :allow_private_network, :supports_ebooks, :supports_audiobooks, :timeout_seconds
+      )
+    end
+
+    def next_priority
+      (AcquisitionProvider.maximum(:priority) || -1) + 1
+    end
+  end
+end

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -11,6 +11,12 @@ class DownloadJob < ApplicationJob
   MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES = 2.gigabytes
   MAX_DIRECT_DOWNLOAD_REDIRECTS = 5
   DIRECT_EBOOK_EXTENSIONS = %w[epub pdf mobi azw3].freeze
+  DIRECT_AUDIOBOOK_ARCHIVE_EXTENSIONS = %w[zip].freeze
+  DIRECT_AUDIOBOOK_FILE_EXTENSIONS = %w[m4b mp3 m4a aac flac ogg opus].freeze
+  DIRECT_AUDIOBOOK_EXTENSIONS = (DIRECT_AUDIOBOOK_ARCHIVE_EXTENSIONS + DIRECT_AUDIOBOOK_FILE_EXTENSIONS).freeze
+  # Extensions that are also ordinary words ("Live at the Opus") and need
+  # format-style context (".opus", "[opus]", "(opus)") in a title to count.
+  AMBIGUOUS_AUDIOBOOK_EXTENSIONS = %w[opus].freeze
 
   def perform(download_id)
     download = Download.find_by(id: download_id)
@@ -50,6 +56,8 @@ class DownloadJob < ApplicationJob
         handle_gutenberg_download(download, search_result)
       elsif search_result.from_librivox?
         handle_librivox_download(download, search_result)
+      elsif search_result.from_custom_provider?
+        handle_custom_provider_download(download, search_result)
       else
         handle_standard_download(download, search_result)
       end
@@ -93,6 +101,11 @@ class DownloadJob < ApplicationJob
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
       download.request.mark_for_attention!("Project Gutenberg error: #{e.message}")
+    rescue CustomAcquisitionProviderClient::Error => e
+      Rails.logger.error "[DownloadJob] Custom provider error for download ##{download.id}: #{e.message}"
+      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+      download.update!(status: :failed)
+      download.request.mark_for_attention!("Custom provider error: #{e.message}")
     end
   end
 
@@ -136,18 +149,73 @@ class DownloadJob < ApplicationJob
   def handle_librivox_download(download, search_result)
     raise LibrivoxClient::Error, "Selected LibriVox result is missing a download URL" if search_result.download_url.blank?
 
+    handle_direct_audiobook_archive_download(download, search_result, search_result.download_url, source_name: "LibriVox")
+  rescue => e
+    Rails.logger.error "[DownloadJob] LibriVox download failed: #{e.message}"
+    Rails.logger.error e.backtrace.first(5).join("\n")
+    track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
+    download.update!(status: :failed)
+    download.request.mark_for_attention!("LibriVox download failed: #{e.message}")
+  end
+
+  def handle_custom_provider_download(download, search_result)
+    provider = search_result.acquisition_provider
+    raise CustomAcquisitionProviderClient::ResponseError, "Selected custom provider result is missing its provider" unless provider&.enabled?
+
+    Rails.logger.info "[DownloadJob] Acquiring custom provider result from #{provider.name}"
+    acquisition = provider.client.acquire(search_result)
+
+    case acquisition.download_type
+    when "direct"
+      if download.request.book.audiobook?
+        handle_direct_audiobook_download(download, search_result, acquisition.direct_url, source_name: provider.name)
+      else
+        handle_direct_http_download(download, search_result, acquisition.direct_url)
+      end
+    when "torrent"
+      torrent_url = acquisition.magnet_url.presence || acquisition.direct_url
+      send_to_torrent_client(download, search_result, validate_dispatch_url!(torrent_url, search_result))
+    when "usenet"
+      nzb_url = acquisition.nzb_url.presence || acquisition.direct_url
+      send_to_usenet_client(download, search_result, validate_dispatch_url!(nzb_url, search_result))
+    else
+      raise CustomAcquisitionProviderClient::ResponseError, "Unsupported custom provider artifact type: #{acquisition.download_type}"
+    end
+  rescue CustomAcquisitionProviderClient::Error
+    raise
+  rescue => e
+    Rails.logger.error "[DownloadJob] Custom provider download failed: #{e.message}"
+    Rails.logger.error e.backtrace.first(5).join("\n")
+    track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
+    download.update!(status: :failed)
+    download.request.mark_for_attention!("Custom provider download failed: #{e.message}")
+  end
+
+  def handle_direct_audiobook_download(download, search_result, download_url, source_name:)
+    extension = infer_audiobook_extension(download_url, search_result)
+
+    if DIRECT_AUDIOBOOK_ARCHIVE_EXTENSIONS.include?(extension)
+      handle_direct_audiobook_archive_download(download, search_result, download_url, source_name: source_name)
+    elsif DIRECT_AUDIOBOOK_FILE_EXTENSIONS.include?(extension)
+      handle_direct_audiobook_file_download(download, search_result, download_url, extension: extension, source_name: source_name)
+    else
+      raise "#{source_name} returned an unsupported audiobook direct download type"
+    end
+  end
+
+  def handle_direct_audiobook_archive_download(download, search_result, download_url, source_name:)
     book = download.request.book
     base_path = SettingsService.get(:audiobook_output_path, default: "/audiobooks")
     destination_dir = PathTemplateService.build_destination(book, base_path: base_path)
 
-    Rails.logger.info "[DownloadJob] Downloading LibriVox audiobook to: #{destination_dir}"
+    Rails.logger.info "[DownloadJob] Downloading #{source_name} audiobook to: #{destination_dir}"
     FileUtils.mkdir_p(destination_dir)
 
-    Tempfile.create([ "shelfarr-librivox-", ".zip" ]) do |archive|
+    Tempfile.create([ "shelfarr-audiobook-", ".zip" ]) do |archive|
       archive.binmode
       download_file_via_http(
         search_result,
-        search_result.download_url,
+        download_url,
         archive.path,
         max_bytes: MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES
       )
@@ -165,15 +233,45 @@ class DownloadJob < ApplicationJob
     download.request.complete!
     trigger_library_scan(book) if AudiobookshelfClient.configured?
     NotificationService.request_completed(download.request)
-    track_request_event(download.request, "completed", download: download, message: "LibriVox download completed")
+    track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
-    Rails.logger.info "[DownloadJob] LibriVox download completed: #{destination_dir}"
+    Rails.logger.info "[DownloadJob] #{source_name} download completed: #{destination_dir}"
+  end
+
+  def handle_direct_audiobook_file_download(download, search_result, download_url, extension:, source_name:)
+    book = download.request.book
+    base_path = SettingsService.get(:audiobook_output_path, default: "/audiobooks")
+    destination_dir = PathTemplateService.build_destination(book, base_path: base_path)
+    filename = infer_audiobook_filename_from_url(download_url, search_result, extension)
+    destination_path = File.join(destination_dir, filename)
+
+    Rails.logger.info "[DownloadJob] Downloading #{source_name} audiobook file to: #{destination_path}"
+    FileUtils.mkdir_p(destination_dir)
+
+    download_file_via_http(
+      search_result,
+      download_url,
+      destination_path,
+      max_bytes: MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES
+    )
+    verify_downloaded_audiobook_file!(destination_path)
+
+    download.update!(
+      status: :completed,
+      download_path: destination_path,
+      download_type: "direct"
+    )
+
+    book.update!(file_path: destination_dir)
+    download.request.complete!
+    trigger_library_scan(book) if AudiobookshelfClient.configured?
+    NotificationService.request_completed(download.request)
+    track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
+
+    Rails.logger.info "[DownloadJob] #{source_name} download completed: #{destination_path}"
   rescue => e
-    Rails.logger.error "[DownloadJob] LibriVox download failed: #{e.message}"
-    Rails.logger.error e.backtrace.first(5).join("\n")
-    track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
-    download.update!(status: :failed)
-    download.request.mark_for_attention!("LibriVox download failed: #{e.message}")
+    FileUtils.rm_f(destination_path) if defined?(destination_path) && destination_path.present?
+    raise e
   end
 
   def handle_direct_http_download(download, search_result, download_url)
@@ -269,6 +367,50 @@ class DownloadJob < ApplicationJob
     "epub"
   end
 
+  def infer_audiobook_extension(url, search_result)
+    extension = extension_from_url(url, DIRECT_AUDIOBOOK_EXTENSIONS)
+    return extension if extension.present?
+
+    title = search_result.title.to_s.downcase
+    DIRECT_AUDIOBOOK_EXTENSIONS.find { |candidate| title_format_hint?(title, candidate) }
+  end
+
+  def title_format_hint?(title, extension)
+    escaped = Regexp.escape(extension)
+    return title.match?(/[\[\(.]#{escaped}[\]\)]?(\b|\z)/) if AMBIGUOUS_AUDIOBOOK_EXTENSIONS.include?(extension)
+
+    title.match?(/\b#{escaped}\b/)
+  end
+
+  def infer_audiobook_filename_from_url(url, search_result, extension)
+    filename_from_url = filename_from_url(url)
+    return sanitize_filename(filename_from_url) if filename_from_url.present? &&
+      File.extname(filename_from_url).delete(".").downcase == extension
+
+    book = search_result.request.book
+    title = book.title.presence || "Unknown"
+    author = book.author.presence || "Unknown"
+    sanitize_filename("#{author} - #{title}.#{extension}")
+  end
+
+  def extension_from_url(url, allowed_extensions)
+    uri = URI.parse(normalize_direct_download_url(url))
+    extension = File.extname(uri.path).delete(".").downcase
+    return extension if allowed_extensions.include?(extension)
+
+    nil
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def filename_from_url(url)
+    uri = URI.parse(normalize_direct_download_url(url))
+    filename = File.basename(uri.path)
+    URI.decode_www_form_component(filename) if filename.present?
+  rescue URI::InvalidURIError
+    nil
+  end
+
   def normalize_url_filename(filename, inferred_extension)
     return nil if filename.blank?
 
@@ -318,7 +460,7 @@ class DownloadJob < ApplicationJob
   end
 
   def download_file_via_http(search_result, url, destination, max_bytes: MAX_DIRECT_DOWNLOAD_BYTES)
-    uri = validate_direct_download_url!(url, search_result)
+    endpoint = validate_direct_download_url!(url, search_result)
 
     Rails.logger.info "[DownloadJob] Starting HTTP download..."
 
@@ -329,8 +471,15 @@ class DownloadJob < ApplicationJob
     loop do
       response_handled = false
 
-      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https", open_timeout: 30, read_timeout: 300) do |http|
-        request = Net::HTTP::Get.new(uri)
+      Net::HTTP.start(
+        endpoint.host,
+        endpoint.port,
+        use_ssl: endpoint.use_ssl?,
+        ipaddr: endpoint.ipaddr,
+        open_timeout: 30,
+        read_timeout: 300
+      ) do |http|
+        request = Net::HTTP::Get.new(endpoint.uri)
         request["User-Agent"] = "Shelfarr/1.0"
 
         http.request(request) do |response|
@@ -341,8 +490,8 @@ class DownloadJob < ApplicationJob
             location = response["Location"]
             raise "Direct download redirect missing Location" if location.blank?
 
-            uri = validate_direct_download_url!(URI.join(uri, normalize_direct_download_url(location)).to_s, search_result)
-            Rails.logger.info "[DownloadJob] Following HTTP redirect to #{uri.host}"
+            endpoint = validate_direct_download_url!(URI.join(endpoint.uri, normalize_direct_download_url(location)).to_s, search_result)
+            Rails.logger.info "[DownloadJob] Following HTTP redirect to #{endpoint.host}"
             response_handled = true
             next
           end
@@ -382,12 +531,27 @@ class DownloadJob < ApplicationJob
   end
 
   def validate_direct_download_url!(url, search_result = nil)
-    uri = URI.parse(normalize_direct_download_url(url))
-    raise "Invalid direct download URL" unless %w[http https].include?(uri.scheme) && uri.host.present?
-
-    uri
-  rescue URI::InvalidURIError => e
+    OutboundUrlGuard.validate!(
+      normalize_direct_download_url(url),
+      allow_private: allow_private_download?(search_result)
+    )
+  rescue OutboundUrlGuard::BlockedUrlError => e
     raise "Invalid direct download URL: #{e.message}"
+  end
+
+  def allow_private_download?(search_result)
+    return false unless search_result&.from_custom_provider?
+
+    search_result.acquisition_provider&.allow_private_network? || false
+  end
+
+  def validate_dispatch_url!(url, search_result)
+    return url if url.to_s.start_with?("magnet:")
+
+    OutboundUrlGuard.validate!(url, allow_private: allow_private_download?(search_result))
+    url
+  rescue OutboundUrlGuard::BlockedUrlError => e
+    raise CustomAcquisitionProviderClient::ResponseError, "Refused download URL from custom provider: #{e.message}"
   end
 
   def normalize_direct_download_url(url)
@@ -417,7 +581,7 @@ class DownloadJob < ApplicationJob
     file_size = File.size(path)
     raise "Downloaded file is empty" if file_size.zero?
 
-    head = File.binread(path, [512, file_size].min)
+    head = File.binread(path, [ 512, file_size ].min)
     lowered = head.downcase
     if lowered.include?("<html") || lowered.include?("<!doctype")
       FileUtils.rm_f(path)
@@ -430,7 +594,7 @@ class DownloadJob < ApplicationJob
     when "pdf"
       raise "Downloaded file is not a valid PDF" unless head.start_with?("%PDF")
     when "mobi"
-      mobi_signature = File.binread(path, [68, file_size].min).byteslice(60, 8)
+      mobi_signature = File.binread(path, [ 68, file_size ].min).byteslice(60, 8)
       raise "Downloaded file is not a valid MOBI" unless mobi_signature == "BOOKMOBI"
     end
   rescue Errno::ENOENT => e
@@ -451,6 +615,22 @@ class DownloadJob < ApplicationJob
     end
 
     raise "Downloaded file is not a valid ZIP archive" unless head.start_with?("PK\x03\x04")
+  rescue Errno::ENOENT => e
+    raise "Downloaded file is missing: #{e.message}"
+  end
+
+  def verify_downloaded_audiobook_file!(path)
+    raise "Downloaded file does not exist" unless File.exist?(path)
+
+    file_size = File.size(path)
+    raise "Downloaded file is empty" if file_size.zero?
+
+    head = File.binread(path, [ 512, file_size ].min)
+    lowered = head.downcase
+    if lowered.include?("<html") || lowered.include?("<!doctype")
+      FileUtils.rm_f(path)
+      raise "Downloaded file is an HTML page, not an audiobook"
+    end
   rescue Errno::ENOENT => e
     raise "Downloaded file is missing: #{e.message}"
   end
@@ -542,6 +722,50 @@ class DownloadJob < ApplicationJob
       download.update!(status: :failed)
       download.request.mark_for_attention!("Failed to add to #{client_record.name}")
       Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
+    end
+  end
+
+  def send_to_usenet_client(download, search_result, nzb_url)
+    client_record = DownloadClient.usenet_clients.enabled.by_priority.find(&:test_connection)
+    raise DownloadClientSelector::NoClientAvailableError, "No usenet client available (all failed connection test)" unless client_record
+
+    client = client_record.adapter
+    Rails.logger.info "[DownloadJob] Using client '#{client_record.name}' for custom usenet download ##{download.id}"
+
+    result = client.add_torrent(nzb_url, nzbname: build_usenet_job_name(search_result))
+    external_id = result.is_a?(Hash) ? result["nzo_ids"]&.first : nil
+
+    if external_id.present?
+      check_for_duplicate_external_id(external_id, download.id)
+
+      download.update!(
+        status: :downloading,
+        download_client: client_record,
+        external_id: external_id,
+        download_type: "usenet"
+      )
+      track_request_event(
+        download.request,
+        "dispatched",
+        download: download,
+        message: "Sent usenet download to #{client_record.name}",
+        details: {
+          client_name: client_record.name,
+          download_type: "usenet",
+          external_id: external_id
+        }
+      )
+    else
+      track_request_event(
+        download.request,
+        "dispatch_failed",
+        download: download,
+        message: "Client did not return an external ID",
+        level: :error,
+        details: { client_name: client_record.name, download_type: "usenet" }
+      )
+      download.update!(status: :failed)
+      download.request.mark_for_attention!("Failed to add to #{client_record.name}")
     end
   end
 
@@ -652,5 +876,4 @@ class DownloadJob < ApplicationJob
       details: details
     )
   end
-
 end

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -19,10 +19,11 @@ class SearchJob < ApplicationJob
     zlibrary_available = !anna_available && ZLibraryClient.configured? && request.book.ebook?
     gutenberg_available = GutenbergClient.configured? && request.book.ebook?
     librivox_available = LibrivoxClient.configured? && request.book.audiobook?
+    custom_providers = AcquisitionProvider.enabled.for_book_type(request.book.book_type).by_priority.to_a
 
-    unless indexer_available || anna_available || zlibrary_available || gutenberg_available || librivox_available
+    unless indexer_available || anna_available || zlibrary_available || gutenberg_available || librivox_available || custom_providers.any?
       Rails.logger.error "[SearchJob] No search sources configured"
-      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, Z-Library, Project Gutenberg, or LibriVox in Admin Settings.")
+      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, Z-Library, Project Gutenberg, LibriVox, or a custom acquisition provider.")
       return
     end
 
@@ -58,6 +59,12 @@ class SearchJob < ApplicationJob
       librivox_results = search_librivox(request)
       all_results.concat(librivox_results)
       Rails.logger.info "[SearchJob] Found #{librivox_results.count} LibriVox results"
+    end
+
+    custom_providers.each do |provider|
+      provider_results = search_custom_provider(request, provider)
+      all_results.concat(provider_results)
+      Rails.logger.info "[SearchJob] Found #{provider_results.count} custom provider results from #{provider.name}"
     end
 
     if all_results.any?
@@ -227,6 +234,15 @@ class SearchJob < ApplicationJob
     []
   end
 
+  def search_custom_provider(request, provider)
+    provider.client.search(request).select(&:downloadable?).map do |result|
+      { result: result, source: SearchResult::SOURCE_CUSTOM, provider: provider }
+    end
+  rescue CustomAcquisitionProviderClient::Error => e
+    Rails.logger.warn "[SearchJob] Custom provider #{provider.name} search failed: #{e.message}"
+    []
+  end
+
   def save_results(request, tagged_results)
     request.search_results.destroy_all
 
@@ -243,6 +259,8 @@ class SearchJob < ApplicationJob
         save_gutenberg_result(request, result)
       when SearchResult::SOURCE_LIBRIVOX
         save_librivox_result(request, result)
+      when SearchResult::SOURCE_CUSTOM
+        save_custom_provider_result(request, result, tagged[:provider])
       else
         save_indexer_result(request, result, source)
       end
@@ -333,6 +351,36 @@ class SearchJob < ApplicationJob
       sr.source = SearchResult::SOURCE_GUTENBERG
       sr.detected_language = result.language
     end
+  end
+
+  def save_custom_provider_result(request, result, provider)
+    request.search_results.find_or_create_by!(
+      acquisition_provider: provider,
+      provider_result_id: result.provider_result_id
+    ) do |sr|
+      sr.guid = "custom:#{provider.id}:#{result.provider_result_id}"
+      sr.title = build_custom_provider_title(result)
+      sr.indexer = provider.name
+      sr.size_bytes = result.size_bytes
+      sr.seeders = nil
+      sr.leechers = nil
+      sr.download_url = result.download_url
+      sr.magnet_url = result.magnet_url
+      sr.info_url = result.info_url
+      sr.published_at = result.published_at
+      sr.source = SearchResult::SOURCE_CUSTOM
+      sr.detected_language = result.language
+      sr.provider_payload = result.payload
+    end
+  end
+
+  def build_custom_provider_title(result)
+    parts = []
+    parts << result.title if result.title.present?
+    parts << "- #{result.author}" if result.author.present?
+    parts << "[#{result.file_type.to_s.upcase}]" if result.file_type.present?
+    parts << "[#{result.language}]" if result.language.present?
+    parts.join(" ")
   end
 
   def build_librivox_title(result)

--- a/app/models/acquisition_provider.rb
+++ b/app/models/acquisition_provider.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "uri"
+
+class AcquisitionProvider < ApplicationRecord
+  encrypts :api_key
+
+  has_many :search_results, dependent: :nullify
+
+  before_validation :normalize_url
+
+  validates :name, presence: true, uniqueness: true
+  validates :url, presence: true
+  validates :priority, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :timeout_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 120 }
+  validate :url_is_http
+  validate :url_private_network_access
+  validate :supports_at_least_one_media_type
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :by_priority, -> { order(priority: :asc, name: :asc) }
+  scope :for_book_type, ->(book_type) {
+    case book_type&.to_s
+    when "ebook"
+      where(supports_ebooks: true)
+    when "audiobook"
+      where(supports_audiobooks: true)
+    else
+      all
+    end
+  }
+
+  def client
+    CustomAcquisitionProviderClient.new(self)
+  end
+
+  def test_connection
+    client.test_connection
+  end
+
+  private
+
+  def normalize_url
+    self.url = url.to_s.strip.delete_suffix("/") if url.present?
+  end
+
+  def url_is_http
+    uri = URI.parse(url.to_s)
+    return if %w[http https].include?(uri.scheme) && uri.host.present? && uri.userinfo.blank?
+
+    errors.add(:url, "must be a valid http or https URL")
+  rescue URI::InvalidURIError
+    errors.add(:url, "must be a valid http or https URL")
+  end
+
+  def url_private_network_access
+    return if allow_private_network?
+    return if url.blank? || errors.include?(:url)
+
+    host = URI.parse(url.to_s).host
+    return unless OutboundUrlGuard.obviously_private_host?(host)
+
+    errors.add(:url, "points to a private network address. Enable \"Allow private network\" if this provider runs on your local network.")
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def supports_at_least_one_media_type
+    return if supports_ebooks? || supports_audiobooks?
+
+    errors.add(:base, "Provider must support ebooks, audiobooks, or both")
+  end
+end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -2,6 +2,7 @@
 
 class SearchResult < ApplicationRecord
   belongs_to :request
+  belongs_to :acquisition_provider, optional: true
   has_many :downloads, dependent: :nullify
 
   after_commit :broadcast_request_show_refresh_later
@@ -19,6 +20,7 @@ class SearchResult < ApplicationRecord
   SOURCE_ZLIBRARY = "zlibrary"
   SOURCE_GUTENBERG = "gutenberg"
   SOURCE_LIBRIVOX = "librivox"
+  SOURCE_CUSTOM = "custom"
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
   validates :title, presence: true
@@ -28,8 +30,27 @@ class SearchResult < ApplicationRecord
   scope :preferred_first, -> {
     ordered_types = SettingsService.preferred_download_types
     type_order_sql = ordered_types.each_with_index.map { |type, index| "WHEN '#{type}' THEN #{index}" }.join(" ")
+    custom_type_sql = <<~SQL.squish
+      LOWER(COALESCE(
+        json_extract(provider_payload, '$.download_type'),
+        json_extract(provider_payload, '$.type'),
+        ''
+      ))
+    SQL
+    custom_direct_url_sql = "NULLIF(json_extract(provider_payload, '$.direct_url'), '')"
+    custom_nzb_url_sql = "NULLIF(json_extract(provider_payload, '$.nzb_url'), '')"
+    custom_magnet_url_sql = "NULLIF(json_extract(provider_payload, '$.magnet_url'), '')"
+    type_aliases_sql = CustomAcquisitionProviderClient::DOWNLOAD_TYPE_ALIASES.transform_values { |aliases|
+      aliases.map { |value| "'#{value}'" }.join(", ")
+    }
     download_type_sql = <<~SQL.squish
       CASE
+        WHEN source = '#{SOURCE_CUSTOM}' AND #{custom_type_sql} IN (#{type_aliases_sql["direct"]}) THEN 'direct'
+        WHEN source = '#{SOURCE_CUSTOM}' AND #{custom_type_sql} IN (#{type_aliases_sql["usenet"]}) THEN 'usenet'
+        WHEN source = '#{SOURCE_CUSTOM}' AND #{custom_type_sql} IN (#{type_aliases_sql["torrent"]}) THEN 'torrent'
+        WHEN source = '#{SOURCE_CUSTOM}' AND #{custom_type_sql} = '' AND #{custom_direct_url_sql} IS NOT NULL THEN 'direct'
+        WHEN source = '#{SOURCE_CUSTOM}' AND #{custom_type_sql} = '' AND #{custom_nzb_url_sql} IS NOT NULL THEN 'usenet'
+        WHEN source = '#{SOURCE_CUSTOM}' AND #{custom_type_sql} = '' AND #{custom_magnet_url_sql} IS NOT NULL THEN 'torrent'
         WHEN source IN ('#{SOURCE_ANNA_ARCHIVE}', '#{SOURCE_ZLIBRARY}', '#{SOURCE_GUTENBERG}', '#{SOURCE_LIBRIVOX}') THEN 'direct'
         WHEN download_url IS NOT NULL AND magnet_url IS NULL AND seeders IS NULL THEN 'usenet'
         ELSE 'torrent'
@@ -56,6 +77,12 @@ class SearchResult < ApplicationRecord
   }
 
   def downloadable?
+    if from_custom_provider?
+      return false unless acquisition_provider&.enabled?
+      return false unless custom_provider_available?
+
+      return true
+    end
     return true if direct_download?
 
     download_url.present? || magnet_url.present?
@@ -78,10 +105,15 @@ class SearchResult < ApplicationRecord
   end
 
   def direct_download?
-    from_anna_archive? || from_zlibrary? || from_gutenberg? || from_librivox?
+    from_anna_archive? ||
+      from_zlibrary? ||
+      from_gutenberg? ||
+      from_librivox? ||
+      (from_custom_provider? && custom_provider_download_type == "direct")
   end
 
   def download_type
+    return custom_provider_download_type if from_custom_provider? && custom_provider_download_type.present?
     return "direct" if direct_download?
     return "usenet" if usenet?
     return "torrent" if torrent?
@@ -206,6 +238,10 @@ class SearchResult < ApplicationRecord
     source == SOURCE_LIBRIVOX
   end
 
+  def from_custom_provider?
+    source == SOURCE_CUSTOM
+  end
+
   def source_display_name
     case source
     when SOURCE_JACKETT
@@ -218,12 +254,37 @@ class SearchResult < ApplicationRecord
       "Project Gutenberg"
     when SOURCE_LIBRIVOX
       "LibriVox"
+    when SOURCE_CUSTOM
+      acquisition_provider&.name || indexer.presence || "Custom Provider"
     else
       indexer.presence || "Prowlarr"
     end
   end
 
   private
+
+  def custom_provider_download_type
+    value = provider_payload_value(:download_type) || provider_payload_value(:type)
+    normalized = CustomAcquisitionProviderClient.normalize_download_type(value)
+    return normalized if normalized.present?
+
+    return "direct" if provider_payload_value(:direct_url).present?
+    return "torrent" if provider_payload_value(:magnet_url).present?
+    return "usenet" if provider_payload_value(:nzb_url).present?
+
+    nil
+  end
+
+  def custom_provider_available?
+    availability = provider_payload_value(:availability).to_s.strip.downcase
+    availability.blank? || availability == "available"
+  end
+
+  def provider_payload_value(key)
+    return nil unless provider_payload.is_a?(Hash)
+
+    provider_payload[key.to_s]
+  end
 
   def score_detail(key)
     return nil unless score_breakdown.is_a?(Hash)

--- a/app/services/custom_acquisition_provider_client.rb
+++ b/app/services/custom_acquisition_provider_client.rb
@@ -1,0 +1,322 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require "json"
+
+class CustomAcquisitionProviderClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class ResponseError < Error; end
+
+  MAX_RESPONSE_BYTES = 10.megabytes
+  HEALTH_CHECK_TIMEOUT_SECONDS = 10
+
+  DOWNLOAD_TYPE_ALIASES = {
+    "direct" => %w[direct http https file],
+    "torrent" => %w[torrent magnet],
+    "usenet" => %w[usenet nzb]
+  }.freeze
+
+  Result = Data.define(
+    :provider_result_id, :title, :author, :file_type, :language, :size_bytes,
+    :download_type, :download_url, :magnet_url, :info_url, :published_at,
+    :availability, :payload
+  ) do
+    def available?
+      availability.blank? || availability == "available"
+    end
+
+    def downloadable?
+      available?
+    end
+  end
+
+  Acquisition = Data.define(:download_type, :direct_url, :magnet_url, :nzb_url, :payload)
+
+  def self.normalize_download_type(value)
+    normalized = value.to_s.strip.downcase
+    return nil if normalized.blank?
+
+    DOWNLOAD_TYPE_ALIASES.each do |canonical, aliases|
+      return canonical if aliases.include?(normalized)
+    end
+
+    normalized
+  end
+
+  def initialize(provider)
+    @provider = provider
+  end
+
+  def search(request)
+    response = post_json("search", search_payload(request))
+    parse_search_results(response)
+  end
+
+  def acquire(search_result)
+    response = post_json("acquire", acquire_payload(search_result))
+    parse_acquisition(response)
+  end
+
+  def test_connection
+    endpoint = validate_endpoint!("health")
+    timeout = [ provider.timeout_seconds, HEALTH_CHECK_TIMEOUT_SECONDS ].min
+    response = start_http(endpoint, read_timeout: timeout) do |http|
+      http.request(build_request(Net::HTTP::Get, endpoint.uri))
+    end
+
+    response.is_a?(Net::HTTPSuccess)
+  rescue Error, *NETWORK_ERRORS
+    false
+  end
+
+  private
+
+  attr_reader :provider
+
+  NETWORK_ERRORS = [
+    SocketError, EOFError, IOError, Errno::ECONNREFUSED, Errno::ECONNRESET,
+    Errno::EHOSTUNREACH, Errno::ENETUNREACH, Net::OpenTimeout, Net::ReadTimeout,
+    OpenSSL::SSL::SSLError
+  ].freeze
+
+  def post_json(path, payload)
+    endpoint = validate_endpoint!(path)
+
+    response_body = nil
+    response = start_http(endpoint, read_timeout: provider.timeout_seconds) do |http|
+      request = build_request(Net::HTTP::Post, endpoint.uri)
+      request["Content-Type"] = "application/json"
+      request.body = JSON.generate(payload)
+
+      http.request(request) do |res|
+        response_body = read_capped_body(res)
+      end
+    end
+
+    unless response.is_a?(Net::HTTPSuccess)
+      raise ResponseError, "#{provider.name} returned HTTP #{response.code}"
+    end
+
+    parse_json(response_body)
+  rescue *NETWORK_ERRORS => e
+    raise ConnectionError, "Failed to connect to #{provider.name}: #{e.message}"
+  end
+
+  def validate_endpoint!(path)
+    OutboundUrlGuard.validate!(
+      "#{provider.url}/#{path}",
+      allow_private: provider.allow_private_network?
+    )
+  rescue OutboundUrlGuard::BlockedUrlError => e
+    raise ConnectionError, "Refused to contact #{provider.name}: #{e.message}"
+  end
+
+  def start_http(endpoint, read_timeout:, &block)
+    Net::HTTP.start(
+      endpoint.host,
+      endpoint.port,
+      use_ssl: endpoint.use_ssl?,
+      ipaddr: endpoint.ipaddr,
+      open_timeout: [ read_timeout, 10 ].min,
+      read_timeout: read_timeout,
+      &block
+    )
+  end
+
+  def build_request(request_class, uri)
+    request = request_class.new(uri)
+    request["User-Agent"] = "Shelfarr/1.0"
+    request["Authorization"] = "Bearer #{provider.api_key}" if provider.api_key.present?
+    request
+  end
+
+  def read_capped_body(response)
+    declared_length = response["Content-Length"].presence&.to_i
+    if declared_length && declared_length > MAX_RESPONSE_BYTES
+      raise ResponseError, "#{provider.name} response exceeds #{MAX_RESPONSE_BYTES / 1.megabyte} MB limit"
+    end
+
+    body = +""
+    response.read_body do |chunk|
+      body << chunk
+      if body.bytesize > MAX_RESPONSE_BYTES
+        raise ResponseError, "#{provider.name} response exceeds #{MAX_RESPONSE_BYTES / 1.megabyte} MB limit"
+      end
+    end
+
+    body
+  end
+
+  def parse_json(body)
+    JSON.parse(body.to_s)
+  rescue JSON::ParserError => e
+    raise ResponseError, "#{provider.name} returned invalid JSON: #{e.message}"
+  end
+
+  def search_payload(request)
+    book = request.book
+
+    {
+      query: [ book.title, book.author ].compact_blank.join(" "),
+      request: {
+        id: request.id,
+        language: request.effective_language
+      },
+      book: {
+        id: book.id,
+        title: book.title,
+        author: book.author,
+        book_type: book.book_type,
+        year: book.year,
+        language: book.language,
+        isbn: book.isbn,
+        open_library_work_id: book.open_library_work_id,
+        open_library_edition_id: book.open_library_edition_id,
+        hardcover_id: book.hardcover_id
+      }.compact
+    }
+  end
+
+  def acquire_payload(search_result)
+    {
+      provider_result_id: search_result.provider_result_id,
+      result: search_result_payload(search_result),
+      request: {
+        id: search_result.request_id,
+        language: search_result.request&.effective_language
+      },
+      book: {
+        id: search_result.request&.book_id,
+        title: search_result.request&.book&.title,
+        author: search_result.request&.book&.author,
+        book_type: search_result.request&.book&.book_type
+      }.compact
+    }
+  end
+
+  def search_result_payload(search_result)
+    {
+      id: search_result.id,
+      title: search_result.title,
+      source: search_result.source,
+      provider_result_id: search_result.provider_result_id,
+      provider_payload: search_result.provider_payload
+    }
+  end
+
+  def parse_search_results(body)
+    results = case body
+    when Array
+      body
+    when Hash
+      body.fetch("results", [])
+    else
+      raise ResponseError, "#{provider.name} returned an invalid search response"
+    end
+
+    unless results.is_a?(Array)
+      raise ResponseError, "#{provider.name} returned an invalid search results list"
+    end
+
+    results.filter_map do |item|
+      parse_search_result(item)
+    end
+  end
+
+  def parse_search_result(item)
+    return unless item.is_a?(Hash)
+
+    data = item
+    provider_result_id = data["id"].presence || data["provider_result_id"].presence || data["guid"].presence
+    title = data["title"].to_s.strip
+    return if provider_result_id.blank? || title.blank?
+    direct_url = data["direct_url"].presence
+    nzb_url = data["nzb_url"].presence
+    download_url = data["download_url"].presence || direct_url || nzb_url
+    magnet_url = data["magnet_url"].presence
+    download_type = self.class.normalize_download_type(data["download_type"].presence || data["type"].presence)
+    download_type ||= infer_download_type(direct_url:, nzb_url:, magnet_url:)
+    availability = normalize_availability(data["availability"].presence || "available")
+    payload = data.merge(
+      "download_type" => download_type,
+      "availability" => availability
+    )
+
+    Result.new(
+      provider_result_id: provider_result_id.to_s,
+      title: title,
+      author: data["author"].presence,
+      file_type: data["file_type"].presence || data["format"].presence,
+      language: data["language"].presence,
+      size_bytes: integer_or_nil(data["size_bytes"]),
+      download_type: download_type,
+      download_url: download_url,
+      magnet_url: magnet_url,
+      info_url: data["info_url"].presence,
+      published_at: time_or_nil(data["published_at"]),
+      availability: availability,
+      payload: payload
+    )
+  end
+
+  def parse_acquisition(body)
+    unless body.is_a?(Hash)
+      raise ResponseError, "#{provider.name} returned an invalid acquire response"
+    end
+
+    data = body
+    download_type = self.class.normalize_download_type(data["download_type"].presence || data["type"].presence)
+    direct_url = data["direct_url"].presence || data["download_url"].presence
+    magnet_url = data["magnet_url"].presence
+    nzb_url = data["nzb_url"].presence
+
+    download_type ||= "direct" if direct_url.present?
+    download_type ||= "torrent" if magnet_url.present?
+    download_type ||= "usenet" if nzb_url.present?
+
+    unless valid_acquisition?(download_type, direct_url:, magnet_url:, nzb_url:)
+      raise ResponseError, "#{provider.name} did not return an acquireable artifact"
+    end
+
+    Acquisition.new(download_type:, direct_url:, magnet_url:, nzb_url:, payload: data)
+  end
+
+  def valid_acquisition?(download_type, direct_url:, magnet_url:, nzb_url:)
+    case download_type
+    when "direct"
+      direct_url.present?
+    when "torrent"
+      magnet_url.present? || direct_url.present?
+    when "usenet"
+      nzb_url.present? || direct_url.present?
+    else
+      false
+    end
+  end
+
+  def infer_download_type(direct_url:, nzb_url:, magnet_url:)
+    return "direct" if direct_url.present?
+    return "torrent" if magnet_url.present?
+    return "usenet" if nzb_url.present?
+
+    nil
+  end
+
+  def normalize_availability(value)
+    value.to_s.strip.downcase.presence
+  end
+
+  def integer_or_nil(value)
+    Integer(value, exception: false)
+  end
+
+  def time_or_nil(value)
+    return if value.blank?
+
+    Time.zone.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+end

--- a/app/services/outbound_url_guard.rb
+++ b/app/services/outbound_url_guard.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+require "resolv"
+require "uri"
+
+# Validates URLs before Shelfarr makes server-side HTTP requests to them,
+# blocking requests to link-local/metadata addresses always and to private
+# networks unless the caller explicitly allows them (admin-configured
+# providers on a home-lab LAN).
+class OutboundUrlGuard
+  class BlockedUrlError < StandardError; end
+  ValidatedUrl = Data.define(:uri, :ipaddr) do
+    delegate :host, :port, :request_uri, :scheme, :to_s, to: :uri
+
+    def use_ssl?
+      scheme == "https"
+    end
+  end
+
+  # Never reachable, regardless of configuration: unspecified, link-local
+  # (incl. cloud metadata at 169.254.169.254), multicast, and reserved space.
+  ALWAYS_BLOCKED_RANGES = %w[
+    0.0.0.0/8
+    169.254.0.0/16
+    224.0.0.0/4
+    240.0.0.0/4
+    ::/128
+    64:ff9b::/96
+    fe80::/10
+    ff00::/8
+  ].map { |cidr| IPAddr.new(cidr) }.freeze
+
+  # Reachable only when the caller opts in via allow_private.
+  PRIVATE_RANGES = %w[
+    10.0.0.0/8
+    100.64.0.0/10
+    127.0.0.0/8
+    172.16.0.0/12
+    192.168.0.0/16
+    ::1/128
+    fc00::/7
+  ].map { |cidr| IPAddr.new(cidr) }.freeze
+
+  DEFAULT_RESOLVER = ->(host) { Resolv.getaddresses(host) }
+
+  cattr_accessor :resolver
+
+  class << self
+    def validate!(url, allow_private: false)
+      uri = URI.parse(url.to_s)
+      unless %w[http https].include?(uri.scheme) && uri.host.present?
+        raise BlockedUrlError, "URL must be a valid http or https URL"
+      end
+
+      addresses = resolve_addresses(uri.host)
+      addresses.each do |address|
+        if ALWAYS_BLOCKED_RANGES.any? { |range| range.include?(address) }
+          raise BlockedUrlError, "#{uri.host} resolves to a blocked address (#{address})"
+        end
+
+        if !allow_private && PRIVATE_RANGES.any? { |range| range.include?(address) }
+          raise BlockedUrlError, "#{uri.host} resolves to a private address (#{address})"
+        end
+      end
+
+      ValidatedUrl.new(uri:, ipaddr: addresses.first.to_s)
+    rescue URI::InvalidURIError => e
+      raise BlockedUrlError, "Invalid URL: #{e.message}"
+    end
+
+    # Cheap check for IP literals and localhost, usable in model validations
+    # without DNS lookups. Hostnames that merely resolve to private addresses
+    # are caught at request time by validate!.
+    def obviously_private_host?(host)
+      return true if host.to_s.casecmp("localhost").zero?
+
+      address = ip_literal(host)
+      return false if address.nil?
+
+      PRIVATE_RANGES.any? { |range| range.include?(address) } ||
+        ALWAYS_BLOCKED_RANGES.any? { |range| range.include?(address) }
+    end
+
+    private
+
+    def resolve_addresses(host)
+      return [ IPAddr.new("127.0.0.1") ] if host.to_s.casecmp("localhost").zero?
+
+      literal = ip_literal(host)
+      return [ literal ] if literal
+
+      addresses = (resolver || DEFAULT_RESOLVER).call(host).filter_map { |value| ip_literal(value) }
+      raise BlockedUrlError, "Could not resolve #{host}" if addresses.empty?
+
+      addresses
+    end
+
+    # IPv4-mapped/compat IPv6 forms (e.g. ::ffff:169.254.169.254) are
+    # normalized to their native IPv4 address, since IPAddr ranges do not
+    # match across address families.
+    def ip_literal(value)
+      address = IPAddr.new(value.to_s.delete_prefix("[").delete_suffix("]"))
+      return address.native if address.ipv6? && (address.ipv4_mapped? || address.ipv4_compat?)
+
+      address
+    rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
+      nil
+    end
+  end
+end

--- a/app/views/admin/acquisition_providers/_form.html.erb
+++ b/app/views/admin/acquisition_providers/_form.html.erb
@@ -1,0 +1,67 @@
+<%= form_with model: [:admin, provider], class: "contents" do |form| %>
+  <% if provider.errors.any? %>
+    <div class="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(provider.errors.count, "error") %> prohibited this provider from being saved:</h2>
+      <ul class="list-disc list-inside mt-2">
+        <% provider.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :name, class: "block text-gray-300 font-medium" %>
+    <%= form.text_field :name, required: true, placeholder: "e.g., Local Provider", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :url, "Base URL", class: "block text-gray-300 font-medium" %>
+    <%= form.url_field :url, required: true, placeholder: "http://localhost:4567", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+    <p class="mt-1 text-sm text-gray-500">Provider must expose POST /search and POST /acquire. GET /health is used for the test button.</p>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :api_key, "Bearer Token", class: "block text-gray-300 font-medium" %>
+    <%= form.password_field :api_key, placeholder: provider.persisted? && provider.api_key.present? ? "Leave blank to keep current" : "Optional token", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+  </div>
+
+  <div class="grid gap-5 md:grid-cols-2">
+    <div>
+      <%= form.label :timeout_seconds, "Timeout Seconds", class: "block text-gray-300 font-medium" %>
+      <%= form.number_field :timeout_seconds, min: 1, max: 120, class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+    </div>
+
+    <div class="space-y-3">
+      <span class="block text-gray-300 font-medium">Media Types</span>
+      <label class="flex items-center gap-2 text-gray-300">
+        <%= form.check_box :supports_ebooks, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+        <span>Ebooks</span>
+      </label>
+      <label class="flex items-center gap-2 text-gray-300">
+        <%= form.check_box :supports_audiobooks, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+        <span>Audiobooks</span>
+      </label>
+    </div>
+  </div>
+
+  <div class="my-5">
+    <label class="flex items-center gap-2 text-gray-300">
+      <%= form.check_box :allow_private_network, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+      <span>Allow private network</span>
+    </label>
+    <p class="mt-1 text-sm text-gray-500">Allow this provider and its download links to use private network addresses (e.g., localhost or 192.168.x.x). Enable for providers running on your local network.</p>
+  </div>
+
+  <div class="my-5">
+    <label class="flex items-center gap-2 text-gray-300">
+      <%= form.check_box :enabled, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+      <span>Enabled</span>
+    </label>
+  </div>
+
+  <div class="flex items-center gap-4 mt-8">
+    <%= form.submit class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
+    <%= link_to "Cancel", admin_acquisition_providers_path, class: "text-gray-400 hover:text-gray-300" %>
+  </div>
+<% end %>

--- a/app/views/admin/acquisition_providers/edit.html.erb
+++ b/app/views/admin/acquisition_providers/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl text-white mb-8">Edit Acquisition Provider</h1>
+  <%= render "form", provider: @provider %>
+</div>

--- a/app/views/admin/acquisition_providers/index.html.erb
+++ b/app/views/admin/acquisition_providers/index.html.erb
@@ -1,0 +1,86 @@
+<div class="mx-auto max-w-5xl">
+  <div class="flex flex-wrap items-center justify-between gap-3 mb-8">
+    <h1 class="font-bold text-3xl sm:text-4xl text-white">Acquisition Providers</h1>
+    <%= link_to "New Provider", new_admin_acquisition_provider_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white whitespace-nowrap" %>
+  </div>
+
+  <% if @providers.empty? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 text-center">
+      <p class="text-gray-400 mb-4">No custom acquisition providers configured yet.</p>
+      <%= link_to "Add your first provider", new_admin_acquisition_provider_path, class: "text-blue-400 hover:text-blue-300" %>
+    </div>
+  <% else %>
+    <%# Card list on small screens; the table below takes over from md: up %>
+    <div class="md:hidden space-y-4">
+      <% @providers.each do |provider| %>
+        <div class="bg-gray-900 rounded-lg border border-gray-800 p-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <%= link_to provider.name, admin_acquisition_provider_path(provider), class: "font-medium text-white hover:text-blue-300 break-words" %>
+              <p class="mt-1 text-sm text-gray-400 break-all"><%= provider.url %></p>
+            </div>
+            <span class="shrink-0 px-2 py-1 text-xs rounded <%= provider.enabled? ? 'bg-green-500/20 text-green-400' : 'bg-gray-700 text-gray-400' %>">
+              <%= provider.enabled? ? "Enabled" : "Disabled" %>
+            </span>
+          </div>
+
+          <p class="mt-2 text-sm text-gray-500">
+            Priority <%= provider.priority + 1 %> &middot;
+            <%= [
+              ("Ebooks" if provider.supports_ebooks?),
+              ("Audiobooks" if provider.supports_audiobooks?)
+            ].compact.join(", ") %>
+          </p>
+
+          <div class="mt-3 pt-3 border-t border-gray-800 flex items-center gap-6 text-sm font-medium">
+            <%= button_to "Test", test_admin_acquisition_provider_path(provider), method: :post, class: "py-1 text-green-400 hover:text-green-300" %>
+            <%= link_to "Edit", edit_admin_acquisition_provider_path(provider), class: "py-1 text-blue-400 hover:text-blue-300" %>
+            <%= button_to "Delete", admin_acquisition_provider_path(provider), method: :delete, class: "py-1 text-red-400 hover:text-red-300", data: { turbo_confirm: "Delete this acquisition provider?" } %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="hidden md:block bg-gray-900 rounded-lg border border-gray-800 overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-800">
+        <thead class="bg-gray-800/50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Priority</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">URL</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Media</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          <% @providers.each do |provider| %>
+            <tr class="hover:bg-gray-800/50 transition">
+              <td class="px-6 py-4 whitespace-nowrap text-gray-300 font-medium"><%= provider.priority + 1 %></td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <%= link_to provider.name, admin_acquisition_provider_path(provider), class: "font-medium text-white hover:text-blue-300" %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-gray-400 text-sm"><%= provider.url %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-gray-400 text-sm">
+                <%= [
+                  ("Ebooks" if provider.supports_ebooks?),
+                  ("Audiobooks" if provider.supports_audiobooks?)
+                ].compact.join(", ") %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="px-2 py-1 text-xs rounded <%= provider.enabled? ? 'bg-green-500/20 text-green-400' : 'bg-gray-700 text-gray-400' %>">
+                  <%= provider.enabled? ? "Enabled" : "Disabled" %>
+                </span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <%= button_to "Test", test_admin_acquisition_provider_path(provider), method: :post, class: "text-green-400 hover:text-green-300 mr-3" %>
+                <%= link_to "Edit", edit_admin_acquisition_provider_path(provider), class: "text-blue-400 hover:text-blue-300 mr-3" %>
+                <%= button_to "Delete", admin_acquisition_provider_path(provider), method: :delete, class: "text-red-400 hover:text-red-300", data: { turbo_confirm: "Delete this acquisition provider?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/acquisition_providers/new.html.erb
+++ b/app/views/admin/acquisition_providers/new.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl text-white mb-8">New Acquisition Provider</h1>
+  <%= render "form", provider: @provider %>
+</div>

--- a/app/views/admin/acquisition_providers/show.html.erb
+++ b/app/views/admin/acquisition_providers/show.html.erb
@@ -1,0 +1,38 @@
+<div class="mx-auto max-w-3xl">
+  <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-8">
+    <h1 class="font-bold text-3xl sm:text-4xl text-white break-words"><%= @provider.name %></h1>
+    <div class="flex flex-wrap gap-3 shrink-0">
+      <%= button_to "Test", test_admin_acquisition_provider_path(@provider), method: :post, class: "rounded-md px-4 py-2 bg-green-700 hover:bg-green-600 text-white" %>
+      <%= link_to "Edit", edit_admin_acquisition_provider_path(@provider), class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
+      <%= link_to "Back", admin_acquisition_providers_path, class: "rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white" %>
+    </div>
+  </div>
+
+  <dl class="bg-gray-900 border border-gray-800 rounded-lg divide-y divide-gray-800">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      <dt class="text-gray-400">URL</dt>
+      <dd class="md:col-span-2 text-gray-100 break-all"><%= @provider.url %></dd>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      <dt class="text-gray-400">Media Types</dt>
+      <dd class="md:col-span-2 text-gray-100">
+        <% media = [] %>
+        <% media << "Ebooks" if @provider.supports_ebooks? %>
+        <% media << "Audiobooks" if @provider.supports_audiobooks? %>
+        <%= media.join(", ") %>
+      </dd>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      <dt class="text-gray-400">Timeout</dt>
+      <dd class="md:col-span-2 text-gray-100"><%= @provider.timeout_seconds %> seconds</dd>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      <dt class="text-gray-400">Private Network</dt>
+      <dd class="md:col-span-2 text-gray-100"><%= @provider.allow_private_network? ? "Allowed" : "Blocked" %></dd>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      <dt class="text-gray-400">Status</dt>
+      <dd class="md:col-span-2 text-gray-100"><%= @provider.enabled? ? "Enabled" : "Disabled" %></dd>
+    </div>
+  </dl>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -128,6 +128,7 @@
         <% end %>
         <%= link_to "Manage Users", admin_users_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Download Clients", admin_download_clients_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
+        <%= link_to "Acquisition Providers", admin_acquisition_providers_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Download Routing", admin_download_routing_rules_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Manual Uploads", admin_uploads_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Settings", admin_settings_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>

--- a/bin/quality
+++ b/bin/quality
@@ -86,7 +86,6 @@ module Quality
   def run_deep
     success = true
     success &&= run_push
-    success &&= run_coverage
 
     expressions = all_mutant_expressions
     success &&= run_mutant_command(expressions) unless expressions.empty?
@@ -99,6 +98,7 @@ module Quality
     success &&= run("RuboCop", "bin/rubocop", "--force-exclusion", "--format", "quiet", "--fail-level", "warning")
     success &&= run_brakeman
     success &&= run("Tests", "bin/rails", "test")
+    success &&= run_coverage
     success ? 0 : 1
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,11 @@ Rails.application.routes.draw do
         post :move_down
       end
     end
+    resources :acquisition_providers do
+      member do
+        post :test
+      end
+    end
     resources :download_routing_rules, except: [ :show ]
     resources :settings, only: [ :index, :update ] do
       collection do

--- a/db/migrate/20260607120000_create_acquisition_providers.rb
+++ b/db/migrate/20260607120000_create_acquisition_providers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateAcquisitionProviders < ActiveRecord::Migration[8.1]
+  def change
+    create_table :acquisition_providers do |t|
+      t.string :name, null: false
+      t.string :url, null: false
+      t.string :api_key
+      t.boolean :enabled, null: false, default: true
+      t.boolean :allow_private_network, null: false, default: false
+      t.boolean :supports_ebooks, null: false, default: true
+      t.boolean :supports_audiobooks, null: false, default: true
+      t.integer :priority, null: false, default: 0
+      t.integer :timeout_seconds, null: false, default: 30
+
+      t.timestamps
+    end
+
+    add_index :acquisition_providers, :enabled
+    add_index :acquisition_providers, :name, unique: true
+    add_index :acquisition_providers, :priority
+
+    add_reference :search_results, :acquisition_provider, foreign_key: true
+    add_column :search_results, :provider_result_id, :string
+    add_column :search_results, :provider_payload, :json, default: {}
+    add_index :search_results, [ :acquisition_provider_id, :provider_result_id ], name: "index_search_results_on_provider_result"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_07_120000) do
+  create_table "acquisition_providers", force: :cascade do |t|
+    t.boolean "allow_private_network", default: false, null: false
+    t.string "api_key"
+    t.datetime "created_at", null: false
+    t.boolean "enabled", default: true, null: false
+    t.string "name", null: false
+    t.integer "priority", default: 0, null: false
+    t.boolean "supports_audiobooks", default: true, null: false
+    t.boolean "supports_ebooks", default: true, null: false
+    t.integer "timeout_seconds", default: 30, null: false
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.index ["enabled"], name: "index_acquisition_providers_on_enabled"
+    t.index ["name"], name: "index_acquisition_providers_on_name", unique: true
+    t.index ["priority"], name: "index_acquisition_providers_on_priority"
+  end
+
   create_table "activity_logs", force: :cascade do |t|
     t.string "action", null: false
     t.string "controller"
@@ -215,6 +232,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
   end
 
   create_table "search_results", force: :cascade do |t|
+    t.integer "acquisition_provider_id"
     t.integer "confidence_score"
     t.datetime "created_at", null: false
     t.string "detected_language"
@@ -224,6 +242,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
     t.string "info_url"
     t.integer "leechers"
     t.string "magnet_url"
+    t.json "provider_payload", default: {}
+    t.string "provider_result_id"
     t.datetime "published_at"
     t.integer "request_id", null: false
     t.json "score_breakdown"
@@ -233,6 +253,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
     t.integer "status", default: 0, null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index ["acquisition_provider_id", "provider_result_id"], name: "index_search_results_on_provider_result"
+    t.index ["acquisition_provider_id"], name: "index_search_results_on_acquisition_provider_id"
     t.index ["request_id", "guid"], name: "index_search_results_on_request_id_and_guid", unique: true
     t.index ["request_id"], name: "index_search_results_on_request_id"
     t.index ["status"], name: "index_search_results_on_status"
@@ -365,6 +387,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_120000) do
   add_foreign_key "request_events", "requests"
   add_foreign_key "requests", "books"
   add_foreign_key "requests", "users"
+  add_foreign_key "search_results", "acquisition_providers"
   add_foreign_key "search_results", "requests"
   add_foreign_key "sessions", "users"
   add_foreign_key "telegram_chat_authorizations", "users", column: "approved_by_id"

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,8 @@
 
 Shelfarr exposes a JSON API under `/api/v1`.
 
+For custom HTTP search/acquisition integrations called by Shelfarr, see [Custom Acquisition Providers](custom-acquisition-providers.md).
+
 ## Authentication
 
 Use bearer authentication:

--- a/docs/custom-acquisition-providers.md
+++ b/docs/custom-acquisition-providers.md
@@ -1,0 +1,200 @@
+# Custom Acquisition Providers
+
+Custom acquisition providers let a local HTTP service participate in Shelfarr search and acquisition without adding a built-in integration.
+
+This is a trusted home-lab integration point. Shelfarr calls the provider over HTTP, stores normalized results, and later asks the same provider to resolve the selected result into a concrete artifact Shelfarr can download or dispatch.
+
+## Provider Setup
+
+Add providers in **Admin > Acquisition Providers**.
+
+Fields:
+
+- `Name` - display name shown in search results.
+- `Base URL` - provider origin, such as `http://provider:4567`.
+- `Bearer Token` - optional token sent as `Authorization: Bearer <token>`.
+- `Media Types` - whether the provider should be searched for ebooks, audiobooks, or both.
+- `Timeout Seconds` - request timeout for provider calls.
+- `Allow private network` - permit the provider and its download links to use private network addresses.
+
+The **Test** action calls `GET /health` on the provider. A `2xx` response means the provider is reachable.
+
+## Network Restrictions
+
+Shelfarr validates every URL before contacting a provider or downloading an artifact it returned:
+
+- Link-local and metadata addresses (for example `169.254.169.254`) are always refused.
+- Private and loopback addresses (`localhost`, `10.x`, `172.16-31.x`, `192.168.x`, `127.x`) are refused unless the provider has **Allow private network** enabled. Enable it for providers running on your home-lab network.
+- The same rules apply to `direct_url`/`nzb_url` artifacts returned by `/acquire`, including any HTTP redirects they go through.
+- JSON responses from `/search` and `/acquire` are limited to 10 MB.
+
+## Search
+
+Shelfarr calls:
+
+```http
+POST /search
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+Request body:
+
+```json
+{
+  "query": "Dune Frank Herbert",
+  "request": {
+    "id": 123,
+    "language": "en"
+  },
+  "book": {
+    "id": 456,
+    "title": "Dune",
+    "author": "Frank Herbert",
+    "book_type": "ebook",
+    "year": 1965,
+    "language": "en",
+    "isbn": "9780441172719",
+    "open_library_work_id": "OL893415W",
+    "open_library_edition_id": "OL26712345M",
+    "hardcover_id": "789"
+  }
+}
+```
+
+Response body can be either a bare array or an object with `results`:
+
+```json
+{
+  "results": [
+    {
+      "id": "provider-result-1",
+      "title": "Dune",
+      "author": "Frank Herbert",
+      "format": "epub",
+      "language": "en",
+      "size_bytes": 5242880,
+      "download_type": "direct",
+      "availability": "available",
+      "info_url": "https://provider.example/books/provider-result-1",
+      "published_at": "2026-06-08T12:00:00Z"
+    }
+  ]
+}
+```
+
+Required result fields:
+
+- `id` or `provider_result_id` or `guid`
+- `title`
+
+Recommended result fields:
+
+- `author`
+- `format` or `file_type`
+- `language`
+- `size_bytes`
+- `download_type`: `direct`, `torrent`, or `usenet`
+- `availability`: `available`, `unknown`, `temporarily_unavailable`, or provider-specific text
+- `info_url`
+- `published_at`
+
+Shelfarr stores the full result object as provider metadata so `/acquire` can receive it later.
+
+## Acquire
+
+Shelfarr calls this after an admin or auto-selection picks a custom provider result:
+
+```http
+POST /acquire
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+Request body:
+
+```json
+{
+  "provider_result_id": "provider-result-1",
+  "result": {
+    "id": 987,
+    "title": "Dune - Frank Herbert [EPUB]",
+    "source": "custom",
+    "provider_result_id": "provider-result-1",
+    "provider_payload": {
+      "id": "provider-result-1",
+      "title": "Dune",
+      "download_type": "direct"
+    }
+  },
+  "request": {
+    "id": 123,
+    "language": "en"
+  },
+  "book": {
+    "id": 456,
+    "title": "Dune",
+    "author": "Frank Herbert",
+    "book_type": "ebook"
+  }
+}
+```
+
+The provider must return one concrete artifact.
+
+Direct download:
+
+```json
+{
+  "download_type": "direct",
+  "direct_url": "https://provider.example/files/dune.epub"
+}
+```
+
+Torrent:
+
+```json
+{
+  "download_type": "torrent",
+  "magnet_url": "magnet:?xt=urn:btih:..."
+}
+```
+
+Usenet:
+
+```json
+{
+  "download_type": "usenet",
+  "nzb_url": "https://provider.example/files/dune.nzb"
+}
+```
+
+Shelfarr then handles the artifact with its normal download flow.
+
+## Direct Artifact Support
+
+Ebook direct downloads support:
+
+- `epub`
+- `pdf`
+- `mobi`
+- `azw3`
+
+Audiobook direct downloads support:
+
+- `zip` archives, extracted into the audiobook destination directory
+- single audio files: `m4b`, `mp3`, `m4a`, `aac`, `flac`, `ogg`, `opus`
+
+Direct downloads are capped by Shelfarr's existing direct-download limits: 512 MB for ebooks and 2 GB for audiobooks.
+
+## Local Development
+
+Use `bin/dev` for the normal development process. It runs Rails and the frontend watcher.
+
+Background jobs use Solid Queue. If you run only `bin/rails server`, queued searches and downloads are persisted but may not execute until a worker is running. For a single-process local run that executes jobs in Puma, start Rails with:
+
+```bash
+SOLID_QUEUE_IN_PUMA=1 bin/rails server
+```
+
+Alternatively, run queued jobs manually from Rails console/runner while testing a provider.

--- a/test/controllers/admin/acquisition_providers_controller_test.rb
+++ b/test/controllers/admin/acquisition_providers_controller_test.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::AcquisitionProvidersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as(users(:two))
+  end
+
+  test "index renders providers ordered by priority" do
+    second = create_provider(name: "Second Provider", url: "http://second-provider.test", priority: 1)
+    first = create_provider(name: "First Provider", url: "http://first-provider.test", priority: 0)
+
+    get admin_acquisition_providers_url
+
+    assert_response :success
+    assert_select "h1", "Acquisition Providers"
+    assert_select "tbody tr:first-child td", text: first.name
+    assert_select "tbody tr:last-child td", text: second.name
+  end
+
+  test "new renders form with defaults" do
+    get new_admin_acquisition_provider_url
+
+    assert_response :success
+    assert_select "form[action='#{admin_acquisition_providers_path}']"
+    assert_select "input[name='acquisition_provider[supports_ebooks]'][value='1'][checked='checked']"
+    assert_select "input[name='acquisition_provider[supports_audiobooks]'][value='1'][checked='checked']"
+  end
+
+  test "show renders provider details without secret" do
+    provider = create_provider(api_key: "secret-token")
+
+    get admin_acquisition_provider_url(provider)
+
+    assert_response :success
+    assert_select "h1", provider.name
+    assert_select "dd", provider.url
+    assert_select "dd", "Enabled"
+    assert_select "dd", text: /secret-token/, count: 0
+  end
+
+  test "create persists provider and assigns next priority" do
+    create_provider(name: "Existing Provider", priority: 2)
+
+    assert_difference -> { AcquisitionProvider.count }, 1 do
+      post admin_acquisition_providers_url, params: {
+        acquisition_provider: provider_params(
+          name: "Created Provider",
+          url: "http://created-provider.test",
+          api_key: "created-secret",
+          enabled: "1",
+          supports_ebooks: "1",
+          supports_audiobooks: "0",
+          timeout_seconds: "45"
+        )
+      }
+    end
+
+    assert_redirected_to admin_acquisition_providers_path
+    provider = AcquisitionProvider.find_by!(name: "Created Provider")
+    assert_equal 3, provider.priority
+    assert_equal "created-secret", provider.api_key
+    assert provider.enabled?
+    assert provider.supports_ebooks?
+    assert_not provider.supports_audiobooks?
+    assert_equal 45, provider.timeout_seconds
+  end
+
+  test "create renders errors for invalid provider" do
+    assert_no_difference -> { AcquisitionProvider.count } do
+      post admin_acquisition_providers_url, params: {
+        acquisition_provider: provider_params(name: "", url: "file:///tmp/provider")
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_select "form[action='#{admin_acquisition_providers_path}']"
+  end
+
+  test "edit renders form" do
+    provider = create_provider
+
+    get edit_admin_acquisition_provider_url(provider)
+
+    assert_response :success
+    assert_select "form[action='#{admin_acquisition_provider_path(provider)}']"
+  end
+
+  test "update changes provider and preserves blank api key" do
+    provider = create_provider(api_key: "existing-secret")
+
+    patch admin_acquisition_provider_url(provider), params: {
+      acquisition_provider: provider_params(
+        name: "Updated Provider",
+        url: "http://updated-provider.test/",
+        api_key: "",
+        enabled: "0",
+        supports_ebooks: "0",
+        supports_audiobooks: "1",
+        timeout_seconds: "60"
+      )
+    }
+
+    assert_redirected_to admin_acquisition_providers_path
+    provider.reload
+    assert_equal "Updated Provider", provider.name
+    assert_equal "http://updated-provider.test", provider.url
+    assert_equal "existing-secret", provider.api_key
+    assert_not provider.enabled?
+    assert_not provider.supports_ebooks?
+    assert provider.supports_audiobooks?
+    assert_equal 60, provider.timeout_seconds
+  end
+
+  test "update renders errors for invalid provider" do
+    provider = create_provider
+
+    patch admin_acquisition_provider_url(provider), params: {
+      acquisition_provider: provider_params(name: "", url: "")
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "form[action='#{admin_acquisition_provider_path(provider)}']"
+  end
+
+  test "destroy removes provider" do
+    provider = create_provider
+
+    assert_difference -> { AcquisitionProvider.count }, -1 do
+      delete admin_acquisition_provider_url(provider)
+    end
+
+    assert_redirected_to admin_acquisition_providers_path
+    assert_equal "Acquisition provider was successfully deleted.", flash[:notice]
+  end
+
+  test "test action reports successful connection" do
+    provider = create_provider
+
+    VCR.turned_off do
+      stub_request(:get, "#{provider.url}/health").to_return(status: 204)
+
+      post test_admin_acquisition_provider_url(provider)
+    end
+
+    assert_redirected_to admin_acquisition_providers_path
+    assert_match /successful/i, flash[:notice]
+  end
+
+  test "test action reports failed connection" do
+    provider = create_provider
+
+    VCR.turned_off do
+      stub_request(:get, "#{provider.url}/health").to_return(status: 500)
+
+      post test_admin_acquisition_provider_url(provider)
+    end
+
+    assert_redirected_to admin_acquisition_providers_path
+    assert_match /failed/i, flash[:alert]
+  end
+
+  private
+
+  def create_provider(**attributes)
+    AcquisitionProvider.create!({
+      name: "Local Provider",
+      url: "http://provider.test",
+      enabled: true,
+      supports_ebooks: true,
+      supports_audiobooks: true,
+      priority: 0,
+      timeout_seconds: 30
+    }.merge(attributes))
+  end
+
+  def provider_params(**attributes)
+    {
+      name: "Local Provider",
+      url: "http://provider.test",
+      enabled: "1",
+      supports_ebooks: "1",
+      supports_audiobooks: "1",
+      timeout_seconds: "30"
+    }.merge(attributes)
+  end
+end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -330,7 +330,7 @@ class DownloadJobTest < ActiveJob::TestCase
           .to_return(
             status: 200,
             headers: { "Content-Type" => "application/json" },
-            body: { "status" => true, "nzo_ids" => ["SABnzbd_nzo_12345"] }.to_json
+            body: { "status" => true, "nzo_ids" => [ "SABnzbd_nzo_12345" ] }.to_json
           )
 
         DownloadJob.perform_now(@download.id)
@@ -473,6 +473,282 @@ class DownloadJobTest < ActiveJob::TestCase
       assert_equal "1342.epub", File.basename(@gutenberg_download.download_path)
       assert_equal File.dirname(@gutenberg_download.download_path), @gutenberg_request.book.file_path
     end
+  end
+
+  test "custom provider download acquires direct URL and completes via HTTP" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .with do |request|
+            body = JSON.parse(request.body)
+            body["provider_result_id"] == "custom-epub-1"
+          end
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "direct", direct_url: "https://files.test/custom-book.epub" }.to_json
+          )
+
+        stub_request(:get, "https://files.test/custom-book.epub")
+          .to_return(status: 200, body: "PK\x03\x04" + ("x" * 1024), headers: { "Content-Type" => "application/epub+zip" })
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      @custom_provider_request.reload
+      assert @custom_provider_download.completed?
+      assert_equal "direct", @custom_provider_download.download_type
+      assert @custom_provider_request.completed?
+      assert File.exist?(@custom_provider_download.download_path)
+      assert_equal "custom-book.epub", File.basename(@custom_provider_download.download_path)
+    end
+  end
+
+  test "custom provider direct audiobook file downloads into audiobook output path" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_audiobook_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .with do |request|
+            body = JSON.parse(request.body)
+            body["provider_result_id"] == "custom-audio-1"
+          end
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "direct", direct_url: "https://files.test/custom-audiobook.m4b" }.to_json
+          )
+
+        stub_request(:get, "https://files.test/custom-audiobook.m4b")
+          .to_return(status: 200, body: "M4B audio data", headers: { "Content-Type" => "audio/mp4" })
+
+        DownloadJob.perform_now(@custom_provider_audiobook_download.id)
+      end
+
+      @custom_provider_audiobook_download.reload
+      @custom_provider_audiobook_request.reload
+      assert @custom_provider_audiobook_download.completed?
+      assert_equal "direct", @custom_provider_audiobook_download.download_type
+      assert @custom_provider_audiobook_request.completed?
+      assert File.exist?(@custom_provider_audiobook_download.download_path)
+      assert_equal "custom-audiobook.m4b", File.basename(@custom_provider_audiobook_download.download_path)
+      assert_equal File.dirname(@custom_provider_audiobook_download.download_path), @custom_provider_audiobook_request.book.file_path
+    end
+  end
+
+  test "custom provider torrent acquisition dispatches magnet to torrent client" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+      magnet = "magnet:?xt=urn:btih:#{"a" * 40}"
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "torrent", magnet_url: magnet }.to_json
+          )
+        stub_qbittorrent_connection("http://localhost:8080")
+        stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+          .to_return(status: 200, body: "Ok.")
+        stub_request(:get, %r{localhost:8080/api/v2/torrents/info})
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: [ { "hash" => "a" * 40, "name" => "Custom Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Custom Torrent" } ].to_json
+          )
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      assert @custom_provider_download.downloading?
+      assert_equal "torrent", @custom_provider_download.download_type
+      assert_equal "a" * 40, @custom_provider_download.external_id
+    end
+  end
+
+  test "custom provider usenet acquisition dispatches NZB URL to usenet client" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+      @client.destroy!
+      DownloadClient.create!(
+        name: "Test SABnzbd",
+        client_type: "sabnzbd",
+        url: "http://localhost:8080",
+        api_key: "test-api-key-12345",
+        priority: 0,
+        enabled: true
+      )
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "usenet", nzb_url: "https://files.test/custom-book.nzb" }.to_json
+          )
+        stub_request(:get, "http://localhost:8080/api")
+          .with(query: hash_including("mode" => "version"))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "version" => "4.0.0" }.to_json
+          )
+        stub_request(:get, "http://localhost:8080/api")
+          .with(query: hash_including(
+            "mode" => "addurl",
+            "name" => "https://files.test/custom-book.nzb"
+          ))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "status" => true, "nzo_ids" => [ "SABnzbd_nzo_67890" ] }.to_json
+          )
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      assert @custom_provider_download.downloading?
+      assert_equal "usenet", @custom_provider_download.download_type
+      assert_equal "SABnzbd_nzo_67890", @custom_provider_download.external_id
+    end
+  end
+
+  test "custom provider acquisition with unsupported artifact type fails with attention" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "ftp", direct_url: "ftp://files.test/book.epub" }.to_json
+          )
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      @custom_provider_request.reload
+      assert @custom_provider_download.failed?
+      assert @custom_provider_request.attention_needed?
+    end
+  end
+
+  test "custom provider direct download to a private address is blocked by default" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "direct", direct_url: "http://192.168.1.5/book.epub" }.to_json
+          )
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      @custom_provider_request.reload
+      assert @custom_provider_download.failed?
+      assert @custom_provider_request.attention_needed?
+      assert_not_requested :get, "http://192.168.1.5/book.epub"
+    end
+  end
+
+  test "custom provider direct download to a private address works when provider allows private network" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+      @custom_provider_download.search_result.acquisition_provider.update!(allow_private_network: true)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "direct", direct_url: "http://192.168.1.5/custom-book.epub" }.to_json
+          )
+        stub_request(:get, "http://192.168.1.5/custom-book.epub")
+          .to_return(status: 200, body: "PK\x03\x04" + ("x" * 1024), headers: { "Content-Type" => "application/epub+zip" })
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      assert @custom_provider_download.completed?
+    end
+  end
+
+  test "custom provider direct download never follows metadata addresses even with private network allowed" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+      @custom_provider_download.search_result.acquisition_provider.update!(allow_private_network: true)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "direct", direct_url: "http://169.254.169.254/latest/meta-data" }.to_json
+          )
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      assert @custom_provider_download.failed?
+      assert_not_requested :get, "http://169.254.169.254/latest/meta-data"
+    end
+  end
+
+  test "direct download redirects to private addresses are blocked" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "direct", direct_url: "https://files.test/custom-book.epub" }.to_json
+          )
+        stub_request(:get, "https://files.test/custom-book.epub")
+          .to_return(status: 302, headers: { "Location" => "http://10.0.0.5/internal-secret" })
+
+        DownloadJob.perform_now(@custom_provider_download.id)
+      end
+
+      @custom_provider_download.reload
+      assert @custom_provider_download.failed?
+      assert_not_requested :get, "http://10.0.0.5/internal-secret"
+    end
+  end
+
+  test "validate_direct_download_url rejects private addresses for non-custom sources" do
+    error = assert_raises RuntimeError do
+      DownloadJob.new.send(:validate_direct_download_url!, "http://127.0.0.1/book.epub")
+    end
+
+    assert_match(/Invalid direct download URL/, error.message)
+  end
+
+  test "infer_audiobook_extension requires format context for ambiguous words like opus" do
+    job = DownloadJob.new
+    result = Struct.new(:title)
+
+    assert_nil job.send(:infer_audiobook_extension, "https://files.test/download", result.new("Live at the Opus House"))
+    assert_equal "opus", job.send(:infer_audiobook_extension, "https://files.test/download", result.new("Book Title [OPUS]"))
+    assert_equal "opus", job.send(:infer_audiobook_extension, "https://files.test/download", result.new("Book Title .opus"))
+    assert_equal "mp3", job.send(:infer_audiobook_extension, "https://files.test/download", result.new("Book Title MP3 64kbps"))
   end
 
   test "librivox download extracts audiobook zip into audiobook output path" do
@@ -768,6 +1044,70 @@ class DownloadJobTest < ActiveJob::TestCase
     )
   end
 
+  def setup_custom_provider_download(output_path:)
+    SettingsService.set(:ebook_output_path, output_path)
+
+    provider = AcquisitionProvider.create!(
+      name: "Local Provider",
+      url: "http://provider.test",
+      supports_ebooks: true,
+      supports_audiobooks: false
+    )
+    book = Book.create!(
+      title: "Custom Provider Book",
+      author: "Provider Author",
+      book_type: :ebook
+    )
+    @custom_provider_request = Request.create!(book: book, user: users(:one), status: :downloading)
+    custom_result = @custom_provider_request.search_results.create!(
+      guid: "custom:#{provider.id}:custom-epub-1",
+      title: "Custom Provider Book - Provider Author [EPUB]",
+      indexer: provider.name,
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "custom-epub-1",
+      provider_payload: { "download_type" => "direct", "format" => "epub" },
+      status: :selected
+    )
+    @custom_provider_download = @custom_provider_request.downloads.create!(
+      name: custom_result.title,
+      search_result: custom_result,
+      status: :queued
+    )
+  end
+
+  def setup_custom_provider_audiobook_download(output_path:)
+    SettingsService.set(:audiobook_output_path, output_path)
+
+    provider = AcquisitionProvider.create!(
+      name: "Local Audio Provider",
+      url: "http://provider.test",
+      supports_ebooks: false,
+      supports_audiobooks: true
+    )
+    book = Book.create!(
+      title: "Custom Provider Audiobook",
+      author: "Provider Narrator",
+      book_type: :audiobook
+    )
+    @custom_provider_audiobook_request = Request.create!(book: book, user: users(:one), status: :downloading)
+    custom_result = @custom_provider_audiobook_request.search_results.create!(
+      guid: "custom:#{provider.id}:custom-audio-1",
+      title: "Custom Provider Audiobook - Provider Narrator [M4B]",
+      indexer: provider.name,
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "custom-audio-1",
+      provider_payload: { "download_type" => "direct", "format" => "m4b" },
+      status: :selected
+    )
+    @custom_provider_audiobook_download = @custom_provider_audiobook_request.downloads.create!(
+      name: custom_result.title,
+      search_result: custom_result,
+      status: :queued
+    )
+  end
+
   def build_zip_archive(entries)
     require "zip"
 
@@ -816,7 +1156,7 @@ class DownloadJobTest < ActiveJob::TestCase
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
-        body: [{ "hash" => expected_hash, "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" }].to_json
+        body: [ { "hash" => expected_hash, "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" } ].to_json
       )
   end
 

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -1078,6 +1078,99 @@ class SearchJobTest < ActiveJob::TestCase
     assert_includes saved_result.title, "[EPUB]"
   end
 
+  test "includes custom acquisition provider results" do
+    SettingsService.set(:prowlarr_api_key, "")
+    provider = AcquisitionProvider.create!(
+      name: "Local Provider",
+      url: "http://provider.test",
+      supports_ebooks: true,
+      supports_audiobooks: false
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["book"]["title"] == @request.book.title &&
+            body["book"]["book_type"] == "ebook"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "provider-1",
+                title: "The Pending Ebook",
+                author: "Another Author",
+                format: "epub",
+                language: "en",
+                size_bytes: 1000,
+                download_type: "direct",
+                info_url: "https://provider.test/books/provider-1"
+              }
+            ]
+          }.to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    saved_result = @request.search_results.first
+    assert_equal SearchResult::SOURCE_CUSTOM, saved_result.source
+    assert_equal provider, saved_result.acquisition_provider
+    assert_equal "provider-1", saved_result.provider_result_id
+    assert_equal "custom:#{provider.id}:provider-1", saved_result.guid
+    assert_equal "direct", saved_result.download_type
+    assert saved_result.downloadable?
+  end
+
+  test "skips unavailable custom acquisition provider results" do
+    SettingsService.set(:prowlarr_api_key, "")
+    provider = AcquisitionProvider.create!(
+      name: "Availability Provider",
+      url: "http://availability-provider.test",
+      supports_ebooks: true,
+      supports_audiobooks: false
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://availability-provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "provider-available",
+                title: "Available Provider Result",
+                format: "epub",
+                direct_url: "https://files.test/available.epub",
+                availability: "available"
+              },
+              {
+                id: "provider-unavailable",
+                title: "Unavailable Provider Result",
+                format: "epub",
+                direct_url: "https://files.test/unavailable.epub",
+                availability: "temporarily_unavailable"
+              }
+            ]
+          }.to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+    end
+
+    @request.reload
+    assert_equal [ "provider-available" ], @request.search_results.pluck(:provider_result_id)
+    saved_result = @request.search_results.first
+    assert_equal provider, saved_result.acquisition_provider
+    assert_equal "direct", saved_result.download_type
+    assert saved_result.downloadable?
+  end
+
   test "skips Project Gutenberg for audiobook requests" do
     SettingsService.set(:prowlarr_api_key, "")
     SettingsService.set(:gutenberg_enabled, true)

--- a/test/models/acquisition_provider_test.rb
+++ b/test/models/acquisition_provider_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AcquisitionProviderTest < ActiveSupport::TestCase
+  test "normalizes trailing slash from URL" do
+    provider = AcquisitionProvider.create!(
+      name: "Provider",
+      url: "http://provider.test/",
+      supports_ebooks: true,
+      supports_audiobooks: false
+    )
+
+    assert_equal "http://provider.test", provider.url
+  end
+
+  test "requires http or https URL" do
+    provider = AcquisitionProvider.new(name: "Provider", url: "file:///tmp/provider")
+
+    assert_not provider.valid?
+    assert_includes provider.errors[:url], "must be a valid http or https URL"
+  end
+
+  test "rejects private network URLs unless allow_private_network is enabled" do
+    provider = AcquisitionProvider.new(name: "Provider", url: "http://localhost:4567")
+
+    assert_not provider.valid?
+    assert_match(/private network address/, provider.errors[:url].first)
+
+    provider.url = "http://192.168.1.80:4567"
+    assert_not provider.valid?
+    assert_match(/private network address/, provider.errors[:url].first)
+
+    provider.allow_private_network = true
+    assert provider.valid?, provider.errors.full_messages.join(", ")
+  end
+
+  test "requires at least one media type" do
+    provider = AcquisitionProvider.new(
+      name: "Provider",
+      url: "http://provider.test",
+      supports_ebooks: false,
+      supports_audiobooks: false
+    )
+
+    assert_not provider.valid?
+    assert_includes provider.errors[:base], "Provider must support ebooks, audiobooks, or both"
+  end
+
+  test "filters by book type" do
+    ebook_provider = AcquisitionProvider.create!(
+      name: "Ebook Provider",
+      url: "http://ebooks.test",
+      supports_ebooks: true,
+      supports_audiobooks: false
+    )
+    audiobook_provider = AcquisitionProvider.create!(
+      name: "Audiobook Provider",
+      url: "http://audio.test",
+      supports_ebooks: false,
+      supports_audiobooks: true
+    )
+
+    assert_includes AcquisitionProvider.for_book_type("ebook"), ebook_provider
+    assert_not_includes AcquisitionProvider.for_book_type("ebook"), audiobook_provider
+    assert_includes AcquisitionProvider.for_book_type("audiobook"), audiobook_provider
+    assert_not_includes AcquisitionProvider.for_book_type("audiobook"), ebook_provider
+  end
+
+  test "encrypts api_key" do
+    provider = AcquisitionProvider.create!(
+      name: "Secure Provider",
+      url: "http://secure-provider.test",
+      api_key: "secret-provider-token"
+    )
+
+    provider.reload
+    assert_equal "secret-provider-token", provider.api_key
+    assert_not_equal "secret-provider-token", provider.api_key_before_type_cast
+  end
+end

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -93,7 +93,89 @@ class SearchResultTest < ActiveSupport::TestCase
 
     SettingsService.set(:preferred_download_types, %w[direct usenet torrent])
 
-    assert_equal [direct_result, usenet_result, torrent_result], request.search_results.best_first.to_a
+    assert_equal [ direct_result, usenet_result, torrent_result ], request.search_results.best_first.to_a
+  end
+
+  test "best_first treats custom provider direct results as direct" do
+    request = requests(:pending_request)
+    request.search_results.destroy_all
+    provider = AcquisitionProvider.create!(
+      name: "Custom Provider",
+      url: "http://provider.test"
+    )
+
+    torrent_result = request.search_results.create!(
+      guid: "custom-torrent",
+      title: "Custom torrent result",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "torrent",
+      provider_payload: { "download_type" => "torrent" },
+      confidence_score: 80
+    )
+    direct_result = request.search_results.create!(
+      guid: "custom-direct",
+      title: "Custom direct result",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "direct",
+      provider_payload: { "download_type" => "direct" },
+      confidence_score: 80
+    )
+
+    SettingsService.set(:preferred_download_types, %w[direct torrent usenet])
+
+    assert_equal [ direct_result, torrent_result ], request.search_results.best_first.to_a
+  end
+
+  test "best_first respects explicit custom provider type before URL inference" do
+    request = requests(:pending_request)
+    request.search_results.destroy_all
+    provider = AcquisitionProvider.create!(
+      name: "Typed Custom Provider",
+      url: "http://typed-provider.test"
+    )
+
+    direct_result = request.search_results.create!(
+      guid: "custom-direct-url",
+      title: "Custom direct result",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "direct-url",
+      provider_payload: {
+        "download_type" => "direct",
+        "direct_url" => "https://files.test/book.epub"
+      },
+      confidence_score: 99
+    )
+    torrent_result = request.search_results.create!(
+      guid: "custom-torrent-url",
+      title: "Custom torrent result",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "torrent-url",
+      provider_payload: {
+        "download_type" => "torrent",
+        "direct_url" => "https://files.test/book.torrent"
+      },
+      confidence_score: 80
+    )
+    usenet_result = request.search_results.create!(
+      guid: "custom-usenet-url",
+      title: "Custom usenet result",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "usenet-url",
+      provider_payload: {
+        "download_type" => "usenet",
+        "direct_url" => "https://files.test/book.nzb"
+      },
+      confidence_score: 70
+    )
+
+    SettingsService.set(:preferred_download_types, %w[usenet torrent direct])
+
+    assert_equal [ usenet_result, torrent_result, direct_result ], request.search_results.best_first.to_a
   end
 
   test "best_first falls back to legacy preferred download type" do
@@ -121,7 +203,7 @@ class SearchResultTest < ActiveSupport::TestCase
       description: "Legacy preferred download type"
     )
 
-    assert_equal [usenet_result, torrent_result], request.search_results.best_first.to_a
+    assert_equal [ usenet_result, torrent_result ], request.search_results.best_first.to_a
   end
 
   # === Methods ===
@@ -161,6 +243,66 @@ class SearchResultTest < ActiveSupport::TestCase
 
     assert result.downloadable?
     assert_equal "direct", result.download_type
+  end
+
+  test "custom provider direct results are downloadable before acquisition" do
+    provider = AcquisitionProvider.new(name: "Custom Provider", url: "http://provider.test")
+    result = SearchResult.new(
+      request: requests(:pending_request),
+      guid: "custom-direct",
+      title: "Custom Provider Book",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "provider-1",
+      provider_payload: { "download_type" => "direct" },
+      download_url: nil,
+      magnet_url: nil
+    )
+
+    assert result.downloadable?
+    assert result.direct_download?
+    assert_equal "direct", result.download_type
+  end
+
+  test "custom provider unavailable results are not downloadable" do
+    provider = AcquisitionProvider.new(name: "Custom Provider", url: "http://provider.test")
+    result = SearchResult.new(
+      request: requests(:pending_request),
+      guid: "custom-unavailable",
+      title: "Custom Provider Book",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "provider-unavailable",
+      provider_payload: {
+        "download_type" => "direct",
+        "availability" => "temporarily_unavailable"
+      }
+    )
+
+    assert_not result.downloadable?
+  end
+
+  test "custom provider results infer download type from payload URLs" do
+    provider = AcquisitionProvider.new(name: "Custom Provider", url: "http://provider.test")
+    direct_result = SearchResult.new(
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_payload: { "direct_url" => "https://files.test/book.epub" }
+    )
+    usenet_result = SearchResult.new(
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_payload: { "nzb_url" => "https://files.test/book.nzb" }
+    )
+    torrent_result = SearchResult.new(
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_payload: { "magnet_url" => "magnet:?xt=urn:btih:abc123" }
+    )
+
+    assert_equal "direct", direct_result.download_type
+    assert_equal "usenet", usenet_result.download_type
+    assert_equal "torrent", torrent_result.download_type
   end
 
   test "download_link prefers magnet_url over download_url" do

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -119,6 +119,37 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert result.reload.selected?
   end
 
+  test "custom provider direct results bypass seeder check" do
+    Setting.find_or_create_by(key: "auto_select_min_seeders").update!(
+      value: "100",
+      value_type: "integer",
+      category: "auto_select"
+    )
+    provider = AcquisitionProvider.create!(
+      name: "Custom Provider",
+      url: "http://provider.test"
+    )
+
+    result = create_search_result(
+      seeders: nil,
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "custom-direct",
+      provider_payload: { "download_type" => "direct" },
+      download_url: nil,
+      magnet_url: nil
+    )
+
+    assert_enqueued_with(job: DownloadJob) do
+      selection = AutoSelectService.call(@request)
+
+      assert selection.success?
+      assert_equal :auto_selected, selection.reason
+    end
+
+    assert result.reload.selected?
+  end
+
   test "creates download record and enqueues job on success" do
     result = create_search_result(
       title: "Test Book - Audiobook",

--- a/test/services/custom_acquisition_provider_client_test.rb
+++ b/test/services/custom_acquisition_provider_client_test.rb
@@ -1,0 +1,447 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CustomAcquisitionProviderClientTest < ActiveSupport::TestCase
+  setup do
+    @provider = AcquisitionProvider.create!(
+      name: "Local Provider",
+      url: "http://provider.test",
+      api_key: "secret",
+      timeout_seconds: 5
+    )
+    @client = @provider.client
+    @request = requests(:pending_request)
+  end
+
+  test "search posts request and book context and parses results" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .with do |request|
+          body = JSON.parse(request.body)
+          request.headers["Authorization"] == "Bearer secret" &&
+            body["book"]["title"] == @request.book.title &&
+            body["book"]["book_type"] == "ebook" &&
+            body["request"]["language"].present?
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "abc123",
+                title: "Provider Result",
+                author: "Provider Author",
+                format: "epub",
+                language: "en",
+                size_bytes: 12345,
+                download_type: "direct",
+                info_url: "https://provider.test/books/abc123"
+              }
+            ]
+          }.to_json
+        )
+
+      results = @client.search(@request)
+
+      assert_equal 1, results.size
+      assert_equal "abc123", results.first.provider_result_id
+      assert_equal "Provider Result", results.first.title
+      assert_equal "epub", results.first.file_type
+      assert_equal "direct", results.first.download_type
+      assert results.first.available?
+    end
+  end
+
+  test "search infers direct download type from direct_url" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "direct-without-type",
+                title: "Provider Direct Result",
+                direct_url: "https://files.test/book.epub"
+              }
+            ]
+          }.to_json
+        )
+
+      result = @client.search(@request).first
+
+      assert_equal "direct", result.download_type
+      assert_equal "https://files.test/book.epub", result.download_url
+      assert_equal "direct", result.payload["download_type"]
+    end
+  end
+
+  test "search infers usenet download type from nzb_url" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "nzb-without-type",
+                title: "Provider NZB Result",
+                nzb_url: "https://files.test/book.nzb"
+              }
+            ]
+          }.to_json
+        )
+
+      result = @client.search(@request).first
+
+      assert_equal "usenet", result.download_type
+      assert_equal "https://files.test/book.nzb", result.download_url
+      assert_equal "usenet", result.payload["download_type"]
+    end
+  end
+
+  test "search infers torrent download type from magnet_url" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "magnet-without-type",
+                title: "Provider Magnet Result",
+                magnet_url: "magnet:?xt=urn:btih:abc123"
+              }
+            ]
+          }.to_json
+        )
+
+      result = @client.search(@request).first
+
+      assert_equal "torrent", result.download_type
+      assert_equal "magnet:?xt=urn:btih:abc123", result.magnet_url
+      assert_equal "torrent", result.payload["download_type"]
+    end
+  end
+
+  test "search marks unavailable results as not downloadable" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "unavailable",
+                title: "Provider Unavailable Result",
+                availability: "temporarily_unavailable",
+                direct_url: "https://files.test/book.epub"
+              }
+            ]
+          }.to_json
+        )
+
+      result = @client.search(@request).first
+
+      assert_equal "temporarily_unavailable", result.availability
+      assert_not result.available?
+      assert_not result.downloadable?
+    end
+  end
+
+  test "search rejects non object response body" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: "[]".to_json
+        )
+
+      assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.search(@request)
+      end
+    end
+  end
+
+  test "search rejects non array results container" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { results: "not-a-list" }.to_json
+        )
+
+      assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.search(@request)
+      end
+    end
+  end
+
+  test "search skips malformed result entries" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              "bad-result",
+              {
+                id: "valid",
+                title: "Valid Provider Result",
+                direct_url: "https://files.test/book.epub"
+              }
+            ]
+          }.to_json
+        )
+
+      results = @client.search(@request)
+
+      assert_equal 1, results.size
+      assert_equal "valid", results.first.provider_result_id
+    end
+  end
+
+  test "search raises ResponseError on non-success status" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(status: 500, body: "boom")
+
+      error = assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.search(@request)
+      end
+
+      assert_includes error.message, "HTTP 500"
+    end
+  end
+
+  test "search raises ResponseError on invalid JSON" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: "not json {"
+        )
+
+      error = assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.search(@request)
+      end
+
+      assert_includes error.message, "invalid JSON"
+    end
+  end
+
+  test "search raises ConnectionError when connection is refused" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search").to_raise(Errno::ECONNREFUSED)
+
+      assert_raises(CustomAcquisitionProviderClient::ConnectionError) do
+        @client.search(@request)
+      end
+    end
+  end
+
+  test "search raises ConnectionError on timeout" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search").to_timeout
+
+      assert_raises(CustomAcquisitionProviderClient::ConnectionError) do
+        @client.search(@request)
+      end
+    end
+  end
+
+  test "search rejects responses exceeding the size limit" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json",
+            "Content-Length" => (CustomAcquisitionProviderClient::MAX_RESPONSE_BYTES + 1).to_s
+          },
+          body: "{}"
+        )
+
+      error = assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.search(@request)
+      end
+
+      assert_includes error.message, "exceeds"
+    end
+  end
+
+  test "search rejects streamed bodies exceeding the size limit" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: "x" * (CustomAcquisitionProviderClient::MAX_RESPONSE_BYTES + 1)
+        )
+
+      assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.search(@request)
+      end
+    end
+  end
+
+  test "search refuses providers that resolve to private addresses" do
+    with_resolver(->(host) { [ "10.0.0.5" ] }) do
+      error = assert_raises(CustomAcquisitionProviderClient::ConnectionError) do
+        @client.search(@request)
+      end
+
+      assert_includes error.message, "Refused to contact"
+    end
+  end
+
+  test "search allows private provider addresses when allow_private_network is enabled" do
+    provider = AcquisitionProvider.create!(
+      name: "LAN Provider",
+      url: "http://192.168.1.80:4567",
+      allow_private_network: true,
+      timeout_seconds: 5
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://192.168.1.80:4567/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { results: [] }.to_json
+        )
+
+      assert_equal [], provider.client.search(@request)
+    end
+  end
+
+  test "acquire parses direct artifact" do
+    search_result = @request.search_results.create!(
+      guid: "custom:#{@provider.id}:abc123",
+      title: "Provider Result [EPUB]",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: @provider,
+      provider_result_id: "abc123",
+      provider_payload: { "download_type" => "direct" }
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/acquire")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["provider_result_id"] == "abc123"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { download_type: "direct", direct_url: "https://files.test/book.epub" }.to_json
+        )
+
+      acquisition = @client.acquire(search_result)
+
+      assert_equal "direct", acquisition.download_type
+      assert_equal "https://files.test/book.epub", acquisition.direct_url
+    end
+  end
+
+  test "acquire rejects missing artifact" do
+    search_result = @request.search_results.create!(
+      guid: "custom:#{@provider.id}:missing",
+      title: "Broken Provider Result",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: @provider,
+      provider_result_id: "missing"
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/acquire")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { download_type: "direct" }.to_json
+        )
+
+      assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.acquire(search_result)
+      end
+    end
+  end
+
+  test "acquire rejects non object response body" do
+    search_result = @request.search_results.create!(
+      guid: "custom:#{@provider.id}:bad-body",
+      title: "Broken Provider Result",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: @provider,
+      provider_result_id: "bad-body"
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/acquire")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: "[]".to_json
+        )
+
+      assert_raises(CustomAcquisitionProviderClient::ResponseError) do
+        @client.acquire(search_result)
+      end
+    end
+  end
+
+  test "test_connection returns true for healthy providers" do
+    VCR.turned_off do
+      stub_request(:get, "http://provider.test/health")
+        .with(headers: { "Authorization" => "Bearer secret" })
+        .to_return(status: 200, body: "ok")
+
+      assert @client.test_connection
+    end
+  end
+
+  test "test_connection returns false on failure responses and connection errors" do
+    VCR.turned_off do
+      stub_request(:get, "http://provider.test/health").to_return(status: 500)
+      assert_not @client.test_connection
+
+      stub_request(:get, "http://provider.test/health").to_raise(Errno::ECONNREFUSED)
+      assert_not @client.test_connection
+    end
+  end
+
+  test "test_connection returns false for blocked provider URLs" do
+    with_resolver(->(host) { [ "10.0.0.5" ] }) do
+      assert_not @client.test_connection
+    end
+  end
+
+  test "normalize_download_type maps aliases to canonical types" do
+    assert_equal "direct", CustomAcquisitionProviderClient.normalize_download_type("HTTP")
+    assert_equal "torrent", CustomAcquisitionProviderClient.normalize_download_type("magnet")
+    assert_equal "usenet", CustomAcquisitionProviderClient.normalize_download_type("nzb")
+    assert_equal "weird", CustomAcquisitionProviderClient.normalize_download_type("weird")
+    assert_nil CustomAcquisitionProviderClient.normalize_download_type("  ")
+    assert_nil CustomAcquisitionProviderClient.normalize_download_type(nil)
+  end
+
+  private
+
+  def with_resolver(resolver)
+    previous = OutboundUrlGuard.resolver
+    OutboundUrlGuard.resolver = resolver
+    yield
+  ensure
+    OutboundUrlGuard.resolver = previous
+  end
+end

--- a/test/services/outbound_url_guard_test.rb
+++ b/test/services/outbound_url_guard_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OutboundUrlGuardTest < ActiveSupport::TestCase
+  test "allows public addresses" do
+    uri = OutboundUrlGuard.validate!("https://example.test/file.epub")
+
+    assert_equal "example.test", uri.host
+    assert_equal "203.0.113.10", uri.ipaddr
+    assert uri.use_ssl?
+  end
+
+  test "rejects non-http schemes and missing hosts" do
+    assert_raises(OutboundUrlGuard::BlockedUrlError) { OutboundUrlGuard.validate!("file:///etc/passwd") }
+    assert_raises(OutboundUrlGuard::BlockedUrlError) { OutboundUrlGuard.validate!("ftp://example.test/file") }
+    assert_raises(OutboundUrlGuard::BlockedUrlError) { OutboundUrlGuard.validate!("not a url") }
+    assert_raises(OutboundUrlGuard::BlockedUrlError) { OutboundUrlGuard.validate!(nil) }
+  end
+
+  test "rejects private addresses by default" do
+    %w[
+      http://127.0.0.1/file
+      http://localhost/file
+      http://10.0.0.5/file
+      http://172.16.10.10/file
+      http://192.168.1.80:4567/file
+      http://[::1]/file
+    ].each do |url|
+      assert_raises(OutboundUrlGuard::BlockedUrlError, "expected #{url} to be blocked") do
+        OutboundUrlGuard.validate!(url)
+      end
+    end
+  end
+
+  test "allows private addresses when allow_private is set" do
+    uri = OutboundUrlGuard.validate!("http://192.168.1.80:4567/search", allow_private: true)
+
+    assert_equal "192.168.1.80", uri.host
+    assert_equal "192.168.1.80", uri.ipaddr
+  end
+
+  test "always rejects link-local and metadata addresses" do
+    %w[
+      http://169.254.169.254/latest/meta-data
+      http://0.0.0.0/file
+      http://[fe80::1]/file
+      http://[64:ff9b::a9fe:a9fe]/file
+    ].each do |url|
+      assert_raises(OutboundUrlGuard::BlockedUrlError, "expected #{url} to be blocked") do
+        OutboundUrlGuard.validate!(url, allow_private: true)
+      end
+    end
+  end
+
+  test "rejects IPv4-mapped IPv6 forms of blocked and private addresses" do
+    assert_raises(OutboundUrlGuard::BlockedUrlError) do
+      OutboundUrlGuard.validate!("http://[::ffff:169.254.169.254]/latest/meta-data", allow_private: true)
+    end
+
+    %w[
+      http://[::ffff:127.0.0.1]/file
+      http://[::ffff:10.0.0.5]/file
+      http://[::ffff:192.168.1.80]/file
+    ].each do |url|
+      assert_raises(OutboundUrlGuard::BlockedUrlError, "expected #{url} to be blocked") do
+        OutboundUrlGuard.validate!(url)
+      end
+    end
+  end
+
+  test "rejects hostnames that resolve to private addresses" do
+    with_resolver(->(host) { [ "10.0.0.5" ] }) do
+      assert_raises(OutboundUrlGuard::BlockedUrlError) do
+        OutboundUrlGuard.validate!("https://internal.test/file.epub")
+      end
+    end
+  end
+
+  test "rejects hostnames when any resolved address is blocked" do
+    with_resolver(->(host) { [ "203.0.113.10", "169.254.169.254" ] }) do
+      assert_raises(OutboundUrlGuard::BlockedUrlError) do
+        OutboundUrlGuard.validate!("https://rebinding.test/file.epub", allow_private: true)
+      end
+    end
+  end
+
+  test "rejects unresolvable hostnames" do
+    with_resolver(->(host) { [] }) do
+      assert_raises(OutboundUrlGuard::BlockedUrlError) do
+        OutboundUrlGuard.validate!("https://unknown.test/file.epub")
+      end
+    end
+  end
+
+  test "pins the first validated resolved address" do
+    with_resolver(->(host) { [ "203.0.113.10", "203.0.113.11" ] }) do
+      uri = OutboundUrlGuard.validate!("https://downloads.test/file.epub")
+
+      assert_equal "downloads.test", uri.host
+      assert_equal "203.0.113.10", uri.ipaddr
+    end
+  end
+
+  test "obviously_private_host? detects localhost and private literals" do
+    assert OutboundUrlGuard.obviously_private_host?("localhost")
+    assert OutboundUrlGuard.obviously_private_host?("127.0.0.1")
+    assert OutboundUrlGuard.obviously_private_host?("192.168.1.80")
+    assert OutboundUrlGuard.obviously_private_host?("169.254.169.254")
+    assert_not OutboundUrlGuard.obviously_private_host?("example.test")
+    assert_not OutboundUrlGuard.obviously_private_host?("8.8.8.8")
+  end
+
+  private
+
+  def with_resolver(resolver)
+    previous = OutboundUrlGuard.resolver
+    OutboundUrlGuard.resolver = resolver
+    yield
+  ensure
+    OutboundUrlGuard.resolver = previous
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,10 @@ require "mutant/minitest/coverage"
 require_relative "test_helpers/session_test_helper"
 require_relative "support/vcr_setup"
 
+# Resolve hostnames to a fixed public test address instead of doing real DNS
+# lookups. Tests for OutboundUrlGuard itself swap the resolver as needed.
+OutboundUrlGuard.resolver = ->(host) { [ "203.0.113.10" ] }
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
## Summary
- add admin-managed custom acquisition providers with search/acquire integration
- support direct, torrent, and usenet custom artifacts across search selection and download dispatch
- add outbound URL guarding with pinned DNS resolution for provider calls and direct downloads
- document the provider API and add UI for provider configuration/testing

## Validation
- bin/quality push
- local Selenium UI smoke against http://127.0.0.1:3000 for provider index/create/edit/mobile layout
- pre-push hook passed during push

## Notes
- mobile provider listing uses cards while desktop keeps the table layout
- local UI test records were cleaned up after verification
