### PR TITLE
Fix Transmission import: report per-torrent content path

### DIFF
--- a/app/services/download_clients/transmission.rb
+++ b/app/services/download_clients/transmission.rb
@@ -373,13 +373,24 @@ module DownloadClients
     end
 
     def parse_torrent(data)
+      name = data["name"]
+      download_dir = transmission_value(data, "download_dir", "downloadDir").to_s
+      # Transmission's RPC exposes only the parent download directory
+      # (`downloadDir`), never the torrent's own content path. Join it with the
+      # torrent name so `download_path` points at the actual per-torrent
+      # file/folder, mirroring qBittorrent's `content_path`. PostProcessingJob
+      # resolves the import source from this value (via File.basename and the
+      # remote->local prefix remap), so reporting the bare parent dir makes it
+      # import the entire download root instead of just this torrent.
+      content_path = name.present? && download_dir.present? ? File.join(download_dir, name) : download_dir
+
       Base::TorrentInfo.new(
         hash: transmission_value(data, "hash_string", "hashString"),
-        name: data["name"],
+        name: name,
         progress: normalize_progress(transmission_value(data, "percent_done", "percentDone")),
         state: normalize_state(data["status"], error: data["error"]),
         size_bytes: transmission_value(data, "total_size", "totalSize"),
-        download_path: transmission_value(data, "download_dir", "downloadDir").to_s
+        download_path: content_path
       )
     end
 

--- a/test/services/download_clients/transmission_test.rb
+++ b/test/services/download_clients/transmission_test.rb
@@ -306,7 +306,9 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
                   "percent_done" => 0.5,
                   "status" => 4,
                   "total_size" => 1073741824,
-                  "download_dir" => "/downloads/Transmission Book",
+                  # Transmission reports the PARENT download dir here, not the
+                  # per-torrent path; the content lives at download_dir/name.
+                  "download_dir" => "/downloads",
                   "error" => 0,
                   "error_string" => ""
                 }
@@ -321,6 +323,75 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
       assert_equal "abc123", info.hash
       assert_equal 50, info.progress
       assert_equal "/downloads/Transmission Book", info.download_path
+    end
+  end
+
+  test "torrent_info reports the per-torrent content path (download_dir + name)" do
+    VCR.turned_off do
+      stub_session_handshake("http://localhost:9091/transmission/rpc")
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => [ "abc123" ], "fields" => JSONRPC_TORRENT_FIELDS }) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "jsonrpc" => "2.0",
+            "result" => {
+              "torrents" => [
+                {
+                  "hash_string" => "abc123",
+                  "name" => "Some Author - Some Book",
+                  "percent_done" => 1.0,
+                  "status" => 6,
+                  "total_size" => 1073741824,
+                  "download_dir" => "/mnt/media/transmission",
+                  "error" => 0
+                }
+              ]
+            },
+            "id" => 1
+          }.to_json
+        )
+
+      info = @client.torrent_info("abc123")
+
+      # download_dir is the parent; the importable path is download_dir/name,
+      # mirroring qBittorrent's content_path. Reporting the bare parent here
+      # makes PostProcessingJob import the whole download root.
+      assert_equal "/mnt/media/transmission/Some Author - Some Book", info.download_path
+    end
+  end
+
+  test "torrent_info falls back to download_dir when name is blank" do
+    VCR.turned_off do
+      stub_session_handshake("http://localhost:9091/transmission/rpc")
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => [ "abc123" ], "fields" => JSONRPC_TORRENT_FIELDS }) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "jsonrpc" => "2.0",
+            "result" => {
+              "torrents" => [
+                {
+                  "hash_string" => "abc123",
+                  "name" => "",
+                  "percent_done" => 1.0,
+                  "status" => 6,
+                  "total_size" => 1073741824,
+                  "download_dir" => "/downloads",
+                  "error" => 0
+                }
+              ]
+            },
+            "id" => 1
+          }.to_json
+        )
+
+      info = @client.torrent_info("abc123")
+
+      assert_equal "/downloads", info.download_path
     end
   end
 
@@ -358,7 +429,9 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
       assert_equal 75, torrent.progress
       assert_equal :downloading, torrent.state
       assert_equal 2048, torrent.size_bytes
-      assert_equal "/downloads/legacy", torrent.download_path
+      # downloadDir is the parent; download_path is the per-torrent content path
+      # (downloadDir/name), same as the JSON-RPC path.
+      assert_equal "/downloads/legacy/Legacy Transmission Book", torrent.download_path
     end
   end
 


### PR DESCRIPTION
## Problem

`DownloadClients::Transmission#parse_torrent` sets `download_path` to the bare
`downloadDir`, which is Transmission's **parent** download directory — never the
torrent's own content path (the content actually lives at `downloadDir/name`).

`PostProcessingJob` resolves the import source from `download_path` (via
`File.basename` and the remote→local prefix remap). Because Transmission reports
the parent dir, imports either:

- find nothing on disk and silently no-op, or
- when a remote→local path remap **is** configured, copy the **entire download
  root** into the single book's destination folder.

The qBittorrent adapter doesn't have this problem because it already reports the
per-torrent path via `content_path` (`File.join(save_path, name)`). The
Transmission adapter just never got the equivalent.

## Fix

Set `download_path = File.join(downloadDir, name)`, falling back to `downloadDir`
when `name` is blank — mirroring qBittorrent's `content_path`. This makes the
reported path point at the actual per-torrent file/folder, so PostProcessing
imports only that torrent.

No settings or schema changes; the adapter now reports what PostProcessing
already expects.

## Tests

- Corrected two existing fixtures that encoded the old assumption (`download_dir`
  set to the per-torrent path rather than the parent).
- Added coverage for the content-path join (`download_dir + name`) and the
  blank-name fallback.

## Verification

Verified end-to-end against a live Transmission + Prowlarr setup: a real torrent
grabbed via Transmission now imports **only** its own `/downloads/<torrent>`
folder into the destination library, instead of ballooning the entire download
root into one book's folder.
