### PR TITLE
Honor download client category in the Transmission adapter

### DIFF
--- a/app/services/download_clients/transmission.rb
+++ b/app/services/download_clients/transmission.rb
@@ -41,7 +41,8 @@ module DownloadClients
       args[:metainfo] = prepared[:metainfo] if prepared[:metainfo].present?
       args[:filename] = prepared[:url] if prepared[:metainfo].blank?
       args[:paused] = options[:paused] unless options[:paused].nil?
-      args[:download_dir] = options[:save_path] if options[:save_path].present?
+      save_path = options[:save_path].presence || category_save_path
+      apply_download_dir!(args, save_path) if save_path.present?
 
       response = rpc_request("torrent-add", args)
       added = transmission_value(response, "torrent_added", "torrent-added")
@@ -110,6 +111,35 @@ module DownloadClients
       # We trigger one request to negotiate the current RPC protocol and fetch session id.
       rpc_request("session-get")
       true
+    end
+
+    # Honor config.category by saving into a per-category subdirectory of the
+    # session download dir. Transmission has no native category/label concept
+    # (unlike qBittorrent's `category` or Deluge's `label`), so the only way to
+    # keep a client's downloads out of the shared download root is to compute the
+    # save path ourselves. Returns nil when no category is configured.
+    def category_save_path
+      category = config.category.presence
+      return nil unless category
+
+      session = rpc_request("session-get")
+      base = transmission_value(session, "download_dir", "download-dir").to_s
+      return nil if base.blank?
+
+      File.join(base, category)
+    end
+
+    # Set the per-torrent download directory on a torrent-add arg hash using the
+    # protocol-correct key. Transmission's torrent-add expects a hyphenated
+    # `download-dir` argument in classic RPC, but snake_case `download_dir` in
+    # JSON-RPC 2.0 (Transmission 4.1+). request_payload only rewrites the method
+    # name, never arg keys, so the key has to be chosen here -- otherwise the dir
+    # is silently ignored and the torrent lands in the session default dir.
+    # protocol_mode is populated by the ensure_authenticated! call at the top of
+    # add_torrent; default to the classic key when it is somehow unset.
+    def apply_download_dir!(args, save_path)
+      key = protocol_mode.to_s == "jsonrpc" ? :download_dir : "download-dir"
+      args[key] = save_path
     end
 
     def rpc_request(method, args = {})

--- a/test/services/download_clients/transmission_test.rb
+++ b/test/services/download_clients/transmission_test.rb
@@ -121,6 +121,125 @@ class DownloadClients::TransmissionTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_torrent saves into a per-category subdirectory of the download dir" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+
+      # session-get is hit twice: once to negotiate auth, once by
+      # category_save_path; both 200s expose the parent download dir.
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| jsonrpc_request?(request, method: "session_get", params: {}) }
+        .to_return(
+          {
+            status: 409,
+            headers: { "x-transmission-session-id" => "session-id" },
+            body: { "result" => "session", "arguments" => {} }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "jsonrpc" => "2.0", "result" => { "download_dir" => "/downloads" }, "id" => 1 }.to_json
+          }
+        )
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => "all", "fields" => [ "hash_string" ] }) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "jsonrpc" => "2.0", "result" => { "torrents" => [] }, "id" => 1 }.to_json
+        )
+      add_stub = stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with do |request|
+          jsonrpc_request?(request, method: "torrent_add", params: {
+            "filename" => "magnet:?xt=urn:btih:abcdef",
+            "download_dir" => "/downloads/shelfarr"
+          })
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "jsonrpc" => "2.0", "result" => { "torrent_added" => { "hash_string" => "new-torrent-id" } }, "id" => 1 }.to_json
+        )
+
+      result = @client.add_torrent("magnet:?xt=urn:btih:abcdef")
+
+      assert_equal "new-torrent-id", result
+      assert_requested(add_stub)
+    end
+  end
+
+  test "add_torrent uses the hyphenated download-dir key for the category in legacy RPC" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      Thread.current[:transmission_sessions][@client_record.id] = "session-id"
+      Thread.current[:transmission_protocols][@client_record.id] = :legacy
+
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| legacy_request?(request, method: "session-get", arguments: {}) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "success", "arguments" => { "download-dir" => "/downloads" } }.to_json
+        )
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| legacy_request?(request, method: "torrent-get", arguments: { "ids" => "all", "fields" => [ "hashString" ] }) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "success", "arguments" => { "torrents" => [] } }.to_json
+        )
+      add_stub = stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with do |request|
+          legacy_request?(request, method: "torrent-add", arguments: {
+            "filename" => "magnet:?xt=urn:btih:abcdef",
+            "download-dir" => "/downloads/shelfarr"
+          })
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "success", "arguments" => { "torrent-added" => { "hashString" => "new-torrent-id" } } }.to_json
+        )
+
+      result = @client.add_torrent("magnet:?xt=urn:btih:abcdef")
+
+      assert_equal "new-torrent-id", result
+      assert_requested(add_stub)
+    end
+  end
+
+  test "add_torrent prefers an explicit save_path over the configured category" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+
+      stub_session_handshake("http://localhost:9091/transmission/rpc")
+      stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with { |request| jsonrpc_request?(request, method: "torrent_get", params: { "ids" => "all", "fields" => [ "hash_string" ] }) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "jsonrpc" => "2.0", "result" => { "torrents" => [] }, "id" => 1 }.to_json
+        )
+      add_stub = stub_request(:post, "http://localhost:9091/transmission/rpc")
+        .with do |request|
+          jsonrpc_request?(request, method: "torrent_add", params: {
+            "filename" => "magnet:?xt=urn:btih:abcdef",
+            "download_dir" => "/downloads/explicit"
+          })
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "jsonrpc" => "2.0", "result" => { "torrent_added" => { "hash_string" => "new-torrent-id" } }, "id" => 1 }.to_json
+        )
+
+      result = @client.add_torrent("magnet:?xt=urn:btih:abcdef", save_path: "/downloads/explicit")
+
+      assert_equal "new-torrent-id", result
+      assert_requested(add_stub)
+    end
+  end
+
   test "add_torrent returns existing torrent id when duplicate" do
     VCR.turned_off do
       stub_session_handshake("http://localhost:9091/transmission/rpc")


### PR DESCRIPTION
## Problem

`DownloadClients::Transmission#add_torrent` ignored `config.category`, so every torrent landed in Transmission's shared session download directory regardless of the category configured on the client. The qBittorrent and Deluge adapters both already respect `config.category` (qBittorrent via its native `category`, Deluge via its `label`); Transmission just never got the equivalent.

## Fix

Transmission has no native category/label concept, so honor the category by saving into a per-category **subdirectory** of the session download dir: `add_torrent` now falls back to `<session download-dir>/<category>` (fetched via `session-get`) when no explicit `save_path` is supplied. An explicit `save_path` still takes precedence.

This also fixes a latent protocol bug surfaced by the change. Transmission's `torrent-add` expects a **hyphenated** `download-dir` argument in classic RPC, but a snake_case `download_dir` in JSON-RPC 2.0 (Transmission 4.1+). `request_payload` only rewrites the RPC *method* name, never argument keys, so a download dir sent as `download_dir` was silently ignored by classic-RPC servers and the torrent fell back to the session default. It never surfaced before because torrent adds never passed `save_path`. `apply_download_dir!` now picks the protocol-correct key.

## Tests

- per-category subdir is honored under JSON-RPC
- the hyphenated `download-dir` key is used under classic/legacy RPC
- an explicit `save_path` overrides the category

`bin/rails test test/services/download_clients/transmission_test.rb` → 26 runs, 0 failures. Full `download_clients` + `jobs` suites → 315 runs, 0 failures.

## Verification

Verified end-to-end against a real (Transmission 4.0.5, classic RPC) server: a categorized grab saved to `<download-dir>/<category>/<torrent>` and imported cleanly from that subdirectory.
