### PR TITLE
fix: rename ebook directory imports

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -4,6 +4,10 @@
 # Files are COPIED (not moved) to preserve seeding for torrent downloads.
 # Usenet downloads are removed from the client after successful import.
 class PostProcessingJob < ApplicationJob
+  EBOOK_FILE_EXTENSIONS = %w[epub pdf mobi azw azw3 cbz cbr djvu].freeze
+  EBOOK_SIDECAR_EXTENSIONS = %w[jpg jpeg png webp opf nfo txt].freeze
+  EBOOK_ALLOWED_EXTENSIONS = (EBOOK_FILE_EXTENSIONS + EBOOK_SIDECAR_EXTENSIONS).freeze
+
   queue_as :default
 
   def perform(download_id, source_path_retry_count = 0)
@@ -129,6 +133,7 @@ class PostProcessingJob < ApplicationJob
     end
 
     Rails.logger.info "[PostProcessingJob] Copying from #{source} to #{destination}"
+    validate_ebook_source!(source) if book&.ebook?
     FileUtils.mkdir_p(destination)
 
     if File.directory?(source)
@@ -139,22 +144,138 @@ class PostProcessingJob < ApplicationJob
       files = Dir.entries(source).reject { |f| f.start_with?(".") }
       Rails.logger.info "[PostProcessingJob] Found #{files.size} files/folders to copy"
       files.each do |file|
-        FileCopyService.cp_r(File.join(source, file), destination)
+        source_file = File.join(source, file)
+
+        if book&.ebook?
+          copy_ebook_directory_entry(source_file, destination, book)
+        else
+          FileCopyService.cp_r(source_file, destination)
+        end
       end
     else
       # Copy single file with renamed filename based on template
-      extension = File.extname(source)
-      new_filename = book ? PathTemplateService.build_filename(book, extension) : File.basename(source)
-      destination_file = File.join(destination, new_filename)
-
-      # Handle duplicate filenames
-      destination_file = handle_duplicate_filename(destination_file) if File.exist?(destination_file)
-
-      Rails.logger.info "[PostProcessingJob] Renaming file to: #{new_filename}"
-      FileCopyService.cp(source, destination_file)
+      copy_renamed_file(source, destination, book)
     end
 
     Rails.logger.info "[PostProcessingJob] Copy completed successfully"
+  end
+
+  def copy_ebook_directory_entry(source_file, destination, book)
+    if File.directory?(source_file)
+      Dir.entries(source_file).reject { |f| f.start_with?(".") }.each do |file|
+        copy_ebook_directory_entry(File.join(source_file, file), destination, book)
+      end
+    elsif ebook_file?(source_file)
+      copy_renamed_file(source_file, destination, book)
+    else
+      copy_sidecar_file(source_file, destination)
+    end
+  end
+
+  def validate_ebook_source!(source)
+    paths = if File.directory?(source)
+      ebook_directory_files(source)
+    else
+      [ source ]
+    end
+
+    paths.each do |path|
+      next if allowed_ebook_import_file?(path)
+
+      raise "Unsupported ebook import file type: #{File.basename(path)}"
+    end
+  end
+
+  def ebook_directory_files(source)
+    Dir.entries(source).reject { |f| f.start_with?(".") }.flat_map do |file|
+      path = File.join(source, file)
+      File.directory?(path) && !File.symlink?(path) ? ebook_directory_files(path) : path
+    end
+  end
+
+  def allowed_ebook_import_file?(path)
+    return false if File.symlink?(path)
+    return false unless File.file?(path)
+
+    extension = File.extname(path).delete_prefix(".").downcase
+    EBOOK_ALLOWED_EXTENSIONS.include?(extension) && valid_ebook_import_content?(path, extension)
+  end
+
+  def valid_ebook_import_content?(path, extension)
+    file_size = File.size(path)
+    return false if file_size.zero?
+
+    head = File.binread(path, [ 512, file_size ].min)
+    return false if executable_file_signature?(head)
+
+    case extension
+    when "epub", "cbz"
+      head.start_with?("PK\x03\x04")
+    when "pdf"
+      head.start_with?("%PDF")
+    when "mobi", "azw", "azw3"
+      head.byteslice(60, 8) == "BOOKMOBI" || head.include?("BOOKMOBI")
+    when "cbr"
+      head.start_with?("Rar!\x1A\x07\x00") || head.start_with?("Rar!\x1A\x07\x01\x00")
+    when "djvu"
+      head.start_with?("AT&TFORM") && %w[DJVU DJVM].include?(head.byteslice(12, 4))
+    when "jpg", "jpeg"
+      head.start_with?("\xFF\xD8\xFF".b)
+    when "png"
+      head.start_with?("\x89PNG\r\n\x1A\n".b)
+    when "webp"
+      head.start_with?("RIFF") && head.byteslice(8, 4) == "WEBP"
+    when "opf"
+      text_file_content?(head) && head.downcase.include?("<package")
+    when "nfo", "txt"
+      text_file_content?(head)
+    else
+      false
+    end
+  rescue Errno::ENOENT, Errno::EACCES
+    false
+  end
+
+  def executable_file_signature?(head)
+    head.start_with?("MZ") ||
+      head.start_with?("\x7FELF".b) ||
+      head.start_with?("\xFE\xED\xFA\xCE".b) ||
+      head.start_with?("\xFE\xED\xFA\xCF".b) ||
+      head.start_with?("\xCE\xFA\xED\xFE".b) ||
+      head.start_with?("\xCF\xFA\xED\xFE".b)
+  end
+
+  def text_file_content?(head)
+    return false if head.include?("\x00")
+
+    head.bytes.all? do |byte|
+      byte == 9 || byte == 10 || byte == 12 || byte == 13 || byte >= 32
+    end
+  end
+
+  def copy_sidecar_file(source_file, destination)
+    destination_file = File.join(destination, File.basename(source_file))
+    destination_file = handle_duplicate_filename(destination_file) if File.exist?(destination_file)
+    FileCopyService.cp(source_file, destination_file)
+  end
+
+  def copy_renamed_file(source, destination, book)
+    destination_file = renamed_destination_file(source, destination, book)
+    Rails.logger.info "[PostProcessingJob] Renaming file to: #{File.basename(destination_file)}"
+    FileCopyService.cp(source, destination_file)
+  end
+
+  def renamed_destination_file(source, destination, book)
+    extension = File.extname(source)
+    new_filename = book ? PathTemplateService.build_filename(book, extension) : File.basename(source)
+    destination_file = File.join(destination, new_filename)
+
+    destination_file = handle_duplicate_filename(destination_file) if File.exist?(destination_file)
+    destination_file
+  end
+
+  def ebook_file?(path)
+    EBOOK_FILE_EXTENSIONS.include?(File.extname(path).delete_prefix(".").downcase)
   end
 
   def handle_duplicate_filename(path)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -395,7 +395,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
   test "remaps Windows download path backslashes after global prefix replacement" do
     FileUtils.rm_rf(@temp_source)
     FileUtils.mkdir_p(@temp_source)
-    File.write(File.join(@temp_source, "Windows Book.epub"), "test ebook content")
+    write_valid_ebook_file(File.join(@temp_source, "Windows Book.epub"))
 
     @book.update!(book_type: :ebook)
     @download.update!(download_path: "D:\\QbittorrentMove\\Windows Book.epub")
@@ -412,10 +412,126 @@ class PostProcessingJobTest < ActiveJob::TestCase
       "Windows backslashes should be converted to container path separators"
   end
 
+  test "renames ebook files copied from a source directory" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    write_valid_ebook_file(File.join(@temp_source, "Jurassic Park by Michael Crichton.epub"))
+
+    @book.update!(
+      title: "Jurassic Park",
+      author: "Michael Crichton",
+      book_type: :ebook,
+      year: 1990
+    )
+
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:ebook_path_template, "{author}/{title}")
+    SettingsService.set(:ebook_filename_template, "{author} - {title} ({year})")
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, "Michael Crichton", "Jurassic Park")
+    assert File.exist?(File.join(expected_dest, "Michael Crichton - Jurassic Park (1990).epub")),
+      "Ebook file from a directory source should use the filename template"
+    assert_not File.exist?(File.join(expected_dest, "Jurassic Park by Michael Crichton.epub")),
+      "Original ebook filename should not be copied into the library"
+  end
+
+  test "renames ebook files copied from nested source directories" do
+    FileUtils.rm_rf(@temp_source)
+    nested_source = File.join(@temp_source, "Calibre Export")
+    FileUtils.mkdir_p(nested_source)
+    write_valid_ebook_file(File.join(nested_source, "Jurassic Park by Michael Crichton.epub"))
+
+    @book.update!(
+      title: "Jurassic Park",
+      author: "Michael Crichton",
+      book_type: :ebook,
+      year: 1990
+    )
+
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:ebook_path_template, "{author}/{title}")
+    SettingsService.set(:ebook_filename_template, "{author} - {title} ({year})")
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, "Michael Crichton", "Jurassic Park")
+    assert File.exist?(File.join(expected_dest, "Michael Crichton - Jurassic Park (1990).epub")),
+      "Nested ebook file should use the filename template"
+    assert_not File.exist?(File.join(expected_dest, "Calibre Export")),
+      "Nested source folder should not be copied when it only contained renamed ebook files"
+    assert_not File.exist?(File.join(expected_dest, "Calibre Export", "Jurassic Park by Michael Crichton.epub")),
+      "Nested original ebook filename should not be copied into the library"
+  end
+
+  test "copies nested ebook sidecars beside the renamed ebook" do
+    FileUtils.rm_rf(@temp_source)
+    nested_source = File.join(@temp_source, "Calibre Export")
+    FileUtils.mkdir_p(nested_source)
+    write_valid_ebook_file(File.join(nested_source, "Jurassic Park by Michael Crichton.epub"))
+    File.binwrite(File.join(nested_source, "cover.jpg"), "\xFF\xD8\xFFvalid cover content".b)
+
+    @book.update!(
+      title: "Jurassic Park",
+      author: "Michael Crichton",
+      book_type: :ebook,
+      year: 1990
+    )
+
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:ebook_path_template, "{author}/{title}")
+    SettingsService.set(:ebook_filename_template, "{author} - {title} ({year})")
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, "Michael Crichton", "Jurassic Park")
+    assert File.exist?(File.join(expected_dest, "Michael Crichton - Jurassic Park (1990).epub"))
+    assert File.exist?(File.join(expected_dest, "cover.jpg"))
+    assert_not File.exist?(File.join(expected_dest, "Calibre Export"))
+  end
+
+  test "imports bundled DjVu ebooks" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    write_valid_ebook_file(File.join(@temp_source, "Bundled Book.djvu"))
+
+    @book.update!(book_type: :ebook)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert @request.reload.completed?
+    assert File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.djvu"))
+  end
+
+  test "imports ebook directories with non UTF-8 nfo sidecars" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    write_valid_ebook_file(File.join(@temp_source, "Valid Book.epub"))
+    File.binwrite(File.join(@temp_source, "release.nfo"), "Release Info\n" + 0xB3.chr)
+
+    @book.update!(book_type: :ebook)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert @request.reload.completed?
+    assert File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
+    assert File.exist?(File.join(expected_dest, "release.nfo"))
+  end
+
   test "remaps Windows download path when remote path uses forward slashes" do
     FileUtils.rm_rf(@temp_source)
     FileUtils.mkdir_p(@temp_source)
-    File.write(File.join(@temp_source, "Forward Remote.mobi"), "test ebook content")
+    write_valid_ebook_file(File.join(@temp_source, "Forward Remote.mobi"))
 
     @book.update!(book_type: :ebook)
     @download.update!(download_path: "D:\\QbittorrentMove\\Forward Remote.mobi")
@@ -523,7 +639,103 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_match /source path not found/i, @request.issue_description
   end
 
+  test "marks ebook directory import for attention when it contains unsupported files" do
+    FileUtils.rm_rf(@temp_source)
+    nested_source = File.join(@temp_source, "Nested")
+    FileUtils.mkdir_p(nested_source)
+    write_valid_ebook_file(File.join(@temp_source, "Valid Book.epub"))
+    File.write(File.join(nested_source, "payload.exe"), "bad executable content")
+
+    @book.update!(book_type: :ebook)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    @request.reload
+    assert @request.attention_needed?
+    assert_match /unsupported ebook import file type/i, @request.issue_description
+    assert_not File.exist?(File.join(expected_dest, "payload.exe"))
+    assert_not File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
+  end
+
+  test "marks single file ebook import for attention when extension is unsupported" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    source_file = File.join(@temp_source, "payload.exe")
+    File.write(source_file, "bad executable content")
+
+    @book.update!(book_type: :ebook)
+    @download.update!(download_path: source_file)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    @request.reload
+    assert @request.attention_needed?
+    assert_match /unsupported ebook import file type/i, @request.issue_description
+    assert_not File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.exe"))
+  end
+
+  test "marks ebook import for attention when allowed ebook extension has invalid content" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    source_file = File.join(@temp_source, "payload.epub")
+    File.binwrite(source_file, "MZ bad executable content")
+
+    @book.update!(book_type: :ebook)
+    @download.update!(download_path: source_file)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    @request.reload
+    assert @request.attention_needed?
+    assert_match /unsupported ebook import file type/i, @request.issue_description
+    assert_not File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
+  end
+
+  test "marks ebook directory import for attention when image sidecar has invalid content" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    write_valid_ebook_file(File.join(@temp_source, "Valid Book.epub"))
+    File.binwrite(File.join(@temp_source, "cover.jpg"), "MZ bad executable content")
+
+    @book.update!(book_type: :ebook)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    @request.reload
+    assert @request.attention_needed?
+    assert_match /unsupported ebook import file type/i, @request.issue_description
+    assert_not File.exist?(File.join(expected_dest, "cover.jpg"))
+    assert_not File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
+  end
+
   private
+
+  def write_valid_ebook_file(path)
+    case File.extname(path).delete_prefix(".").downcase
+    when "epub", "cbz"
+      File.binwrite(path, "PK\x03\x04valid ebook content")
+    when "mobi", "azw", "azw3"
+      File.binwrite(path, ("\0" * 60) + "BOOKMOBI")
+    when "pdf"
+      File.binwrite(path, "%PDF-1.7\n")
+    when "djvu"
+      File.binwrite(path, "AT&TFORM\0\0\0\0DJVM")
+    else
+      raise "Unsupported test ebook extension: #{path}"
+    end
+  end
 
   def stub_audiobookshelf_library(base_path)
     stub_request(:get, "http://localhost:13378/api/libraries/lib-123")


### PR DESCRIPTION
## Summary
- rename ebook files found inside directory downloads using the configured ebook filename template
- recursively handle nested ebook directory imports and place sidecars beside the renamed ebook
- validate ebook import files by extension and content signature before copying

Fixes #304

## Tests
- bin/rails test test/jobs/post_processing_job_test.rb