### PR TITLE
[codex] Add Newznab indexer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Think Jellyseerr, but for books. Your users request ebooks and audiobooks; Shelf
 ## Features
 
 - **Book Discovery** — Search millions of titles via Open Library and Hardcover
-- **Smart Acquisition** — Search Prowlarr or Jackett indexers; download via qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet
+- **Smart Acquisition** — Search Prowlarr, Jackett or Newznab/NZBHydra2 indexers; download via qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet
 - **Direct Downloads** — Ebooks from Anna's Archive and Z-Library, public-domain audiobooks from LibriVox — no torrent client needed
 - **Auto-Selection & Format Preferences** — Pick the best release automatically, scored by your preferred formats, bitrate and language
 - **Auto-Processing** — Rename and organize files with path/filename templates, then deliver to Audiobookshelf
@@ -104,7 +104,7 @@ After logging in, go to **Admin → Settings**:
 
 | Setting | Description |
 |---------|-------------|
-| Indexer | Prowlarr or Jackett URL + API key for searches |
+| Indexer | Prowlarr, Jackett or Newznab/NZBHydra2 URL + API key for searches |
 | Download Clients | qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet (Admin → Download Clients) |
 | Output Paths | Where to place completed audiobooks/ebooks |
 | Audiobookshelf | URL + API key for library integration (optional) |
@@ -140,7 +140,7 @@ Shelfarr supports OpenID Connect for single sign-on with identity providers like
 | Service | Purpose |
 |---------|---------|
 | **Open Library** / **Hardcover** | Book metadata and search |
-| **Prowlarr** / **Jackett** | Indexer management |
+| **Prowlarr** / **Jackett** / **NZBHydra2** | Indexer management |
 | **qBittorrent**, **Decypharr**, **Deluge**, **Transmission** | Torrent downloads |
 | **SABnzbd**, **NZBGet** | Usenet downloads |
 | **Anna's Archive** / **Z-Library** | Direct ebook downloads |
@@ -152,7 +152,7 @@ Shelfarr supports OpenID Connect for single sign-on with identity providers like
 
 - Docker
 - At least one way to find books:
-  - An indexer — Prowlarr or Jackett — plus a download client (qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet), **and/or**
+  - An indexer — Prowlarr, Jackett or Newznab/NZBHydra2 — plus a download client (qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet), **and/or**
   - A direct source — Anna's Archive or Z-Library (ebooks), LibriVox (audiobooks)
 - Audiobookshelf (optional, for library integration)
 

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -471,7 +471,7 @@ module Admin
     end
 
     def indexer_setting_key?(key)
-      key.start_with?("indexer_") || key.start_with?("prowlarr") || key.start_with?("jackett")
+      key.start_with?("indexer_") || key.start_with?("prowlarr") || key.start_with?("jackett") || key.start_with?("newznab")
     end
   end
 end

--- a/app/javascript/controllers/settings_form_controller.js
+++ b/app/javascript/controllers/settings_form_controller.js
@@ -6,7 +6,8 @@ export default class extends Controller {
     "status",
     "indexerProvider",
     "prowlarrFields",
-    "jackettFields"
+    "jackettFields",
+    "newznabFields"
   ];
 
   connect() {
@@ -141,6 +142,10 @@ export default class extends Controller {
 
     if (this.hasJackettFieldsTarget) {
       this.jackettFieldsTarget.classList.toggle("hidden", provider !== "jackett");
+    }
+
+    if (this.hasNewznabFieldsTarget) {
+      this.newznabFieldsTarget.classList.toggle("hidden", provider !== "newznab");
     }
   }
 

--- a/app/models/download_routing_rule.rb
+++ b/app/models/download_routing_rule.rb
@@ -3,7 +3,8 @@
 class DownloadRoutingRule < ApplicationRecord
   PROVIDERS = {
     "prowlarr" => "Prowlarr",
-    "jackett" => "Jackett"
+    "jackett" => "Jackett",
+    "newznab" => "NZBHydra2 / Newznab"
   }.freeze
   DOWNLOAD_TYPES = %w[torrent usenet].freeze
 
@@ -50,7 +51,10 @@ class DownloadRoutingRule < ApplicationRecord
     private
 
     def provider_for_result(search_result)
-      search_result.from_jackett? ? "jackett" : "prowlarr"
+      return "jackett" if search_result.from_jackett?
+      return "newznab" if search_result.respond_to?(:from_newznab?) && search_result.from_newznab?
+
+      "prowlarr"
     end
   end
 

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -16,6 +16,7 @@ class SearchResult < ApplicationRecord
   # Source constants
   SOURCE_PROWLARR = "prowlarr"
   SOURCE_JACKETT = "jackett"
+  SOURCE_NEWZNAB = "newznab"
   SOURCE_ANNA_ARCHIVE = "anna_archive"
   SOURCE_ZLIBRARY = "zlibrary"
   SOURCE_GUTENBERG = "gutenberg"
@@ -218,8 +219,12 @@ class SearchResult < ApplicationRecord
     source == SOURCE_JACKETT
   end
 
+  def from_newznab?
+    source == SOURCE_NEWZNAB
+  end
+
   def from_indexer?
-    from_prowlarr? || from_jackett?
+    from_prowlarr? || from_jackett? || from_newznab?
   end
 
   def from_anna_archive?
@@ -246,6 +251,8 @@ class SearchResult < ApplicationRecord
     case source
     when SOURCE_JACKETT
       indexer.presence || "Jackett"
+    when SOURCE_NEWZNAB
+      indexer.presence || "NZBHydra2 / Newznab"
     when SOURCE_ANNA_ARCHIVE
       "Anna's Archive"
     when SOURCE_ZLIBRARY

--- a/app/services/indexer_client.rb
+++ b/app/services/indexer_client.rb
@@ -3,7 +3,8 @@
 class IndexerClient
   PROVIDERS = {
     "prowlarr" => IndexerClients::Prowlarr,
-    "jackett" => IndexerClients::Jackett
+    "jackett" => IndexerClients::Jackett,
+    "newznab" => IndexerClients::Newznab
   }.freeze
 
   class << self

--- a/app/services/indexer_clients/jackett.rb
+++ b/app/services/indexer_clients/jackett.rb
@@ -80,14 +80,14 @@ module IndexerClients
         when 200
           yield response.body
         when 401, 403
-          raise AuthenticationError, "Invalid Jackett API key"
+          raise AuthenticationError, "Invalid #{display_name} API key"
         when 404
-          raise Error, "Jackett endpoint not found"
+          raise Error, "#{display_name} endpoint not found"
         else
-          raise Error, "Jackett API error: #{response.status}"
+          raise Error, "#{display_name} API error: #{response.status}"
         end
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-        raise ConnectionError, "Failed to connect to Jackett: #{e.message}"
+        raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
       end
 
       def parse_results(xml, limit:)
@@ -98,7 +98,7 @@ module IndexerClients
 
         doc.xpath("//rss/channel/item").first(limit).map { |item| parse_item(item) }
       rescue Nokogiri::XML::SyntaxError => e
-        raise Error, "Failed to parse Jackett response: #{e.message}"
+        raise Error, "Failed to parse #{display_name} response: #{e.message}"
       end
 
       def parse_item(item)
@@ -113,7 +113,7 @@ module IndexerClients
         Result.new(
           guid: item.at_xpath("guid")&.text.to_s.strip.presence || enclosure_url || link || SecureRandom.uuid,
           title: item.at_xpath("title")&.text.to_s.strip,
-          indexer: item.at_xpath("jackettindexer")&.text.to_s.strip.presence || item.at_xpath("comments")&.text.to_s.strip.presence || "Jackett",
+          indexer: indexer_name_for(item, attrs),
           size_bytes: integer_attr(enclosure_length) || integer_attr(item.at_xpath("size")&.text) || integer_attr(attrs["size"]),
           seeders: integer_attr(attrs["seeders"]),
           leechers: integer_attr(attrs["peers"]) || integer_attr(attrs["leechers"]),
@@ -123,6 +123,12 @@ module IndexerClients
           published_at: parse_date(item.at_xpath("pubDate")&.text),
           category_ids: extract_category_ids(item)
         )
+      end
+
+      def indexer_name_for(item, _attrs)
+        item.at_xpath("jackettindexer")&.text.to_s.strip.presence ||
+          item.at_xpath("comments")&.text.to_s.strip.presence ||
+          display_name
       end
 
       def extract_category_ids(item)

--- a/app/services/indexer_clients/newznab.rb
+++ b/app/services/indexer_clients/newznab.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module IndexerClients
+  class Newznab < Jackett
+    class << self
+      def configured?
+        SettingsService.newznab_configured?
+      end
+
+      def display_name
+        "Newznab"
+      end
+
+      private
+
+      def base_url
+        normalize_base_url(strip_api_path(SettingsService.get(:newznab_url)))
+      end
+
+      def api_key
+        SettingsService.get(:newznab_api_key)
+      end
+
+      def search_path
+        "api"
+      end
+
+      def indexer_name_for(_item, attrs)
+        attrs["hydraIndexerName"].presence ||
+          attrs["indexer"].presence ||
+          attrs["provider"].presence ||
+          "NZBHydra2 / Newznab"
+      end
+
+      def strip_api_path(url)
+        value = url.to_s.strip
+        uri = URI.parse(value)
+        path = uri.path.to_s
+        normalized_path = path.delete_suffix("/")
+
+        if normalized_path.end_with?("/api")
+          base_path = normalized_path.delete_suffix("/api")
+          uri.path = base_path.presence || "/"
+        end
+
+        uri.to_s
+      rescue URI::InvalidURIError
+        value
+      end
+    end
+  end
+end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -54,6 +54,8 @@ class SettingsService
     jackett_url: { type: "string", default: "", category: "indexer", description: "Base URL for Jackett instance (e.g., http://localhost:9117)" },
     jackett_api_key: { type: "string", default: "", category: "indexer", description: "API key from Jackett dashboard" },
     jackett_indexer_filter: { type: "string", default: "all", category: "indexer", description: "Jackett indexer filter for Torznab queries. Use 'all' for every indexer, or a specific Jackett filter such as 'tag:books'." },
+    newznab_url: { type: "string", default: "", category: "indexer", description: "Newznab-compatible API URL for NZBHydra2 or another Newznab provider (e.g., http://localhost:5076)" },
+    newznab_api_key: { type: "string", default: "", category: "indexer", description: "API key from NZBHydra2 or your Newznab provider" },
 
     # Download Settings (clients are now managed separately via Admin > Download Clients)
     preferred_download_types: { type: "json", default: '["torrent","usenet","direct"]', category: "download", description: "Download types in preference order. Higher-ranked types are preferred when multiple result types are available." },
@@ -294,9 +296,13 @@ class SettingsService
       configured?(:jackett_url) && configured?(:jackett_api_key)
     end
 
+    def newznab_configured?
+      configured?(:newznab_url) && configured?(:newznab_api_key)
+    end
+
     def active_indexer_provider
       provider = get(:indexer_provider).to_s.strip
-      return provider if %w[none prowlarr jackett].include?(provider)
+      return provider if %w[none prowlarr jackett newznab].include?(provider)
 
       return "prowlarr" if prowlarr_configured?
 
@@ -309,6 +315,8 @@ class SettingsService
         prowlarr_configured?
       when "jackett"
         jackett_configured?
+      when "newznab"
+        newznab_configured?
       else
         false
       end

--- a/app/views/admin/settings/_indexer_section.html.erb
+++ b/app/views/admin/settings/_indexer_section.html.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="md:w-2/3">
         <%= form.select "settings[indexer_provider]",
-          options_for_select([["None", "none"], ["Prowlarr", "prowlarr"], ["Jackett", "jackett"]], indexer_provider_value),
+          options_for_select([["None", "none"], ["Prowlarr", "prowlarr"], ["Jackett", "jackett"], ["NZBHydra2 / Newznab", "newznab"]], indexer_provider_value),
           {},
           id: "settings_indexer_provider",
           class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2",
@@ -118,6 +118,28 @@
         </div>
         <div class="md:w-2/3">
           <%= form.text_field "settings[jackett_indexer_filter]", value: settings.dig(:jackett_indexer_filter, :value), id: "settings_jackett_indexer_filter", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+        </div>
+      </div>
+    </div>
+
+    <div data-settings-form-target="newznabFields" class="<%= 'hidden' unless selected_provider == 'newznab' %> space-y-6">
+      <div class="flex flex-col md:flex-row md:items-start gap-4">
+        <div class="md:w-1/3">
+          <label for="settings_newznab_url" class="font-medium text-gray-300">Newznab Url</label>
+          <p class="text-sm text-gray-500"><%= settings.dig(:newznab_url, :definition, :description) %></p>
+        </div>
+        <div class="md:w-2/3">
+          <%= form.text_field "settings[newznab_url]", value: settings.dig(:newznab_url, :value), id: "settings_newznab_url", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+        </div>
+      </div>
+
+      <div class="flex flex-col md:flex-row md:items-start gap-4">
+        <div class="md:w-1/3">
+          <label for="settings_newznab_api_key" class="font-medium text-gray-300">Newznab Api Key</label>
+          <p class="text-sm text-gray-500"><%= settings.dig(:newznab_api_key, :definition, :description) %></p>
+        </div>
+        <div class="md:w-2/3">
+          <%= form.password_field "settings[newznab_api_key]", value: settings.dig(:newznab_api_key, :value), placeholder: settings.dig(:newznab_api_key, :value).present? ? "********" : "", id: "settings_newznab_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
         </div>
       </div>
     </div>

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -519,18 +519,20 @@
         </section>
 
         <h2 id="indexers">Indexers <a class="anchor" href="#indexers" aria-label="Link to Indexers">#</a></h2>
-        <p class="section-desc">Shelfarr searches indexers through Prowlarr or Jackett. Pick one provider with <code>indexer_provider</code>.</p>
+        <p class="section-desc">Shelfarr searches indexers through Prowlarr, Jackett or Newznab/NZBHydra2. Pick one provider with <code>indexer_provider</code>.</p>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
             <tbody>
-              <tr><td class="key"><code>indexer_provider</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Active provider: <code>prowlarr</code>, <code>jackett</code> or <code>none</code>. Leave unset on upgrades to keep legacy Prowlarr config.</td></tr>
+              <tr><td class="key"><code>indexer_provider</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Active provider: <code>prowlarr</code>, <code>jackett</code>, <code>newznab</code> or <code>none</code>. Leave unset on upgrades to keep legacy Prowlarr config.</td></tr>
               <tr><td class="key"><code>prowlarr_url</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Base URL for Prowlarr (e.g. <code>http://localhost:9696</code>).</td></tr>
               <tr><td class="key"><code>prowlarr_api_key</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">API key from Prowlarr &rarr; Settings &rarr; General.</td></tr>
               <tr><td class="key"><code>prowlarr_tags</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Comma-separated tag IDs or names to filter indexers (empty = all).</td></tr>
               <tr><td class="key"><code>jackett_url</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Base URL for Jackett (e.g. <code>http://localhost:9117</code>).</td></tr>
               <tr><td class="key"><code>jackett_api_key</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">API key from the Jackett dashboard.</td></tr>
               <tr><td class="key"><code>jackett_indexer_filter</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>all</code></td><td class="desc">Torznab indexer filter. Use <code>all</code> or a Jackett filter such as <code>tag:books</code>.</td></tr>
+              <tr><td class="key"><code>newznab_url</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Base URL or <code>/api</code> endpoint for NZBHydra2 or another Newznab-compatible provider (e.g. <code>http://localhost:5076</code>).</td></tr>
+              <tr><td class="key"><code>newznab_api_key</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">API key from NZBHydra2 or your Newznab provider.</td></tr>
             </tbody>
           </table>
         </div>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -231,7 +231,7 @@
           <div class="flow">
             <div class="node"><span class="n">METADATA</span><strong>Open Library / Hardcover</strong><span>Search &amp; cover art</span></div>
             <div class="node"><span class="n">YOU ARE HERE</span><strong>Shelfarr</strong><span>Requests &amp; orchestration</span></div>
-            <div class="node"><span class="n">INDEXERS</span><strong>Prowlarr / Jackett</strong><span>Find releases</span></div>
+            <div class="node"><span class="n">INDEXERS</span><strong>Prowlarr / Jackett / NZBHydra2</strong><span>Find releases</span></div>
             <div class="node"><span class="n">DOWNLOAD</span><strong>qBittorrent, SABnzbd, …</strong><span>Fetch the files</span></div>
             <div class="node"><span class="n">LIBRARY</span><strong>Audiobookshelf</strong><span>Read &amp; listen</span></div>
           </div>
@@ -248,7 +248,7 @@
           <ol class="steps">
             <li><span class="step-title">Discover</span> A user searches metadata (Open Library, or Hardcover if configured) and finds the title and format they want &mdash; ebook or audiobook.</li>
             <li><span class="step-title">Request</span> The request is created. Admin requests (and, optionally, everyone's) are queued for searching immediately; otherwise an admin approves them.</li>
-            <li><span class="step-title">Search</span> Shelfarr queries your indexer (Prowlarr or Jackett) and any enabled direct sources, then scores the results against your format preferences and language.</li>
+            <li><span class="step-title">Search</span> Shelfarr queries your indexer (Prowlarr, Jackett or Newznab/NZBHydra2) and any enabled direct sources, then scores the results against your format preferences and language.</li>
             <li><span class="step-title">Select</span> The best result is chosen automatically (when auto-selection is on) or presented for an admin to pick.</li>
             <li><span class="step-title">Download</span> The release is sent to a matching download client &mdash; routed by type, priority and any per-indexer routing rules.</li>
             <li><span class="step-title">Import</span> When the download finishes, files are renamed and moved into your output folders using your path and filename templates.</li>
@@ -324,7 +324,7 @@ services:
           <p class="section-desc">Once you're logged in as the admin, wire up the essentials. Each step links to its full field reference.</p>
           <ol class="steps">
             <li><span class="step-title">Create your admin account</span> Register the first user at <code>http://&lt;server&gt;:5056</code>. Add more users later from <strong>Admin &rarr; Users</strong>.</li>
-            <li><span class="step-title">Connect an indexer</span> In <strong>Admin &rarr; Settings &rarr; Indexer</strong>, choose Prowlarr or Jackett and enter its URL and API key. See the <a class="inline" href="#guide-indexers">indexer guide</a>. <em>(Skip if you'll only use direct sources.)</em></li>
+            <li><span class="step-title">Connect an indexer</span> In <strong>Admin &rarr; Settings &rarr; Indexer</strong>, choose Prowlarr, Jackett or Newznab/NZBHydra2 and enter its URL and API key. See the <a class="inline" href="#guide-indexers">indexer guide</a>. <em>(Skip if you'll only use direct sources.)</em></li>
             <li><span class="step-title">Add a download client</span> In <strong>Admin &rarr; Download Clients</strong>, add qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet. See the <a class="inline" href="#guide-clients">download client guide</a>.</li>
             <li><span class="step-title">Confirm your output paths</span> In <strong>Admin &rarr; Settings &rarr; Output Paths</strong>, make sure <code>/audiobooks</code> and <code>/ebooks</code> match the volumes you mounted, and tune the <a class="inline" href="configuration.html#paths">path templates</a> if you like.</li>
             <li><span class="step-title">(Optional) Connect Audiobookshelf</span> Add its URL, an API token and your library IDs in <strong>Admin &rarr; Settings &rarr; Audiobookshelf</strong>. See the <a class="inline" href="#guide-abs">Audiobookshelf guide</a>.</li>
@@ -348,6 +348,8 @@ services:
           </ol>
           <h3>Jackett</h3>
           <p>Prefer Jackett? Set <code>indexer_provider</code> to <code>jackett</code>, then fill <code>jackett_url</code> and <code>jackett_api_key</code> (from the Jackett dashboard). Use <code>jackett_indexer_filter</code> to limit which indexers are queried.</p>
+          <h3>Newznab / NZBHydra2</h3>
+          <p>Use NZBHydra2 or another Newznab-compatible provider by setting <code>indexer_provider</code> to <code>newznab</code>, then fill <code>newznab_url</code> and <code>newznab_api_key</code>. Shelfarr accepts either the application base URL or the direct <code>/api</code> endpoint.</p>
           <p class="section-desc">Full field list: <a class="inline" href="configuration.html#indexers">Settings reference &rarr; Indexers</a>.</p>
         </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -786,8 +786,8 @@
                         </p>
                         <ul class="feature-list">
                             <li>
-                                <span class="check">✓</span> Prowlarr &amp;
-                                Jackett indexer search
+                                <span class="check">✓</span> Prowlarr,
+                                Jackett &amp; NZBHydra2 indexer search
                             </li>
                             <li>
                                 <span class="check">✓</span> Direct ebook &amp;
@@ -846,7 +846,7 @@
                     <span class="integration-arrow">→</span>
                     <div class="integration-item">
                         <div class="integration-icon">🔎</div>
-                        <span class="integration-name">Prowlarr / Jackett</span>
+                        <span class="integration-name">Prowlarr / Jackett / NZBHydra2</span>
                     </div>
                     <span class="integration-arrow">→</span>
                     <div class="integration-item">
@@ -977,7 +977,7 @@
                             Not necessarily. You can use Anna's Archive or
                             Z-Library for ebooks, or LibriVox for public-domain
                             audiobooks, without any indexer. For the widest
-                            selection, Prowlarr or Jackett is recommended.
+                            selection, Prowlarr, Jackett or NZBHydra2 is recommended.
                         </p>
                     </div>
                     <div class="faq-item">

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -38,6 +38,9 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "select[name='settings[indexer_provider]']"
     assert_select "option[value='prowlarr']", text: "Prowlarr"
     assert_select "option[value='jackett']", text: "Jackett"
+    assert_select "option[value='newznab']", text: "NZBHydra2 / Newznab"
+    assert_select "input[name='settings[newznab_url]']"
+    assert_select "input[name='settings[newznab_api_key]']"
   end
 
   test "index warns when disabling authentication is enabled" do
@@ -461,6 +464,23 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     VCR.turned_off do
       stub_request(:get, %r{localhost:9117/api/v2\.0/indexers/all/results/torznab/api})
         .with(query: hash_including("apikey" => "jackett-key", "t" => "caps"))
+        .to_return(status: 200, body: "<caps />", headers: { "Content-Type" => "application/xml" })
+
+      post test_indexer_admin_settings_url
+
+      assert_redirected_to admin_settings_path
+      assert_match /successful/i, flash[:notice]
+    end
+  end
+
+  test "test_indexer succeeds for newznab when selected" do
+    SettingsService.set(:indexer_provider, "newznab")
+    SettingsService.set(:newznab_url, "http://localhost:5076")
+    SettingsService.set(:newznab_api_key, "newznab-key")
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:5076/api")
+        .with(query: hash_including("apikey" => "newznab-key", "t" => "caps"))
         .to_return(status: 200, body: "<caps />", headers: { "Content-Type" => "application/xml" })
 
       post test_indexer_admin_settings_url

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -351,6 +351,67 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_not_includes log_output, "apikey=secret"
   end
 
+  test "sends selected newznab result directly to a usenet client" do
+    @client.destroy!
+    sabnzbd = DownloadClient.create!(
+      name: "Test SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://localhost:8080",
+      api_key: "test-api-key-12345",
+      priority: 0,
+      enabled: true
+    )
+    newznab_result = @request.search_results.create!(
+      guid: "newznab-guid-123",
+      title: "Newznab Ebook Result",
+      indexer: "NZBHydra Books",
+      source: SearchResult::SOURCE_NEWZNAB,
+      download_url: "http://nzbhydra:5076/getnzb/api/123?apikey=secret",
+      magnet_url: nil,
+      seeders: nil,
+      status: :selected
+    )
+    @download.update!(search_result: newznab_result)
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including(
+          "mode" => "version",
+          "apikey" => "test-api-key-12345",
+          "output" => "json"
+        ))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "version" => "4.0.0" }.to_json
+        )
+
+      request_stub = stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including(
+          "mode" => "addurl",
+          "name" => "http://nzbhydra:5076/getnzb/api/123?apikey=secret",
+          "nzbname" => "Another Author - The Pending Ebook",
+          "apikey" => "test-api-key-12345",
+          "output" => "json"
+        ))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => true, "nzo_ids" => [ "SABnzbd_nzo_newznab" ] }.to_json
+        )
+
+      DownloadJob.perform_now(@download.id)
+
+      assert_requested request_stub
+    end
+
+    @download.reload
+    assert @download.downloading?
+    assert_equal sabnzbd.id.to_s, @download.download_client_id
+    assert_equal "SABnzbd_nzo_newznab", @download.external_id
+    assert_equal "usenet", @download.download_type
+  end
+
   test "skips non-existent downloads" do
     assert_nothing_raised do
       DownloadJob.perform_now(999999)

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -1234,6 +1234,41 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "uses newznab when explicitly selected as the indexer provider" do
+    SettingsService.set(:indexer_provider, "newznab")
+    SettingsService.set(:newznab_url, "http://localhost:5076")
+    SettingsService.set(:newznab_api_key, "newznab-key")
+
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+        <channel>
+          <item>
+            <title>Newznab Search Result</title>
+            <guid>newznab-guid-1</guid>
+            <link>https://example.com/details/1</link>
+            <enclosure url="http://localhost:5076/getnzb/api/1?apikey=newznab-key" length="12345" type="application/x-nzb" />
+            <newznab:attr name="hydraIndexerName" value="NZBHydra Books" />
+          </item>
+        </channel>
+      </rss>
+    XML
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:5076/api")
+        .with(query: hash_including("apikey" => "newznab-key", "t" => "search"))
+        .to_return(status: 200, body: body, headers: { "Content-Type" => "application/xml" })
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert @request.search_results.any?
+      assert_equal SearchResult::SOURCE_NEWZNAB, @request.search_results.first.source
+      assert_equal "NZBHydra Books", @request.search_results.first.indexer
+      assert @request.search_results.first.usenet?
+    end
+  end
+
   private
 
   def stub_prowlarr_search_with_results

--- a/test/models/download_routing_rule_test.rb
+++ b/test/models/download_routing_rule_test.rb
@@ -5,11 +5,15 @@ require "test_helper"
 class DownloadRoutingRuleTest < ActiveSupport::TestCase
   Result = Struct.new(:source, :indexer, :download_type, keyword_init: true) do
     def from_indexer?
-      source.in?([SearchResult::SOURCE_PROWLARR, SearchResult::SOURCE_JACKETT]) || source.blank?
+      source.in?([SearchResult::SOURCE_PROWLARR, SearchResult::SOURCE_JACKETT, SearchResult::SOURCE_NEWZNAB]) || source.blank?
     end
 
     def from_jackett?
       source == SearchResult::SOURCE_JACKETT
+    end
+
+    def from_newznab?
+      source == SearchResult::SOURCE_NEWZNAB
     end
   end
 
@@ -70,6 +74,14 @@ class DownloadRoutingRuleTest < ActiveSupport::TestCase
     result = Result.new(source: SearchResult::SOURCE_JACKETT, indexer: "Books", download_type: "torrent")
 
     assert_equal jackett_rule, DownloadRoutingRule.for_result(result)
+  end
+
+  test "finds newznab route separately from other indexer providers" do
+    newznab_rule = create_rule(provider: "newznab", indexer_name: "NZBHydra Books", download_type: "usenet", download_client: create_client(name: "SAB", client_type: "sabnzbd", api_key: "key"))
+    create_rule(provider: "prowlarr", indexer_name: "NZBHydra Books", download_type: "usenet", download_client: create_client(name: "Other SAB", client_type: "sabnzbd", url: "http://other-sab", api_key: "key"))
+    result = Result.new(source: SearchResult::SOURCE_NEWZNAB, indexer: "NZBHydra Books", download_type: "usenet")
+
+    assert_equal newznab_rule, DownloadRoutingRule.for_result(result)
   end
 
   test "ignores disabled routes" do

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -402,11 +402,14 @@ class SearchResultTest < ActiveSupport::TestCase
     assert SearchResult.new(source: nil).from_prowlarr?
     assert SearchResult.new(source: SearchResult::SOURCE_JACKETT).from_jackett?
     assert SearchResult.new(source: SearchResult::SOURCE_JACKETT).from_indexer?
+    assert SearchResult.new(source: SearchResult::SOURCE_NEWZNAB).from_newznab?
+    assert SearchResult.new(source: SearchResult::SOURCE_NEWZNAB).from_indexer?
     assert SearchResult.new(source: SearchResult::SOURCE_ANNA_ARCHIVE).from_anna_archive?
     assert SearchResult.new(source: SearchResult::SOURCE_ZLIBRARY).from_zlibrary?
     assert SearchResult.new(source: SearchResult::SOURCE_GUTENBERG).from_gutenberg?
 
     assert_equal "Custom Jackett", SearchResult.new(source: SearchResult::SOURCE_JACKETT, indexer: "Custom Jackett").source_display_name
+    assert_equal "NZBHydra Books", SearchResult.new(source: SearchResult::SOURCE_NEWZNAB, indexer: "NZBHydra Books").source_display_name
     assert_equal "Anna's Archive", SearchResult.new(source: SearchResult::SOURCE_ANNA_ARCHIVE).source_display_name
     assert_equal "Z-Library", SearchResult.new(source: SearchResult::SOURCE_ZLIBRARY).source_display_name
     assert_equal "Project Gutenberg", SearchResult.new(source: SearchResult::SOURCE_GUTENBERG).source_display_name

--- a/test/services/indexer_clients/newznab_test.rb
+++ b/test/services/indexer_clients/newznab_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class IndexerClients::NewznabTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:newznab_url, "http://localhost:5076")
+    SettingsService.set(:newznab_api_key, "newznab-api-key")
+  end
+
+  teardown do
+    IndexerClients::Newznab.reset_connection!
+  end
+
+  test "configured? returns true when newznab credentials are present" do
+    assert IndexerClients::Newznab.configured?
+  end
+
+  test "search parses newznab xml results" do
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+        <channel>
+          <item>
+            <title>Test Newznab Result</title>
+            <guid>newznab-guid-123</guid>
+            <link>https://example.com/details/123</link>
+            <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+            <enclosure url="http://localhost:5076/getnzb/api/123?apikey=newznab-api-key" length="1048576" type="application/x-nzb" />
+            <newznab:attr name="hydraIndexerName" value="NZBHydra Books" />
+            <newznab:attr name="category" value="7030" />
+            <newznab:attr name="size" value="1048576" />
+          </item>
+        </channel>
+      </rss>
+    XML
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:5076/api")
+        .with(query: hash_including("apikey" => "newznab-api-key", "t" => "search", "cat" => "7020,7000"))
+        .to_return(status: 200, body: body, headers: { "Content-Type" => "application/xml" })
+
+      results = IndexerClients::Newznab.search("test query", book_type: :ebook)
+
+      assert_equal 1, results.size
+      result = results.first
+      assert_equal "newznab-guid-123", result.guid
+      assert_equal "Test Newznab Result", result.title
+      assert_equal "NZBHydra Books", result.indexer
+      assert_equal 1_048_576, result.size_bytes
+      assert_nil result.seeders
+      assert_equal "http://localhost:5076/getnzb/api/123?apikey=newznab-api-key", result.download_url
+      assert_nil result.magnet_url
+      assert_equal [ 7030 ], result.category_ids
+    end
+  end
+
+  test "accepts configured URL that already points at the api endpoint" do
+    SettingsService.set(:newznab_url, "http://localhost:5076/api")
+    IndexerClients::Newznab.reset_connection!
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:5076/api")
+        .with(query: hash_including("apikey" => "newznab-api-key", "t" => "caps"))
+        .to_return(status: 200, body: "<caps />", headers: { "Content-Type" => "application/xml" })
+
+      assert IndexerClients::Newznab.test_connection
+    end
+  end
+
+  test "preserves reverse proxy subpath when configured URL ends with api" do
+    SettingsService.set(:newznab_url, "http://localhost:5076/nzbhydra2/api")
+    IndexerClients::Newznab.reset_connection!
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:5076/nzbhydra2/api")
+        .with(query: hash_including("apikey" => "newznab-api-key", "t" => "caps"))
+        .to_return(status: 200, body: "<caps />", headers: { "Content-Type" => "application/xml" })
+
+      assert IndexerClients::Newznab.test_connection
+    end
+  end
+end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url]).delete_all
+    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -27,6 +27,15 @@ class SettingsServiceTest < ActiveSupport::TestCase
     SettingsService.set(:jackett_api_key, "jackett-key")
 
     assert_equal "jackett", SettingsService.active_indexer_provider
+    assert SettingsService.active_indexer_configured?
+  end
+
+  test "active_indexer_provider respects explicit newznab selection" do
+    SettingsService.set(:indexer_provider, "newznab")
+    SettingsService.set(:newznab_url, "http://localhost:5076")
+    SettingsService.set(:newznab_api_key, "newznab-key")
+
+    assert_equal "newznab", SettingsService.active_indexer_provider
     assert SettingsService.active_indexer_configured?
   end
 


### PR DESCRIPTION
## Summary

- Add native Newznab/NZBHydra2 as an indexer provider alongside Prowlarr and Jackett
- Wire Newznab settings, admin UI fields, search result source handling, and per-indexer download routing
- Reuse the existing Torznab/Newznab RSS parsing path and support base URLs or direct `/api` endpoints
- Update README and docs to describe Newznab/NZBHydra2 support

Closes #303

## Validation

- `bin/quality commit --staged`
- pre-commit lefthook quality gate
- pre-push lefthook quality gate
- focused Rails tests for Newznab search, SearchJob, DownloadJob dispatch, routing, settings, and UI
- full Rails suite was run locally before commit: `1356 runs, 3903 assertions, 0 failures`