### PR TITLE
fix: extract manual audiobook zip uploads

### DIFF
--- a/app/jobs/upload_processing_job.rb
+++ b/app/jobs/upload_processing_job.rb
@@ -7,6 +7,9 @@
 # 4. Creates book with proper metadata
 # 5. Renames file and moves to library location
 class UploadProcessingJob < ApplicationJob
+  MAX_AUDIOBOOK_ZIP_EXTRACTED_BYTES = 2.gigabytes
+  MAX_AUDIOBOOK_ZIP_FILES = 10_000
+
   queue_as :default
 
   def perform(upload_id)
@@ -319,6 +322,12 @@ class UploadProcessingJob < ApplicationJob
     destination_dir = build_destination_path(book)
     FileUtils.mkdir_p(destination_dir)
 
+    if book.audiobook? && File.extname(upload.original_filename).casecmp?(".zip")
+      extract_zip_upload_to_directory(source_path, destination_dir)
+      FileUtils.rm_f(source_path)
+      return destination_dir
+    end
+
     # Rename file to standardized format: "Author - Title.ext"
     extension = File.extname(upload.original_filename)
     new_filename = build_filename(book, extension)
@@ -339,6 +348,56 @@ class UploadProcessingJob < ApplicationJob
     end
 
     destination_dir
+  end
+
+  def extract_zip_upload_to_directory(
+    zip_path,
+    destination_dir,
+    max_bytes: MAX_AUDIOBOOK_ZIP_EXTRACTED_BYTES,
+    max_files: MAX_AUDIOBOOK_ZIP_FILES
+  )
+    require "zip"
+
+    destination_root = File.expand_path(destination_dir)
+
+    Zip::File.open(zip_path) do |zipfile|
+      files = zipfile.reject(&:directory?)
+      validate_zip_upload_entries!(files, destination_root, max_bytes: max_bytes, max_files: max_files)
+
+      files.each do |entry|
+        target = File.expand_path(File.join(destination_root, entry.name))
+        FileUtils.mkdir_p(File.dirname(target))
+        entry.get_input_stream do |input|
+          File.open(target, "wb") { |output| IO.copy_stream(input, output) }
+        end
+      end
+    end
+  rescue Zip::Error => e
+    raise "Failed to extract audiobook archive: #{e.message}"
+  end
+
+  def validate_zip_upload_entries!(entries, destination_root, max_bytes:, max_files:)
+    raise "ZIP archive did not contain any files" if entries.empty?
+    raise "ZIP archive contains too many files (max #{max_files})" if entries.size > max_files
+
+    total_size = 0
+    targets = {}
+
+    entries.each do |entry|
+      target = File.expand_path(File.join(destination_root, entry.name))
+      unless target.start_with?("#{destination_root}#{File::SEPARATOR}")
+        raise "ZIP archive contains an unsafe path: #{entry.name}"
+      end
+      raise "ZIP archive contains duplicate file path: #{entry.name}" if targets[target]
+      raise "ZIP archive would overwrite an existing file: #{entry.name}" if File.exist?(target)
+
+      targets[target] = true
+
+      total_size += entry.size.to_i
+      if total_size > max_bytes
+        raise "ZIP archive exceeds #{max_bytes / 1.megabyte} MB extracted size limit"
+      end
+    end
   end
 
   def build_filename(book, extension)

--- a/test/jobs/upload_processing_job_test.rb
+++ b/test/jobs/upload_processing_job_test.rb
@@ -153,6 +153,119 @@ class UploadProcessingJobTest < ActiveJob::TestCase
     assert request.request_events.exists?(event_type: "upload_fulfilled")
   end
 
+  test "targeted audiobook zip upload extracts files into library" do
+    request = requests(:failed_request)
+    zip_file = File.join(@temp_source, "Third Author - The Failed Audiobook.zip")
+    build_zip_archive(
+      zip_file,
+      "chapter_01.mp3" => "audio-one",
+      "disc_02/chapter_02.mp3" => "audio-two"
+    )
+
+    upload = Upload.create!(
+      user: @user,
+      request: request,
+      original_filename: "Third Author - The Failed Audiobook.zip",
+      file_path: zip_file,
+      file_size: File.size(zip_file),
+      status: :pending
+    )
+
+    UploadProcessingJob.perform_now(upload.id)
+
+    upload.reload
+    request.reload
+
+    expected_path = File.join(@temp_audiobook_dest, "Third Author", "The Failed Audiobook")
+
+    assert upload.completed?
+    assert request.completed?
+    assert_equal expected_path, request.book.reload.file_path
+    assert File.exist?(File.join(expected_path, "chapter_01.mp3"))
+    assert File.exist?(File.join(expected_path, "disc_02", "chapter_02.mp3"))
+    assert_not File.exist?(File.join(expected_path, "Third Author - The Failed Audiobook.zip"))
+    assert_not File.exist?(zip_file)
+  end
+
+  test "targeted audiobook zip upload rejects unsafe archive paths" do
+    request = requests(:failed_request)
+    zip_file = File.join(@temp_source, "Unsafe Audiobook.zip")
+    build_zip_archive(zip_file, "../escape.mp3" => "audio")
+
+    upload = Upload.create!(
+      user: @user,
+      request: request,
+      original_filename: "Unsafe Audiobook.zip",
+      file_path: zip_file,
+      file_size: File.size(zip_file),
+      status: :pending
+    )
+
+    UploadProcessingJob.perform_now(upload.id)
+
+    upload.reload
+    request.reload
+
+    assert upload.failed?
+    assert_includes upload.error_message, "unsafe path"
+    assert request.failed?
+    assert_nil request.book.reload.file_path
+    assert File.exist?(zip_file)
+    assert_not File.exist?(File.join(@temp_audiobook_dest, "Third Author", "escape.mp3"))
+  end
+
+  test "audiobook zip extraction rejects archives over extracted size limit" do
+    zip_file = File.join(@temp_source, "Oversized Audiobook.zip")
+    destination = File.join(@temp_audiobook_dest, "Oversized")
+    build_zip_archive(zip_file, "chapter_01.mp3" => "audio-data")
+
+    error = assert_raises(RuntimeError) do
+      UploadProcessingJob.new.send(:extract_zip_upload_to_directory, zip_file, destination, max_bytes: 5)
+    end
+
+    assert_includes error.message, "extracted size limit"
+    assert_not File.exist?(File.join(destination, "chapter_01.mp3"))
+  end
+
+  test "audiobook zip extraction rejects archives with too many files" do
+    zip_file = File.join(@temp_source, "Too Many Files.zip")
+    destination = File.join(@temp_audiobook_dest, "Too Many Files")
+    build_zip_archive(
+      zip_file,
+      "chapter_01.mp3" => "audio-one",
+      "chapter_02.mp3" => "audio-two"
+    )
+
+    error = assert_raises(RuntimeError) do
+      UploadProcessingJob.new.send(:extract_zip_upload_to_directory, zip_file, destination, max_files: 1)
+    end
+
+    assert_includes error.message, "too many files"
+    assert_not File.exist?(File.join(destination, "chapter_01.mp3"))
+    assert_not File.exist?(File.join(destination, "chapter_02.mp3"))
+  end
+
+  test "audiobook zip extraction rejects files that would overwrite existing library files" do
+    zip_file = File.join(@temp_source, "Existing File.zip")
+    destination = File.join(@temp_audiobook_dest, "Existing File")
+    existing_file = File.join(destination, "chapter_01.mp3")
+    FileUtils.mkdir_p(destination)
+    File.write(existing_file, "existing-audio")
+    build_zip_archive(
+      zip_file,
+      "chapter_02.mp3" => "new-audio",
+      "chapter_01.mp3" => "replacement-audio"
+    )
+
+    error = assert_raises(RuntimeError) do
+      UploadProcessingJob.new.send(:extract_zip_upload_to_directory, zip_file, destination)
+    end
+
+    assert_includes error.message, "overwrite an existing file"
+    assert_equal "existing-audio", File.read(existing_file)
+    assert_not File.exist?(File.join(destination, "chapter_02.mp3"))
+  end
+
   test "targeted upload fails if request completed before processing" do
     request = requests(:pending_request)
     ebook_file = File.join(@temp_source, "Late Ebook.epub")
@@ -349,7 +462,7 @@ class UploadProcessingJobTest < ActiveJob::TestCase
       series_position: nil
     )
 
-    MetadataService.stub(:search, [weak, strong]) do
+    MetadataService.stub(:search, [ weak, strong ]) do
       assert_equal strong, job.send(:fetch_metadata, "Mistborn", "Brandon Sanderson")
     end
   end
@@ -407,7 +520,7 @@ class UploadProcessingJobTest < ActiveJob::TestCase
       UploadProcessingJob.new.send(:trigger_library_scan, book)
     end
 
-    assert_equal ["audio-lib"], scanned
+    assert_equal [ "audio-lib" ], scanned
 
     AudiobookshelfClient.stub(:scan_library, ->(*) { raise AudiobookshelfClient::Error, "scan failed" }) do
       assert_nothing_raised { UploadProcessingJob.new.send(:trigger_library_scan, book) }
@@ -425,6 +538,16 @@ class UploadProcessingJobTest < ActiveJob::TestCase
         headers: { "Content-Type" => "application/json" },
         body: { numFound: 0, docs: [] }.to_json
       )
+  end
+
+  def build_zip_archive(path, entries)
+    require "zip"
+
+    Zip::File.open(path, create: true) do |zipfile|
+      entries.each do |name, content|
+        zipfile.get_output_stream(name) { |stream| stream.write(content) }
+      end
+    end
   end
 
   def stub_hardcover_upload_metadata_search(query:, id:, series_position:)


### PR DESCRIPTION
## Summary
- extract manual audiobook ZIP uploads into the configured library destination instead of moving the archive as-is
- validate ZIP contents before extraction for unsafe paths, extracted size, file count, duplicate entries, and existing-file collisions
- add upload processing job coverage for ZIP extraction and rejection cases

Fixes #311

## Tests
- bin/rails test test/jobs/upload_processing_job_test.rb
- bundle exec rubocop app/jobs/upload_processing_job.rb test/jobs/upload_processing_job_test.rb