### PR TITLE
feat: add Google Books metadata source

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Think Jellyseerr, but for books. Your users request ebooks and audiobooks; Shelf
 
 ## Features
 
-- **Book Discovery** — Search millions of titles via Open Library and Hardcover
+- **Book Discovery** — Search millions of titles via Hardcover, Google Books and Open Library
 - **Smart Acquisition** — Search Prowlarr, Jackett or Newznab/NZBHydra2 indexers; download via qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet
 - **Direct Downloads** — Ebooks from Anna's Archive and Z-Library, public-domain audiobooks from LibriVox — no torrent client needed
 - **Auto-Selection & Format Preferences** — Pick the best release automatically, scored by your preferred formats, bitrate and language
@@ -139,7 +139,7 @@ Shelfarr supports OpenID Connect for single sign-on with identity providers like
 
 | Service | Purpose |
 |---------|---------|
-| **Open Library** / **Hardcover** | Book metadata and search |
+| **Open Library** / **Google Books** / **Hardcover** | Book metadata and search |
 | **Prowlarr** / **Jackett** / **NZBHydra2** | Indexer management |
 | **qBittorrent**, **Decypharr**, **Deluge**, **Transmission** | Torrent downloads |
 | **SABnzbd**, **NZBGet** | Usenet downloads |

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -166,6 +166,7 @@ module Admin
       end
 
       if HardcoverClient.test_connection
+        MetadataProviderStatus.for_provider("hardcover").record_success!
         health.check_succeeded!(message: "Connection successful")
         respond_with_flash(notice: "Hardcover connection successful!")
       else
@@ -175,6 +176,38 @@ module Admin
     rescue HardcoverClient::Error => e
       health&.check_failed!(message: e.message)
       respond_with_flash(alert: "Hardcover error: #{e.message}")
+    end
+
+    def test_google_books
+      unless GoogleBooksClient.configured?
+        respond_with_flash(alert: "Google Books is not enabled.")
+        return
+      end
+
+      if GoogleBooksClient.test_connection
+        MetadataProviderStatus.for_provider("google_books").record_success!
+        respond_with_flash(notice: "Google Books connection successful!")
+      else
+        respond_with_flash(alert: "Google Books connection failed.")
+      end
+    rescue GoogleBooksClient::Error => e
+      respond_with_flash(alert: "Google Books error: #{e.message}")
+    end
+
+    def test_open_library
+      unless OpenLibraryClient.configured?
+        respond_with_flash(alert: "Open Library is not enabled.")
+        return
+      end
+
+      if OpenLibraryClient.test_connection
+        MetadataProviderStatus.for_provider("openlibrary").record_success!
+        respond_with_flash(notice: "Open Library connection successful!")
+      else
+        respond_with_flash(alert: "Open Library connection failed.")
+      end
+    rescue OpenLibraryClient::Error => e
+      respond_with_flash(alert: "Open Library error: #{e.message}")
     end
 
     def test_zlibrary
@@ -399,9 +432,18 @@ module Admin
       if changed_keys.any? { |k| k.start_with?("librivox") }
         LibrivoxClient.reset_connection!
       end
+      if changed_keys.any? { |k| metadata_provider_setting?(k) }
+        MetadataProviderStatus.clear_after_credential_change_for_settings!(changed_keys)
+      end
       if changed_keys.any? { |k| k.start_with?("hardcover") }
         HardcoverClient.reset_connection!
         run_service_health_check("hardcover")
+      end
+      if changed_keys.any? { |k| k.start_with?("google_books") }
+        GoogleBooksClient.reset_connection!
+      end
+      if changed_keys.any? { |k| k.start_with?("open_library") }
+        OpenLibraryClient.reset_connection!
       end
       if changed_keys.any? { |k| k.start_with?("telegram") }
         sync_telegram_transport
@@ -472,6 +514,10 @@ module Admin
 
     def indexer_setting_key?(key)
       key.start_with?("indexer_") || key.start_with?("prowlarr") || key.start_with?("jackett") || key.start_with?("newznab")
+    end
+
+    def metadata_provider_setting?(key)
+      MetadataProviderStatus.provider_for_setting(key).present?
     end
   end
 end

--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -33,6 +33,7 @@ class API::V1::RequestsController < API::V1::ApplicationController
       metadata_attrs: create_params.slice(:title, :author, :cover_url, :year, :first_publish_year),
       notes: create_params[:notes],
       language: create_params[:language],
+      source_work_ids: create_params[:source_work_ids],
       origin: {
         created_via: "api",
         external_source: create_params[:external_source].presence || "api",
@@ -117,6 +118,7 @@ class API::V1::RequestsController < API::V1::ApplicationController
       :external_source,
       :external_user_id,
       :external_chat_id,
+      source_work_ids: [],
       book_types: []
     )
   end

--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -141,7 +141,10 @@ class API::V1::RequestsController < API::V1::ApplicationController
         title: request.book.title,
         author: request.book.author,
         book_type: request.book.book_type,
-        work_id: request.book.unified_work_id
+        work_id: request.book.unified_work_id,
+        metadata_source_name: request.book.metadata_source_name,
+        metadata_source_url: request.book.metadata_source_url,
+        metadata_source_attribution: request.book.metadata_source_attribution
       },
       user: {
         id: request.user_id,

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -26,12 +26,16 @@ class API::V1::SearchController < API::V1::ApplicationController
 
   def search_result_payload(result)
     {
+      canonical_key: result.respond_to?(:canonical_key) ? result.canonical_key : result.work_id,
       work_id: result.work_id,
       source: result.source,
       source_id: result.source_id,
       source_name: result.source_name,
       source_url: result.source_url,
       source_attribution: result.source_attribution,
+      sources: result_sources_payload(result),
+      editions: result.respond_to?(:editions) ? result.editions : [],
+      confidence: result.respond_to?(:confidence) ? result.confidence : nil,
       title: result.title,
       author: result.author,
       year: result.year,
@@ -41,5 +45,27 @@ class API::V1::SearchController < API::V1::ApplicationController
       series_name: result.series_name,
       series_position: result.series_position
     }
+  end
+
+  def result_sources_payload(result)
+    if result.respond_to?(:sources)
+      result.sources.map do |source|
+        {
+          source: source[:source],
+          source_id: source[:source_id],
+          source_name: source[:source_name],
+          source_url: source[:source_url],
+          work_id: source[:work_id]
+        }
+      end
+    else
+      [ {
+        source: result.source,
+        source_id: result.source_id,
+        source_name: result.source_name,
+        source_url: result.source_url,
+        work_id: result.work_id
+      } ]
+    end
   end
 end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -12,9 +12,9 @@ class API::V1::SearchController < API::V1::ApplicationController
 
     results = MetadataService.search(query, limit: search_limit)
     render json: { results: results.map { |result| search_result_payload(result) } }
-  rescue HardcoverClient::ConnectionError, OpenLibraryClient::ConnectionError
+  rescue HardcoverClient::ConnectionError, GoogleBooksClient::ConnectionError, OpenLibraryClient::ConnectionError
     render json: { errors: [ "Unable to connect to metadata service" ] }, status: :service_unavailable
-  rescue HardcoverClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+  rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
     render json: { errors: [ e.message.presence || "Search failed" ] }, status: :bad_gateway
   end
 
@@ -29,6 +29,9 @@ class API::V1::SearchController < API::V1::ApplicationController
       work_id: result.work_id,
       source: result.source,
       source_id: result.source_id,
+      source_name: result.source_name,
+      source_url: result.source_url,
+      source_attribution: result.source_attribution,
       title: result.title,
       author: result.author,
       year: result.year,

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -44,6 +44,7 @@ class RequestsController < ApplicationController
     @author = params[:author]
     @cover_url = params[:cover_url]
     @first_publish_year = params[:first_publish_year]
+    @source_work_ids = Array(params[:source_work_ids]).compact_blank
 
     if @work_id.blank? || @title.blank?
       redirect_to search_path, alert: "Missing book information"
@@ -65,7 +66,8 @@ class RequestsController < ApplicationController
       book_types: book_types,
       metadata_attrs: request_metadata_attrs,
       notes: params[:notes],
-      language: params[:language]
+      language: params[:language],
+      source_work_ids: params[:source_work_ids]
     )
 
     if result.created_requests.empty?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -21,12 +21,12 @@ class SearchController < ApplicationController
           Array.new(@results.size) { [] }
         end
         @error = nil
-      rescue HardcoverClient::ConnectionError, OpenLibraryClient::ConnectionError => e
+      rescue HardcoverClient::ConnectionError, GoogleBooksClient::ConnectionError, OpenLibraryClient::ConnectionError => e
         @results = []
         @audiobookshelf_matches = []
         @error = "Unable to connect to metadata service. Please try again later."
         Rails.logger.error("Metadata service connection error: #{e.message}")
-      rescue HardcoverClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+      rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
         @results = []
         @audiobookshelf_matches = []
         @error = "Search failed. Please try again."

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SearchController < ApplicationController
+  include ActionController::Live
+
   def index
     @query = params[:q]
   end
@@ -12,23 +14,23 @@ class SearchController < ApplicationController
       @results = []
       @error = nil
       @audiobookshelf_matches = []
+      @existing_books_lookup = {}
     else
       begin
         @results = MetadataService.search(@query)
-        @audiobookshelf_matches = if LibraryItem.exists?
-          AudiobookshelfLibraryMatcherService.matches_for_many(@results, limit_per_result: 3)
-        else
-          Array.new(@results.size) { [] }
-        end
+        @audiobookshelf_matches = audiobookshelf_matches_for(@results)
+        @existing_books_lookup = existing_books_lookup_for(@results)
         @error = nil
       rescue HardcoverClient::ConnectionError, GoogleBooksClient::ConnectionError, OpenLibraryClient::ConnectionError => e
         @results = []
         @audiobookshelf_matches = []
+        @existing_books_lookup = {}
         @error = "Unable to connect to metadata service. Please try again later."
         Rails.logger.error("Metadata service connection error: #{e.message}")
       rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
         @results = []
         @audiobookshelf_matches = []
+        @existing_books_lookup = {}
         @error = "Search failed. Please try again."
         Rails.logger.error("Metadata service error: #{e.message}")
       end
@@ -38,5 +40,127 @@ class SearchController < ApplicationController
       format.turbo_stream
       format.html { render :index }
     end
+  end
+
+  def stream_results
+    @query = params[:q].to_s.strip
+
+    response.headers["Content-Type"] = "text/vnd.turbo-stream.html; charset=utf-8"
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+
+    if @query.blank?
+      write_search_results_stream(results: [], loading: false)
+      return
+    end
+
+    providers = MetadataService.enabled_metadata_providers
+    if providers.empty?
+      write_search_results_stream(results: [], loading: false)
+      return
+    end
+
+    query = @query
+    results_by_provider = {}
+    completed_providers = []
+
+    write_search_results_stream(
+      results: [],
+      loading: true,
+      pending_providers: providers,
+      completed_providers: completed_providers
+    )
+
+    MetadataService.each_provider_search(query) do |provider, results|
+      completed_providers << provider
+      results_by_provider[provider] = results
+
+      candidates = MetadataService.aggregate_provider_results(
+        MetadataService.merge_provider_results(results_by_provider)
+      )
+      pending_providers = providers - completed_providers
+
+      write_search_results_stream(
+        results: candidates,
+        loading: pending_providers.any?,
+        pending_providers: pending_providers,
+        completed_providers: completed_providers
+      )
+    end
+  rescue IOError, ActionController::Live::ClientDisconnected
+    Rails.logger.info("Search results stream disconnected")
+  rescue HardcoverClient::ConnectionError, GoogleBooksClient::ConnectionError, OpenLibraryClient::ConnectionError => e
+    Rails.logger.error("Metadata service connection error: #{e.message}")
+    write_search_results_stream(results: [], error: "Unable to connect to metadata service. Please try again later.", loading: false)
+  rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+    Rails.logger.error("Metadata service error: #{e.message}")
+    write_search_results_stream(results: [], error: "Search failed. Please try again.", loading: false)
+  ensure
+    response.stream.close
+  end
+
+  private
+
+  def write_search_results_stream(results:, loading:, pending_providers: [], completed_providers: [], error: nil)
+    response.stream.write(
+      render_search_results_stream(
+        results: results,
+        loading: loading,
+        pending_providers: pending_providers,
+        completed_providers: completed_providers,
+        error: error
+      )
+    )
+  end
+
+  def render_search_results_stream(results:, loading:, pending_providers:, completed_providers:, error:)
+    @results = results
+    @error = error
+    @search_loading = loading
+    @search_pending_provider_names = provider_names(pending_providers)
+    @search_completed_provider_names = provider_names(completed_providers)
+    enrichment = stream_enrichment_for(results, loading: loading)
+    @audiobookshelf_matches = enrichment[:audiobookshelf_matches]
+    @existing_books_lookup = enrichment[:existing_books_lookup]
+
+    render_to_string(
+      template: "search/results",
+      formats: [ :turbo_stream ],
+      layout: false
+    )
+  end
+
+  def audiobookshelf_matches_for(results)
+    if results.any? && LibraryItem.exists?
+      AudiobookshelfLibraryMatcherService.matches_for_many(results, limit_per_result: 3)
+    else
+      Array.new(results.size) { [] }
+    end
+  end
+
+  def stream_enrichment_for(results, loading:)
+    return { audiobookshelf_matches: [], existing_books_lookup: {} } if loading
+
+    {
+      audiobookshelf_matches: audiobookshelf_matches_for(results),
+      existing_books_lookup: existing_books_lookup_for(results)
+    }
+  end
+
+  def existing_books_lookup_for(results)
+    work_ids = results.flat_map { |result| source_work_ids_for(result) }
+    Book.preload_by_work_ids(work_ids)
+  end
+
+  def source_work_ids_for(result)
+    if result.respond_to?(:sources)
+      Array(result.sources).filter_map { |source| source[:work_id] }
+    else
+      [ result.work_id ]
+    end
+  end
+
+  def provider_names(providers)
+    providers.map { |provider| MetadataSources.display_name(provider) }
   end
 end

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
   static targets = ["input", "results", "spinner"]
   static values = {
     url: String,
+    streamUrl: String,
     debounce: { type: Number, default: 700 }
   }
 
@@ -50,7 +51,7 @@ export default class extends Controller {
   }
 
   async performSearch(query) {
-    const url = `${this.urlValue}?q=${encodeURIComponent(query)}`
+    const url = `${this.searchUrl}?q=${encodeURIComponent(query)}`
     const requestId = ++this.requestSequence
     const abortController = new AbortController()
 
@@ -66,8 +67,12 @@ export default class extends Controller {
       })
 
       if (response.ok && requestId === this.requestSequence && this.inputTarget.value.trim() === query) {
-        const html = await response.text()
-        Turbo.renderStreamMessage(html)
+        if (response.body) {
+          await this.renderStreamingResponse(response, requestId, query)
+        } else {
+          const html = await response.text()
+          this.renderStreamMessage(html, requestId, query)
+        }
       }
     } catch (error) {
       if (error.name === "AbortError") {
@@ -87,6 +92,44 @@ export default class extends Controller {
     if (this.currentAbortController) {
       this.currentAbortController.abort()
       this.currentAbortController = null
+    }
+  }
+
+  get searchUrl() {
+    return this.hasStreamUrlValue ? this.streamUrlValue : this.urlValue
+  }
+
+  async renderStreamingResponse(response, requestId, query) {
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    const closingTag = "</turbo-stream>"
+    let buffer = ""
+
+    while (true) {
+      const { done, value } = await reader.read()
+      buffer += decoder.decode(value || new Uint8Array(), { stream: !done })
+
+      let closingIndex = buffer.indexOf(closingTag)
+      while (closingIndex !== -1) {
+        const endIndex = closingIndex + closingTag.length
+        const message = buffer.slice(0, endIndex)
+        buffer = buffer.slice(endIndex)
+        this.renderStreamMessage(message, requestId, query)
+        closingIndex = buffer.indexOf(closingTag)
+      }
+
+      if (done) {
+        if (buffer.trim().length > 0) {
+          this.renderStreamMessage(buffer, requestId, query)
+        }
+        break
+      }
+    }
+  }
+
+  renderStreamMessage(html, requestId, query) {
+    if (requestId === this.requestSequence && this.inputTarget.value.trim() === query) {
+      Turbo.renderStreamMessage(html)
     }
   }
 

--- a/app/jobs/upload_processing_job.rb
+++ b/app/jobs/upload_processing_job.rb
@@ -3,7 +3,7 @@
 # Processes uploaded files:
 # 1. Extracts metadata from file (ID3 tags, EPUB OPF, etc.)
 # 2. Falls back to filename parsing if extraction fails
-# 3. Searches metadata sources (Hardcover/OpenLibrary) for enrichment
+# 3. Searches metadata sources (Hardcover/Google Books/OpenLibrary) for enrichment
 # 4. Creates book with proper metadata
 # 5. Renames file and moves to library location
 class UploadProcessingJob < ApplicationJob
@@ -133,7 +133,7 @@ class UploadProcessingJob < ApplicationJob
     # Only return if score is reasonable
     score = score_result(best_match, title, author)
     score >= 30 ? best_match : nil
-  rescue HardcoverClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+  rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
     Rails.logger.warn "[UploadProcessingJob] Metadata search failed: #{e.message}"
     nil
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -91,6 +91,12 @@ class Book < ApplicationRecord
     end
   end
 
+  def self.find_by_any_work_id(work_ids, book_type:)
+    Array(work_ids).filter_map do |work_id|
+      find_by_work_id(work_id, book_type: book_type)
+    end.first
+  end
+
   # Find or initialize a book by work_id and book_type
   def self.find_or_initialize_by_work_id(work_id, book_type:)
     source, source_id = parse_work_id(work_id)
@@ -101,6 +107,20 @@ class Book < ApplicationRecord
       find_or_initialize_by(google_books_id: source_id, book_type: book_type)
     else
       find_or_initialize_by(open_library_work_id: source_id, book_type: book_type)
+    end
+  end
+
+  def assign_work_id(work_id)
+    source, source_id = self.class.parse_work_id(work_id)
+    return if source_id.blank?
+
+    case source
+    when "hardcover"
+      self.hardcover_id ||= source_id
+    when "google_books"
+      self.google_books_id ||= source_id
+    else
+      self.open_library_work_id ||= source_id
     end
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,9 +1,5 @@
 class Book < ApplicationRecord
-  METADATA_SOURCE_NAMES = {
-    "hardcover" => "Hardcover",
-    "google_books" => "Google Books",
-    "openlibrary" => "Open Library"
-  }.freeze
+  METADATA_SOURCE_NAMES = MetadataSources::NAMES
 
   has_many :requests, dependent: :restrict_with_error
   has_many :uploads, dependent: :nullify
@@ -30,7 +26,7 @@ class Book < ApplicationRecord
     return nil if unified_work_id.blank?
 
     source, = Book.parse_work_id(unified_work_id)
-    METADATA_SOURCE_NAMES.fetch(source, source.titleize)
+    MetadataSources.display_name(source)
   end
 
   def metadata_source_url
@@ -92,9 +88,66 @@ class Book < ApplicationRecord
   end
 
   def self.find_by_any_work_id(work_ids, book_type:)
-    Array(work_ids).filter_map do |work_id|
-      find_by_work_id(work_id, book_type: book_type)
-    end.first
+    find_in_lookup(preload_by_work_ids(work_ids), work_ids, book_type: book_type)
+  end
+
+  def self.find_in_lookup(lookup, work_ids, book_type:)
+    Array(work_ids).each do |work_id|
+      source, source_id = parse_work_id(work_id)
+      lookup_keys = [ work_id.to_s, "#{source}:#{source_id}" ].uniq
+      book = lookup_keys.filter_map { |key| lookup.dig(key, book_type.to_s) }.first
+      return book if book
+    end
+
+    nil
+  end
+
+  def self.preload_by_work_ids(work_ids)
+    ids = Array(work_ids).compact_blank.map(&:to_s).uniq
+    return {} if ids.empty?
+
+    hardcover_ids = []
+    google_books_ids = []
+    openlibrary_ids = []
+
+    ids.each do |work_id|
+      source, source_id = parse_work_id(work_id)
+      next if source_id.blank?
+
+      case source
+      when "hardcover"
+        hardcover_ids << source_id
+      when "google_books"
+        google_books_ids << source_id
+      else
+        openlibrary_ids << source_id
+      end
+    end
+
+    scope = none
+    scope = scope.or(where(hardcover_id: hardcover_ids)) if hardcover_ids.any?
+    scope = scope.or(where(google_books_id: google_books_ids)) if google_books_ids.any?
+    scope = scope.or(where(open_library_work_id: openlibrary_ids)) if openlibrary_ids.any?
+
+    lookup = Hash.new { |hash, key| hash[key] = {} }
+    scope.includes(:requests).find_each do |book|
+      work_ids_for(book).each do |unified_work_id|
+        lookup[unified_work_id][book.book_type] = book
+
+        source, source_id = parse_work_id(unified_work_id)
+        lookup[source_id][book.book_type] = book if source == "openlibrary"
+      end
+    end
+
+    lookup
+  end
+
+  def self.work_ids_for(book)
+    [
+      ("hardcover:#{book.hardcover_id}" if book.hardcover_id.present?),
+      ("google_books:#{book.google_books_id}" if book.google_books_id.present?),
+      ("openlibrary:#{book.open_library_work_id}" if book.open_library_work_id.present?)
+    ].compact
   end
 
   # Find or initialize a book by work_id and book_type

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,4 +1,10 @@
 class Book < ApplicationRecord
+  METADATA_SOURCE_NAMES = {
+    "hardcover" => "Hardcover",
+    "google_books" => "Google Books",
+    "openlibrary" => "Open Library"
+  }.freeze
+
   has_many :requests, dependent: :restrict_with_error
   has_many :uploads, dependent: :nullify
 
@@ -20,10 +26,41 @@ class Book < ApplicationRecord
     author.present? ? "#{title} by #{author}" : title
   end
 
+  def metadata_source_name
+    return nil if unified_work_id.blank?
+
+    source, = Book.parse_work_id(unified_work_id)
+    METADATA_SOURCE_NAMES.fetch(source, source.titleize)
+  end
+
+  def metadata_source_url
+    return nil if unified_work_id.blank?
+
+    source, source_id = Book.parse_work_id(unified_work_id)
+    return nil if source_id.blank?
+
+    case source
+    when "hardcover"
+      "https://hardcover.app/books/#{source_id}"
+    when "google_books"
+      "https://books.google.com/books?id=#{source_id}"
+    when "openlibrary"
+      "https://openlibrary.org/works/#{source_id}"
+    end
+  end
+
+  def metadata_source_attribution
+    return nil if metadata_source_name.blank?
+
+    "Metadata from #{metadata_source_name}"
+  end
+
   # Returns unified work_id in format "source:id"
   def unified_work_id
     if hardcover_id.present?
       "hardcover:#{hardcover_id}"
+    elsif google_books_id.present?
+      "google_books:#{google_books_id}"
     elsif open_library_work_id.present?
       "openlibrary:#{open_library_work_id}"
     end
@@ -47,6 +84,8 @@ class Book < ApplicationRecord
     case source
     when "hardcover"
       find_by(hardcover_id: source_id, book_type: book_type)
+    when "google_books"
+      find_by(google_books_id: source_id, book_type: book_type)
     else
       find_by(open_library_work_id: source_id, book_type: book_type)
     end
@@ -58,6 +97,8 @@ class Book < ApplicationRecord
     case source
     when "hardcover"
       find_or_initialize_by(hardcover_id: source_id, book_type: book_type)
+    when "google_books"
+      find_or_initialize_by(google_books_id: source_id, book_type: book_type)
     else
       find_or_initialize_by(open_library_work_id: source_id, book_type: book_type)
     end

--- a/app/models/metadata_provider_status.rb
+++ b/app/models/metadata_provider_status.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class MetadataProviderStatus < ApplicationRecord
+  STATUSES = %w[unknown healthy degraded rate_limited auth_failed down].freeze
+
+  validates :provider, presence: true, uniqueness: true
+  validates :status, presence: true, inclusion: { in: STATUSES }
+
+  class << self
+    def for_provider(provider)
+      find_or_create_by!(provider: provider.to_s) do |record|
+        record.status = "unknown"
+      end
+    end
+  end
+
+  def available?
+    status != "auth_failed" && !rate_limited?
+  end
+
+  def rate_limited?
+    rate_limited_until.present? && rate_limited_until.future?
+  end
+
+  def record_success!
+    update!(
+      status: "healthy",
+      rate_limited_until: nil,
+      last_error: nil,
+      last_success_at: Time.current,
+      failure_count: 0
+    )
+  end
+
+  def record_failure!(error)
+    update!(
+      status: status_for(error),
+      rate_limited_until: backoff_until_for(error),
+      last_error: error.message,
+      last_failure_at: Time.current,
+      failure_count: failure_count.to_i + 1
+    )
+  end
+
+  private
+
+  def status_for(error)
+    return "rate_limited" if rate_limit_error?(error)
+    return "auth_failed" if auth_error?(error)
+    return "down" if connection_error?(error)
+
+    "degraded"
+  end
+
+  def backoff_until_for(error)
+    return nil if auth_error?(error)
+
+    seconds = if rate_limit_error?(error)
+      15.minutes.to_i
+    elsif connection_error?(error)
+      2.minutes.to_i
+    else
+      5.minutes.to_i
+    end
+
+    Time.current + [ seconds * (2**failure_count.to_i), 6.hours.to_i ].min
+  end
+
+  def rate_limit_error?(error)
+    error.class.name.ends_with?("::RateLimitError")
+  end
+
+  def auth_error?(error)
+    error.class.name.ends_with?("::AuthenticationError")
+  end
+
+  def connection_error?(error)
+    error.class.name.ends_with?("::ConnectionError")
+  end
+end

--- a/app/models/metadata_provider_status.rb
+++ b/app/models/metadata_provider_status.rb
@@ -12,6 +12,45 @@ class MetadataProviderStatus < ApplicationRecord
         record.status = "unknown"
       end
     end
+
+    def clear_after_credential_change!(provider)
+      record = find_by(provider: provider.to_s)
+      return unless record
+
+      record.clear_after_credential_change!
+    end
+
+    def clear_after_credential_change_for_settings!(changed_keys)
+      providers = []
+      reset_all = false
+
+      Array(changed_keys).each do |key|
+        provider = provider_for_setting(key)
+        reset_all ||= provider == :all
+        providers << provider if provider.is_a?(String)
+      end
+
+      target_providers = reset_all ? MetadataSources::NAMES.keys : providers.uniq
+      target_providers.each { |provider| clear_after_credential_change!(provider) }
+    end
+
+    def provider_for_setting(key)
+      case key.to_s
+      when /\Ahardcover_/ then "hardcover"
+      when /\Agoogle_books_/ then "google_books"
+      when /\Aopen_library_/ then "openlibrary"
+      when "metadata_source", "metadata_provider_priority" then :all
+      end
+    end
+  end
+
+  def clear_after_credential_change!
+    update!(
+      status: "unknown",
+      rate_limited_until: nil,
+      last_error: nil,
+      failure_count: 0
+    )
   end
 
   def available?

--- a/app/models/metadata_sources.rb
+++ b/app/models/metadata_sources.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MetadataSources
+  NAMES = {
+    "hardcover" => "Hardcover",
+    "google_books" => "Google Books",
+    "openlibrary" => "Open Library"
+  }.freeze
+
+  def self.display_name(source)
+    NAMES.fetch(source.to_s, source.to_s.titleize)
+  end
+end

--- a/app/services/book_metadata_backfill_service.rb
+++ b/app/services/book_metadata_backfill_service.rb
@@ -7,10 +7,10 @@ class BookMetadataBackfillService
     def apply!(book, work_id:, fallback_attrs: {})
       details = fetch_details(work_id)
       attrs = attributes_for(book, work_id, details, fallback_attrs)
-      return false if attrs.empty?
+      book.assign_attributes(attrs) unless attrs.empty?
+      return false unless book.changed?
 
-      book.assign_attributes(attrs)
-      book.save! if book.changed?
+      book.save!
       book.saved_changes?
     end
 

--- a/app/services/book_metadata_backfill_service.rb
+++ b/app/services/book_metadata_backfill_service.rb
@@ -53,7 +53,7 @@ class BookMetadataBackfillService
     end
 
     def metadata_lookup_errors
-      errors = [ HardcoverClient::Error, OpenLibraryClient::Error, MetadataService::Error, ArgumentError ]
+      errors = [ HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error, ArgumentError ]
       errors << VCR::Errors::UnhandledHTTPRequestError if defined?(VCR::Errors::UnhandledHTTPRequestError)
       errors << WebMock::NetConnectNotAllowedError if defined?(WebMock::NetConnectNotAllowedError)
       errors

--- a/app/services/custom_acquisition_provider_client.rb
+++ b/app/services/custom_acquisition_provider_client.rb
@@ -174,6 +174,7 @@ class CustomAcquisitionProviderClient
         isbn: book.isbn,
         open_library_work_id: book.open_library_work_id,
         open_library_edition_id: book.open_library_edition_id,
+        google_books_id: book.google_books_id,
         hardcover_id: book.hardcover_id
       }.compact
     }

--- a/app/services/duplicate_detection_service.rb
+++ b/app/services/duplicate_detection_service.rb
@@ -25,8 +25,9 @@ class DuplicateDetectionService
   class << self
     # Check if a book can be requested
     # Returns a Result with status, message, and any existing records
-    def check(work_id:, edition_id: nil, book_type:)
+    def check(work_id:, edition_id: nil, book_type:, source_work_ids: nil)
       book_type = book_type.to_s
+      work_ids = [ work_id, *Array(source_work_ids) ].compact_blank.uniq
 
       # Check 1: Same edition already acquired (most specific)
       if edition_id.present?
@@ -42,7 +43,7 @@ class DuplicateDetectionService
       end
 
       # Check 2: Same work + type already acquired
-      existing_book = Book.find_by_work_id(work_id, book_type: book_type)
+      existing_book = Book.find_by_any_work_id(work_ids, book_type: book_type)
       if existing_book&.acquired?
         return Result.new(
           status: BLOCK,
@@ -67,7 +68,7 @@ class DuplicateDetectionService
 
       # Check 4: Same work exists as different type (warn only)
       other_type = book_type == "audiobook" ? "ebook" : "audiobook"
-      other_book = Book.find_by_work_id(work_id, book_type: other_type)
+      other_book = Book.find_by_any_work_id(work_ids, book_type: other_type)
       if other_book
         return Result.new(
           status: WARN,
@@ -100,8 +101,8 @@ class DuplicateDetectionService
     end
 
     # Quick check - just returns true/false for whether request is allowed
-    def can_request?(work_id:, edition_id: nil, book_type:)
-      result = check(work_id: work_id, edition_id: edition_id, book_type: book_type)
+    def can_request?(work_id:, edition_id: nil, book_type:, source_work_ids: nil)
+      result = check(work_id: work_id, edition_id: edition_id, book_type: book_type, source_work_ids: source_work_ids)
       !result.block?
     end
 

--- a/app/services/duplicate_detection_service.rb
+++ b/app/services/duplicate_detection_service.rb
@@ -25,7 +25,7 @@ class DuplicateDetectionService
   class << self
     # Check if a book can be requested
     # Returns a Result with status, message, and any existing records
-    def check(work_id:, edition_id: nil, book_type:, source_work_ids: nil)
+    def check(work_id:, edition_id: nil, book_type:, source_work_ids: nil, existing_books_lookup: nil)
       book_type = book_type.to_s
       work_ids = [ work_id, *Array(source_work_ids) ].compact_blank.uniq
 
@@ -43,7 +43,7 @@ class DuplicateDetectionService
       end
 
       # Check 2: Same work + type already acquired
-      existing_book = Book.find_by_any_work_id(work_ids, book_type: book_type)
+      existing_book = find_existing_book(work_ids, book_type: book_type, existing_books_lookup: existing_books_lookup)
       if existing_book&.acquired?
         return Result.new(
           status: BLOCK,
@@ -68,7 +68,7 @@ class DuplicateDetectionService
 
       # Check 4: Same work exists as different type (warn only)
       other_type = book_type == "audiobook" ? "ebook" : "audiobook"
-      other_book = Book.find_by_any_work_id(work_ids, book_type: other_type)
+      other_book = find_existing_book(work_ids, book_type: other_type, existing_books_lookup: existing_books_lookup)
       if other_book
         return Result.new(
           status: WARN,
@@ -101,9 +101,23 @@ class DuplicateDetectionService
     end
 
     # Quick check - just returns true/false for whether request is allowed
-    def can_request?(work_id:, edition_id: nil, book_type:, source_work_ids: nil)
-      result = check(work_id: work_id, edition_id: edition_id, book_type: book_type, source_work_ids: source_work_ids)
+    def can_request?(work_id:, edition_id: nil, book_type:, source_work_ids: nil, existing_books_lookup: nil)
+      result = check(
+        work_id: work_id,
+        edition_id: edition_id,
+        book_type: book_type,
+        source_work_ids: source_work_ids,
+        existing_books_lookup: existing_books_lookup
+      )
       !result.block?
+    end
+
+    def find_existing_book(work_ids, book_type:, existing_books_lookup: nil)
+      if existing_books_lookup.present?
+        Book.find_in_lookup(existing_books_lookup, work_ids, book_type: book_type)
+      else
+        Book.find_by_any_work_id(work_ids, book_type: book_type)
+      end
     end
 
   end

--- a/app/services/google_books_client.rb
+++ b/app/services/google_books_client.rb
@@ -140,9 +140,18 @@ class GoogleBooksClient
       end
     end
 
+    AUTH_FAILURE_MARKERS = [
+      "api key",
+      "invalid key",
+      "invalid api key",
+      "not valid",
+      "permission",
+      "forbidden"
+    ].freeze
+
     def authentication_failure?(response)
-      message = response_error_message(response.body)
-      message.match?(/API key|invalid.*key|not valid|permission|forbidden/i)
+      message = response_error_message(response.body).downcase
+      AUTH_FAILURE_MARKERS.any? { |marker| message.include?(marker) }
     end
 
     def response_error_message(body)

--- a/app/services/google_books_client.rb
+++ b/app/services/google_books_client.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+# Client for interacting with the Google Books Volumes API
+# https://developers.google.com/books/docs/v1/using
+class GoogleBooksClient
+  BASE_URL = "https://www.googleapis.com"
+  MAX_RESULTS = 40
+
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class NotFoundError < Error; end
+  class RateLimitError < Error; end
+
+  SearchResult = Data.define(
+    :id, :title, :author, :description, :published_date,
+    :cover_url, :has_ebook, :language
+  ) do
+    def work_id
+      "google_books:#{id}"
+    end
+
+    def first_publish_year
+      GoogleBooksClient.parse_year(published_date)
+    end
+
+    def cover_id
+      nil
+    end
+  end
+
+  BookDetails = Data.define(
+    :id, :title, :author, :description, :published_date,
+    :cover_url, :has_ebook, :language, :page_count, :categories
+  ) do
+    def work_id
+      "google_books:#{id}"
+    end
+
+    def release_year
+      GoogleBooksClient.parse_year(published_date)
+    end
+  end
+
+  class << self
+    def configured?
+      true
+    end
+
+    def search(query, limit: nil)
+      limit = normalize_limit(limit || SettingsService.get(:google_books_search_limit, default: 20))
+
+      response = connection.get("/books/v1/volumes", {
+        q: query,
+        maxResults: limit,
+        printType: "books"
+      }.merge(api_key_param))
+
+      handle_response(response) do |data|
+        Array(data["items"]).filter_map { |item| parse_search_result(item) }
+      end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise ConnectionError, "Failed to connect to Google Books: #{e.message}"
+    end
+
+    def book(volume_id)
+      response = connection.get("/books/v1/volumes/#{volume_id}", api_key_param)
+
+      handle_response(response) do |data|
+        parse_book_details(data)
+      end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise ConnectionError, "Failed to connect to Google Books: #{e.message}"
+    end
+
+    def test_connection
+      search("test", limit: 1)
+      true
+    rescue Error => e
+      Rails.logger.error "[GoogleBooksClient] Connection test failed: #{e.message}"
+      false
+    end
+
+    def reset_connection!
+      @connection = nil
+    end
+
+    def parse_year(date_string)
+      return nil if date_string.blank?
+
+      match = date_string.to_s.match(/\b(1[89]\d{2}|20[0-2]\d)\b/)
+      match ? match[1].to_i : nil
+    end
+
+    private
+
+    def connection
+      @connection ||= Faraday.new(url: BASE_URL) do |f|
+        f.request :url_encoded
+        f.response :json, parser_options: { symbolize_names: false }
+        f.adapter Faraday.default_adapter
+        f.headers["User-Agent"] = "Shelfarr/1.0"
+        f.options.timeout = 15
+        f.options.open_timeout = 5
+      end
+    end
+
+    def handle_response(response)
+      case response.status
+      when 200
+        yield response.body
+      when 404
+        raise NotFoundError, "Volume not found"
+      when 403, 429
+        raise RateLimitError, "Rate limit exceeded"
+      else
+        raise Error, "API request failed with status #{response.status}"
+      end
+    end
+
+    def api_key_param
+      key = SettingsService.get(:google_books_api_key).to_s.strip
+      key.present? ? { key: key } : {}
+    end
+
+    def parse_search_result(item)
+      volume = item["volumeInfo"] || {}
+      return nil if item["id"].blank? || volume["title"].blank?
+
+      SearchResult.new(
+        id: item["id"].to_s,
+        title: volume["title"],
+        author: Array(volume["authors"]).first,
+        description: volume["description"],
+        published_date: volume["publishedDate"],
+        cover_url: extract_cover_url(volume),
+        has_ebook: ebook_available?(item),
+        language: volume["language"]
+      )
+    end
+
+    def parse_book_details(item)
+      volume = item["volumeInfo"] || {}
+      raise NotFoundError, "Volume not found" if item["id"].blank? || volume.blank?
+
+      BookDetails.new(
+        id: item["id"].to_s,
+        title: volume["title"],
+        author: Array(volume["authors"]).first,
+        description: volume["description"],
+        published_date: volume["publishedDate"],
+        cover_url: extract_cover_url(volume),
+        has_ebook: ebook_available?(item),
+        language: volume["language"],
+        page_count: volume["pageCount"],
+        categories: Array(volume["categories"])
+      )
+    end
+
+    def extract_cover_url(volume)
+      links = volume["imageLinks"] || {}
+      url = links["extraLarge"] || links["large"] || links["medium"] || links["thumbnail"] || links["smallThumbnail"]
+      url&.sub(/^http:/, "https:")
+    end
+
+    def ebook_available?(item)
+      sale_info = item["saleInfo"] || {}
+      access_info = item["accessInfo"] || {}
+
+      sale_info["isEbook"] == true ||
+        access_info.dig("epub", "isAvailable") == true ||
+        access_info.dig("pdf", "isAvailable") == true
+    end
+
+    def normalize_limit(limit)
+      limit.to_i.clamp(1, MAX_RESULTS)
+    end
+  end
+end

--- a/app/services/google_books_client.rb
+++ b/app/services/google_books_client.rb
@@ -13,8 +13,13 @@ class GoogleBooksClient
 
   SearchResult = Data.define(
     :id, :title, :author, :description, :published_date,
-    :cover_url, :has_ebook, :language
+    :cover_url, :has_ebook, :language, :isbn_10, :isbn_13,
+    :publisher, :page_count, :source_url
   ) do
+    def initialize(id:, title:, author:, description:, published_date:, cover_url:, has_ebook:, language:, isbn_10: nil, isbn_13: nil, publisher: nil, page_count: nil, source_url: nil)
+      super
+    end
+
     def work_id
       "google_books:#{id}"
     end
@@ -30,8 +35,13 @@ class GoogleBooksClient
 
   BookDetails = Data.define(
     :id, :title, :author, :description, :published_date,
-    :cover_url, :has_ebook, :language, :page_count, :categories
+    :cover_url, :has_ebook, :language, :page_count, :categories,
+    :isbn_10, :isbn_13, :publisher, :source_url
   ) do
+    def initialize(id:, title:, author:, description:, published_date:, cover_url:, has_ebook:, language:, page_count:, categories:, isbn_10: nil, isbn_13: nil, publisher: nil, source_url: nil)
+      super
+    end
+
     def work_id
       "google_books:#{id}"
     end
@@ -134,7 +144,12 @@ class GoogleBooksClient
         published_date: volume["publishedDate"],
         cover_url: extract_cover_url(volume),
         has_ebook: ebook_available?(item),
-        language: volume["language"]
+        language: volume["language"],
+        isbn_10: industry_identifier(volume, "ISBN_10"),
+        isbn_13: industry_identifier(volume, "ISBN_13"),
+        publisher: volume["publisher"],
+        page_count: volume["pageCount"],
+        source_url: volume["canonicalVolumeLink"].presence || volume["infoLink"]
       )
     end
 
@@ -152,8 +167,16 @@ class GoogleBooksClient
         has_ebook: ebook_available?(item),
         language: volume["language"],
         page_count: volume["pageCount"],
-        categories: Array(volume["categories"])
+        categories: Array(volume["categories"]),
+        isbn_10: industry_identifier(volume, "ISBN_10"),
+        isbn_13: industry_identifier(volume, "ISBN_13"),
+        publisher: volume["publisher"],
+        source_url: volume["canonicalVolumeLink"].presence || volume["infoLink"]
       )
+    end
+
+    def industry_identifier(volume, type)
+      Array(volume["industryIdentifiers"]).find { |identifier| identifier["type"] == type }&.dig("identifier")
     end
 
     def extract_cover_url(volume)

--- a/app/services/google_books_client.rb
+++ b/app/services/google_books_client.rb
@@ -9,6 +9,7 @@ class GoogleBooksClient
   class Error < StandardError; end
   class ConnectionError < Error; end
   class NotFoundError < Error; end
+  class AuthenticationError < Error; end
   class RateLimitError < Error; end
 
   SearchResult = Data.define(
@@ -53,7 +54,7 @@ class GoogleBooksClient
 
   class << self
     def configured?
-      true
+      SettingsService.get(:google_books_enabled, default: true)
     end
 
     def search(query, limit: nil)
@@ -83,6 +84,8 @@ class GoogleBooksClient
     end
 
     def test_connection
+      return false unless configured?
+
       search("test", limit: 1)
       true
     rescue Error => e
@@ -120,10 +123,36 @@ class GoogleBooksClient
         yield response.body
       when 404
         raise NotFoundError, "Volume not found"
-      when 403, 429
+      when 403
+        raise authentication_error_for(response)
+      when 429
         raise RateLimitError, "Rate limit exceeded"
       else
         raise Error, "API request failed with status #{response.status}"
+      end
+    end
+
+    def authentication_error_for(response)
+      if authentication_failure?(response)
+        AuthenticationError.new("Invalid or restricted Google Books API key")
+      else
+        RateLimitError.new("Rate limit exceeded")
+      end
+    end
+
+    def authentication_failure?(response)
+      message = response_error_message(response.body)
+      message.match?(/API key|invalid.*key|not valid|permission|forbidden/i)
+    end
+
+    def response_error_message(body)
+      return body.to_s unless body.is_a?(Hash)
+
+      error = body["error"]
+      if error.is_a?(Hash)
+        [ error["message"], error["reason"] ].compact.join(" ")
+      else
+        body.to_s
       end
     end
 
@@ -155,7 +184,7 @@ class GoogleBooksClient
 
     def parse_book_details(item)
       volume = item["volumeInfo"] || {}
-      raise NotFoundError, "Volume not found" if item["id"].blank? || volume.blank?
+      raise NotFoundError, "Volume not found" if item["id"].blank? || volume["title"].blank?
 
       BookDetails.new(
         id: item["id"].to_s,

--- a/app/services/integrations/command_processor.rb
+++ b/app/services/integrations/command_processor.rb
@@ -13,11 +13,12 @@ module Integrations
       end
     end
 
-    def initialize(command:, arguments:, user:, origin: {})
+    def initialize(command:, arguments:, user:, origin: {}, request_selection: nil)
       @command = command.to_s.downcase
       @arguments = arguments.to_s.strip
       @user = user
       @origin = origin
+      @request_selection = request_selection&.to_h&.symbolize_keys
     end
 
     def call
@@ -39,7 +40,7 @@ module Integrations
 
     private
 
-    attr_reader :command, :arguments, :user, :origin
+    attr_reader :command, :arguments, :user, :origin, :request_selection
 
     def help_text
       [
@@ -71,8 +72,18 @@ module Integrations
     end
 
     def create_request(raw_arguments)
-      work_id, requested_type, language = raw_arguments.to_s.split(/\s+/, 3)
-      book_types = book_types_for(requested_type)
+      if request_selection.present?
+        work_id = request_selection[:work_id]
+        source_work_ids = request_selection[:source_work_ids]
+        metadata_attrs = request_selection[:metadata_attrs] || {}
+        requested_type, language = raw_arguments.to_s.split(/\s+/, 2)
+        book_types = book_types_for(requested_type)
+      else
+        work_id, requested_type, language = raw_arguments.to_s.split(/\s+/, 3)
+        source_work_ids = nil
+        metadata_attrs = {}
+        book_types = book_types_for(requested_type)
+      end
 
       if work_id.blank? || book_types.empty?
         return result("Usage: /request <work_id> <ebook|audiobook|both> [language]")
@@ -81,7 +92,9 @@ module Integrations
       creation = RequestCreationService.call(
         user: user,
         work_id: work_id,
+        source_work_ids: source_work_ids,
         book_types: book_types,
+        metadata_attrs: metadata_attrs,
         language: language,
         origin: origin
       )

--- a/app/services/integrations/command_processor.rb
+++ b/app/services/integrations/command_processor.rb
@@ -59,14 +59,14 @@ module Integrations
 
       lines = [ "Search results for #{query}:" ]
       results.each_with_index do |search_result, index|
-        lines << "#{index + 1}. #{search_result.title}#{author_suffix(search_result)}"
+        lines << "#{index + 1}. #{search_result.title}#{author_suffix(search_result)}#{source_suffix(search_result)}"
       end
       lines << "Choose a format below."
 
       result(lines.join("\n"), search_results: results)
-    rescue HardcoverClient::ConnectionError, OpenLibraryClient::ConnectionError
+    rescue HardcoverClient::ConnectionError, GoogleBooksClient::ConnectionError, OpenLibraryClient::ConnectionError
       result("Shelfarr could not reach the metadata service.")
-    rescue HardcoverClient::Error, OpenLibraryClient::Error, MetadataService::Error
+    rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error
       result("Search failed. Try again later.")
     end
 
@@ -132,6 +132,10 @@ module Integrations
 
     def author_suffix(search_result)
       search_result.author.present? ? " by #{search_result.author}" : ""
+    end
+
+    def source_suffix(search_result)
+      search_result.source_name.present? ? " (#{search_result.source_name})" : ""
     end
 
     def result(text, search_results: [])

--- a/app/services/integrations/command_processor.rb
+++ b/app/services/integrations/command_processor.rb
@@ -135,7 +135,13 @@ module Integrations
     end
 
     def source_suffix(search_result)
-      search_result.source_name.present? ? " (#{search_result.source_name})" : ""
+      source_names = if search_result.respond_to?(:sources)
+        search_result.sources.map { |source| source[:source_name] }
+      else
+        [ search_result.source_name ]
+      end.compact_blank
+
+      source_names.any? ? " (#{source_names.join(', ')})" : ""
     end
 
     def result(text, search_results: [])

--- a/app/services/integrations/telegram/command_handler.rb
+++ b/app/services/integrations/telegram/command_handler.rb
@@ -80,10 +80,19 @@ module Integrations
       end
 
       def handle_callback
-        action, work_id, requested_type = callback_query["data"].to_s.split("|", 3)
-        return reply("Unknown action.") unless action == "request"
+        action, identifier, requested_type = callback_query["data"].to_s.split("|", 3)
 
-        process("/request", [ work_id, requested_type ].compact.join(" "))
+        case action
+        when "req"
+          selection = SearchResultCache.fetch(identifier)
+          return reply("This search result expired. Run /search again.") unless selection
+
+          process_request_selection(selection, requested_type)
+        when "request"
+          process("/request", [ identifier, requested_type ].compact.join(" "))
+        else
+          reply("Unknown action.")
+        end
       end
 
       def parse_command
@@ -140,12 +149,32 @@ module Integrations
         {
           inline_keyboard: results.each_with_index.map do |result, index|
             label = index + 1
+            token = SearchResultCache.store(result)
             [
-              { text: "#{label}. Ebook", callback_data: "request|#{result.work_id}|ebook" },
-              { text: "#{label}. Audio", callback_data: "request|#{result.work_id}|audiobook" }
+              { text: "#{label}. Ebook", callback_data: SearchResultCache.callback_data(token, "ebook") },
+              { text: "#{label}. Audio", callback_data: SearchResultCache.callback_data(token, "audiobook") }
             ]
           end
         }
+      end
+
+      def process_request_selection(selection, requested_type)
+        return reply("Telegram request owner is not configured in Shelfarr.") unless request_user
+
+        result = Integrations::CommandProcessor.call(
+          command: "/request",
+          arguments: requested_type.to_s,
+          user: request_user,
+          origin: {
+            created_via: "telegram",
+            external_source: "telegram",
+            external_user_id: sender_id,
+            external_chat_id: chat_id
+          },
+          request_selection: selection
+        )
+
+        reply(result.text)
       end
 
       def process(command, arguments)

--- a/app/services/integrations/telegram/search_result_cache.rb
+++ b/app/services/integrations/telegram/search_result_cache.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Telegram
+    class SearchResultCache
+      CACHE_PREFIX = "telegram_search_result"
+      TTL = 1.hour
+
+      class << self
+        def store(result)
+          token = SecureRandom.hex(16)
+          Rails.cache.write(cache_key(token), selection_for(result), expires_in: TTL)
+          token
+        end
+
+        def fetch(token)
+          value = Rails.cache.read(cache_key(token))
+          return nil if value.blank?
+
+          value.symbolize_keys
+        end
+
+        def callback_data(token, book_type)
+          data = "req|#{token}|#{book_type}"
+          raise ArgumentError, "Telegram callback_data exceeds 64 bytes" if data.bytesize > 64
+
+          data
+        end
+
+        private
+
+        def cache_key(token)
+          "#{CACHE_PREFIX}:#{token}"
+        end
+
+        def selection_for(result)
+          {
+            work_id: result.work_id,
+            source_work_ids: source_work_ids_for(result),
+            metadata_attrs: {
+              title: result.title,
+              author: result.author,
+              year: result_year(result)
+            }.compact
+          }
+        end
+
+        def source_work_ids_for(result)
+          if result.respond_to?(:sources)
+            Array(result.sources).filter_map { |source| source[:work_id] }.uniq
+          else
+            [ result.work_id ]
+          end
+        end
+
+        def result_year(result)
+          if result.respond_to?(:year)
+            result.year
+          elsif result.respond_to?(:first_publish_year)
+            result.first_publish_year
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/metadata_search/aggregator.rb
+++ b/app/services/metadata_search/aggregator.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module MetadataSearch
+  class Aggregator
+    class << self
+      def call(results, priority: [])
+        new(results, priority: priority).call
+      end
+    end
+
+    def initialize(results, priority: [])
+      @results = Array(results).compact
+      @priority = Array(priority).map(&:to_s)
+    end
+
+    def call
+      clusters.map { |cluster| candidate_for(cluster) }
+    end
+
+    private
+
+    attr_reader :results, :priority
+
+    def clusters
+      results.each_with_object([]) do |result, groups|
+        group = groups.find { |candidate_group| match?(candidate_group.first, result) }
+        group ? group << result : groups << [ result ]
+      end
+    end
+
+    def match?(left, right)
+      return true if shared_isbn?(left, right)
+      return false if conflicting_isbn?(left, right)
+      return false unless normalized_text(left.title) == normalized_text(right.title)
+      return false unless normalized_text(left.author) == normalized_text(right.author)
+
+      close_year?(left.year, right.year)
+    end
+
+    def shared_isbn?(left, right)
+      (isbns(left) & isbns(right)).any?
+    end
+
+    def conflicting_isbn?(left, right)
+      left_isbns = isbns(left)
+      right_isbns = isbns(right)
+      left_isbns.any? && right_isbns.any? && (left_isbns & right_isbns).empty?
+    end
+
+    def isbns(result)
+      [ result.isbn_10, result.isbn_13 ].compact.map { |isbn| isbn.to_s.delete(" -") }.reject(&:blank?)
+    end
+
+    def normalized_text(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]+/, " ").squish
+    end
+
+    def close_year?(left_year, right_year)
+      return true if left_year.blank? || right_year.blank?
+
+      (left_year.to_i - right_year.to_i).abs <= 1
+    end
+
+    def candidate_for(group)
+      ordered = group.sort_by { |result| provider_rank(result.source) }
+      primary = ordered.first
+
+      Candidate.new(
+        canonical_key: canonical_key_for(group),
+        title: first_present(ordered, :title),
+        author: first_present(ordered, :author),
+        year: first_present(ordered, :year),
+        description: first_present(ordered, :description),
+        cover_url: first_present(ordered, :cover_url),
+        series_name: first_present(ordered, :series_name),
+        series_position: first_present(ordered, :series_position),
+        has_ebook: any_truthy?(group, :has_ebook),
+        has_audiobook: any_truthy?(group, :has_audiobook),
+        sources: ordered.map { |result| source_entry(result) },
+        editions: edition_entries(group, primary),
+        confidence: confidence_for(group)
+      )
+    end
+
+    def canonical_key_for(group)
+      isbn = group.flat_map { |result| isbns(result) }.first
+      return "isbn:#{isbn}" if isbn.present?
+
+      primary = group.min_by { |result| provider_rank(result.source) }
+      primary.work_id
+    end
+
+    def first_present(group, field)
+      group.map { |result| result.public_send(field) }.find(&:present?)
+    end
+
+    def any_truthy?(group, field)
+      return true if group.any? { |result| result.public_send(field) == true }
+      return false if group.any? { |result| result.public_send(field) == false }
+
+      nil
+    end
+
+    def source_entry(result)
+      {
+        source: result.source,
+        source_id: result.source_id,
+        source_name: result.source_name,
+        source_url: result.source_url,
+        work_id: result.work_id
+      }
+    end
+
+    def edition_entries(group, primary)
+      group.reject { |result| result == primary }.map do |result|
+        {
+          source: result.source,
+          source_id: result.source_id,
+          isbn_10: result.isbn_10,
+          isbn_13: result.isbn_13,
+          publisher: result.publisher,
+          year: result.year,
+          page_count: result.page_count
+        }.compact
+      end
+    end
+
+    def confidence_for(group)
+      return 100 if group.size > 1 && group.any? { |result| isbns(result).any? }
+      return 90 if group.size > 1
+
+      70
+    end
+
+    def provider_rank(source)
+      priority.index(source.to_s) || priority.size
+    end
+  end
+end

--- a/app/services/metadata_search/aggregator.rb
+++ b/app/services/metadata_search/aggregator.rb
@@ -23,7 +23,7 @@ module MetadataSearch
 
     def clusters
       results.each_with_object([]) do |result, groups|
-        group = groups.find { |candidate_group| match?(candidate_group.first, result) }
+        group = groups.find { |candidate_group| candidate_group.any? { |member| match?(member, result) } }
         group ? group << result : groups << [ result ]
       end
     end
@@ -32,7 +32,11 @@ module MetadataSearch
       return true if shared_isbn?(left, right)
       return false if conflicting_isbn?(left, right)
       return false unless normalized_text(left.title) == normalized_text(right.title)
-      return false unless normalized_text(left.author) == normalized_text(right.author)
+
+      left_author = normalized_text(left.author)
+      right_author = normalized_text(right.author)
+      return false if left_author.blank? || right_author.blank?
+      return false unless left_author == right_author
 
       close_year?(left.year, right.year)
     end

--- a/app/services/metadata_search/candidate.rb
+++ b/app/services/metadata_search/candidate.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module MetadataSearch
+  class Candidate
+    attr_reader :canonical_key, :title, :author, :year, :description, :cover_url,
+      :series_name, :series_position, :has_ebook, :has_audiobook,
+      :sources, :editions, :confidence
+
+    def initialize(canonical_key:, title:, author:, year:, description:, cover_url:,
+      series_name:, series_position:, has_ebook:, has_audiobook:, sources:, editions:, confidence:)
+      @canonical_key = canonical_key
+      @title = title
+      @author = author
+      @year = year
+      @description = description
+      @cover_url = cover_url
+      @series_name = series_name
+      @series_position = series_position
+      @has_ebook = has_ebook
+      @has_audiobook = has_audiobook
+      @sources = Array(sources)
+      @editions = Array(editions)
+      @confidence = confidence
+    end
+
+    def source
+      primary_source&.fetch(:source, nil)
+    end
+
+    def source_id
+      primary_source&.fetch(:source_id, nil)
+    end
+
+    def work_id
+      primary_source&.fetch(:work_id, nil) || canonical_key
+    end
+
+    def first_publish_year
+      year
+    end
+
+    def cover_id
+      nil
+    end
+
+    def source_name
+      primary_source&.fetch(:source_name, nil) || source.to_s.titleize
+    end
+
+    def source_url
+      primary_source&.fetch(:source_url, nil)
+    end
+
+    def source_attribution
+      "Metadata from #{source_name}"
+    end
+
+    def google_books?
+      sources.any? { |source| source[:source] == "google_books" }
+    end
+
+    def primary_source
+      sources.first
+    end
+  end
+end

--- a/app/services/metadata_search/provider_result.rb
+++ b/app/services/metadata_search/provider_result.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module MetadataSearch
+  ProviderResult = Data.define(
+    :source, :source_id, :title, :author, :year, :description, :cover_url,
+    :isbn_10, :isbn_13, :publisher, :page_count, :language,
+    :series_name, :series_position, :has_ebook, :has_audiobook,
+    :source_url, :raw_payload
+  ) do
+    SOURCE_NAMES = {
+      "hardcover" => "Hardcover",
+      "google_books" => "Google Books",
+      "openlibrary" => "Open Library"
+    }.freeze
+
+    def work_id
+      "#{source}:#{source_id}"
+    end
+
+    def source_name
+      SOURCE_NAMES.fetch(source.to_s, source.to_s.titleize)
+    end
+
+    def source_attribution
+      "Metadata from #{source_name}"
+    end
+  end
+end

--- a/app/services/metadata_search/provider_result.rb
+++ b/app/services/metadata_search/provider_result.rb
@@ -7,18 +7,12 @@ module MetadataSearch
     :series_name, :series_position, :has_ebook, :has_audiobook,
     :source_url, :raw_payload
   ) do
-    SOURCE_NAMES = {
-      "hardcover" => "Hardcover",
-      "google_books" => "Google Books",
-      "openlibrary" => "Open Library"
-    }.freeze
-
     def work_id
       "#{source}:#{source_id}"
     end
 
     def source_name
-      SOURCE_NAMES.fetch(source.to_s, source.to_s.titleize)
+      MetadataSources.display_name(source)
     end
 
     def source_attribution

--- a/app/services/metadata_search/result_normalizer.rb
+++ b/app/services/metadata_search/result_normalizer.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module MetadataSearch
+  class ResultNormalizer
+    class << self
+      def call(source, result)
+        case source.to_s
+        when "hardcover"
+          hardcover(result)
+        when "google_books"
+          google_books(result)
+        when "openlibrary"
+          openlibrary(result)
+        else
+          raise ArgumentError, "Unknown metadata source: #{source}"
+        end
+      end
+
+      private
+
+      def hardcover(result)
+        ProviderResult.new(
+          source: "hardcover",
+          source_id: result.id.to_s,
+          title: result.title,
+          author: result.author,
+          year: result.release_year,
+          description: truncate_description(result.description),
+          cover_url: result.cover_url,
+          isbn_10: nil,
+          isbn_13: nil,
+          publisher: nil,
+          page_count: nil,
+          language: nil,
+          series_name: result.series_name,
+          series_position: result.series_position,
+          has_ebook: result.has_ebook,
+          has_audiobook: result.has_audiobook,
+          source_url: "https://hardcover.app/books/#{result.id}",
+          raw_payload: nil
+        )
+      end
+
+      def google_books(result)
+        ProviderResult.new(
+          source: "google_books",
+          source_id: result.id,
+          title: result.title,
+          author: result.author,
+          year: result.first_publish_year,
+          description: truncate_description(result.description),
+          cover_url: result.cover_url,
+          isbn_10: result.respond_to?(:isbn_10) ? result.isbn_10 : nil,
+          isbn_13: result.respond_to?(:isbn_13) ? result.isbn_13 : nil,
+          publisher: result.respond_to?(:publisher) ? result.publisher : nil,
+          page_count: result.respond_to?(:page_count) ? result.page_count : nil,
+          language: result.language,
+          series_name: nil,
+          series_position: nil,
+          has_ebook: result.has_ebook,
+          has_audiobook: nil,
+          source_url: result.respond_to?(:source_url) ? result.source_url : "https://books.google.com/books?id=#{result.id}",
+          raw_payload: nil
+        )
+      end
+
+      def openlibrary(result)
+        ProviderResult.new(
+          source: "openlibrary",
+          source_id: result.work_id,
+          title: result.title,
+          author: result.author,
+          year: result.first_publish_year,
+          description: nil,
+          cover_url: result.cover_url(size: :l),
+          isbn_10: nil,
+          isbn_13: nil,
+          publisher: nil,
+          page_count: nil,
+          language: nil,
+          series_name: nil,
+          series_position: nil,
+          has_ebook: nil,
+          has_audiobook: nil,
+          source_url: "https://openlibrary.org/works/#{result.work_id}",
+          raw_payload: nil
+        )
+      end
+
+      def truncate_description(desc)
+        return nil if desc.blank?
+
+        desc.length > 500 ? "#{desc[0, 497]}..." : desc
+      end
+    end
+  end
+end

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -5,17 +5,10 @@
 class MetadataService
   class Error < StandardError; end
 
-  # Unified result structure compatible with both sources
   SearchResult = Data.define(
     :source, :source_id, :title, :author, :description, :year,
     :cover_url, :has_audiobook, :has_ebook, :series_name, :series_position
   ) do
-    SOURCE_NAMES = {
-      "hardcover" => "Hardcover",
-      "google_books" => "Google Books",
-      "openlibrary" => "Open Library"
-    }.freeze
-
     def work_id
       "#{source}:#{source_id}"
     end
@@ -30,7 +23,7 @@ class MetadataService
     end
 
     def source_name
-      SOURCE_NAMES.fetch(source.to_s, source.to_s.titleize)
+      MetadataSources.display_name(source)
     end
 
     def source_url
@@ -60,11 +53,60 @@ class MetadataService
       providers = enabled_metadata_providers
       Rails.logger.info "[MetadataService] Searching '#{query}' using providers: #{providers.join(', ')}"
 
-      provider_results = providers.flat_map do |provider|
-        search_provider(provider, query, limit)
+      provider_results = search_providers_concurrently(providers, query, limit: limit)
+      aggregate_provider_results(provider_results, limit: limit)
+    end
+
+    def each_provider_search(query, limit: nil)
+      providers = enabled_metadata_providers
+      return enum_for(__method__, query, limit: limit) unless block_given?
+
+      queue = Queue.new
+      threads = providers.map do |provider|
+        Thread.new do
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection do
+              queue << [ provider, search_provider(provider, query, limit: limit) ]
+            end
+          end
+        rescue StandardError => e
+          Rails.logger.warn "[MetadataService] #{provider} search failed: #{e.message}"
+          queue << [ provider, [] ]
+        end
       end
 
-      MetadataSearch::Aggregator.call(provider_results, priority: provider_priority).first(limit || default_search_limit)
+      providers.size.times do
+        yield queue.pop
+      end
+    ensure
+      threads&.each(&:join)
+    end
+
+    def search_provider(provider, query, limit: nil)
+      status = MetadataProviderStatus.for_provider(provider)
+      unless status.available?
+        Rails.logger.info "[MetadataService] Skipping #{provider}: #{status.status}"
+        return []
+      end
+
+      results = send("search_#{provider}", query, provider_limit(provider, limit))
+      status.record_success!
+      results
+    rescue *provider_errors(provider) => e
+      status&.record_failure!(e)
+      Rails.logger.warn "[MetadataService] #{provider} search failed: #{e.message}"
+      []
+    end
+
+    def aggregate_provider_results(provider_results, limit: nil)
+      candidates = MetadataSearch::Aggregator.call(provider_results, priority: provider_priority)
+      min_confidence = SettingsService.get(:min_match_confidence).to_i
+      candidates = candidates.select { |candidate| candidate.confidence >= min_confidence }
+      sort_candidates(candidates).first(limit || default_search_limit)
+    end
+
+    def merge_provider_results(results_by_provider)
+      ordered_provider_results(results_by_provider)
     end
 
     # Get book details by unified work_id (format: "source:id")
@@ -93,14 +135,12 @@ class MetadataService
         results[:hardcover] = HardcoverClient.test_connection rescue false
       end
 
-      results[:google_books] = GoogleBooksClient.test_connection rescue false
+      if GoogleBooksClient.configured?
+        results[:google_books] = GoogleBooksClient.test_connection rescue false
+      end
 
-      # OpenLibrary doesn't require configuration
-      results[:openlibrary] = begin
-        OpenLibraryClient.search("test", limit: 1)
-        true
-      rescue
-        false
+      if OpenLibraryClient.configured?
+        results[:openlibrary] = OpenLibraryClient.test_connection rescue false
       end
 
       results
@@ -126,22 +166,6 @@ class MetadataService
 
     private
 
-    def search_provider(provider, query, limit)
-      status = MetadataProviderStatus.for_provider(provider)
-      unless status.available?
-        Rails.logger.info "[MetadataService] Skipping #{provider}: #{status.status}"
-        return []
-      end
-
-      results = send("search_#{provider}", query, provider_limit(provider, limit))
-      status.record_success!
-      results
-    rescue *provider_errors(provider) => e
-      status&.record_failure!(e)
-      Rails.logger.warn "[MetadataService] #{provider} search failed: #{e.message}"
-      []
-    end
-
     def provider_errors(provider)
       errors = case provider.to_s
       when "hardcover"
@@ -166,13 +190,64 @@ class MetadataService
     end
 
     def search_openlibrary(query, limit)
+      return [] unless OpenLibraryClient.configured?
+
       results = OpenLibraryClient.search(query, limit: limit)
       results.map { |result| MetadataSearch::ResultNormalizer.call("openlibrary", result) }
     end
 
     def search_google_books(query, limit)
+      return [] unless GoogleBooksClient.configured?
+
       results = GoogleBooksClient.search(query, limit: limit)
       results.map { |result| MetadataSearch::ResultNormalizer.call("google_books", result) }
+    end
+
+    def search_providers_concurrently(providers, query, limit: nil)
+      results_by_provider = collect_provider_results(providers, query, limit: limit)
+      ordered_provider_results(results_by_provider)
+    end
+
+    def collect_provider_results(providers, query, limit: nil)
+      results_by_provider = {}
+      queue = Queue.new
+      threads = providers.map do |provider|
+        Thread.new do
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection do
+              queue << [ provider, search_provider(provider, query, limit: limit) ]
+            end
+          end
+        rescue StandardError => e
+          Rails.logger.warn "[MetadataService] #{provider} search failed: #{e.message}"
+          queue << [ provider, [] ]
+        end
+      end
+
+      providers.size.times do
+        provider, results = queue.pop
+        results_by_provider[provider] = results
+      end
+      threads.each(&:join)
+      results_by_provider
+    end
+
+    def ordered_provider_results(results_by_provider)
+      priority = provider_priority
+      priority.flat_map { |provider| results_by_provider[provider] || [] } +
+        results_by_provider.except(*priority).values.flatten
+    end
+
+    def sort_candidates(candidates)
+      priority = provider_priority
+      candidates.sort_by do |candidate|
+        [
+          priority.index(candidate.source.to_s) || priority.size,
+          -candidate.confidence,
+          candidate.title.to_s.downcase,
+          candidate.canonical_key.to_s
+        ]
+      end
     end
 
     def provider_limit(provider, requested_limit)
@@ -207,54 +282,6 @@ class MetadataService
     def fetch_google_books_details(id)
       details = GoogleBooksClient.book(id)
       normalize_google_books_details(details)
-    end
-
-    def normalize_hardcover_result(result)
-      SearchResult.new(
-        source: "hardcover",
-        source_id: result.id.to_s,
-        title: result.title,
-        author: result.author,
-        description: truncate_description(result.description),
-        year: result.release_year,
-        cover_url: result.cover_url,
-        has_audiobook: result.has_audiobook,
-        has_ebook: result.has_ebook,
-        series_name: result.series_name,
-        series_position: result.series_position
-      )
-    end
-
-    def normalize_openlibrary_result(result)
-      SearchResult.new(
-        source: "openlibrary",
-        source_id: result.work_id,
-        title: result.title,
-        author: result.author,
-        description: nil, # OpenLibrary search doesn't return description
-        year: result.first_publish_year,
-        cover_url: result.cover_url(size: :l),
-        has_audiobook: nil, # Unknown from OpenLibrary
-        has_ebook: nil,
-        series_name: nil,
-        series_position: nil
-      )
-    end
-
-    def normalize_google_books_result(result)
-      SearchResult.new(
-        source: "google_books",
-        source_id: result.id,
-        title: result.title,
-        author: result.author,
-        description: truncate_description(result.description),
-        year: result.first_publish_year,
-        cover_url: result.cover_url,
-        has_audiobook: nil,
-        has_ebook: result.has_ebook,
-        series_name: nil,
-        series_position: nil
-      )
     end
 
     def normalize_hardcover_details(details)

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Unified service for fetching book metadata from configured sources
-# Orchestrates Hardcover (primary) and OpenLibrary (fallback) based on settings
+# Orchestrates Hardcover, Google Books, and OpenLibrary based on settings
 class MetadataService
   class Error < StandardError; end
 
@@ -10,6 +10,12 @@ class MetadataService
     :source, :source_id, :title, :author, :description, :year,
     :cover_url, :has_audiobook, :has_ebook, :series_name, :series_position
   ) do
+    SOURCE_NAMES = {
+      "hardcover" => "Hardcover",
+      "google_books" => "Google Books",
+      "openlibrary" => "Open Library"
+    }.freeze
+
     def work_id
       "#{source}:#{source_id}"
     end
@@ -21,6 +27,29 @@ class MetadataService
 
     def cover_id
       nil
+    end
+
+    def source_name
+      SOURCE_NAMES.fetch(source.to_s, source.to_s.titleize)
+    end
+
+    def source_url
+      case source.to_s
+      when "hardcover"
+        "https://hardcover.app/books/#{source_id}" if source_id.present?
+      when "google_books"
+        "https://books.google.com/books?id=#{source_id}" if source_id.present?
+      when "openlibrary"
+        "https://openlibrary.org/works/#{source_id}" if source_id.present?
+      end
+    end
+
+    def source_attribution
+      "Metadata from #{source_name}"
+    end
+
+    def google_books?
+      source.to_s == "google_books"
     end
   end
 
@@ -35,6 +64,8 @@ class MetadataService
       case source
       when "hardcover"
         search_hardcover(query, limit)
+      when "google_books"
+        search_google_books(query, limit)
       when "openlibrary"
         search_openlibrary(query, limit)
       else # "auto"
@@ -51,6 +82,8 @@ class MetadataService
       case source
       when "hardcover"
         fetch_hardcover_details(id)
+      when "google_books"
+        fetch_google_books_details(id)
       when "openlibrary", "OL"
         fetch_openlibrary_details(id)
       else
@@ -65,6 +98,8 @@ class MetadataService
       if HardcoverClient.configured?
         results[:hardcover] = HardcoverClient.test_connection rescue false
       end
+
+      results[:google_books] = GoogleBooksClient.test_connection rescue false
 
       # OpenLibrary doesn't require configuration
       results[:openlibrary] = begin
@@ -85,8 +120,9 @@ class MetadataService
     # Check if any metadata source is available
     def available?
       metadata_source == "openlibrary" ||
+        metadata_source == "google_books" ||
         (metadata_source == "hardcover" && HardcoverClient.configured?) ||
-        (metadata_source == "auto") # OpenLibrary always available as fallback
+        (metadata_source == "auto") # OpenLibrary and Google Books are always available as fallbacks
     end
 
     private
@@ -109,6 +145,14 @@ class MetadataService
       []
     end
 
+    def search_google_books(query, limit)
+      results = GoogleBooksClient.search(query, limit: limit)
+      results.map { |r| normalize_google_books_result(r) }
+    rescue GoogleBooksClient::Error => e
+      Rails.logger.error "[MetadataService] Google Books search failed: #{e.message}"
+      []
+    end
+
     def search_with_fallback(query, limit)
       # Try Hardcover first if configured
       if HardcoverClient.configured?
@@ -121,9 +165,17 @@ class MetadataService
         Rails.logger.info "[MetadataService] No Hardcover results, falling back to OpenLibrary"
       end
 
-      # Fallback to OpenLibrary
+      # Keep OpenLibrary ahead of Google Books to preserve existing work-id matching.
       results = search_openlibrary(query, limit)
-      Rails.logger.info "[MetadataService] Found #{results.size} results from OpenLibrary"
+      if results.any?
+        Rails.logger.info "[MetadataService] Found #{results.size} results from OpenLibrary"
+        return results
+      end
+
+      Rails.logger.info "[MetadataService] No OpenLibrary results, falling back to Google Books"
+
+      results = search_google_books(query, limit)
+      Rails.logger.info "[MetadataService] Found #{results.size} results from Google Books"
       results
     end
 
@@ -135,6 +187,11 @@ class MetadataService
     def fetch_openlibrary_details(work_id)
       work = OpenLibraryClient.work(work_id)
       normalize_openlibrary_work(work)
+    end
+
+    def fetch_google_books_details(id)
+      details = GoogleBooksClient.book(id)
+      normalize_google_books_details(details)
     end
 
     def normalize_hardcover_result(result)
@@ -169,6 +226,22 @@ class MetadataService
       )
     end
 
+    def normalize_google_books_result(result)
+      SearchResult.new(
+        source: "google_books",
+        source_id: result.id,
+        title: result.title,
+        author: result.author,
+        description: truncate_description(result.description),
+        year: result.first_publish_year,
+        cover_url: result.cover_url,
+        has_audiobook: nil,
+        has_ebook: result.has_ebook,
+        series_name: nil,
+        series_position: nil
+      )
+    end
+
     def normalize_hardcover_details(details)
       SearchResult.new(
         source: "hardcover",
@@ -196,6 +269,22 @@ class MetadataService
         cover_url: work.cover_url(size: :l),
         has_audiobook: nil,
         has_ebook: nil,
+        series_name: nil,
+        series_position: nil
+      )
+    end
+
+    def normalize_google_books_details(details)
+      SearchResult.new(
+        source: "google_books",
+        source_id: details.id,
+        title: details.title,
+        author: details.author,
+        description: details.description,
+        year: details.release_year,
+        cover_url: details.cover_url,
+        has_audiobook: nil,
+        has_ebook: details.has_ebook,
         series_name: nil,
         series_position: nil
       )

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -54,23 +54,17 @@ class MetadataService
   end
 
   class << self
-    # Search for books across configured metadata sources
-    # Returns array of SearchResult
+    # Search for books across enabled metadata sources and aggregate duplicates
+    # into Shelfarr candidates.
     def search(query, limit: nil)
-      source = metadata_source
+      providers = enabled_metadata_providers
+      Rails.logger.info "[MetadataService] Searching '#{query}' using providers: #{providers.join(', ')}"
 
-      Rails.logger.info "[MetadataService] Searching '#{query}' using source: #{source}"
-
-      case source
-      when "hardcover"
-        search_hardcover(query, limit)
-      when "google_books"
-        search_google_books(query, limit)
-      when "openlibrary"
-        search_openlibrary(query, limit)
-      else # "auto"
-        search_with_fallback(query, limit)
+      provider_results = providers.flat_map do |provider|
+        search_provider(provider, query, limit)
       end
+
+      MetadataSearch::Aggregator.call(provider_results, priority: provider_priority).first(limit || default_search_limit)
     end
 
     # Get book details by unified work_id (format: "source:id")
@@ -117,66 +111,87 @@ class MetadataService
       SettingsService.get(:metadata_source, default: "auto")
     end
 
+    def enabled_metadata_providers
+      SettingsService.enabled_metadata_providers
+    end
+
+    def provider_priority
+      SettingsService.metadata_provider_priority
+    end
+
     # Check if any metadata source is available
     def available?
-      metadata_source == "openlibrary" ||
-        metadata_source == "google_books" ||
-        (metadata_source == "hardcover" && HardcoverClient.configured?) ||
-        (metadata_source == "auto") # OpenLibrary and Google Books are always available as fallbacks
+      enabled_metadata_providers.any?
     end
 
     private
+
+    def search_provider(provider, query, limit)
+      status = MetadataProviderStatus.for_provider(provider)
+      unless status.available?
+        Rails.logger.info "[MetadataService] Skipping #{provider}: #{status.status}"
+        return []
+      end
+
+      results = send("search_#{provider}", query, provider_limit(provider, limit))
+      status.record_success!
+      results
+    rescue *provider_errors(provider) => e
+      status&.record_failure!(e)
+      Rails.logger.warn "[MetadataService] #{provider} search failed: #{e.message}"
+      []
+    end
+
+    def provider_errors(provider)
+      errors = case provider.to_s
+      when "hardcover"
+        [ HardcoverClient::Error ]
+      when "google_books"
+        [ GoogleBooksClient::Error ]
+      when "openlibrary"
+        [ OpenLibraryClient::Error ]
+      else
+        [ StandardError ]
+      end
+      errors << VCR::Errors::UnhandledHTTPRequestError if defined?(VCR::Errors::UnhandledHTTPRequestError)
+      errors << WebMock::NetConnectNotAllowedError if defined?(WebMock::NetConnectNotAllowedError)
+      errors
+    end
 
     def search_hardcover(query, limit)
       return [] unless HardcoverClient.configured?
 
       results = HardcoverClient.search(query, limit: limit)
-      results.map { |r| normalize_hardcover_result(r) }
-    rescue HardcoverClient::Error => e
-      Rails.logger.error "[MetadataService] Hardcover search failed: #{e.message}"
-      []
+      results.map { |result| MetadataSearch::ResultNormalizer.call("hardcover", result) }
     end
 
     def search_openlibrary(query, limit)
       results = OpenLibraryClient.search(query, limit: limit)
-      results.map { |r| normalize_openlibrary_result(r) }
-    rescue OpenLibraryClient::Error => e
-      Rails.logger.error "[MetadataService] OpenLibrary search failed: #{e.message}"
-      []
+      results.map { |result| MetadataSearch::ResultNormalizer.call("openlibrary", result) }
     end
 
     def search_google_books(query, limit)
       results = GoogleBooksClient.search(query, limit: limit)
-      results.map { |r| normalize_google_books_result(r) }
-    rescue GoogleBooksClient::Error => e
-      Rails.logger.error "[MetadataService] Google Books search failed: #{e.message}"
-      []
+      results.map { |result| MetadataSearch::ResultNormalizer.call("google_books", result) }
     end
 
-    def search_with_fallback(query, limit)
-      # Try Hardcover first if configured
-      if HardcoverClient.configured?
-        results = search_hardcover(query, limit)
-        if results.any?
-          Rails.logger.info "[MetadataService] Found #{results.size} results from Hardcover"
-          return results
-        end
+    def provider_limit(provider, requested_limit)
+      return requested_limit if requested_limit.present?
 
-        Rails.logger.info "[MetadataService] No Hardcover results, falling back to OpenLibrary"
+      case provider.to_s
+      when "hardcover"
+        SettingsService.get(:hardcover_search_limit, default: 10)
+      when "google_books"
+        SettingsService.get(:google_books_search_limit, default: 20)
+      when "openlibrary"
+        SettingsService.get(:open_library_search_limit, default: 20)
+      else
+        default_search_limit
       end
+    end
 
-      # Keep OpenLibrary ahead of Google Books to preserve existing work-id matching.
-      results = search_openlibrary(query, limit)
-      if results.any?
-        Rails.logger.info "[MetadataService] Found #{results.size} results from OpenLibrary"
-        return results
-      end
-
-      Rails.logger.info "[MetadataService] No OpenLibrary results, falling back to Google Books"
-
-      results = search_google_books(query, limit)
-      Rails.logger.info "[MetadataService] Found #{results.size} results from Google Books"
-      results
+    def default_search_limit
+      20
     end
 
     def fetch_hardcover_details(id)

--- a/app/services/open_library_client.rb
+++ b/app/services/open_library_client.rb
@@ -48,6 +48,10 @@ class OpenLibraryClient
   end
 
   class << self
+    def configured?
+      SettingsService.get(:open_library_enabled, default: true)
+    end
+
     # Search for books by query
     # Returns array of SearchResult
     def search(query, limit: nil)
@@ -139,6 +143,20 @@ class OpenLibraryClient
           )
         end
       end
+    end
+
+    def test_connection
+      return false unless configured?
+
+      search("test", limit: 1)
+      true
+    rescue Error => e
+      Rails.logger.error "[OpenLibraryClient] Connection test failed: #{e.message}"
+      false
+    end
+
+    def reset_connection!
+      @connection = nil
     end
 
     # Generate cover image URL

--- a/app/services/request_creation_service.rb
+++ b/app/services/request_creation_service.rb
@@ -30,12 +30,14 @@ class RequestCreationService
     created_requests = []
     warnings = []
     errors = []
+    existing_books_lookup = Book.preload_by_work_ids(source_work_ids)
 
     book_types.each do |book_type|
       duplicate_check = DuplicateDetectionService.check(
         work_id: work_id,
         source_work_ids: source_work_ids,
-        book_type: book_type
+        book_type: book_type,
+        existing_books_lookup: existing_books_lookup
       )
 
       if duplicate_check.block?
@@ -45,7 +47,7 @@ class RequestCreationService
 
       warnings << duplicate_check.message if duplicate_check.warn?
 
-      book = find_or_create_book_for_source(book_type)
+      book = find_or_create_book_for_source(book_type, existing_books_lookup: existing_books_lookup)
       request = build_request(book)
 
       if request.save
@@ -74,8 +76,9 @@ class RequestCreationService
     end.uniq
   end
 
-  def find_or_create_book_for_source(book_type)
-    book = Book.find_or_initialize_by_work_id(work_id, book_type: book_type)
+  def find_or_create_book_for_source(book_type, existing_books_lookup:)
+    book = Book.find_in_lookup(existing_books_lookup, source_work_ids, book_type: book_type)
+    book ||= Book.find_or_initialize_by_work_id(work_id, book_type: book_type)
     source_work_ids.each { |source_work_id| book.assign_work_id(source_work_id) }
     BookMetadataBackfillService.apply!(
       book,

--- a/app/services/request_creation_service.rb
+++ b/app/services/request_creation_service.rb
@@ -13,9 +13,10 @@ class RequestCreationService
     end
   end
 
-  def initialize(user:, work_id:, book_types:, metadata_attrs: {}, notes: nil, language: nil, origin: {})
+  def initialize(user:, work_id:, book_types:, metadata_attrs: {}, notes: nil, language: nil, origin: {}, source_work_ids: nil)
     @user = user
     @work_id = work_id.to_s.strip
+    @source_work_ids = [ @work_id, *Array(source_work_ids) ].compact_blank.map(&:to_s).uniq
     @book_types = normalize_book_types(book_types)
     @metadata_attrs = metadata_attrs.to_h.symbolize_keys
     @notes = notes
@@ -33,6 +34,7 @@ class RequestCreationService
     book_types.each do |book_type|
       duplicate_check = DuplicateDetectionService.check(
         work_id: work_id,
+        source_work_ids: source_work_ids,
         book_type: book_type
       )
 
@@ -59,7 +61,7 @@ class RequestCreationService
 
   private
 
-  attr_reader :user, :work_id, :book_types, :metadata_attrs, :notes, :language, :origin
+  attr_reader :user, :work_id, :source_work_ids, :book_types, :metadata_attrs, :notes, :language, :origin
 
   def failure(message)
     Result.new(created_requests: [], warnings: [], errors: [ message ])
@@ -74,6 +76,7 @@ class RequestCreationService
 
   def find_or_create_book_for_source(book_type)
     book = Book.find_or_initialize_by_work_id(work_id, book_type: book_type)
+    source_work_ids.each { |source_work_id| book.assign_work_id(source_work_id) }
     BookMetadataBackfillService.apply!(
       book,
       work_id: work_id,

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -93,9 +93,11 @@ class SettingsService
     retry_max_delay_days: { type: "integer", default: 7, category: "queue", description: "Maximum delay in days between retries" },
 
     # Open Library
+    open_library_enabled: { type: "boolean", default: true, category: "open_library", description: "Enable Open Library as a metadata provider" },
     open_library_search_limit: { type: "integer", default: 20, category: "open_library", description: "Maximum number of search results to return" },
 
     # Google Books
+    google_books_enabled: { type: "boolean", default: true, category: "google_books", description: "Enable Google Books as a metadata provider" },
     google_books_api_key: { type: "string", default: "", category: "google_books", description: "Optional Google Books API key. Leave blank to use anonymous public access; add a key for dedicated quota and more reliable requests." },
     google_books_search_limit: { type: "integer", default: 20, category: "google_books", description: "Maximum number of Google Books search results to return" },
 
@@ -156,8 +158,10 @@ class SettingsService
     gutenberg_search_limit: { type: "integer", default: 10, category: "gutenberg", description: "Maximum number of Project Gutenberg ebook results to return" },
 
     # Hardcover Integration
+    hardcover_enabled: { type: "boolean", default: true, category: "hardcover", description: "Enable Hardcover as a metadata provider when an API token is configured" },
     hardcover_api_token: { type: "string", default: "", category: "hardcover", description: "API token from Hardcover account settings (hardcover.app/account/api)" },
-    metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Primary metadata source: auto (Hardcover, OpenLibrary, Google Books), hardcover, openlibrary, or google_books" },
+    metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Legacy metadata source selector. Auto uses all enabled providers; selecting a provider restricts metadata search to that provider." },
+    metadata_provider_priority: { type: "string", default: "hardcover,openlibrary,google_books", category: "hardcover", description: "Comma-separated metadata provider priority used when merging duplicate search results." },
     hardcover_search_limit: { type: "integer", default: 10, category: "hardcover", description: "Maximum number of search results from Hardcover" },
 
     # Webhook Notifications
@@ -400,6 +404,22 @@ class SettingsService
       configured?(:hardcover_api_token)
     end
 
+    def metadata_provider_priority
+      providers = normalize_metadata_providers(get(:metadata_provider_priority))
+      providers = default_metadata_provider_priority if providers.empty?
+
+      providers + (default_metadata_provider_priority - providers)
+    end
+
+    def enabled_metadata_providers
+      legacy_source = get(:metadata_source, default: "auto").to_s.strip
+      if metadata_provider_keys.include?(legacy_source) && legacy_source != "auto"
+        return provider_enabled?(legacy_source) ? [ legacy_source ] : []
+      end
+
+      metadata_provider_priority.select { |provider| provider_enabled?(provider) }
+    end
+
     def api_token
       setting = Setting.find_by(key: "api_token")
       return nil unless setting
@@ -463,6 +483,34 @@ class SettingsService
     end
 
     private
+
+    def provider_enabled?(provider)
+      case provider.to_s
+      when "hardcover"
+        get(:hardcover_enabled, default: true) && hardcover_configured?
+      when "google_books"
+        get(:google_books_enabled, default: true)
+      when "openlibrary"
+        get(:open_library_enabled, default: true)
+      else
+        false
+      end
+    end
+
+    def normalize_metadata_providers(value)
+      Array(value).flat_map { |entry| entry.to_s.split(/[,\s]+/) }.filter_map do |provider|
+        normalized = provider.strip.downcase
+        normalized if metadata_provider_keys.include?(normalized)
+      end.uniq
+    end
+
+    def default_metadata_provider_priority
+      %w[hardcover openlibrary google_books]
+    end
+
+    def metadata_provider_keys
+      %w[hardcover openlibrary google_books]
+    end
 
     def raw_setting_value(key)
       setting = Setting.find_by(key: key.to_s)

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -95,6 +95,10 @@ class SettingsService
     # Open Library
     open_library_search_limit: { type: "integer", default: 20, category: "open_library", description: "Maximum number of search results to return" },
 
+    # Google Books
+    google_books_api_key: { type: "string", default: "", category: "google_books", description: "Optional Google Books API key. Leave blank to use anonymous public access; add a key for dedicated quota and more reliable requests." },
+    google_books_search_limit: { type: "integer", default: 20, category: "google_books", description: "Maximum number of Google Books search results to return" },
+
     # Health Monitoring
     health_check_interval: { type: "integer", default: 300, category: "health", description: "Seconds between system health checks (default: 5 minutes)" },
 
@@ -153,7 +157,7 @@ class SettingsService
 
     # Hardcover Integration
     hardcover_api_token: { type: "string", default: "", category: "hardcover", description: "API token from Hardcover account settings (hardcover.app/account/api)" },
-    metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Primary metadata source: auto (Hardcover first, OpenLibrary fallback), hardcover, or openlibrary" },
+    metadata_source: { type: "string", default: "auto", category: "hardcover", description: "Primary metadata source: auto (Hardcover, OpenLibrary, Google Books), hardcover, openlibrary, or google_books" },
     hardcover_search_limit: { type: "integer", default: 10, category: "hardcover", description: "Maximum number of search results from Hardcover" },
 
     # Webhook Notifications
@@ -200,6 +204,7 @@ class SettingsService
     "gutenberg" => "Project Gutenberg",
     "librivox" => "LibriVox",
     "hardcover" => "Hardcover",
+    "google_books" => "Google Books",
     "paths" => "Output Paths",
     "queue" => "Queue Settings",
     "open_library" => "Open Library",

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -11,7 +11,7 @@
     },
     "integrations" => {
       label: "Integrations",
-      categories: %w[audiobookshelf hardcover open_library discord telegram]
+      categories: %w[audiobookshelf hardcover google_books open_library discord telegram]
     },
     "system" => {
       label: "Queue & System",
@@ -108,6 +108,8 @@
                           <p class="mt-1 text-xs text-yellow-500">Enter Audiobookshelf URL and API key above to select from available libraries</p>
                         <% elsif key.to_s == "oidc_default_role" %>
                           <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% elsif key.to_s == "metadata_source" %>
+                          <%= form.select "settings[#{key}]", options_for_select([["Auto", "auto"], ["Hardcover", "hardcover"], ["Google Books", "google_books"], ["Open Library", "openlibrary"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s == "telegram_update_mode" %>
                           <%= form.select "settings[#{key}]", options_for_select([["Polling", "polling"], ["Webhook", "webhook"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s == "discord_webhook_url" %>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -24,17 +24,17 @@
   }
 %>
 
-<%= form_with url: bulk_update_admin_settings_path, method: :patch, data: { settings_form_target: "form" } do |form| %>
-  <div class="flex justify-between items-center mb-6">
-    <h1 class="font-bold text-4xl text-white">Settings</h1>
-    <div class="flex items-center gap-4">
-      <span data-settings-form-target="status" class="text-sm text-gray-500 hidden">Saving...</span>
-      <%= form.submit "Save All", class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
+<div data-controller="settings-tabs" data-settings-tabs-active-value="search">
+  <%= form_with url: bulk_update_admin_settings_path, method: :patch, data: { settings_form_target: "form" } do |form| %>
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="font-bold text-4xl text-white">Settings</h1>
+      <div class="flex items-center gap-4">
+        <span data-settings-form-target="status" class="text-sm text-gray-500 hidden">Saving...</span>
+        <%= form.submit "Save All", class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
+      </div>
     </div>
-  </div>
 
-  <%# Tab navigation %>
-  <div data-controller="settings-tabs" data-settings-tabs-active-value="search">
+    <%# Tab navigation %>
     <div class="border-b border-gray-800 mb-6">
       <nav class="flex gap-1 -mb-px overflow-x-auto" role="tablist">
         <% tab_groups.each do |tab_key, tab_config| %>
@@ -251,6 +251,26 @@
                       <%= link_to "Test Hardcover Connection", test_hardcover_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
                     </div>
                   </div>
+                <% elsif category == "google_books" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test Connection</span>
+                      <p class="text-sm text-gray-500">Verify Google Books search is reachable using the current API key setting</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test Google Books Connection", test_google_books_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
+                <% elsif category == "open_library" %>
+                  <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
+                    <div class="md:w-1/3">
+                      <span class="font-medium text-gray-300">Test Connection</span>
+                      <p class="text-sm text-gray-500">Verify Open Library search is reachable</p>
+                    </div>
+                    <div class="md:w-2/3">
+                      <%= link_to "Test Open Library Connection", test_open_library_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                    </div>
+                  </div>
                 <% elsif category == "zlibrary" %>
                   <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
                     <div class="md:w-1/3">
@@ -329,78 +349,11 @@
         <% end %>
       </div>
     <% end %>
-  </div>
-<% end %>
+  <% end %>
 
-<div class="mt-6 bg-gray-900 rounded-lg border border-gray-800">
-  <div class="px-6 py-4 border-b border-gray-800">
-    <h2 class="font-bold text-xl text-white">Telegram Group Authorization</h2>
-  </div>
-  <div class="p-6 space-y-5">
-    <div class="flex flex-col gap-4 md:flex-row md:items-start">
-      <div class="md:w-1/3">
-        <span class="font-medium text-gray-300">Approve group</span>
-        <p class="text-sm text-gray-500">When an unknown Telegram group messages the bot, Shelfarr replies with a 6-digit code that expires after 2 minutes.</p>
-      </div>
-      <div class="md:w-2/3">
-        <%= form_with url: approve_telegram_chat_admin_settings_path, method: :post, class: "flex flex-col gap-3 sm:flex-row", data: { turbo: false } do |form| %>
-          <%= form.text_field :telegram_group_code, maxlength: 6, inputmode: "numeric", pattern: "\\d{6}", placeholder: "123456", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2" %>
-          <%= form.submit "Authorize Group", class: "rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white cursor-pointer whitespace-nowrap" %>
-        <% end %>
-      </div>
-    </div>
-
-    <% authorizations = @telegram_chat_authorizations || [] %>
-    <% if authorizations.any? %>
-      <div class="space-y-2">
-        <% authorizations.each do |authorization| %>
-          <% telegram_chat_label = authorization.chat_title.presence || authorization.chat_id %>
-          <div class="flex flex-col gap-1 rounded-lg border border-gray-800 bg-gray-950/50 px-4 py-3 md:flex-row md:items-center md:justify-between">
-            <div>
-              <p class="text-sm font-medium text-gray-200"><%= telegram_chat_label %></p>
-              <p class="text-xs text-gray-500"><%= authorization.chat_id %></p>
-            </div>
-            <div class="flex items-center gap-3">
-              <% if authorization.paused? %>
-                <span class="text-sm text-yellow-400">Paused</span>
-              <% elsif authorization.approved? %>
-                <span class="text-sm text-green-400">Authorized</span>
-              <% elsif authorization.expired? %>
-                <span class="text-sm text-gray-500">Expired</span>
-              <% else %>
-                <span class="text-sm text-yellow-400">Pending</span>
-              <% end %>
-
-              <% if authorization.approved? %>
-                <div class="flex items-center gap-1">
-                  <% if authorization.paused? %>
-                    <%= button_to resume_telegram_chat_admin_settings_path(authorization), method: :post, form: { data: { turbo: false } }, class: "inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-green-300", title: "Resume #{telegram_chat_label}", "aria-label": "Resume #{telegram_chat_label}" do %>
-                      <span class="sr-only">Resume <%= telegram_chat_label %></span>
-                      <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                        <path d="M6.5 4.8v10.4c0 .6.7 1 1.2.6l7.2-5.2c.4-.3.4-.9 0-1.2L7.7 4.2c-.5-.4-1.2 0-1.2.6Z" />
-                      </svg>
-                    <% end %>
-                  <% else %>
-                    <%= button_to pause_telegram_chat_admin_settings_path(authorization), method: :post, form: { data: { turbo: false } }, class: "inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-yellow-300", title: "Pause #{telegram_chat_label}", "aria-label": "Pause #{telegram_chat_label}" do %>
-                      <span class="sr-only">Pause <%= telegram_chat_label %></span>
-                      <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                        <path d="M5 4.75C5 4.34 5.34 4 5.75 4h2.5c.41 0 .75.34.75.75v10.5c0 .41-.34.75-.75.75h-2.5a.75.75 0 0 1-.75-.75V4.75Zm6 0c0-.41.34-.75.75-.75h2.5c.41 0 .75.34.75.75v10.5c0 .41-.34.75-.75.75h-2.5a.75.75 0 0 1-.75-.75V4.75Z" />
-                      </svg>
-                    <% end %>
-                  <% end %>
-
-                  <%= button_to delete_telegram_chat_admin_settings_path(authorization), method: :delete, form: { data: { turbo: false, turbo_confirm: "Remove this Telegram group from Shelfarr?" } }, class: "inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-red-300", title: "Delete #{telegram_chat_label}", "aria-label": "Delete #{telegram_chat_label}" do %>
-                    <span class="sr-only">Delete <%= telegram_chat_label %></span>
-                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 7h12M9 7V5h6v2m-8 0 1 13h8l1-13M10 11v6m4-6v6" />
-                    </svg>
-                  <% end %>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+  <div data-settings-tabs-target="panel"
+       data-tab="integrations"
+       class="mt-6">
+    <%= render "admin/settings/telegram_group_authorization" %>
   </div>
 </div>

--- a/app/views/admin/settings/_telegram_group_authorization.html.erb
+++ b/app/views/admin/settings/_telegram_group_authorization.html.erb
@@ -1,0 +1,72 @@
+<div class="bg-gray-900 rounded-lg border border-gray-800">
+  <div class="px-6 py-4 border-b border-gray-800">
+    <h2 class="font-bold text-xl text-white">Telegram Group Authorization</h2>
+  </div>
+  <div class="p-6 space-y-5">
+    <div class="flex flex-col gap-4 md:flex-row md:items-start">
+      <div class="md:w-1/3">
+        <span class="font-medium text-gray-300">Approve group</span>
+        <p class="text-sm text-gray-500">When an unknown Telegram group messages the bot, Shelfarr replies with a 6-digit code that expires after 2 minutes.</p>
+      </div>
+      <div class="md:w-2/3">
+        <%= form_with url: approve_telegram_chat_admin_settings_path, method: :post, class: "flex flex-col gap-3 sm:flex-row", data: { turbo: false } do |form| %>
+          <%= form.text_field :telegram_group_code, maxlength: 6, inputmode: "numeric", pattern: "\\d{6}", placeholder: "123456", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2" %>
+          <%= form.submit "Authorize Group", class: "rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white cursor-pointer whitespace-nowrap" %>
+        <% end %>
+      </div>
+    </div>
+
+    <% authorizations = @telegram_chat_authorizations || [] %>
+    <% if authorizations.any? %>
+      <div class="space-y-2">
+        <% authorizations.each do |authorization| %>
+          <% telegram_chat_label = authorization.chat_title.presence || authorization.chat_id %>
+          <div class="flex flex-col gap-1 rounded-lg border border-gray-800 bg-gray-950/50 px-4 py-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p class="text-sm font-medium text-gray-200"><%= telegram_chat_label %></p>
+              <p class="text-xs text-gray-500"><%= authorization.chat_id %></p>
+            </div>
+            <div class="flex items-center gap-3">
+              <% if authorization.paused? %>
+                <span class="text-sm text-yellow-400">Paused</span>
+              <% elsif authorization.approved? %>
+                <span class="text-sm text-green-400">Authorized</span>
+              <% elsif authorization.expired? %>
+                <span class="text-sm text-gray-500">Expired</span>
+              <% else %>
+                <span class="text-sm text-yellow-400">Pending</span>
+              <% end %>
+
+              <% if authorization.approved? %>
+                <div class="flex items-center gap-1">
+                  <% if authorization.paused? %>
+                    <%= button_to resume_telegram_chat_admin_settings_path(authorization), method: :post, form: { data: { turbo: false } }, class: "inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-green-300", title: "Resume #{telegram_chat_label}", "aria-label": "Resume #{telegram_chat_label}" do %>
+                      <span class="sr-only">Resume <%= telegram_chat_label %></span>
+                      <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                        <path d="M6.5 4.8v10.4c0 .6.7 1 1.2.6l7.2-5.2c.4-.3.4-.9 0-1.2L7.7 4.2c-.5-.4-1.2 0-1.2.6Z" />
+                      </svg>
+                    <% end %>
+                  <% else %>
+                    <%= button_to pause_telegram_chat_admin_settings_path(authorization), method: :post, form: { data: { turbo: false } }, class: "inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-yellow-300", title: "Pause #{telegram_chat_label}", "aria-label": "Pause #{telegram_chat_label}" do %>
+                      <span class="sr-only">Pause <%= telegram_chat_label %></span>
+                      <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                        <path d="M5 4.75C5 4.34 5.34 4 5.75 4h2.5c.41 0 .75.34.75.75v10.5c0 .41-.34.75-.75.75h-2.5a.75.75 0 0 1-.75-.75V4.75Zm6 0c0-.41.34-.75.75-.75h2.5c.41 0 .75.34.75.75v10.5c0 .41-.34.75-.75.75h-2.5a.75.75 0 0 1-.75-.75V4.75Z" />
+                      </svg>
+                    <% end %>
+                  <% end %>
+
+                  <%= button_to delete_telegram_chat_admin_settings_path(authorization), method: :delete, form: { data: { turbo: false, turbo_confirm: "Remove this Telegram group from Shelfarr?" } }, class: "inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-red-300", title: "Delete #{telegram_chat_label}", "aria-label": "Delete #{telegram_chat_label}" do %>
+                    <span class="sr-only">Delete <%= telegram_chat_label %></span>
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 7h12M9 7V5h6v2m-8 0 1 13h8l1-13M10 11v6m4-6v6" />
+                    </svg>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -37,13 +37,16 @@
       <%= hidden_field_tag :author, @author %>
       <%= hidden_field_tag :cover_url, @cover_url %>
       <%= hidden_field_tag :first_publish_year, @first_publish_year %>
+      <% @source_work_ids.each do |source_work_id| %>
+        <%= hidden_field_tag "source_work_ids[]", source_work_id %>
+      <% end %>
 
       <div>
         <label class="block text-sm font-medium text-gray-300 mb-3">Select format(s):</label>
         <div class="grid grid-cols-2 gap-4">
           <%
-            audiobook_check = DuplicateDetectionService.check(work_id: @work_id, book_type: 'audiobook')
-            ebook_check = DuplicateDetectionService.check(work_id: @work_id, book_type: 'ebook')
+            audiobook_check = DuplicateDetectionService.check(work_id: @work_id, source_work_ids: @source_work_ids, book_type: 'audiobook')
+            ebook_check = DuplicateDetectionService.check(work_id: @work_id, source_work_ids: @source_work_ids, book_type: 'ebook')
           %>
 
           <label class="relative flex cursor-pointer rounded-lg border p-4 shadow-sm focus:outline-none <%= audiobook_check.block? ? 'bg-gray-800/50 border-gray-700 opacity-60 cursor-not-allowed' : 'bg-gray-800 border-gray-700 hover:border-purple-500' %>" data-format="audiobook">

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -48,6 +48,15 @@
             <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium <%= request_status_color(@request.status) %>">
               <%= @request.status.humanize %>
             </span>
+            <% if @request.book.metadata_source_name.present? %>
+              <% if @request.book.metadata_source_url.present? %>
+                <%= link_to @request.book.metadata_source_name, @request.book.metadata_source_url, target: "_blank", rel: "noopener", title: @request.book.metadata_source_attribution, class: "inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-white" %>
+              <% else %>
+                <span title="<%= @request.book.metadata_source_attribution %>" class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-800 text-gray-300">
+                  <%= @request.book.metadata_source_name %>
+                </span>
+              <% end %>
+            <% end %>
           </div>
 
           <% if @request.book.year.present? %>

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -1,5 +1,6 @@
 <%
   audiobookshelf_matches ||= []
+  existing_books_lookup ||= {}
   result_sources = if result.respond_to?(:sources)
     Array(result.sources)
   else
@@ -8,9 +9,8 @@
   source_work_ids = result_sources.filter_map { |source| source[:work_id] }
   source_work_ids = [ result.work_id ] if source_work_ids.blank?
 
-  # Check if this book already exists in our system
-  existing_audiobook = Book.find_by_any_work_id(source_work_ids, book_type: :audiobook)
-  existing_ebook = Book.find_by_any_work_id(source_work_ids, book_type: :ebook)
+  existing_audiobook = Book.find_in_lookup(existing_books_lookup, source_work_ids, book_type: :audiobook)
+  existing_ebook = Book.find_in_lookup(existing_books_lookup, source_work_ids, book_type: :ebook)
 
   audiobook_status = if existing_audiobook&.acquired?
     :acquired

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -1,9 +1,16 @@
 <%
   audiobookshelf_matches ||= []
+  result_sources = if result.respond_to?(:sources)
+    Array(result.sources)
+  else
+    [ { source_name: result.source_name, source_url: result.source_url, work_id: result.work_id } ]
+  end
+  source_work_ids = result_sources.filter_map { |source| source[:work_id] }
+  source_work_ids = [ result.work_id ] if source_work_ids.blank?
 
   # Check if this book already exists in our system
-  existing_audiobook = Book.find_by_work_id(result.work_id, book_type: :audiobook)
-  existing_ebook = Book.find_by_work_id(result.work_id, book_type: :ebook)
+  existing_audiobook = Book.find_by_any_work_id(source_work_ids, book_type: :audiobook)
+  existing_ebook = Book.find_by_any_work_id(source_work_ids, book_type: :ebook)
 
   audiobook_status = if existing_audiobook&.acquired?
     :acquired
@@ -101,6 +108,7 @@
             author: result.author,
             cover_url: result.cover_url,
             first_publish_year: result.first_publish_year,
+            source_work_ids: source_work_ids,
             book_type: 'audiobook'
           ), class: "flex items-center justify-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium bg-purple-600 hover:bg-purple-500 text-white transition-colors" do %>
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -117,6 +125,7 @@
             author: result.author,
             cover_url: result.cover_url,
             first_publish_year: result.first_publish_year,
+            source_work_ids: source_work_ids,
             book_type: 'ebook'
           ), class: "flex items-center justify-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors" do %>
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -141,13 +150,15 @@
 
   <%# Title & Author (always visible) %>
   <div class="p-3 bg-gray-900">
-    <div class="mb-2">
-      <% if result.source_url.present? %>
-        <%= link_to result.source_name, result.source_url, target: "_blank", rel: "noopener", title: result.source_attribution, class: "inline-flex max-w-full items-center rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-400 transition hover:border-gray-500 hover:text-gray-200" %>
-      <% else %>
-        <span title="<%= result.source_attribution %>" class="inline-flex max-w-full items-center rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-400">
-          <%= result.source_name %>
-        </span>
+    <div class="mb-2 flex flex-wrap gap-1">
+      <% result_sources.each do |source| %>
+        <% if source[:source_url].present? %>
+          <%= link_to source[:source_name], source[:source_url], target: "_blank", rel: "noopener", title: "Metadata from #{source[:source_name]}", class: "inline-flex max-w-full items-center rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-400 transition hover:border-gray-500 hover:text-gray-200" %>
+        <% else %>
+          <span title="Metadata from <%= source[:source_name] %>" class="inline-flex max-w-full items-center rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-400">
+            <%= source[:source_name] %>
+          </span>
+        <% end %>
       <% end %>
     </div>
     <h3 class="font-semibold text-white text-sm leading-tight line-clamp-2"><%= result.title %></h3>

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -141,6 +141,15 @@
 
   <%# Title & Author (always visible) %>
   <div class="p-3 bg-gray-900">
+    <div class="mb-2">
+      <% if result.source_url.present? %>
+        <%= link_to result.source_name, result.source_url, target: "_blank", rel: "noopener", title: result.source_attribution, class: "inline-flex max-w-full items-center rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-400 transition hover:border-gray-500 hover:text-gray-200" %>
+      <% else %>
+        <span title="<%= result.source_attribution %>" class="inline-flex max-w-full items-center rounded-full border border-gray-700 bg-gray-950 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-400">
+          <%= result.source_name %>
+        </span>
+      <% end %>
+    </div>
     <h3 class="font-semibold text-white text-sm leading-tight line-clamp-2"><%= result.title %></h3>
     <% if result.author.present? %>
       <p class="text-xs text-gray-400 mt-1 truncate"><%= result.author %></p>

--- a/app/views/search/_results.html.erb
+++ b/app/views/search/_results.html.erb
@@ -2,6 +2,17 @@
   <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4 text-red-400">
     <%= @error %>
   </div>
+<% elsif @results.blank? && @search_loading %>
+  <div class="text-center py-16">
+    <svg class="mx-auto h-16 w-16 mb-4 animate-spin text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+    <p class="text-lg font-medium text-gray-400">Searching metadata providers</p>
+    <% if @search_pending_provider_names.present? %>
+      <p class="text-sm mt-1 text-gray-500">Waiting for <%= @search_pending_provider_names.to_sentence %></p>
+    <% end %>
+  </div>
 <% elsif @results.blank? %>
   <div class="text-center py-16">
     <svg class="mx-auto h-16 w-16 mb-4 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -12,15 +23,31 @@
   </div>
 <% else %>
   <div class="mb-6 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-    <p class="text-sm text-gray-500"><%= @results.size %> result<%= @results.size == 1 ? '' : 's' %> for "<span class="font-medium text-gray-300"><%= @query %></span>"</p>
-    <% if @results.any?(&:google_books?) %>
-      <p class="text-xs font-medium text-gray-500">Powered by Google</p>
-    <% end %>
+    <div>
+      <p class="text-sm text-gray-500"><%= @results.size %> result<%= @results.size == 1 ? '' : 's' %> for "<span class="font-medium text-gray-300"><%= @query %></span>"</p>
+      <% if @search_loading && @search_pending_provider_names.present? %>
+        <p class="mt-1 text-xs text-gray-600">Still checking <%= @search_pending_provider_names.to_sentence %></p>
+      <% end %>
+    </div>
+    <div class="flex items-center gap-3">
+      <% if @search_loading %>
+        <span class="inline-flex items-center gap-2 text-xs font-medium text-blue-400">
+          <svg class="h-3 w-3 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          Updating
+        </span>
+      <% end %>
+      <% if @results.any?(&:google_books?) %>
+        <p class="text-xs font-medium text-gray-500">Powered by Google</p>
+      <% end %>
+    </div>
   </div>
 
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
     <% @results.each_with_index do |result, index| %>
-      <%= render "result_card", result: result, audiobookshelf_matches: Array(@audiobookshelf_matches)[index] %>
+      <%= render "result_card", result: result, audiobookshelf_matches: Array(@audiobookshelf_matches)[index], existing_books_lookup: @existing_books_lookup %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/search/_results.html.erb
+++ b/app/views/search/_results.html.erb
@@ -11,7 +11,12 @@
     <p class="text-sm mt-1 text-gray-500">Try different keywords or check your spelling</p>
   </div>
 <% else %>
-  <p class="text-sm text-gray-500 mb-6"><%= @results.size %> result<%= @results.size == 1 ? '' : 's' %> for "<span class="font-medium text-gray-300"><%= @query %></span>"</p>
+  <div class="mb-6 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+    <p class="text-sm text-gray-500"><%= @results.size %> result<%= @results.size == 1 ? '' : 's' %> for "<span class="font-medium text-gray-300"><%= @query %></span>"</p>
+    <% if @results.any?(&:google_books?) %>
+      <p class="text-xs font-medium text-gray-500">Powered by Google</p>
+    <% end %>
+  </div>
 
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
     <% @results.each_with_index do |result, index| %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,7 @@
 <div class="mx-auto max-w-6xl">
   <h1 class="font-bold text-3xl mb-6 text-white">Search Books</h1>
 
-  <div data-controller="search" data-search-url-value="<%= search_results_path %>" data-search-debounce-value="700">
+  <div data-controller="search" data-search-url-value="<%= search_results_path %>" data-search-stream-url-value="<%= search_results_stream_path %>" data-search-debounce-value="700">
     <div class="relative mb-8">
       <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
         <svg class="h-5 w-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   # Search
   get "search", to: "search#index"
   get "search/results", to: "search#results"
+  get "search/results/stream", to: "search#stream_results"
 
   # Library
   resources :library, only: [ :index, :show, :destroy ] do
@@ -116,6 +117,8 @@ Rails.application.routes.draw do
         post :test_gutenberg
         post :test_librivox
         post :test_hardcover
+        post :test_google_books
+        post :test_open_library
         post :test_oidc
         post :test_webhook
         post :test_discord

--- a/db/migrate/20260615000000_add_google_books_id_to_books.rb
+++ b/db/migrate/20260615000000_add_google_books_id_to_books.rb
@@ -1,0 +1,6 @@
+class AddGoogleBooksIdToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :google_books_id, :string
+    add_index :books, :google_books_id
+  end
+end

--- a/db/migrate/20260615120000_create_metadata_provider_statuses.rb
+++ b/db/migrate/20260615120000_create_metadata_provider_statuses.rb
@@ -1,0 +1,16 @@
+class CreateMetadataProviderStatuses < ActiveRecord::Migration[8.1]
+  def change
+    create_table :metadata_provider_statuses do |t|
+      t.string :provider, null: false
+      t.string :status, null: false, default: "unknown"
+      t.datetime :rate_limited_until
+      t.string :last_error
+      t.datetime :last_success_at
+      t.datetime :last_failure_at
+      t.integer :failure_count, default: 0, null: false
+      t.timestamps
+    end
+
+    add_index :metadata_provider_statuses, :provider, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -171,6 +171,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_000000) do
     t.index ["library_id"], name: "index_library_items_on_library_id"
     t.index ["missing"], name: "index_library_items_on_missing"
     t.index ["synced_at"], name: "index_library_items_on_synced_at"
+  end
+
+  create_table "metadata_provider_statuses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "failure_count", default: 0, null: false
+    t.string "last_error"
+    t.datetime "last_failure_at"
+    t.datetime "last_success_at"
+    t.string "provider", null: false
+    t.datetime "rate_limited_until"
+    t.string "status", default: "unknown", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider"], name: "index_metadata_provider_statuses_on_provider", unique: true
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_000000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_120000) do
     t.datetime "created_at", null: false
     t.text "description"
     t.string "file_path"
+    t.string "google_books_id"
     t.string "hardcover_id"
     t.string "isbn"
     t.string "language", default: "en"
@@ -83,6 +84,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_120000) do
     t.datetime "updated_at", null: false
     t.integer "year"
     t.index ["book_type"], name: "index_books_on_book_type"
+    t.index ["google_books_id"], name: "index_books_on_google_books_id"
     t.index ["hardcover_id"], name: "index_books_on_hardcover_id"
     t.index ["isbn"], name: "index_books_on_isbn"
     t.index ["open_library_edition_id"], name: "index_books_on_open_library_edition_id"

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -9,6 +9,8 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     AudiobookshelfClient.reset_connection!
     ProwlarrClient.reset_connection!
     FlaresolverrClient.reset_connection!
+    GoogleBooksClient.reset_connection!
+    OpenLibraryClient.reset_connection!
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
   end
 
@@ -16,6 +18,8 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     AudiobookshelfClient.reset_connection!
     ProwlarrClient.reset_connection!
     FlaresolverrClient.reset_connection!
+    GoogleBooksClient.reset_connection!
+    OpenLibraryClient.reset_connection!
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
   end
 
@@ -31,6 +35,20 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Settings"
   end
 
+  test "index shows telegram group authorization only in integrations tab" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "[data-settings-tabs-target='panel'][data-tab='integrations'] h2",
+      text: "Telegram Group Authorization",
+      count: 1
+    %w[search downloads system security].each do |tab|
+      assert_select "[data-settings-tabs-target='panel'][data-tab='#{tab}'] h2",
+        text: "Telegram Group Authorization",
+        count: 0
+    end
+  end
+
   test "index shows indexer provider dropdown" do
     get admin_settings_url
 
@@ -41,6 +59,14 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "option[value='newznab']", text: "NZBHydra2 / Newznab"
     assert_select "input[name='settings[newznab_url]']"
     assert_select "input[name='settings[newznab_api_key]']"
+  end
+
+  test "index shows google books and open library test buttons" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "a[href='#{test_google_books_admin_settings_path}']", text: "Test Google Books Connection"
+    assert_select "a[href='#{test_open_library_admin_settings_path}']", text: "Test Open Library Connection"
   end
 
   test "index warns when disabling authentication is enabled" do
@@ -1357,6 +1383,135 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_settings_path
     assert_match /hard boom/, flash[:alert]
+  end
+
+  test "test_google_books fails when disabled" do
+    SettingsService.set(:google_books_enabled, false)
+
+    post test_google_books_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match /not enabled/i, flash[:alert]
+  end
+
+  test "test_google_books succeeds when connection works" do
+    SettingsService.set(:google_books_enabled, true)
+
+    GoogleBooksClient.stub(:test_connection, true) do
+      post test_google_books_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /successful/i, flash[:notice]
+  end
+
+  test "test_google_books marks provider healthy after success" do
+    SettingsService.set(:google_books_enabled, true)
+    MetadataProviderStatus.create!(provider: "google_books", status: "auth_failed", last_error: "bad key")
+
+    GoogleBooksClient.stub(:test_connection, true) do
+      post test_google_books_admin_settings_url
+    end
+
+    assert_equal "healthy", MetadataProviderStatus.for_provider("google_books").status
+    assert_nil MetadataProviderStatus.for_provider("google_books").last_error
+  end
+
+  test "bulk update of google books api key clears auth failed provider status" do
+    MetadataProviderStatus.create!(provider: "google_books", status: "auth_failed", last_error: "bad key")
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        google_books_api_key: "new-key"
+      }
+    }
+
+    status = MetadataProviderStatus.for_provider("google_books")
+    assert_equal "unknown", status.status
+    assert_nil status.last_error
+  end
+
+  test "bulk update of metadata provider priority clears all provider status" do
+    MetadataProviderStatus.create!(provider: "hardcover", status: "auth_failed", last_error: "bad token")
+    MetadataProviderStatus.create!(provider: "google_books", status: "rate_limited", last_error: "quota", rate_limited_until: 5.minutes.from_now)
+    MetadataProviderStatus.create!(provider: "openlibrary", status: "down", last_error: "timeout")
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        metadata_provider_priority: "google_books,openlibrary,hardcover"
+      }
+    }
+
+    %w[hardcover google_books openlibrary].each do |provider|
+      status = MetadataProviderStatus.for_provider(provider)
+      assert_equal "unknown", status.status
+      assert_nil status.last_error
+      assert_nil status.rate_limited_until
+    end
+  end
+
+  test "test_google_books fails when connection fails" do
+    SettingsService.set(:google_books_enabled, true)
+
+    GoogleBooksClient.stub(:test_connection, false) do
+      post test_google_books_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /failed/i, flash[:alert]
+  end
+
+  test "test_google_books reports client errors" do
+    SettingsService.set(:google_books_enabled, true)
+
+    GoogleBooksClient.stub(:test_connection, -> { raise GoogleBooksClient::Error, "google boom" }) do
+      post test_google_books_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /google boom/, flash[:alert]
+  end
+
+  test "test_open_library fails when disabled" do
+    SettingsService.set(:open_library_enabled, false)
+
+    post test_open_library_admin_settings_url
+
+    assert_redirected_to admin_settings_path
+    assert_match /not enabled/i, flash[:alert]
+  end
+
+  test "test_open_library succeeds when connection works" do
+    SettingsService.set(:open_library_enabled, true)
+
+    OpenLibraryClient.stub(:test_connection, true) do
+      post test_open_library_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /successful/i, flash[:notice]
+  end
+
+  test "test_open_library fails when connection fails" do
+    SettingsService.set(:open_library_enabled, true)
+
+    OpenLibraryClient.stub(:test_connection, false) do
+      post test_open_library_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /failed/i, flash[:alert]
+  end
+
+  test "test_open_library reports client errors" do
+    SettingsService.set(:open_library_enabled, true)
+
+    OpenLibraryClient.stub(:test_connection, -> { raise OpenLibraryClient::Error, "open boom" }) do
+      post test_open_library_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match /open boom/, flash[:alert]
   end
 
   test "test_flaresolverr returns turbo stream when requested" do

--- a/test/controllers/api/v1/requests_controller_test.rb
+++ b/test/controllers/api/v1/requests_controller_test.rb
@@ -29,6 +29,43 @@ class API::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "api", body.dig("requests", 0, "request", "external_source")
   end
 
+  test "creates request with all candidate source work ids" do
+    assert_difference [ "Book.count", "Request.count" ], 1 do
+      post api_v1_requests_path,
+        headers: { "Authorization" => "Bearer apitoken" },
+        params: {
+          username: @user.username,
+          work_id: "openlibrary:OL_API_MULTI_SOURCE_W",
+          source_work_ids: [ "openlibrary:OL_API_MULTI_SOURCE_W", "google_books:gb-api-source" ],
+          book_type: "ebook",
+          title: "API Multi Source Book"
+        }
+    end
+
+    assert_response :created
+    book = Request.last.book
+    assert_equal "OL_API_MULTI_SOURCE_W", book.open_library_work_id
+    assert_equal "gb-api-source", book.google_books_id
+  end
+
+  test "blocks API request when alternate candidate source has active request" do
+    book = Book.create!(title: "Existing Google API Book", book_type: :ebook, google_books_id: "gb-api-existing")
+    Request.create!(book: book, user: @user, status: :pending)
+
+    post api_v1_requests_path,
+      headers: { "Authorization" => "Bearer apitoken" },
+      params: {
+        username: @user.username,
+        work_id: "openlibrary:OL_API_NEW_SOURCE_W",
+        source_work_ids: [ "google_books:gb-api-existing" ],
+        book_type: "ebook",
+        title: "Existing Google API Book"
+      }
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "already has an active request"
+  end
+
   test "creates a request for the scoped token user when no user is supplied" do
     _token, raw = APIToken.issue!(
       name: "Requester",

--- a/test/controllers/api/v1/search_controller_test.rb
+++ b/test/controllers/api/v1/search_controller_test.rb
@@ -32,6 +32,8 @@ class API::V1::SearchControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert_equal "openlibrary:OL_API_SEARCH_123W", body.dig("results", 0, "work_id")
     assert_equal "API Search Book", body.dig("results", 0, "title")
+    assert_equal "Open Library", body.dig("results", 0, "source_name")
+    assert_equal "https://openlibrary.org/works/OL_API_SEARCH_123W", body.dig("results", 0, "source_url")
   end
 
   test "requires a query" do

--- a/test/controllers/api/v1/search_controller_test.rb
+++ b/test/controllers/api/v1/search_controller_test.rb
@@ -36,6 +36,43 @@ class API::V1::SearchControllerTest < ActionDispatch::IntegrationTest
     assert_equal "https://openlibrary.org/works/OL_API_SEARCH_123W", body.dig("results", 0, "source_url")
   end
 
+  test "returns aggregated candidate fields" do
+    candidate = MetadataSearch::Candidate.new(
+      canonical_key: "isbn:9780547928227",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      year: 1937,
+      description: nil,
+      cover_url: nil,
+      series_name: nil,
+      series_position: nil,
+      has_ebook: true,
+      has_audiobook: nil,
+      confidence: 100,
+      editions: [ { source: "google_books", source_id: "gb123", isbn_13: "9780547928227" } ],
+      sources: [
+        { source: "openlibrary", source_id: "OL123W", source_name: "Open Library", source_url: "https://openlibrary.org/works/OL123W", work_id: "openlibrary:OL123W" },
+        { source: "google_books", source_id: "gb123", source_name: "Google Books", source_url: "https://books.google.com/books?id=gb123", work_id: "google_books:gb123" }
+      ]
+    )
+
+    MetadataService.stub(:search, [ candidate ]) do
+      get api_v1_search_path,
+        headers: { "Authorization" => "Bearer apitoken" },
+        params: { q: "hobbit" }
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    payload = body.fetch("results").first
+    assert_equal "isbn:9780547928227", payload["canonical_key"]
+    assert_equal "openlibrary:OL123W", payload["work_id"]
+    assert_equal "openlibrary", payload["source"]
+    assert_equal [ "openlibrary", "google_books" ], payload.fetch("sources").map { |source| source["source"] }
+    assert_equal 1, payload.fetch("editions").size
+    assert_equal 100, payload["confidence"]
+  end
+
   test "requires a query" do
     get api_v1_search_path,
       headers: { "Authorization" => "Bearer apitoken" }

--- a/test/controllers/integrations/telegram_webhooks_controller_test.rb
+++ b/test/controllers/integrations/telegram_webhooks_controller_test.rb
@@ -4,6 +4,9 @@ require "test_helper"
 
 class Integrations::TelegramWebhooksControllerTest < ActionDispatch::IntegrationTest
   setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+
     SettingsService.set(:telegram_enabled, true)
     SettingsService.set(:telegram_update_mode, "webhook")
     SettingsService.set(:telegram_bot_token, "telegram-token")
@@ -12,6 +15,10 @@ class Integrations::TelegramWebhooksControllerTest < ActionDispatch::Integration
     SettingsService.set(:telegram_allowed_chat_ids, "-100123")
     SettingsService.set(:telegram_request_username, "userone")
     @user = users(:one)
+  end
+
+  teardown do
+    Rails.cache = @original_cache
   end
 
   test "ignores webhook delivery while Telegram is in polling mode" do
@@ -179,6 +186,46 @@ class Integrations::TelegramWebhooksControllerTest < ActionDispatch::Integration
     assert_response :success
     assert_equal 1, TelegramUpdate.where(update_id: "999").count
     assert_empty response.body
+  end
+
+  test "creates requests from cached inline callback query with source work ids" do
+    book = Book.create!(
+      title: "Existing Google Book",
+      book_type: :ebook,
+      google_books_id: "gb-telegram-cache"
+    )
+    Request.create!(book: book, user: @user, status: :pending)
+
+    candidate = MetadataSearch::Candidate.new(
+      canonical_key: "openlibrary:OL_TELEGRAM_CACHE_W",
+      title: "Existing Google Book",
+      author: "Author",
+      year: 2024,
+      description: nil,
+      cover_url: nil,
+      series_name: nil,
+      series_position: nil,
+      has_ebook: nil,
+      has_audiobook: nil,
+      sources: [
+        { source: "openlibrary", source_id: "OL_TELEGRAM_CACHE_W", source_name: "Open Library", source_url: nil, work_id: "openlibrary:OL_TELEGRAM_CACHE_W" },
+        { source: "google_books", source_id: "gb-telegram-cache", source_name: "Google Books", source_url: nil, work_id: "google_books:gb-telegram-cache" }
+      ],
+      editions: [],
+      confidence: 90
+    )
+    token = Integrations::Telegram::SearchResultCache.store(candidate)
+
+    assert_no_difference "Request.count" do
+      post integrations_telegram_webhook_path,
+        headers: { "X-Telegram-Bot-Api-Secret-Token" => "telegram-secret" },
+        params: telegram_callback("req|#{token}|ebook"),
+        as: :json
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_includes body["text"], "already has an active request"
   end
 
   test "creates requests from inline callback query" do

--- a/test/controllers/search_controller_rendering_test.rb
+++ b/test/controllers/search_controller_rendering_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchControllerRenderingTest < ActionController::TestCase
+  tests SearchController
+
+  setup do
+    @request.host = "www.example.com"
+  end
+
+  test "render_search_results_stream renders loading provider names" do
+    @controller.instance_variable_set(:@query, "dune")
+
+    html = @controller.send(
+      :render_search_results_stream,
+      results: [],
+      loading: true,
+      pending_providers: %w[openlibrary google_books],
+      completed_providers: [],
+      error: nil
+    )
+
+    assert_includes html, "Searching metadata providers"
+    assert_includes html, "Waiting for Open Library and Google Books"
+  end
+
+  test "render_search_results_stream renders result update state" do
+    @controller.instance_variable_set(:@query, "dune")
+
+    html = @controller.send(
+      :render_search_results_stream,
+      results: [ candidate ],
+      loading: true,
+      pending_providers: %w[google_books],
+      completed_providers: %w[openlibrary],
+      error: nil
+    )
+
+    assert_includes html, "1 result"
+    assert_includes html, "Still checking Google Books"
+    assert_includes html, "Updating"
+    assert_includes html, "Open Library"
+  end
+
+  test "render_search_results_stream renders errors" do
+    @controller.instance_variable_set(:@query, "dune")
+
+    html = @controller.send(
+      :render_search_results_stream,
+      results: [],
+      loading: false,
+      pending_providers: [],
+      completed_providers: [],
+      error: "Search failed. Please try again."
+    )
+
+    assert_includes html, "Search failed. Please try again."
+  end
+
+  test "audiobookshelf_matches_for returns placeholders without library items" do
+    LibraryItem.destroy_all
+
+    matches = @controller.send(:audiobookshelf_matches_for, [ candidate ])
+
+    assert_equal [ [] ], matches
+  end
+
+  test "provider_names humanizes known and unknown providers" do
+    assert_equal(
+      [ "Open Library", "Google Books", "Custom Provider" ],
+      @controller.send(:provider_names, %w[openlibrary google_books custom_provider])
+    )
+  end
+
+  private
+
+  def candidate
+    MetadataSearch::Candidate.new(
+      canonical_key: "openlibrary:OL_DUNE_W",
+      title: "Dune",
+      author: "Frank Herbert",
+      year: 1965,
+      description: nil,
+      cover_url: nil,
+      series_name: nil,
+      series_position: nil,
+      has_ebook: nil,
+      has_audiobook: nil,
+      sources: [
+        {
+          source: "openlibrary",
+          source_id: "OL_DUNE_W",
+          source_name: "Open Library",
+          source_url: "https://openlibrary.org/works/OL_DUNE_W",
+          work_id: "openlibrary:OL_DUNE_W"
+        }
+      ],
+      editions: [],
+      confidence: 70
+    )
+  end
+end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -6,6 +6,29 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
     sign_in_as(@user)
+    @original_metadata_source = SettingsService.get(:metadata_source)
+    @original_metadata_provider_priority = SettingsService.get(:metadata_provider_priority)
+    @original_hardcover_api_token = SettingsService.get(:hardcover_api_token)
+    @original_hardcover_enabled = SettingsService.get(:hardcover_enabled)
+    @original_google_books_enabled = SettingsService.get(:google_books_enabled)
+    @original_open_library_enabled = SettingsService.get(:open_library_enabled)
+    MetadataProviderStatus.delete_all
+    HardcoverClient.reset_connection!
+    GoogleBooksClient.reset_connection!
+    OpenLibraryClient.reset_connection!
+  end
+
+  teardown do
+    SettingsService.set(:metadata_source, @original_metadata_source || "auto")
+    SettingsService.set(:metadata_provider_priority, @original_metadata_provider_priority || "hardcover,openlibrary,google_books")
+    SettingsService.set(:hardcover_api_token, @original_hardcover_api_token.to_s)
+    SettingsService.set(:hardcover_enabled, @original_hardcover_enabled.nil? ? true : @original_hardcover_enabled)
+    SettingsService.set(:google_books_enabled, @original_google_books_enabled.nil? ? true : @original_google_books_enabled)
+    SettingsService.set(:open_library_enabled, @original_open_library_enabled.nil? ? true : @original_open_library_enabled)
+    MetadataProviderStatus.delete_all
+    HardcoverClient.reset_connection!
+    GoogleBooksClient.reset_connection!
+    OpenLibraryClient.reset_connection!
   end
 
   test "index requires authentication" do
@@ -19,6 +42,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "input[type='text']"
     assert_select "[data-controller='search'][data-search-debounce-value='700']"
+    assert_select "[data-search-stream-url-value='#{search_results_stream_path}']"
   end
 
   test "results returns search results" do
@@ -43,6 +67,24 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
         assert_match "turbo-stream", response.body
       end
     end
+  end
+
+  test "results renders connection error message" do
+    MetadataService.stub(:search, ->(_) { raise GoogleBooksClient::ConnectionError, "network down" }) do
+      get search_results_path, params: { q: "fiction" }
+    end
+
+    assert_response :success
+    assert_match "Unable to connect to metadata service", response.body
+  end
+
+  test "results renders generic metadata error message" do
+    MetadataService.stub(:search, ->(_) { raise GoogleBooksClient::Error, "api down" }) do
+      get search_results_path, params: { q: "fiction" }
+    end
+
+    assert_response :success
+    assert_match "Search failed. Please try again.", response.body
   end
 
   test "results shows related titles when matching audiobookshelf items exist" do
@@ -77,6 +119,136 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_match "Likely match", response.body
     assert_match "There and Back Again", response.body
     assert_match "Andy Serkis", response.body
+  end
+
+  test "results aggregates mocked hardcover google books and open library responses" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:metadata_provider_priority, "hardcover,openlibrary,google_books")
+    SettingsService.set(:hardcover_enabled, true)
+    SettingsService.set(:hardcover_api_token, "test-token")
+    SettingsService.set(:open_library_enabled, true)
+    SettingsService.set(:google_books_enabled, true)
+    HardcoverClient.reset_connection!
+    GoogleBooksClient.reset_connection!
+    OpenLibraryClient.reset_connection!
+
+    query = "three provider book"
+
+    VCR.turned_off do
+      stub_hardcover_search([
+        {
+          "id" => 101,
+          "title" => "Three Provider Book",
+          "author_names" => [ "Ada Writer" ],
+          "description" => "Hardcover description",
+          "release_year" => 2024,
+          "cached_image" => "https://images.example/hardcover.jpg",
+          "has_audiobook" => true,
+          "has_ebook" => false
+        }
+      ])
+      stub_openlibrary_search(query, [
+        {
+          "key" => "/works/OL_THREE_W",
+          "title" => "Three Provider Book",
+          "author_name" => [ "Ada Writer" ],
+          "first_publish_year" => 2024,
+          "cover_i" => 12345,
+          "edition_count" => 7
+        }
+      ])
+      stub_google_books_search(query, [
+        google_books_item("gb-three", "Three Provider Book", "Ada Writer", published_date: "2024-01-05")
+      ])
+
+      get search_results_path, params: { q: query }
+    end
+
+    assert_response :success
+    assert_select "p", text: /1 result for/
+    assert_select "h3", text: "Three Provider Book", count: 1
+    assert_select "a", text: "Hardcover", count: 1
+    assert_select "a", text: "Open Library", count: 1
+    assert_select "a", text: "Google Books", count: 1
+    assert_match "Powered by Google", response.body
+  end
+
+  test "stream_results accepts streaming search requests" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:metadata_provider_priority, "hardcover,openlibrary,google_books")
+    SettingsService.set(:hardcover_enabled, true)
+    SettingsService.set(:hardcover_api_token, "test-token")
+    SettingsService.set(:open_library_enabled, true)
+    SettingsService.set(:google_books_enabled, true)
+    HardcoverClient.reset_connection!
+    GoogleBooksClient.reset_connection!
+    OpenLibraryClient.reset_connection!
+
+    query = "streamed provider book"
+
+    VCR.turned_off do
+      stub_hardcover_search([
+        {
+          "id" => 202,
+          "title" => "Streamed Provider Book",
+          "author_names" => [ "Ada Writer" ],
+          "description" => "Hardcover description",
+          "release_year" => 2025,
+          "cached_image" => "https://images.example/streamed.jpg",
+          "has_audiobook" => true,
+          "has_ebook" => false
+        }
+      ])
+      stub_openlibrary_search(query, [
+        {
+          "key" => "/works/OL_STREAMED_W",
+          "title" => "Streamed Provider Book",
+          "author_name" => [ "Ada Writer" ],
+          "first_publish_year" => 2025,
+          "cover_i" => 67890,
+          "edition_count" => 3
+        }
+      ])
+      stub_google_books_search(query, [
+        google_books_item("gb-streamed", "Streamed Provider Book", "Ada Writer", published_date: "2025-02-03")
+      ])
+
+      get search_results_stream_path, params: { q: query }
+    end
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+  end
+
+  test "stream_results handles blank query" do
+    get search_results_stream_path, params: { q: "" }
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+  end
+
+  test "stream_results handles no enabled providers" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:hardcover_enabled, false)
+    SettingsService.set(:open_library_enabled, false)
+    SettingsService.set(:google_books_enabled, false)
+
+    get search_results_stream_path, params: { q: "fiction" }
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+  end
+
+  test "stream_results handles provider thread failures" do
+    SettingsService.set(:metadata_source, "openlibrary")
+    SettingsService.set(:open_library_enabled, true)
+
+    MetadataService.stub(:search_provider, ->(*) { raise StandardError, "provider boom" }) do
+      get search_results_stream_path, params: { q: "fiction" }
+    end
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
   end
 
   test "results does not show related titles when no similar audiobookshelf item exists" do
@@ -146,5 +318,58 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       series_name: nil,
       series_position: nil
     )
+  end
+
+  def stub_hardcover_search(results)
+    typesense_response = {
+      "facet_counts" => [],
+      "found" => results.size,
+      "hits" => results.map { |result| { "document" => result } },
+      "request_params" => {},
+      "search_cutoff" => false,
+      "search_time_ms" => 5
+    }
+
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { "data" => { "search" => { "results" => typesense_response } } }.to_json
+      )
+  end
+
+  def stub_openlibrary_search(query, docs)
+    stub_request(:get, "#{OpenLibraryClient::BASE_URL}/search.json")
+      .with(query: hash_including("q" => query))
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { "docs" => docs }.to_json
+      )
+  end
+
+  def google_books_item(id, title, author, published_date:)
+    {
+      "id" => id,
+      "volumeInfo" => {
+        "title" => title,
+        "authors" => [ author ],
+        "description" => "Google Books description",
+        "publishedDate" => published_date,
+        "imageLinks" => { "thumbnail" => "https://books.google.example/cover.jpg" },
+        "canonicalVolumeLink" => "https://books.google.com/books?id=#{id}"
+      },
+      "saleInfo" => { "isEbook" => true }
+    }
+  end
+
+  def stub_google_books_search(query, items)
+    stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
+      .with(query: hash_including("q" => query))
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { "items" => items }.to_json
+      )
   end
 end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -22,9 +22,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "results returns search results" do
-    with_cassette("open_library/search_harry_potter") do
-      get search_results_path, params: { q: "harry potter" }
-      assert_response :success
+    GoogleBooksClient.stub(:search, []) do
+      with_cassette("open_library/search_harry_potter") do
+        get search_results_path, params: { q: "harry potter" }
+        assert_response :success
+      end
     end
   end
 
@@ -34,10 +36,12 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "results handles turbo stream format" do
-    with_cassette("open_library/search_fiction") do
-      get search_results_path, params: { q: "fiction" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
-      assert_response :success
-      assert_match "turbo-stream", response.body
+    GoogleBooksClient.stub(:search, []) do
+      with_cassette("open_library/search_fiction") do
+        get search_results_path, params: { q: "fiction" }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        assert_response :success
+        assert_match "turbo-stream", response.body
+      end
     end
   end
 
@@ -56,12 +60,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       synced_at: Time.current
     )
 
-    result = Struct.new(:work_id, :title, :author, :cover_url, :first_publish_year, keyword_init: true)
-    metadata_result = result.new(
-      work_id: "work-hobbit",
+    metadata_result = metadata_result(
+      source_id: "OL_HOBBITW",
       title: "The Hobbit",
       author: "J.R.R. Tolkien",
-      first_publish_year: 1937
+      year: 1937
     )
 
     MetadataService.stub(:search, [ metadata_result ]) do
@@ -86,12 +89,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       synced_at: Time.current
     )
 
-    result = Struct.new(:work_id, :title, :author, :cover_url, :first_publish_year, keyword_init: true)
-    metadata_result = result.new(
-      work_id: "work-1984",
+    metadata_result = metadata_result(
+      source_id: "OL_1984W",
       title: "1984",
       author: "George Orwell",
-      first_publish_year: 1949
+      year: 1949
     )
 
     MetadataService.stub(:search, [ metadata_result ]) do
@@ -113,12 +115,11 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       synced_at: Time.current
     )
 
-    result = Struct.new(:work_id, :title, :author, :cover_url, :first_publish_year, keyword_init: true)
-    metadata_result = result.new(
-      work_id: "work-hobbit",
+    metadata_result = metadata_result(
+      source_id: "OL_HOBBITW",
       title: "The Hobbit",
       author: "J.R.R. Tolkien",
-      first_publish_year: 1937
+      year: 1937
     )
 
     MetadataService.stub(:search, [ metadata_result ]) do
@@ -127,5 +128,23 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_no_match "Related titles in your library", response.body
+  end
+
+  private
+
+  def metadata_result(source_id:, title:, author:, year:)
+    MetadataService::SearchResult.new(
+      source: "openlibrary",
+      source_id: source_id,
+      title: title,
+      author: author,
+      description: nil,
+      year: year,
+      cover_url: nil,
+      has_audiobook: nil,
+      has_ebook: nil,
+      series_name: nil,
+      series_position: nil
+    )
   end
 end

--- a/test/jobs/upload_processing_job_test.rb
+++ b/test/jobs/upload_processing_job_test.rb
@@ -530,6 +530,13 @@ class UploadProcessingJobTest < ActiveJob::TestCase
   private
 
   def stub_open_library_search(query)
+    stub_request(:get, %r{https://www\.googleapis\.com/books/v1/volumes})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { items: [] }.to_json
+      )
+
     # Stub Open Library search to return empty results
     # This allows tests to focus on file operations and book creation
     stub_request(:get, %r{https://openlibrary\.org/search\.json})

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -20,6 +20,25 @@ class BookTest < ActiveSupport::TestCase
     assert_equal "audiobook", initialized.book_type
   end
 
+  test "preload_by_work_ids returns books keyed by work id and book type" do
+    audiobook = Book.create!(
+      title: "Audio",
+      book_type: :audiobook,
+      google_books_id: "gb-audio"
+    )
+    ebook = Book.create!(
+      title: "Ebook",
+      book_type: :ebook,
+      open_library_work_id: "OL123W"
+    )
+
+    lookup = Book.preload_by_work_ids([ "google_books:gb-audio", "openlibrary:OL123W" ])
+
+    assert_equal audiobook, lookup.dig("google_books:gb-audio", "audiobook")
+    assert_equal ebook, lookup.dig("openlibrary:OL123W", "ebook")
+    assert_equal audiobook, Book.find_in_lookup(lookup, [ "google_books:gb-audio" ], book_type: :audiobook)
+  end
+
   test "metadata source helpers expose provider label and url" do
     google_book = Book.new(title: "Google Book", book_type: :ebook, google_books_id: "abc123")
     open_library_book = Book.new(title: "Open Book", book_type: :ebook, open_library_work_id: "OL123W")

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BookTest < ActiveSupport::TestCase
+  test "work_id helpers support google books ids" do
+    book = Book.create!(
+      title: "Test Book",
+      book_type: :ebook,
+      google_books_id: "abc123"
+    )
+
+    assert_equal "google_books:abc123", book.unified_work_id
+    assert_equal book, Book.find_by_work_id("google_books:abc123", book_type: :ebook)
+
+    initialized = Book.find_or_initialize_by_work_id("google_books:def456", book_type: :audiobook)
+
+    assert initialized.new_record?
+    assert_equal "def456", initialized.google_books_id
+    assert_equal "audiobook", initialized.book_type
+  end
+
+  test "metadata source helpers expose provider label and url" do
+    google_book = Book.new(title: "Google Book", book_type: :ebook, google_books_id: "abc123")
+    open_library_book = Book.new(title: "Open Book", book_type: :ebook, open_library_work_id: "OL123W")
+    hardcover_book = Book.new(title: "Hardcover Book", book_type: :ebook, hardcover_id: "789")
+
+    assert_equal "Google Books", google_book.metadata_source_name
+    assert_equal "https://books.google.com/books?id=abc123", google_book.metadata_source_url
+    assert_equal "Metadata from Google Books", google_book.metadata_source_attribution
+    assert_equal "Open Library", open_library_book.metadata_source_name
+    assert_equal "https://openlibrary.org/works/OL123W", open_library_book.metadata_source_url
+    assert_equal "Hardcover", hardcover_book.metadata_source_name
+    assert_equal "https://hardcover.app/books/789", hardcover_book.metadata_source_url
+  end
+end

--- a/test/models/metadata_provider_status_test.rb
+++ b/test/models/metadata_provider_status_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MetadataProviderStatusTest < ActiveSupport::TestCase
+  test "for_provider creates unknown status once" do
+    status = MetadataProviderStatus.for_provider("google_books")
+
+    assert_equal "unknown", status.status
+    assert_equal status, MetadataProviderStatus.for_provider("google_books")
+  end
+
+  test "record_success clears failure state" do
+    status = MetadataProviderStatus.create!(
+      provider: "openlibrary",
+      status: "rate_limited",
+      rate_limited_until: 10.minutes.from_now,
+      last_error: "too many requests",
+      failure_count: 2
+    )
+
+    status.record_success!
+
+    assert_equal "healthy", status.status
+    assert_nil status.rate_limited_until
+    assert_nil status.last_error
+    assert_equal 0, status.failure_count
+    assert status.last_success_at.present?
+  end
+
+  test "record_failure classifies rate limit errors with backoff" do
+    status = MetadataProviderStatus.create!(provider: "google_books", status: "healthy")
+
+    status.record_failure!(GoogleBooksClient::RateLimitError.new("quota exceeded"))
+
+    assert_equal "rate_limited", status.status
+    assert status.rate_limited_until.future?
+    assert_equal "quota exceeded", status.last_error
+    assert_equal 1, status.failure_count
+    assert_not status.available?
+  end
+
+  test "record_failure classifies auth errors without retry backoff" do
+    status = MetadataProviderStatus.create!(provider: "hardcover", status: "healthy")
+
+    status.record_failure!(HardcoverClient::AuthenticationError.new("bad token"))
+
+    assert_equal "auth_failed", status.status
+    assert_nil status.rate_limited_until
+    assert_not status.available?
+  end
+
+  test "record_failure classifies connection and generic errors" do
+    connection_status = MetadataProviderStatus.create!(provider: "openlibrary", status: "healthy")
+    generic_status = MetadataProviderStatus.create!(provider: "other", status: "healthy")
+
+    connection_status.record_failure!(OpenLibraryClient::ConnectionError.new("timeout"))
+    generic_status.record_failure!(StandardError.new("unknown"))
+
+    assert_equal "down", connection_status.status
+    assert connection_status.rate_limited_until.future?
+    assert_equal "degraded", generic_status.status
+    assert generic_status.rate_limited_until.future?
+  end
+
+  test "expired rate limit is available again" do
+    status = MetadataProviderStatus.create!(provider: "google_books", status: "rate_limited", rate_limited_until: 1.minute.ago)
+
+    assert_not status.rate_limited?
+    assert status.available?
+  end
+end

--- a/test/models/metadata_provider_status_test.rb
+++ b/test/models/metadata_provider_status_test.rb
@@ -50,6 +50,16 @@ class MetadataProviderStatusTest < ActiveSupport::TestCase
     assert_not status.available?
   end
 
+  test "record_failure classifies google books auth errors" do
+    status = MetadataProviderStatus.create!(provider: "google_books", status: "healthy")
+
+    status.record_failure!(GoogleBooksClient::AuthenticationError.new("invalid api key"))
+
+    assert_equal "auth_failed", status.status
+    assert_nil status.rate_limited_until
+    assert_not status.available?
+  end
+
   test "record_failure classifies connection and generic errors" do
     connection_status = MetadataProviderStatus.create!(provider: "openlibrary", status: "healthy")
     generic_status = MetadataProviderStatus.create!(provider: "other", status: "healthy")
@@ -61,6 +71,35 @@ class MetadataProviderStatusTest < ActiveSupport::TestCase
     assert connection_status.rate_limited_until.future?
     assert_equal "degraded", generic_status.status
     assert generic_status.rate_limited_until.future?
+  end
+
+  test "clear_after_credential_change resets auth failed state" do
+    status = MetadataProviderStatus.create!(
+      provider: "google_books",
+      status: "auth_failed",
+      last_error: "invalid api key",
+      failure_count: 2
+    )
+
+    status.clear_after_credential_change!
+
+    assert_equal "unknown", status.status
+    assert_nil status.last_error
+    assert_nil status.rate_limited_until
+    assert_equal 0, status.failure_count
+    assert status.available?
+  end
+
+  test "clear_after_credential_change_for_settings resets affected providers" do
+    google_status = MetadataProviderStatus.create!(provider: "google_books", status: "auth_failed")
+    hardcover_status = MetadataProviderStatus.create!(provider: "hardcover", status: "auth_failed")
+    openlibrary_status = MetadataProviderStatus.create!(provider: "openlibrary", status: "healthy")
+
+    MetadataProviderStatus.clear_after_credential_change_for_settings!([ "google_books_api_key" ])
+
+    assert_equal "unknown", google_status.reload.status
+    assert_equal "auth_failed", hardcover_status.reload.status
+    assert_equal "healthy", openlibrary_status.reload.status
   end
 
   test "expired rate limit is available again" do

--- a/test/services/book_metadata_backfill_service_test.rb
+++ b/test/services/book_metadata_backfill_service_test.rb
@@ -111,6 +111,43 @@ class BookMetadataBackfillServiceTest < ActiveSupport::TestCase
     assert_nil book.series_position
   end
 
+  test "persists pending work id assignments when metadata attrs are already complete" do
+    book = Book.create!(
+      title: "Complete Book",
+      author: "Known Author",
+      book_type: :ebook,
+      open_library_work_id: "OL123W",
+      description: "Known description",
+      cover_url: "https://example.com/cover.jpg",
+      year: 2020,
+      metadata_source: "openlibrary"
+    )
+    book.assign_work_id("google_books:gb-new")
+
+    details = MetadataService::SearchResult.new(
+      source: "openlibrary",
+      source_id: "OL123W",
+      title: "Fetched Title",
+      author: "Fetched Author",
+      description: "Fetched description",
+      year: 2021,
+      cover_url: "https://example.com/new-cover.jpg",
+      has_audiobook: nil,
+      has_ebook: nil,
+      series_name: nil,
+      series_position: nil
+    )
+
+    result = MetadataService.stub(:book_details, details) do
+      BookMetadataBackfillService.apply!(book, work_id: "openlibrary:OL123W")
+    end
+
+    assert result
+    book.reload
+    assert_equal "gb-new", book.google_books_id
+    assert_equal "Complete Book", book.title
+  end
+
   test "returns false when there is nothing to fill" do
     book = Book.create!(
       title: "Complete Book",

--- a/test/services/duplicate_detection_service_test.rb
+++ b/test/services/duplicate_detection_service_test.rb
@@ -80,6 +80,27 @@ class DuplicateDetectionServiceTest < ActiveSupport::TestCase
     assert_equal request, result.existing_request
   end
 
+  test "reuses preloaded lookup for same and other book type checks" do
+    book = Book.create!(
+      title: "Existing Audiobook",
+      book_type: :audiobook,
+      google_books_id: "gb-preload"
+    )
+    lookup = Book.preload_by_work_ids([ "google_books:gb-preload" ])
+
+    Book.stub(:preload_by_work_ids, ->(*) { raise "should not query again" }) do
+      result = DuplicateDetectionService.check(
+        work_id: "openlibrary:OL_PRELOAD_W",
+        source_work_ids: [ "google_books:gb-preload" ],
+        book_type: "ebook",
+        existing_books_lookup: lookup
+      )
+
+      assert result.warn?
+      assert_equal book, result.existing_book
+    end
+  end
+
   test "blocks request when any candidate source matches active request" do
     book = Book.create!(
       title: "Pending Google Book",

--- a/test/services/duplicate_detection_service_test.rb
+++ b/test/services/duplicate_detection_service_test.rb
@@ -80,6 +80,26 @@ class DuplicateDetectionServiceTest < ActiveSupport::TestCase
     assert_equal request, result.existing_request
   end
 
+  test "blocks request when any candidate source matches active request" do
+    book = Book.create!(
+      title: "Pending Google Book",
+      book_type: :ebook,
+      google_books_id: "gb-pending"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending)
+
+    result = DuplicateDetectionService.check(
+      work_id: "openlibrary:OL_DIFFERENT_W",
+      source_work_ids: [ "google_books:gb-pending" ],
+      book_type: "ebook"
+    )
+
+    assert result.block?
+    assert_includes result.message, "active request"
+    assert_equal book, result.existing_book
+    assert_equal request, result.existing_request
+  end
+
   test "warns when same work exists as different type" do
     Book.create!(
       title: "Has Audiobook",

--- a/test/services/google_books_client_test.rb
+++ b/test/services/google_books_client_test.rb
@@ -114,6 +114,48 @@ class GoogleBooksClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "book raises NotFoundError when volumeInfo title is missing" do
+    VCR.turned_off do
+      stub_google_books_book("abc123", { "id" => "abc123" })
+
+      assert_raises GoogleBooksClient::NotFoundError do
+        GoogleBooksClient.book("abc123")
+      end
+    end
+  end
+
+  test "search raises AuthenticationError for invalid api key" do
+    VCR.turned_off do
+      stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
+        .with(query: hash_including("q" => "fiction"))
+        .to_return(
+          status: 403,
+          headers: { "Content-Type" => "application/json" },
+          body: { "error" => { "message" => "API key not valid. Please pass a valid API key." } }.to_json
+        )
+
+      assert_raises GoogleBooksClient::AuthenticationError do
+        GoogleBooksClient.search("fiction")
+      end
+    end
+  end
+
+  test "search raises RateLimitError for quota exceeded 403" do
+    VCR.turned_off do
+      stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
+        .with(query: hash_including("q" => "fiction"))
+        .to_return(
+          status: 403,
+          headers: { "Content-Type" => "application/json" },
+          body: { "error" => { "message" => "Daily Limit Exceeded" } }.to_json
+        )
+
+      assert_raises GoogleBooksClient::RateLimitError do
+        GoogleBooksClient.search("fiction")
+      end
+    end
+  end
+
   test "book raises NotFoundError for invalid id" do
     VCR.turned_off do
       stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes/missing")

--- a/test/services/google_books_client_test.rb
+++ b/test/services/google_books_client_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GoogleBooksClientTest < ActiveSupport::TestCase
+  setup do
+    @original_api_key = SettingsService.get(:google_books_api_key)
+    @original_limit = SettingsService.get(:google_books_search_limit)
+    GoogleBooksClient.reset_connection!
+  end
+
+  teardown do
+    SettingsService.set(:google_books_api_key, @original_api_key || "")
+    SettingsService.set(:google_books_search_limit, @original_limit || 20)
+    GoogleBooksClient.reset_connection!
+  end
+
+  test "search returns array of SearchResult" do
+    VCR.turned_off do
+      stub_google_books_search("harry potter", [ google_books_item ])
+
+      results = GoogleBooksClient.search("harry potter")
+
+      assert_kind_of Array, results
+      assert_equal 1, results.size
+      assert_kind_of GoogleBooksClient::SearchResult, results.first
+
+      result = results.first
+      assert_equal "abc123", result.id
+      assert_equal "Harry Potter and the Philosopher's Stone", result.title
+      assert_equal "J.K. Rowling", result.author
+      assert_equal 1997, result.first_publish_year
+      assert_equal "https://books.google.com/cover.jpg", result.cover_url
+      assert result.has_ebook
+    end
+  end
+
+  test "search returns empty array for no results" do
+    VCR.turned_off do
+      stub_google_books_search("asdfghjklqwertyuiop", [])
+
+      assert_equal [], GoogleBooksClient.search("asdfghjklqwertyuiop")
+    end
+  end
+
+  test "search respects configured limit" do
+    SettingsService.set(:google_books_search_limit, 13)
+
+    VCR.turned_off do
+      stub_google_books_search("fiction", [], expected_max_results: 13)
+
+      assert_equal [], GoogleBooksClient.search("fiction")
+    end
+  end
+
+  test "search includes api key when configured" do
+    SettingsService.set(:google_books_api_key, "secret-key")
+
+    VCR.turned_off do
+      stub_google_books_search("fiction", [], expected_key: "secret-key")
+
+      assert_equal [], GoogleBooksClient.search("fiction")
+    end
+  end
+
+  test "search omits api key when not configured" do
+    SettingsService.set(:google_books_api_key, "")
+
+    VCR.turned_off do
+      stub = stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
+        .with(query: hash_including("q" => "fiction"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "items" => [] }.to_json
+        )
+
+      assert_equal [], GoogleBooksClient.search("fiction")
+      assert_requested(:get, %r{#{Regexp.escape(GoogleBooksClient::BASE_URL)}/books/v1/volumes}) do |request|
+        Rack::Utils.parse_query(URI(request.uri).query).exclude?("key")
+      end
+    end
+  end
+
+  test "search clamps limit to Google Books maximum" do
+    VCR.turned_off do
+      stub_google_books_search("fiction", [], expected_max_results: 40)
+
+      assert_equal [], GoogleBooksClient.search("fiction", limit: 99)
+    end
+  end
+
+  test "book returns BookDetails" do
+    VCR.turned_off do
+      stub_google_books_book("abc123", google_books_item)
+
+      book = GoogleBooksClient.book("abc123")
+
+      assert_kind_of GoogleBooksClient::BookDetails, book
+      assert_equal "abc123", book.id
+      assert_equal "Harry Potter and the Philosopher's Stone", book.title
+      assert_equal 1997, book.release_year
+      assert_equal [ "Fantasy" ], book.categories
+    end
+  end
+
+  test "book includes api key when configured" do
+    SettingsService.set(:google_books_api_key, "secret-key")
+
+    VCR.turned_off do
+      stub_google_books_book("abc123", google_books_item, expected_key: "secret-key")
+
+      assert_equal "abc123", GoogleBooksClient.book("abc123").id
+    end
+  end
+
+  test "book raises NotFoundError for invalid id" do
+    VCR.turned_off do
+      stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes/missing")
+        .to_return(status: 404, body: { "error" => "Not found" }.to_json)
+
+      assert_raises GoogleBooksClient::NotFoundError do
+        GoogleBooksClient.book("missing")
+      end
+    end
+  end
+
+  test "work_id includes source prefix" do
+    result = GoogleBooksClient::SearchResult.new(
+      id: "abc123",
+      title: "Test",
+      author: "Author",
+      description: nil,
+      published_date: "2020",
+      cover_url: nil,
+      has_ebook: false,
+      language: "en"
+    )
+
+    assert_equal "google_books:abc123", result.work_id
+  end
+
+  private
+
+  def google_books_item
+    {
+      "id" => "abc123",
+      "volumeInfo" => {
+        "title" => "Harry Potter and the Philosopher's Stone",
+        "authors" => [ "J.K. Rowling" ],
+        "description" => "A wizarding school story",
+        "publishedDate" => "1997-06-26",
+        "imageLinks" => { "thumbnail" => "http://books.google.com/cover.jpg" },
+        "language" => "en",
+        "pageCount" => 223,
+        "categories" => [ "Fantasy" ]
+      },
+      "saleInfo" => { "isEbook" => true },
+      "accessInfo" => { "epub" => { "isAvailable" => true } }
+    }
+  end
+
+  def stub_google_books_search(query, items, expected_max_results: nil, expected_key: nil)
+    stub = stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
+      .with(query: hash_including("q" => query))
+
+    if expected_max_results
+      stub = stub.with(query: hash_including("q" => query, "maxResults" => expected_max_results.to_s))
+    end
+
+    if expected_key
+      stub = stub.with(query: hash_including("q" => query, "key" => expected_key))
+    end
+
+    stub.to_return(
+      status: 200,
+      headers: { "Content-Type" => "application/json" },
+      body: { "items" => items }.to_json
+    )
+  end
+
+  def stub_google_books_book(id, item, expected_key: nil)
+    stub = stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes/#{id}")
+    stub = stub.with(query: hash_including("key" => expected_key)) if expected_key
+
+    stub
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: item.to_json
+      )
+  end
+end

--- a/test/services/integrations/command_processor_test.rb
+++ b/test/services/integrations/command_processor_test.rb
@@ -50,6 +50,29 @@ class Integrations::CommandProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "processes cached telegram request selection with source work ids" do
+    book = Book.create!(
+      title: "Existing Google Book",
+      book_type: :ebook,
+      google_books_id: "gb-existing"
+    )
+    Request.create!(book: book, user: @user, status: :pending)
+
+    result = Integrations::CommandProcessor.call(
+      command: "/request",
+      arguments: "ebook",
+      user: @user,
+      origin: { created_via: "telegram", external_source: "telegram" },
+      request_selection: {
+        work_id: "openlibrary:OL_TELEGRAM_SELECTION_W",
+        source_work_ids: [ "openlibrary:OL_TELEGRAM_SELECTION_W", "google_books:gb-existing" ],
+        metadata_attrs: { title: "Existing Google Book", author: "Author" }
+      }
+    )
+
+    assert_includes result.text, "already has an active request"
+  end
+
   test "processes request command through shared request creation" do
     details = MetadataService::SearchResult.new(
       source: "openlibrary",

--- a/test/services/integrations/command_processor_test.rb
+++ b/test/services/integrations/command_processor_test.rb
@@ -43,6 +43,7 @@ class Integrations::CommandProcessorTest < ActiveSupport::TestCase
       )
 
       assert_includes result.text, "Command Search Book"
+      assert_includes result.text, "Open Library"
       assert_includes result.text, "Choose a format below."
       assert_not_includes result.text, search_result.work_id
       assert_equal [ search_result ], result.search_results

--- a/test/services/integrations/telegram/search_result_cache_test.rb
+++ b/test/services/integrations/telegram/search_result_cache_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Integrations
+  module Telegram
+    class SearchResultCacheTest < ActiveSupport::TestCase
+      setup do
+        @original_cache = Rails.cache
+        Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      end
+
+      teardown do
+        Rails.cache = @original_cache
+      end
+
+      test "stores and fetches merged candidate source work ids" do
+        candidate = MetadataSearch::Candidate.new(
+          canonical_key: "openlibrary:OL123W",
+          title: "Dune",
+          author: "Frank Herbert",
+          year: 1965,
+          description: nil,
+          cover_url: nil,
+          series_name: nil,
+          series_position: nil,
+          has_ebook: nil,
+          has_audiobook: nil,
+          sources: [
+            { source: "openlibrary", source_id: "OL123W", source_name: "Open Library", source_url: nil, work_id: "openlibrary:OL123W" },
+            { source: "google_books", source_id: "gb123", source_name: "Google Books", source_url: nil, work_id: "google_books:gb123" }
+          ],
+          editions: [],
+          confidence: 90
+        )
+
+        token = SearchResultCache.store(candidate)
+        selection = SearchResultCache.fetch(token)
+
+        assert_equal 32, token.length
+        assert_equal "openlibrary:OL123W", selection[:work_id]
+        assert_equal %w[openlibrary:OL123W google_books:gb123], selection[:source_work_ids]
+        assert_equal "Dune", selection[:metadata_attrs][:title]
+      end
+
+      test "callback data stays within telegram limit" do
+        data = SearchResultCache.callback_data("a1b2c3d4e5f60718293a4b5c6d7e8f90", "audiobook")
+
+        assert data.bytesize <= 64
+        assert_equal "req|a1b2c3d4e5f60718293a4b5c6d7e8f90|audiobook", data
+      end
+    end
+  end
+end

--- a/test/services/metadata_search/aggregator_test.rb
+++ b/test/services/metadata_search/aggregator_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MetadataSearch
+  class AggregatorTest < ActiveSupport::TestCase
+    test "merges results with shared isbn even when provider titles vary" do
+      results = Aggregator.call([
+        provider_result(source: "openlibrary", source_id: "OL123W", title: "The Hobbit", isbn_13: "9780547928227"),
+        provider_result(source: "google_books", source_id: "gb123", title: "The Hobbit: Or There and Back Again", isbn_13: "9780547928227")
+      ], priority: %w[openlibrary google_books])
+
+      assert_equal 1, results.size
+      candidate = results.first
+      assert_equal "isbn:9780547928227", candidate.canonical_key
+      assert_equal "openlibrary:OL123W", candidate.work_id
+      assert_equal %w[openlibrary google_books], candidate.sources.map { |source| source[:source] }
+      assert_equal 100, candidate.confidence
+    end
+
+    test "merges results with normalized title author and close year when isbn is missing" do
+      results = Aggregator.call([
+        provider_result(source: "openlibrary", source_id: "OL123W", title: "Dune!", author: "Frank Herbert", year: 1965),
+        provider_result(source: "google_books", source_id: "gb123", title: "Dune", author: "Frank Herbert", year: 1966)
+      ], priority: %w[openlibrary google_books])
+
+      assert_equal 1, results.size
+      assert_equal "openlibrary:OL123W", results.first.canonical_key
+      assert_equal 90, results.first.confidence
+    end
+
+    test "keeps same title and author separate when isbn conflicts" do
+      results = Aggregator.call([
+        provider_result(source: "google_books", source_id: "paperback", title: "Dune", isbn_13: "9780441172719"),
+        provider_result(source: "google_books", source_id: "hardcover", title: "Dune", isbn_13: "9780593099322")
+      ], priority: %w[google_books])
+
+      assert_equal 2, results.size
+      assert_equal %w[google_books:paperback google_books:hardcover], results.map(&:work_id)
+    end
+
+    test "keeps same title and author separate when years are far apart" do
+      results = Aggregator.call([
+        provider_result(source: "openlibrary", source_id: "OL1937W", title: "The Hobbit", author: "J.R.R. Tolkien", year: 1937),
+        provider_result(source: "google_books", source_id: "gb2020", title: "The Hobbit", author: "J.R.R. Tolkien", year: 2020)
+      ], priority: %w[openlibrary google_books])
+
+      assert_equal 2, results.size
+    end
+
+    test "uses provider priority for primary source and first-present fields" do
+      results = Aggregator.call([
+        provider_result(source: "google_books", source_id: "gb123", description: "Google description", cover_url: "https://google.example/cover.jpg", has_ebook: true),
+        provider_result(source: "openlibrary", source_id: "OL123W", description: nil, cover_url: nil, has_ebook: nil)
+      ], priority: %w[openlibrary google_books])
+
+      candidate = results.first
+      assert_equal "openlibrary", candidate.source
+      assert_equal "Google description", candidate.description
+      assert_equal "https://google.example/cover.jpg", candidate.cover_url
+      assert_equal true, candidate.has_ebook
+      assert_equal 1, candidate.editions.size
+    end
+
+    test "returns false availability only when a provider explicitly reports false" do
+      candidate = Aggregator.call([
+        provider_result(source: "openlibrary", source_id: "OL123W", has_ebook: nil),
+        provider_result(source: "google_books", source_id: "gb123", has_ebook: false)
+      ], priority: %w[openlibrary google_books]).first
+
+      assert_equal false, candidate.has_ebook
+      assert_nil candidate.has_audiobook
+    end
+
+    private
+
+    def provider_result(source:, source_id:, title: "The Hobbit", author: "J.R.R. Tolkien", year: 1937,
+      description: nil, cover_url: nil, isbn_10: nil, isbn_13: nil, has_ebook: nil, has_audiobook: nil)
+      ProviderResult.new(
+        source: source,
+        source_id: source_id,
+        title: title,
+        author: author,
+        year: year,
+        description: description,
+        cover_url: cover_url,
+        isbn_10: isbn_10,
+        isbn_13: isbn_13,
+        publisher: nil,
+        page_count: nil,
+        language: nil,
+        series_name: nil,
+        series_position: nil,
+        has_ebook: has_ebook,
+        has_audiobook: has_audiobook,
+        source_url: "https://example.test/#{source_id}",
+        raw_payload: nil
+      )
+    end
+  end
+end

--- a/test/services/metadata_search/aggregator_test.rb
+++ b/test/services/metadata_search/aggregator_test.rb
@@ -62,6 +62,26 @@ module MetadataSearch
       assert_equal 1, candidate.editions.size
     end
 
+    test "merges transitive title author and year matches across provider chain" do
+      results = Aggregator.call([
+        provider_result(source: "openlibrary", source_id: "OL_A", title: "Dune", author: "Frank Herbert", year: 1965),
+        provider_result(source: "google_books", source_id: "GB_B", title: "Dune", author: "Frank Herbert", year: 1966),
+        provider_result(source: "hardcover", source_id: "HC_C", title: "Dune", author: "Frank Herbert", year: 1965)
+      ], priority: %w[openlibrary google_books hardcover])
+
+      assert_equal 1, results.size
+      assert_equal 3, results.first.sources.size
+    end
+
+    test "keeps same title separate when author metadata is missing" do
+      results = Aggregator.call([
+        provider_result(source: "openlibrary", source_id: "OL_A", title: "Shared Title", author: nil, year: 2020),
+        provider_result(source: "google_books", source_id: "GB_B", title: "Shared Title", author: nil, year: 2020)
+      ], priority: %w[openlibrary google_books])
+
+      assert_equal 2, results.size
+    end
+
     test "returns false availability only when a provider explicitly reports false" do
       candidate = Aggregator.call([
         provider_result(source: "openlibrary", source_id: "OL123W", has_ebook: nil),

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -9,6 +9,11 @@ class MetadataServiceTest < ActiveSupport::TestCase
     @original_hardcover_search_limit = SettingsService.get(:hardcover_search_limit)
     @original_open_library_search_limit = SettingsService.get(:open_library_search_limit)
     @original_google_books_search_limit = SettingsService.get(:google_books_search_limit)
+    @original_google_books_enabled = SettingsService.get(:google_books_enabled)
+    @original_open_library_enabled = SettingsService.get(:open_library_enabled)
+    @original_hardcover_enabled = SettingsService.get(:hardcover_enabled)
+    @original_provider_priority = SettingsService.get(:metadata_provider_priority)
+    MetadataProviderStatus.delete_all
     HardcoverClient.reset_connection!
     GoogleBooksClient.reset_connection!
   end
@@ -19,6 +24,11 @@ class MetadataServiceTest < ActiveSupport::TestCase
     SettingsService.set(:hardcover_search_limit, @original_hardcover_search_limit || 10)
     SettingsService.set(:open_library_search_limit, @original_open_library_search_limit || 20)
     SettingsService.set(:google_books_search_limit, @original_google_books_search_limit || 20)
+    SettingsService.set(:google_books_enabled, @original_google_books_enabled.nil? ? true : @original_google_books_enabled)
+    SettingsService.set(:open_library_enabled, @original_open_library_enabled.nil? ? true : @original_open_library_enabled)
+    SettingsService.set(:hardcover_enabled, @original_hardcover_enabled.nil? ? true : @original_hardcover_enabled)
+    SettingsService.set(:metadata_provider_priority, @original_provider_priority || "hardcover,openlibrary,google_books")
+    MetadataProviderStatus.delete_all
     HardcoverClient.reset_connection!
     GoogleBooksClient.reset_connection!
   end
@@ -170,6 +180,96 @@ class MetadataServiceTest < ActiveSupport::TestCase
 
       assert results.any?
       assert_equal "openlibrary", results.first.source
+    end
+  end
+
+  test "search aggregates matching openlibrary and google books results" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:hardcover_api_token, "")
+
+    VCR.turned_off do
+      stub_openlibrary_search([
+        {
+          "key" => "/works/OL_AGGREGATE_W",
+          "title" => "The Hobbit",
+          "author_name" => [ "J.R.R. Tolkien" ],
+          "first_publish_year" => 1937
+        }
+      ])
+      stub_google_books_search([
+        google_books_item("gb-aggregate", "The Hobbit", "J.R.R. Tolkien", isbn_13: "9780547928227", published_date: "1937-09-21")
+      ])
+
+      results = MetadataService.search("harry potter")
+
+      assert_equal 1, results.size
+      assert_equal "openlibrary", results.first.source
+      assert_equal "isbn:9780547928227", results.first.canonical_key
+      assert_equal [ "openlibrary", "google_books" ], results.first.sources.map { |source| source[:source] }
+      assert results.first.google_books?
+    end
+  end
+
+  test "search keeps meaningful editions separate when isbns conflict" do
+    SettingsService.set(:metadata_source, "google_books")
+
+    VCR.turned_off do
+      stub_google_books_search([
+        google_books_item("gb-paperback", "Dune", "Frank Herbert", isbn_13: "9780441172719"),
+        google_books_item("gb-hardcover", "Dune", "Frank Herbert", isbn_13: "9780593099322")
+      ])
+
+      results = MetadataService.search("harry potter")
+
+      assert_equal 2, results.size
+      assert_equal [ "gb-paperback", "gb-hardcover" ], results.map(&:source_id)
+    end
+  end
+
+  test "search returns healthy provider candidates when google books is rate limited" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:hardcover_api_token, "")
+
+    VCR.turned_off do
+      stub_openlibrary_search([
+        {
+          "key" => "/works/OL_HEALTHY_W",
+          "title" => "Healthy Result",
+          "author_name" => [ "Author" ],
+          "first_publish_year" => 2024
+        }
+      ])
+      stub_google_books_search([], expected_status: 429)
+
+      results = MetadataService.search("harry potter")
+
+      assert_equal 1, results.size
+      assert_equal "openlibrary", results.first.source
+      assert_equal "rate_limited", MetadataProviderStatus.find_by(provider: "google_books").status
+    end
+  end
+
+  test "search skips provider while rate limited" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:hardcover_api_token, "")
+    MetadataProviderStatus.create!(provider: "google_books", status: "rate_limited", rate_limited_until: 10.minutes.from_now)
+
+    VCR.turned_off do
+      stub_openlibrary_search([
+        {
+          "key" => "/works/OL_SKIP_W",
+          "title" => "Skip Result",
+          "author_name" => [ "Author" ],
+          "first_publish_year" => 2024
+        }
+      ])
+      google_request = stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
+
+      results = MetadataService.search("harry potter")
+
+      assert_equal 1, results.size
+      assert_equal "openlibrary", results.first.source
+      assert_not_requested google_request
     end
   end
 
@@ -370,21 +470,25 @@ class MetadataServiceTest < ActiveSupport::TestCase
       )
   end
 
-  def google_books_item(id, title, author)
+  def google_books_item(id, title, author, isbn_13: nil, published_date: "1997-06-26")
+    identifiers = []
+    identifiers << { "type" => "ISBN_13", "identifier" => isbn_13 } if isbn_13.present?
+
     {
       "id" => id,
       "volumeInfo" => {
         "title" => title,
         "authors" => [ author ],
         "description" => "Description",
-        "publishedDate" => "1997-06-26",
+        "publishedDate" => published_date,
+        "industryIdentifiers" => identifiers,
         "imageLinks" => { "thumbnail" => "https://books.google.com/cover.jpg" }
       },
       "saleInfo" => { "isEbook" => true }
     }
   end
 
-  def stub_google_books_search(items, expected_max_results: nil)
+  def stub_google_books_search(items, expected_max_results: nil, expected_status: 200)
     stub = stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
       .with(query: hash_including("q" => "harry potter"))
 
@@ -393,7 +497,7 @@ class MetadataServiceTest < ActiveSupport::TestCase
     end
 
     stub.to_return(
-      status: 200,
+      status: expected_status,
       headers: { "Content-Type" => "application/json" },
       body: { "items" => items }.to_json
     )

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -8,7 +8,9 @@ class MetadataServiceTest < ActiveSupport::TestCase
     @original_token = SettingsService.get(:hardcover_api_token)
     @original_hardcover_search_limit = SettingsService.get(:hardcover_search_limit)
     @original_open_library_search_limit = SettingsService.get(:open_library_search_limit)
+    @original_google_books_search_limit = SettingsService.get(:google_books_search_limit)
     HardcoverClient.reset_connection!
+    GoogleBooksClient.reset_connection!
   end
 
   teardown do
@@ -16,7 +18,9 @@ class MetadataServiceTest < ActiveSupport::TestCase
     SettingsService.set(:hardcover_api_token, @original_token || "")
     SettingsService.set(:hardcover_search_limit, @original_hardcover_search_limit || 10)
     SettingsService.set(:open_library_search_limit, @original_open_library_search_limit || 20)
+    SettingsService.set(:google_books_search_limit, @original_google_books_search_limit || 20)
     HardcoverClient.reset_connection!
+    GoogleBooksClient.reset_connection!
   end
 
   test "search uses openlibrary when source is openlibrary" do
@@ -44,6 +48,23 @@ class MetadataServiceTest < ActiveSupport::TestCase
 
       assert results.any?
       assert_equal "hardcover", results.first.source
+    end
+  end
+
+  test "search uses google books when source is google_books" do
+    SettingsService.set(:metadata_source, "google_books")
+
+    VCR.turned_off do
+      stub_google_books_search([
+        google_books_item("abc123", "Harry Potter", "J.K. Rowling")
+      ])
+
+      results = MetadataService.search("harry potter")
+
+      assert results.any?
+      assert_equal "google_books", results.first.source
+      assert_equal "abc123", results.first.source_id
+      assert_equal 1997, results.first.year
     end
   end
 
@@ -92,12 +113,26 @@ class MetadataServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "search uses configured google books limit when no limit is provided" do
+    SettingsService.set(:metadata_source, "google_books")
+    SettingsService.set(:google_books_search_limit, 17)
+
+    VCR.turned_off do
+      stub_google_books_search([
+        google_books_item("abc123", "Harry Potter", "J.K. Rowling")
+      ], expected_max_results: 17)
+
+      results = MetadataService.search("harry potter")
+
+      assert_equal "google_books", results.first.source
+    end
+  end
+
   test "search falls back to openlibrary when hardcover returns no results in auto mode" do
     SettingsService.set(:metadata_source, "auto")
     SettingsService.set(:hardcover_api_token, "test_token")
 
     VCR.turned_off do
-      # First call - Hardcover returns no results
       stub_hardcover_search([])
     end
 
@@ -106,6 +141,23 @@ class MetadataServiceTest < ActiveSupport::TestCase
 
       assert results.any?
       assert_equal "openlibrary", results.first.source
+    end
+  end
+
+  test "search falls back to google books when openlibrary returns no results in auto mode" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      stub_hardcover_search([])
+      stub_openlibrary_search([])
+      stub_google_books_search([
+        google_books_item("abc123", "Harry Potter", "J.K. Rowling")
+      ])
+      results = MetadataService.search("harry potter")
+
+      assert results.any?
+      assert_equal "google_books", results.first.source
     end
   end
 
@@ -153,6 +205,18 @@ class MetadataServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "book_details handles google books work_id" do
+    VCR.turned_off do
+      stub_google_books_book("abc123", google_books_item("abc123", "Test Book", "Test Author"))
+
+      result = MetadataService.book_details("google_books:abc123")
+
+      assert_equal "google_books", result.source
+      assert_equal "Test Book", result.title
+      assert_equal "Test Author", result.author
+    end
+  end
+
   test "book_details handles legacy work_id without prefix" do
     with_cassette("open_library/work_details") do
       result = MetadataService.book_details("OL45804W")
@@ -180,6 +244,44 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert_equal 2020, result.first_publish_year
     assert_nil result.cover_id
     assert_equal "1", result.series_position
+    assert_equal "Hardcover", result.source_name
+    assert_equal "https://hardcover.app/books/123", result.source_url
+    assert_equal "Metadata from Hardcover", result.source_attribution
+  end
+
+  test "SearchResult exposes source metadata for each provider" do
+    open_library = MetadataService::SearchResult.new(
+      source: "openlibrary",
+      source_id: "OL123W",
+      title: "Open Book",
+      author: nil,
+      description: nil,
+      year: nil,
+      cover_url: nil,
+      has_audiobook: nil,
+      has_ebook: nil,
+      series_name: nil,
+      series_position: nil
+    )
+    google_books = MetadataService::SearchResult.new(
+      source: "google_books",
+      source_id: "abc123",
+      title: "Google Book",
+      author: nil,
+      description: nil,
+      year: nil,
+      cover_url: nil,
+      has_audiobook: nil,
+      has_ebook: nil,
+      series_name: nil,
+      series_position: nil
+    )
+
+    assert_equal "Open Library", open_library.source_name
+    assert_equal "https://openlibrary.org/works/OL123W", open_library.source_url
+    assert_equal "Google Books", google_books.source_name
+    assert_equal "https://books.google.com/books?id=abc123", google_books.source_url
+    assert google_books.google_books?
   end
 
   test "metadata_source returns configured value" do
@@ -189,12 +291,20 @@ class MetadataServiceTest < ActiveSupport::TestCase
     SettingsService.set(:metadata_source, "openlibrary")
     assert_equal "openlibrary", MetadataService.metadata_source
 
+    SettingsService.set(:metadata_source, "google_books")
+    assert_equal "google_books", MetadataService.metadata_source
+
     SettingsService.set(:metadata_source, "auto")
     assert_equal "auto", MetadataService.metadata_source
   end
 
   test "available? returns true when openlibrary source" do
     SettingsService.set(:metadata_source, "openlibrary")
+    assert MetadataService.available?
+  end
+
+  test "available? returns true when google books source" do
+    SettingsService.set(:metadata_source, "google_books")
     assert MetadataService.available?
   end
 
@@ -247,6 +357,54 @@ class MetadataServiceTest < ActiveSupport::TestCase
         status: 200,
         headers: { "Content-Type" => "application/json" },
         body: { "data" => { "books" => [ book_data ] } }.to_json
+      )
+  end
+
+  def stub_openlibrary_search(docs)
+    stub_request(:get, "#{OpenLibraryClient::BASE_URL}/search.json")
+      .with(query: hash_including("q" => "harry potter"))
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { "docs" => docs }.to_json
+      )
+  end
+
+  def google_books_item(id, title, author)
+    {
+      "id" => id,
+      "volumeInfo" => {
+        "title" => title,
+        "authors" => [ author ],
+        "description" => "Description",
+        "publishedDate" => "1997-06-26",
+        "imageLinks" => { "thumbnail" => "https://books.google.com/cover.jpg" }
+      },
+      "saleInfo" => { "isEbook" => true }
+    }
+  end
+
+  def stub_google_books_search(items, expected_max_results: nil)
+    stub = stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes")
+      .with(query: hash_including("q" => "harry potter"))
+
+    if expected_max_results
+      stub = stub.with(query: hash_including("q" => "harry potter", "maxResults" => expected_max_results.to_s))
+    end
+
+    stub.to_return(
+      status: 200,
+      headers: { "Content-Type" => "application/json" },
+      body: { "items" => items }.to_json
+    )
+  end
+
+  def stub_google_books_book(id, item)
+    stub_request(:get, "#{GoogleBooksClient::BASE_URL}/books/v1/volumes/#{id}")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: item.to_json
       )
   end
 end

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -13,6 +13,7 @@ class MetadataServiceTest < ActiveSupport::TestCase
     @original_open_library_enabled = SettingsService.get(:open_library_enabled)
     @original_hardcover_enabled = SettingsService.get(:hardcover_enabled)
     @original_provider_priority = SettingsService.get(:metadata_provider_priority)
+    @original_min_match_confidence = SettingsService.get(:min_match_confidence)
     MetadataProviderStatus.delete_all
     HardcoverClient.reset_connection!
     GoogleBooksClient.reset_connection!
@@ -28,6 +29,7 @@ class MetadataServiceTest < ActiveSupport::TestCase
     SettingsService.set(:open_library_enabled, @original_open_library_enabled.nil? ? true : @original_open_library_enabled)
     SettingsService.set(:hardcover_enabled, @original_hardcover_enabled.nil? ? true : @original_hardcover_enabled)
     SettingsService.set(:metadata_provider_priority, @original_provider_priority || "hardcover,openlibrary,google_books")
+    SettingsService.set(:min_match_confidence, @original_min_match_confidence || 50)
     MetadataProviderStatus.delete_all
     HardcoverClient.reset_connection!
     GoogleBooksClient.reset_connection!
@@ -425,7 +427,76 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert_not MetadataService.available?
   end
 
+  test "aggregate_provider_results orders candidates by provider priority" do
+    SettingsService.set(:metadata_provider_priority, "hardcover,openlibrary,google_books")
+
+    provider_results = [
+      metadata_provider_result(source: "google_books", source_id: "gb1", title: "Google Result"),
+      metadata_provider_result(source: "hardcover", source_id: "hc1", title: "Hardcover Result"),
+      metadata_provider_result(source: "openlibrary", source_id: "ol1", title: "Open Library Result")
+    ]
+
+    results = MetadataService.aggregate_provider_results(provider_results)
+
+    assert_equal %w[hardcover openlibrary google_books], results.map(&:source)
+  end
+
+  test "aggregate_provider_results filters candidates below min_match_confidence" do
+    SettingsService.set(:min_match_confidence, 80)
+
+    provider_results = [
+      metadata_provider_result(source: "openlibrary", source_id: "OL_LOW", title: "Low Confidence"),
+      metadata_provider_result(source: "openlibrary", source_id: "OL_HIGH_A", title: "High Confidence", year: 1965),
+      metadata_provider_result(source: "google_books", source_id: "GB_HIGH_B", title: "High Confidence", year: 1966)
+    ]
+
+    results = MetadataService.aggregate_provider_results(provider_results)
+
+    assert_equal 1, results.size
+    assert_equal "High Confidence", results.first.title
+    assert_equal 90, results.first.confidence
+  end
+
+  test "search_google_books returns empty array when provider disabled" do
+    SettingsService.set(:google_books_enabled, false)
+
+    GoogleBooksClient.stub(:search, ->(*) { raise "should not be called" }) do
+      assert_equal [], MetadataService.send(:search_google_books, "fiction", 10)
+    end
+  end
+
+  test "search_openlibrary returns empty array when provider disabled" do
+    SettingsService.set(:open_library_enabled, false)
+
+    OpenLibraryClient.stub(:search, ->(*) { raise "should not be called" }) do
+      assert_equal [], MetadataService.send(:search_openlibrary, "fiction", 10)
+    end
+  end
+
   private
+
+  def metadata_provider_result(source:, source_id:, title:, author: "Author", year: 1937)
+    MetadataSearch::ProviderResult.new(
+      source: source,
+      source_id: source_id,
+      title: title,
+      author: author,
+      year: year,
+      description: nil,
+      cover_url: nil,
+      isbn_10: nil,
+      isbn_13: nil,
+      publisher: nil,
+      page_count: nil,
+      language: nil,
+      series_name: nil,
+      series_position: nil,
+      has_ebook: nil,
+      has_audiobook: nil,
+      source_url: "https://example.test/#{source_id}",
+      raw_payload: nil
+    )
+  end
 
   def stub_hardcover_search(results, expected_per_page: nil)
     typesense_response = {

--- a/test/services/request_creation_service_test.rb
+++ b/test/services/request_creation_service_test.rb
@@ -105,6 +105,58 @@ class RequestCreationServiceTest < ActiveSupport::TestCase
     assert_equal "gb-multi-source", book.google_books_id
   end
 
+  test "persists newly assigned source ids on reused book with complete metadata" do
+    book = Book.create!(
+      title: "Existing Google Book",
+      author: "Existing Author",
+      book_type: :ebook,
+      google_books_id: "gb-existing",
+      year: 2020,
+      description: "Known description",
+      cover_url: "https://example.com/cover.jpg",
+      metadata_source: "google_books"
+    )
+
+    result = RequestCreationService.call(
+      user: @user,
+      work_id: "openlibrary:OL_NEW_SOURCE_W",
+      source_work_ids: [ "google_books:gb-existing", "hardcover:123" ],
+      book_types: [ "ebook" ],
+      metadata_attrs: {
+        title: "Existing Google Book"
+      }
+    )
+
+    assert result.success?
+    book.reload
+    assert_equal "gb-existing", book.google_books_id
+    assert_equal "123", book.hardcover_id
+    assert_equal "OL_NEW_SOURCE_W", book.open_library_work_id
+  end
+
+  test "reuses existing book matched only via alternate source identifier" do
+    book = Book.create!(
+      title: "Existing Google Book",
+      book_type: :ebook,
+      google_books_id: "gb-existing"
+    )
+
+    assert_no_difference "Book.count" do
+      result = RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_NEW_SOURCE_W",
+        source_work_ids: [ "google_books:gb-existing" ],
+        book_types: [ "ebook" ],
+        metadata_attrs: {
+          title: "Existing Google Book"
+        }
+      )
+
+      assert result.success?
+      assert_equal book, result.created_requests.first.book
+    end
+  end
+
   test "blocks duplicate using alternate source identifier" do
     book = Book.create!(
       title: "Existing Google Book",

--- a/test/services/request_creation_service_test.rb
+++ b/test/services/request_creation_service_test.rb
@@ -86,4 +86,44 @@ class RequestCreationServiceTest < ActiveSupport::TestCase
     assert_equal "42", request.external_user_id
     assert_equal "-100123", request.external_chat_id
   end
+
+  test "stores all candidate source identifiers on created book" do
+    result = RequestCreationService.call(
+      user: @user,
+      work_id: "openlibrary:OL_MULTI_SOURCE_W",
+      source_work_ids: [ "openlibrary:OL_MULTI_SOURCE_W", "google_books:gb-multi-source" ],
+      book_types: [ "ebook" ],
+      metadata_attrs: {
+        title: "Multi Source Book",
+        author: "Source Author"
+      }
+    )
+
+    assert result.success?
+    book = result.created_requests.first.book
+    assert_equal "OL_MULTI_SOURCE_W", book.open_library_work_id
+    assert_equal "gb-multi-source", book.google_books_id
+  end
+
+  test "blocks duplicate using alternate source identifier" do
+    book = Book.create!(
+      title: "Existing Google Book",
+      book_type: :ebook,
+      google_books_id: "gb-existing"
+    )
+    Request.create!(book: book, user: @user, status: :pending)
+
+    result = RequestCreationService.call(
+      user: @user,
+      work_id: "openlibrary:OL_NEW_SOURCE_W",
+      source_work_ids: [ "google_books:gb-existing" ],
+      book_types: [ "ebook" ],
+      metadata_attrs: {
+        title: "Existing Google Book"
+      }
+    )
+
+    assert_not result.success?
+    assert_includes result.errors.join, "already has an active request"
+  end
 end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url]).delete_all
+    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -134,5 +134,42 @@ class SettingsServiceTest < ActiveSupport::TestCase
 
     SettingsService.set(:gutenberg_enabled, false)
     assert_not SettingsService.gutenberg_configured?
+  end
+
+  test "metadata provider priority normalizes configured order and appends missing providers" do
+    SettingsService.set(:metadata_provider_priority, "google_books, unknown openlibrary google_books")
+
+    assert_equal %w[google_books openlibrary hardcover], SettingsService.metadata_provider_priority
+  end
+
+  test "enabled metadata providers use all enabled auto providers in priority order" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:metadata_provider_priority, "google_books,openlibrary")
+    SettingsService.set(:hardcover_api_token, "token")
+
+    assert_equal %w[google_books openlibrary hardcover], SettingsService.enabled_metadata_providers
+  end
+
+  test "enabled metadata providers exclude disabled providers and unconfigured hardcover" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:google_books_enabled, false)
+    SettingsService.set(:hardcover_api_token, "")
+
+    assert_equal %w[openlibrary], SettingsService.enabled_metadata_providers
+  end
+
+  test "legacy metadata source restricts search to selected provider" do
+    SettingsService.set(:metadata_source, "google_books")
+    SettingsService.set(:open_library_enabled, true)
+    SettingsService.set(:hardcover_api_token, "token")
+
+    assert_equal %w[google_books], SettingsService.enabled_metadata_providers
+  end
+
+  test "legacy metadata source respects provider enabled flag" do
+    SettingsService.set(:metadata_source, "openlibrary")
+    SettingsService.set(:open_library_enabled, false)
+
+    assert_equal [], SettingsService.enabled_metadata_providers
   end
 end


### PR DESCRIPTION
## Summary
- add Google Books as a metadata provider with anonymous access, optional API key support, source attribution, and admin connection testing
- aggregate enabled metadata providers instead of treating them as fallback-only sources, merging duplicate book/edition results while preserving source links and complementary metadata
- stream search results as each provider completes so the UI can show first results earlier and continue updating while slower providers finish
- track metadata provider health, rate limits, auth failures, and credential-change recovery so unavailable providers are skipped without surfacing provider errors in the UI
- preload existing book lookups and persist all matched provider source IDs during request creation to improve duplicate detection across UI, API, and Telegram request flows
- move Telegram group authorization into the Integrations settings tab and add cached Telegram inline search-result callbacks that retain merged source IDs

Closes #310

## Test plan
- `bundle exec rails test`
- `bin/quality fast --staged`
- pre-commit and pre-push hooks passed on the pushed branch