### PR TITLE
feat: add manual magnet downloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -216,7 +216,7 @@ GEM
       logger
     mini_mime (1.1.5)
     minitest (5.27.0)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multipart-post (2.4.1)
     mutant (0.16.2)
       diff-lcs (>= 1.6, < 3)

--- a/app/controllers/admin/search_results_controller.rb
+++ b/app/controllers/admin/search_results_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class SearchResultsController < BaseController
     before_action :set_request
-    before_action :set_search_result, only: [:select]
+    before_action :set_search_result, only: [ :select ]
 
     def index
       @search_results = @request.search_results.best_first
@@ -26,8 +26,8 @@ module Admin
     end
 
     def refresh
-      # Clear existing results and re-queue for search
-      @request.search_results.destroy_all
+      # Clear existing results and re-queue for search, keeping manually added magnets
+      @request.search_results.where.not(source: SearchResult::SOURCE_MANUAL_MAGNET).destroy_all
       @request.update!(status: :pending)
       SearchJob.perform_later(@request.id)
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RequestsController < ApplicationController
-  before_action :set_request, only: [ :show, :destroy, :retry ]
+  before_action :set_request, only: [ :show, :destroy, :retry, :manual_magnet ]
   before_action :set_request_for_download, only: [ :download ]
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
@@ -119,6 +119,20 @@ class RequestsController < ApplicationController
 
     @request.retry_now!
     redirect_back fallback_location: @request, notice: "Request has been queued for retry."
+  end
+
+  def manual_magnet
+    unless Current.user.admin?
+      redirect_to @request, alert: "You don't have permission to add magnet links"
+      return
+    end
+
+    @request.add_manual_magnet!(params[:magnet_url])
+    redirect_to @request, notice: "Magnet link queued for download."
+  rescue ArgumentError => e
+    redirect_to @request, alert: e.message
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+    redirect_to @request, alert: "Magnet link could not be queued. Please try again."
   end
 
   def download

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -244,7 +244,7 @@ class SearchJob < ApplicationJob
   end
 
   def save_results(request, tagged_results)
-    request.search_results.destroy_all
+    request.search_results.where.not(source: SearchResult::SOURCE_MANUAL_MAGNET).destroy_all
 
     tagged_results.each do |tagged|
       result = tagged[:result]

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -261,7 +261,10 @@ class Request < ApplicationRecord
     raise ArgumentError, "Cannot add a magnet link to a completed request" if completed?
     raise ArgumentError, "Cannot add a magnet link while post-processing is active" if processing?
 
-    search_result = search_results.find_or_initialize_by(guid: manual_magnet_guid(magnet_link))
+    info_hash = MagnetLink.info_hash(magnet_link)
+    raise ArgumentError, "Enter a magnet link with a valid info hash" if info_hash.blank?
+
+    search_result = search_results.find_or_initialize_by(guid: manual_magnet_guid(info_hash))
     search_result.assign_attributes(
       title: "Manual magnet for #{book.display_name}",
       magnet_url: magnet_link,
@@ -321,8 +324,8 @@ class Request < ApplicationRecord
     )
   end
 
-  def manual_magnet_guid(magnet_link)
-    "#{MANUAL_MAGNET_GUID_PREFIX}:#{Digest::SHA256.hexdigest(magnet_link)}"
+  def manual_magnet_guid(info_hash)
+    "#{MANUAL_MAGNET_GUID_PREFIX}:#{info_hash}"
   end
 
   def set_default_language

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,5 +1,6 @@
 class Request < ApplicationRecord
   CREATED_VIA_VALUES = %w[web api telegram].freeze
+  MANUAL_MAGNET_GUID_PREFIX = "manual-magnet"
 
   belongs_to :book
   belongs_to :user
@@ -206,6 +207,10 @@ class Request < ApplicationRecord
     not_found? && next_retry_at.present? && next_retry_at <= Time.current
   end
 
+  def manual_magnet_allowed?
+    !completed? && !processing?
+  end
+
   # Select a search result and initiate download
   # Returns the created Download record
   def select_result!(search_result)
@@ -230,6 +235,7 @@ class Request < ApplicationRecord
 
       update!(
         status: :downloading,
+        next_retry_at: nil,
         attention_needed: false,
         issue_description: nil
       )
@@ -247,6 +253,28 @@ class Request < ApplicationRecord
     )
     DownloadJob.perform_later(download.id)
     download
+  end
+
+  def add_manual_magnet!(magnet_link)
+    magnet_link = magnet_link.to_s.strip
+    raise ArgumentError, "Enter a valid magnet link" unless magnet_link.start_with?("magnet:?")
+    raise ArgumentError, "Cannot add a magnet link to a completed request" if completed?
+    raise ArgumentError, "Cannot add a magnet link while post-processing is active" if processing?
+
+    search_result = search_results.find_or_initialize_by(guid: manual_magnet_guid(magnet_link))
+    search_result.assign_attributes(
+      title: "Manual magnet for #{book.display_name}",
+      magnet_url: magnet_link,
+      source: SearchResult::SOURCE_MANUAL_MAGNET,
+      indexer: "Manual Magnet",
+      seeders: nil,
+      leechers: nil,
+      download_url: nil,
+      status: :pending
+    )
+    search_result.save!
+
+    select_result!(search_result)
   end
 
   def next_retry_in_words
@@ -291,6 +319,10 @@ class Request < ApplicationRecord
       level: level,
       details: details
     )
+  end
+
+  def manual_magnet_guid(magnet_link)
+    "#{MANUAL_MAGNET_GUID_PREFIX}:#{Digest::SHA256.hexdigest(magnet_link)}"
   end
 
   def set_default_language

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -22,6 +22,7 @@ class SearchResult < ApplicationRecord
   SOURCE_GUTENBERG = "gutenberg"
   SOURCE_LIBRIVOX = "librivox"
   SOURCE_CUSTOM = "custom"
+  SOURCE_MANUAL_MAGNET = "manual_magnet"
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
   validates :title, presence: true
@@ -263,6 +264,8 @@ class SearchResult < ApplicationRecord
       "LibriVox"
     when SOURCE_CUSTOM
       acquisition_provider&.name || indexer.presence || "Custom Provider"
+    when SOURCE_MANUAL_MAGNET
+      "Manual Magnet"
     else
       indexer.presence || "Prowlarr"
     end

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -248,16 +248,7 @@ module DownloadClients
     end
 
     def extract_hash_from_magnet(url)
-      decoded_url = URI.decode_www_form_component(url.to_s)
-      match = decoded_url.match(/btih:([a-fA-F0-9]{40}|[a-zA-Z2-7]{32})/i)
-      return nil unless match
-
-      hash = match[1]
-      return hash.downcase if hash.match?(/\A[a-fA-F0-9]{40}\z/)
-
-      base32_to_hex(hash)
-    rescue ArgumentError
-      nil
+      MagnetLink.info_hash(url)
     end
 
     # Check if URL points to a .torrent file
@@ -332,21 +323,6 @@ module DownloadClients
     rescue BEncode::DecodeError => e
       Rails.logger.warn "[Qbittorrent] Failed to parse torrent file (not valid bencode): #{e.message}"
       nil
-    end
-
-    def base32_to_hex(value)
-      alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
-      bits = value.upcase.each_char.map do |char|
-        index = alphabet.index(char)
-        return nil unless index
-
-        index.to_s(2).rjust(5, "0")
-      end.join
-
-      bytes = bits.scan(/.{8}/).map { |byte| byte.to_i(2) }
-      return nil unless bytes.length == 20
-
-      bytes.pack("C*").unpack1("H*")
     end
 
     def normalized_torrent_url(raw_url)

--- a/app/services/magnet_link.rb
+++ b/app/services/magnet_link.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "uri"
+
+class MagnetLink
+  BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+  # Extract the BitTorrent info hash from a magnet link.
+  # Returns the 40-character lowercase hex hash, or nil when the link
+  # doesn't carry a valid btih hash.
+  def self.info_hash(url)
+    decoded_url = URI.decode_www_form_component(url.to_s)
+    match = decoded_url.match(/btih:([a-fA-F0-9]{40}|[a-zA-Z2-7]{32})/i)
+    return nil unless match
+
+    hash = match[1]
+    return hash.downcase if hash.match?(/\A[a-fA-F0-9]{40}\z/)
+
+    base32_to_hex(hash)
+  rescue ArgumentError
+    nil
+  end
+
+  def self.base32_to_hex(value)
+    bits = value.upcase.each_char.map do |char|
+      index = BASE32_ALPHABET.index(char)
+      return nil unless index
+
+      index.to_s(2).rjust(5, "0")
+    end.join
+
+    bytes = bits.scan(/.{8}/).map { |byte| byte.to_i(2) }
+    return nil unless bytes.length == 20
+
+    bytes.pack("C*").unpack1("H*")
+  end
+  private_class_method :base32_to_hex
+end

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -231,6 +231,21 @@
         </div>
       <% end %>
 
+      <% if Current.user.admin? && @request.manual_magnet_allowed? %>
+        <div class="mt-6 pt-6 border-t border-gray-800">
+          <h3 class="text-sm font-medium text-gray-500 mb-2">Manual Magnet Link</h3>
+          <p class="text-sm text-gray-400 mb-3">Paste a magnet link to send it to the configured torrent client for this request. If a download is already active, it will be replaced.</p>
+          <%= form_with url: manual_magnet_request_path(@request), method: :post, local: true, class: "flex flex-col sm:flex-row gap-3" do |f| %>
+            <%= f.text_field :magnet_url,
+                name: :magnet_url,
+                placeholder: "magnet:?xt=urn:btih:...",
+                class: "flex-1 rounded-lg bg-gray-800 border border-gray-700 text-white placeholder-gray-500 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500" %>
+            <%= f.submit "Add Magnet",
+                class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition text-sm" %>
+          <% end %>
+        </div>
+      <% end %>
+
       <% if @request.downloads.any? %>
         <div class="mt-6 pt-6 border-t border-gray-800">
           <h3 class="text-sm font-medium text-gray-500 mb-2">Downloads</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
   resources :requests, only: [ :index, :show, :new, :create, :destroy ] do
     member do
       get :download
+      post :manual_magnet
       post :retry
     end
   end

--- a/test/controllers/admin/search_results_controller_test.rb
+++ b/test/controllers/admin/search_results_controller_test.rb
@@ -152,5 +152,21 @@ module Admin
       assert_redirected_to request_path(@request_record)
       assert_match /refreshed/, flash[:notice]
     end
+
+    test "refresh preserves manual magnet results" do
+      manual_result = @request_record.search_results.create!(
+        guid: "manual-magnet:#{'a' * 40}",
+        title: "Manual magnet result",
+        magnet_url: "magnet:?xt=urn:btih:#{'a' * 40}",
+        source: SearchResult::SOURCE_MANUAL_MAGNET,
+        indexer: "Manual Magnet",
+        status: :selected
+      )
+
+      post refresh_admin_request_search_results_path(@request_record)
+
+      @request_record.reload
+      assert_equal [ manual_result ], @request_record.search_results.to_a
+    end
   end
 end

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -611,6 +611,132 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "show displays manual magnet form for open request" do
+    sign_out
+    sign_in_as(@admin)
+
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']"
+    assert_select "input[name='magnet_url']"
+  end
+
+  test "show hides manual magnet form from regular users" do
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']", count: 0
+  end
+
+  test "show hides manual magnet form for completed request" do
+    @pending_request.complete!
+    sign_out
+    sign_in_as(@admin)
+
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']", count: 0
+  end
+
+  test "show hides manual magnet form for processing request" do
+    @pending_request.update!(status: :processing)
+    sign_out
+    sign_in_as(@admin)
+
+    get request_path(@pending_request)
+
+    assert_response :success
+    assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']", count: 0
+  end
+
+  test "manual magnet creates selected result and queues download" do
+    sign_out
+    sign_in_as(@admin)
+    magnet = " magnet:?xt=urn:btih:#{'a' * 40}&dn=Manual+Book "
+
+    assert_enqueued_with(job: DownloadJob) do
+      assert_difference [ "SearchResult.count", "Download.count" ], 1 do
+        post manual_magnet_request_path(@pending_request), params: { magnet_url: magnet }
+      end
+    end
+
+    @pending_request.reload
+    result = @pending_request.search_results.find_by(source: SearchResult::SOURCE_MANUAL_MAGNET)
+    download = @pending_request.downloads.order(:created_at).last
+
+    assert @pending_request.downloading?
+    assert result.selected?
+    assert_equal "magnet:?xt=urn:btih:#{'a' * 40}&dn=Manual+Book", result.magnet_url
+    assert_equal result, download.search_result
+    assert_equal "Magnet link queued for download.", flash[:notice]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual magnet rejects invalid link" do
+    sign_out
+    sign_in_as(@admin)
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      post manual_magnet_request_path(@pending_request), params: { magnet_url: "https://example.com/file.torrent" }
+    end
+
+    assert_equal "Enter a valid magnet link", flash[:alert]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual magnet rejects processing request" do
+    @pending_request.update!(status: :processing)
+    sign_out
+    sign_in_as(@admin)
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      post manual_magnet_request_path(@pending_request), params: { magnet_url: "magnet:?xt=urn:btih:#{'d' * 40}" }
+    end
+
+    assert_equal "Cannot add a magnet link while post-processing is active", flash[:alert]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual magnet redirects when duplicate result save races" do
+    sign_out
+    sign_in_as(@admin)
+
+    request = @pending_request
+    request.define_singleton_method(:add_manual_magnet!) do |_magnet_url|
+      raise ActiveRecord::RecordNotUnique, "duplicate"
+    end
+    finder = Object.new
+    finder.define_singleton_method(:find) { |_id| request }
+
+    Request.stub(:includes, finder) do
+      post manual_magnet_request_path(@pending_request), params: { magnet_url: "magnet:?xt=urn:btih:#{'f' * 40}" }
+    end
+
+    assert_equal "Magnet link could not be queued. Please try again.", flash[:alert]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual magnet cannot be added by regular users" do
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      post manual_magnet_request_path(@pending_request), params: { magnet_url: "magnet:?xt=urn:btih:#{'b' * 40}" }
+    end
+
+    assert_equal "You don't have permission to add magnet links", flash[:alert]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual magnet cannot be added to another user's request" do
+    other_request = Request.create!(book: books(:ebook_pending), user: @admin, status: :pending)
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      post manual_magnet_request_path(other_request), params: { magnet_url: "magnet:?xt=urn:btih:#{'c' * 40}" }
+    end
+
+    assert_response :not_found
+  end
+
   test "destroy rejects non-cancellable status" do
     # Only completed requests cannot be cancelled
     @pending_request.update!(status: :completed)

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -64,6 +64,27 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "preserves manual magnet results when saving new results" do
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+
+      manual_result = @request.search_results.create!(
+        guid: "manual-magnet:#{'b' * 40}",
+        title: "Manual magnet result",
+        magnet_url: "magnet:?xt=urn:btih:#{'b' * 40}",
+        source: SearchResult::SOURCE_MANUAL_MAGNET,
+        indexer: "Manual Magnet",
+        status: :selected
+      )
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_includes @request.search_results, manual_result
+      assert manual_result.reload.selected?
+    end
+  end
+
   test "schedules retry when no results found" do
     VCR.turned_off do
       stub_prowlarr_search_empty

--- a/test/models/request_manual_magnet_test.rb
+++ b/test/models/request_manual_magnet_test.rb
@@ -37,6 +37,38 @@ class RequestManualMagnetTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_manual_magnet rejects magnet links without a valid info hash" do
+    assert_raises(ArgumentError, match: /info hash/) do
+      @request.add_manual_magnet!("magnet:?xt=urn:btih:tooshort")
+    end
+
+    assert_raises(ArgumentError, match: /info hash/) do
+      @request.add_manual_magnet!("magnet:?dn=No+Hash+Here")
+    end
+  end
+
+  test "add_manual_magnet dedups magnets with the same info hash" do
+    hash = "f" * 40
+    @request.add_manual_magnet!("magnet:?xt=urn:btih:#{hash}&dn=First&tr=http://tracker-a.example")
+
+    updated_magnet = "magnet:?xt=urn:btih:#{hash}&dn=Second&tr=http://tracker-b.example"
+    assert_no_difference "SearchResult.count" do
+      @request.add_manual_magnet!(updated_magnet)
+    end
+
+    result = @request.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_MAGNET)
+    assert_equal "manual-magnet:#{hash}", result.guid
+    assert_equal updated_magnet, result.magnet_url
+  end
+
+  test "add_manual_magnet dedups hex and base32 encodings of the same info hash" do
+    @request.add_manual_magnet!("magnet:?xt=urn:btih:#{'aa' * 20}")
+
+    assert_no_difference "SearchResult.count" do
+      @request.add_manual_magnet!("magnet:?xt=urn:btih:#{'VK' * 16}")
+    end
+  end
+
   test "add_manual_magnet rejects completed requests" do
     @request.complete!
 

--- a/test/models/request_manual_magnet_test.rb
+++ b/test/models/request_manual_magnet_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RequestManualMagnetTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @request = requests(:pending_request)
+  end
+
+  test "add_manual_magnet creates manual search result and download" do
+    @request.update!(status: :not_found, next_retry_at: 1.hour.from_now)
+    magnet = "magnet:?xt=urn:btih:#{'c' * 40}&dn=Manual"
+
+    assert_enqueued_with(job: DownloadJob) do
+      assert_difference [ "SearchResult.count", "Download.count" ], 1 do
+        @request.add_manual_magnet!(magnet)
+      end
+    end
+
+    result = @request.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_MAGNET)
+    download = @request.downloads.order(:created_at).last
+
+    assert_equal magnet, result.magnet_url
+    assert_equal "Manual Magnet", result.indexer
+    assert result.selected?
+    assert @request.reload.downloading?
+    assert_nil @request.next_retry_at
+    assert_equal result, download.search_result
+    assert download.queued?
+  end
+
+  test "add_manual_magnet rejects non magnet links" do
+    assert_raises(ArgumentError, match: /valid magnet/) do
+      @request.add_manual_magnet!("https://example.com/file.torrent")
+    end
+  end
+
+  test "add_manual_magnet rejects completed requests" do
+    @request.complete!
+
+    assert_raises(ArgumentError, match: /completed request/) do
+      @request.add_manual_magnet!("magnet:?xt=urn:btih:#{'d' * 40}")
+    end
+  end
+
+  test "add_manual_magnet rejects processing requests" do
+    @request.update!(status: :processing)
+
+    assert_raises(ArgumentError, match: /post-processing/) do
+      @request.add_manual_magnet!("magnet:?xt=urn:btih:#{'e' * 40}")
+    end
+  end
+
+  test "manual_magnet_allowed allows downloading override but not processing" do
+    @request.update!(status: :downloading)
+    assert @request.manual_magnet_allowed?
+
+    @request.update!(status: :processing)
+    assert_not @request.manual_magnet_allowed?
+  end
+end

--- a/test/services/magnet_link_test.rb
+++ b/test/services/magnet_link_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MagnetLinkTest < ActiveSupport::TestCase
+  test "extracts hex info hash" do
+    hash = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+    magnet = "magnet:?xt=urn:btih:#{hash.upcase}&dn=Example"
+
+    assert_equal hash, MagnetLink.info_hash(magnet)
+  end
+
+  test "converts base32 info hash to hex" do
+    assert_equal "aa" * 20, MagnetLink.info_hash("magnet:?xt=urn:btih:#{'VK' * 16}")
+  end
+
+  test "extracts hash from url-encoded magnet" do
+    hash = "b" * 40
+    encoded = CGI.escape("magnet:?xt=urn:btih:#{hash}")
+
+    assert_equal hash, MagnetLink.info_hash(encoded)
+  end
+
+  test "returns nil when no valid hash is present" do
+    assert_nil MagnetLink.info_hash("magnet:?dn=No+Hash")
+    assert_nil MagnetLink.info_hash("magnet:?xt=urn:btih:tooshort")
+    assert_nil MagnetLink.info_hash(nil)
+    assert_nil MagnetLink.info_hash("")
+  end
+end


### PR DESCRIPTION
## Summary
- Add an admin-only manual magnet form on request pages.
- Create a manual search result and queue the existing download flow for valid magnet links.
- Clear stale retry state when a request is moved back to downloading.

Closes #317

## Test plan
- bin/rails test test/controllers/requests_controller_test.rb test/models/request_manual_magnet_test.rb test/models/request_retry_test.rb
- bin/rubocop app/controllers/requests_controller.rb app/models/request.rb app/models/search_result.rb test/controllers/requests_controller_test.rb test/models/request_manual_magnet_test.rb
- bin/rails test