### PR TITLE
feat: add move import option

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -32,13 +32,14 @@ class PostProcessingJob < ApplicationJob
       cleanup_usenet_download(download)
 
       book.update!(file_path: destination)
+      remove_import_source(source_cleanup)
+
       request.complete!
 
       # Pre-create zip for directories (audiobooks) so download is instant
       pre_create_download_zip(book, destination) if File.directory?(destination)
 
       trigger_library_scan(book) if AudiobookshelfClient.configured?
-      source_cleanup&.call
 
       NotificationService.request_completed(request)
 
@@ -133,13 +134,15 @@ class PostProcessingJob < ApplicationJob
       raise source_path_not_found_message(source)
     end
 
+    directory_source = File.directory?(source)
+    @defer_source_removal = directory_source && move_completed_downloads?
     action = move_completed_downloads? ? "Moving" : "Copying"
     Rails.logger.info "[PostProcessingJob] #{action} from #{source} to #{destination}"
     validate_ebook_source!(source) if book&.ebook?
     FileUtils.mkdir_p(destination)
     source_cleanup = nil
 
-    if File.directory?(source)
+    if directory_source
       # Import all files from source directory to destination
       # Use Dir.entries instead of Dir.glob to avoid pattern matching issues
       # (e.g., [AUDIOBOOK] in path being treated as character class)
@@ -155,7 +158,7 @@ class PostProcessingJob < ApplicationJob
         end
       end
 
-      source_cleanup = -> { remove_empty_directory(source) } if move_completed_downloads?
+      source_cleanup = -> { remove_import_source_tree(source) } if move_completed_downloads?
     else
       # Import single file with renamed filename based on template
       import_renamed_file(source, destination, book)
@@ -163,6 +166,8 @@ class PostProcessingJob < ApplicationJob
 
     Rails.logger.info "[PostProcessingJob] #{action} completed successfully"
     source_cleanup
+  ensure
+    remove_instance_variable(:@defer_source_removal) if instance_variable_defined?(:@defer_source_removal)
   end
 
   def import_ebook_directory_entry(source_file, destination, book)
@@ -170,7 +175,6 @@ class PostProcessingJob < ApplicationJob
       Dir.entries(source_file).reject { |f| f.start_with?(".") }.each do |file|
         import_ebook_directory_entry(File.join(source_file, file), destination, book)
       end
-      remove_empty_directory(source_file) if move_completed_downloads?
     elsif ebook_file?(source_file)
       import_renamed_file(source_file, destination, book)
     else
@@ -272,34 +276,15 @@ class PostProcessingJob < ApplicationJob
   end
 
   def import_file(source, destination)
-    if move_completed_downloads?
-      move_file_or_directory(source, destination)
+    if move_completed_downloads? && !@defer_source_removal
+      FileCopyService.mv(source, destination)
     else
       FileCopyService.cp(source, destination)
     end
   end
 
   def import_directory_entry(source, destination)
-    if move_completed_downloads?
-      move_file_or_directory(source, destination)
-    else
-      FileCopyService.cp_r(source, destination)
-    end
-  end
-
-  def move_file_or_directory(source, destination)
-    FileUtils.mv(source, destination)
-  rescue Errno::EACCES => e
-    raise unless e.message.include?("copy_file_range")
-
-    Rails.logger.info "[PostProcessingJob] move fallback using buffered copy for #{File.basename(source)}"
-    if File.directory?(source)
-      FileCopyService.cp_r(source, destination)
-      FileUtils.rm_rf(source)
-    else
-      FileCopyService.cp(source, destination)
-      FileUtils.rm_f(source)
-    end
+    FileCopyService.cp_r(source, destination)
   end
 
   def move_completed_downloads?
@@ -308,9 +293,15 @@ class PostProcessingJob < ApplicationJob
     @move_completed_downloads = SettingsService.get(:move_completed_downloads, default: false)
   end
 
-  def remove_empty_directory(path)
-    FileUtils.rmdir(path)
-  rescue Errno::ENOENT, Errno::ENOTEMPTY
+  def remove_import_source(source_cleanup)
+    source_cleanup&.call
+  rescue => e
+    Rails.logger.warn "[PostProcessingJob] Failed to remove import source (non-fatal): #{e.message}"
+  end
+
+  def remove_import_source_tree(path)
+    FileUtils.rm_rf(path)
+  rescue Errno::ENOENT
     nil
   end
 

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Copies completed downloads to library folder and triggers library scan.
-# Files are COPIED (not moved) to preserve seeding for torrent downloads.
+# Imports completed downloads to the library folder and triggers library scan.
+# Files are copied by default to preserve seeding for torrent downloads.
 # Usenet downloads are removed from the client after successful import.
 class PostProcessingJob < ApplicationJob
   EBOOK_FILE_EXTENSIONS = %w[epub pdf mobi azw azw3 cbz cbr djvu].freeze
@@ -28,7 +28,7 @@ class PostProcessingJob < ApplicationJob
         return retry_source_path_later(download, request, source_path, source_path_retry_count)
       end
 
-      copy_files(source_path, destination, book: book)
+      source_cleanup = import_files(source_path, destination, book: book)
       cleanup_usenet_download(download)
 
       book.update!(file_path: destination)
@@ -38,6 +38,7 @@ class PostProcessingJob < ApplicationJob
       pre_create_download_zip(book, destination) if File.directory?(destination)
 
       trigger_library_scan(book) if AudiobookshelfClient.configured?
+      source_cleanup&.call
 
       NotificationService.request_completed(request)
 
@@ -118,7 +119,7 @@ class PostProcessingJob < ApplicationJob
     end
   end
 
-  def copy_files(source, destination, book: nil)
+  def import_files(source, destination, book: nil)
     unless source.present?
       Rails.logger.error "[PostProcessingJob] Source path is blank - download client may not have reported the path"
       raise "Source path is blank. Check download client configuration and ensure the download completed successfully."
@@ -132,43 +133,48 @@ class PostProcessingJob < ApplicationJob
       raise source_path_not_found_message(source)
     end
 
-    Rails.logger.info "[PostProcessingJob] Copying from #{source} to #{destination}"
+    action = move_completed_downloads? ? "Moving" : "Copying"
+    Rails.logger.info "[PostProcessingJob] #{action} from #{source} to #{destination}"
     validate_ebook_source!(source) if book&.ebook?
     FileUtils.mkdir_p(destination)
+    source_cleanup = nil
 
     if File.directory?(source)
-      # Copy all files from source directory to destination
+      # Import all files from source directory to destination
       # Use Dir.entries instead of Dir.glob to avoid pattern matching issues
       # (e.g., [AUDIOBOOK] in path being treated as character class)
-      # Files are COPIED (not moved) to preserve seeding on private trackers
       files = Dir.entries(source).reject { |f| f.start_with?(".") }
-      Rails.logger.info "[PostProcessingJob] Found #{files.size} files/folders to copy"
+      Rails.logger.info "[PostProcessingJob] Found #{files.size} files/folders to import"
       files.each do |file|
         source_file = File.join(source, file)
 
         if book&.ebook?
-          copy_ebook_directory_entry(source_file, destination, book)
+          import_ebook_directory_entry(source_file, destination, book)
         else
-          FileCopyService.cp_r(source_file, destination)
+          import_directory_entry(source_file, destination)
         end
       end
+
+      source_cleanup = -> { remove_empty_directory(source) } if move_completed_downloads?
     else
-      # Copy single file with renamed filename based on template
-      copy_renamed_file(source, destination, book)
+      # Import single file with renamed filename based on template
+      import_renamed_file(source, destination, book)
     end
 
-    Rails.logger.info "[PostProcessingJob] Copy completed successfully"
+    Rails.logger.info "[PostProcessingJob] #{action} completed successfully"
+    source_cleanup
   end
 
-  def copy_ebook_directory_entry(source_file, destination, book)
+  def import_ebook_directory_entry(source_file, destination, book)
     if File.directory?(source_file)
       Dir.entries(source_file).reject { |f| f.start_with?(".") }.each do |file|
-        copy_ebook_directory_entry(File.join(source_file, file), destination, book)
+        import_ebook_directory_entry(File.join(source_file, file), destination, book)
       end
+      remove_empty_directory(source_file) if move_completed_downloads?
     elsif ebook_file?(source_file)
-      copy_renamed_file(source_file, destination, book)
+      import_renamed_file(source_file, destination, book)
     else
-      copy_sidecar_file(source_file, destination)
+      import_sidecar_file(source_file, destination)
     end
   end
 
@@ -253,16 +259,59 @@ class PostProcessingJob < ApplicationJob
     end
   end
 
-  def copy_sidecar_file(source_file, destination)
+  def import_sidecar_file(source_file, destination)
     destination_file = File.join(destination, File.basename(source_file))
     destination_file = handle_duplicate_filename(destination_file) if File.exist?(destination_file)
-    FileCopyService.cp(source_file, destination_file)
+    import_file(source_file, destination_file)
   end
 
-  def copy_renamed_file(source, destination, book)
+  def import_renamed_file(source, destination, book)
     destination_file = renamed_destination_file(source, destination, book)
     Rails.logger.info "[PostProcessingJob] Renaming file to: #{File.basename(destination_file)}"
-    FileCopyService.cp(source, destination_file)
+    import_file(source, destination_file)
+  end
+
+  def import_file(source, destination)
+    if move_completed_downloads?
+      move_file_or_directory(source, destination)
+    else
+      FileCopyService.cp(source, destination)
+    end
+  end
+
+  def import_directory_entry(source, destination)
+    if move_completed_downloads?
+      move_file_or_directory(source, destination)
+    else
+      FileCopyService.cp_r(source, destination)
+    end
+  end
+
+  def move_file_or_directory(source, destination)
+    FileUtils.mv(source, destination)
+  rescue Errno::EACCES => e
+    raise unless e.message.include?("copy_file_range")
+
+    Rails.logger.info "[PostProcessingJob] move fallback using buffered copy for #{File.basename(source)}"
+    if File.directory?(source)
+      FileCopyService.cp_r(source, destination)
+      FileUtils.rm_rf(source)
+    else
+      FileCopyService.cp(source, destination)
+      FileUtils.rm_f(source)
+    end
+  end
+
+  def move_completed_downloads?
+    return @move_completed_downloads if defined?(@move_completed_downloads)
+
+    @move_completed_downloads = SettingsService.get(:move_completed_downloads, default: false)
+  end
+
+  def remove_empty_directory(path)
+    FileUtils.rmdir(path)
+  rescue Errno::ENOENT, Errno::ENOTEMPTY
+    nil
   end
 
   def renamed_destination_file(source, destination, book)
@@ -321,7 +370,7 @@ class PostProcessingJob < ApplicationJob
     Rails.logger.warn "[PostProcessingJob] No remapped path exists on disk. Candidates tried:"
     candidates.each { |c| Rails.logger.warn "[PostProcessingJob]   #{c[:strategy]}: #{c[:path]}" }
 
-    # Return the first non-nil candidate so copy_files produces a clear "not found" error
+    # Return the first non-nil candidate so import_files produces a clear "not found" error
     best_guess = candidates.find { |c| c[:path].present? }
     best_guess ? best_guess[:path] : path
   end

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -16,7 +16,7 @@ class FileCopyService
     def cp(src, dest)
       FileUtils.cp(src, dest)
     rescue Errno::EACCES => e
-      raise unless e.message.include?("copy_file_range")
+      raise unless copy_file_range_error?(e)
 
       Rails.logger.info "[FileCopyService] copy_file_range failed on NFS, falling back to buffered copy for #{File.basename(src)}"
       buffered_copy(src, dest)
@@ -25,13 +25,62 @@ class FileCopyService
     def cp_r(src, dest)
       FileUtils.cp_r(src, dest)
     rescue Errno::EACCES => e
-      raise unless e.message.include?("copy_file_range")
+      raise unless copy_file_range_error?(e)
 
       Rails.logger.info "[FileCopyService] copy_file_range failed on NFS, falling back to buffered recursive copy"
       recursive_buffered_copy(src, dest)
     end
 
+    def mv(src, dest)
+      FileUtils.mv(src, dest)
+    rescue Errno::EACCES => e
+      raise unless copy_file_range_error?(e)
+
+      Rails.logger.info "[FileCopyService] copy_file_range failed on NFS, falling back to buffered move for #{File.basename(src)}"
+      move_via_copy(src, dest)
+    end
+
     private
+
+    def copy_file_range_error?(error)
+      error.message.include?("copy_file_range")
+    end
+
+    def move_via_copy(src, dest)
+      cp(src, dest)
+      remove_source_safely(src, dest)
+    end
+
+    def remove_source_safely(src, dest)
+      if File.directory?(src)
+        FileUtils.rm_rf(src)
+      else
+        FileUtils.rm_f(src)
+      end
+    rescue => e
+      if source_move_verified?(src, dest)
+        Rails.logger.warn "[FileCopyService] Source removal failed after successful copy (non-fatal): #{e.message}"
+      else
+        raise
+      end
+    end
+
+    def source_move_verified?(src, dest)
+      dest_path = resolved_destination_path(src, dest)
+      return false unless dest_path && File.exist?(dest_path)
+
+      if File.directory?(src)
+        File.directory?(dest_path)
+      else
+        File.file?(dest_path) && File.size(dest_path) == File.size(src)
+      end
+    rescue Errno::ENOENT, Errno::EACCES
+      false
+    end
+
+    def resolved_destination_path(src, dest)
+      File.directory?(dest) ? File.join(dest, File.basename(src)) : dest
+    end
 
     def buffered_copy(src, dest)
       dest = File.join(dest, File.basename(src)) if File.directory?(dest)

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -62,6 +62,7 @@ class SettingsService
     download_check_interval: { type: "integer", default: 60, category: "download", description: "Seconds between download status checks" },
     download_enqueue_timeout_minutes: { type: "integer", default: 5, category: "download", description: "Minutes a download may stay queued in Shelfarr before being flagged as never dispatched to the download client" },
     post_processing_source_path_retries: { type: "integer", default: 10, category: "download", description: "Number of post-processing retries while waiting for completed download files to appear" },
+    move_completed_downloads: { type: "boolean", default: false, category: "download", description: "Move completed download files into the library instead of copying them. Disable to preserve torrent seeding." },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
     # Audiobookshelf Integration

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -662,6 +662,7 @@
               <tr><td class="key"><code>download_check_interval</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>60</code></td><td class="desc">Seconds between download status checks.</td></tr>
               <tr><td class="key"><code>download_enqueue_timeout_minutes</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>5</code></td><td class="desc">Minutes a download may stay queued before being flagged as never dispatched.</td></tr>
               <tr><td class="key"><code>post_processing_source_path_retries</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>10</code></td><td class="desc">Retries while waiting for completed download files to appear.</td></tr>
+              <tr><td class="key"><code>move_completed_downloads</code></td><td><span class="badge t-boolean">boolean</span></td><td class="default"><code>false</code></td><td class="desc">Move completed download files into the library instead of copying them. Keep disabled to preserve torrent seeding.</td></tr>
               <tr><td class="key"><code>remove_completed_usenet_downloads</code></td><td><span class="badge t-boolean">boolean</span></td><td class="default"><code>true</code></td><td class="desc">Remove completed usenet jobs from the client after import.</td></tr>
             </tbody>
           </table>

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -40,6 +40,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
     # Set output path to temp destination (Shelfarr always uses its own settings)
     SettingsService.set(:audiobook_output_path, @temp_dest_base)
+    SettingsService.set(:move_completed_downloads, false)
 
     # Update download path to temp source
     @download.update!(download_path: @temp_source)
@@ -111,6 +112,90 @@ class PostProcessingJobTest < ActiveJob::TestCase
       expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
       assert File.exist?(File.join(expected_dest, "audiobook.mp3")), "Destination file should exist"
     end
+  end
+
+  test "moves directory imports when enabled" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:move_completed_downloads, true)
+
+    original_file = File.join(@temp_source, "audiobook.mp3")
+    assert File.exist?(original_file), "Source file should exist before processing"
+
+    FileCopyService.stub(:cp_r, ->(*) { flunk "Move imports should not copy directory entries" }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert File.exist?(File.join(expected_dest, "audiobook.mp3")), "Destination file should exist"
+    assert_not File.exist?(original_file), "Source file should be moved out of the download folder"
+    assert_not File.exist?(@temp_source), "Empty source download folder should be removed"
+  end
+
+  test "moves and renames single file imports when enabled" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.write(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
+    SettingsService.set(:move_completed_downloads, true)
+
+    FileCopyService.stub(:cp, ->(*) { flunk "Move imports should not copy files" }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.m4b"))
+    assert_not File.exist?(source_file), "Source file should no longer exist after move import"
+  end
+
+  test "keeps source file when move import fails" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:move_completed_downloads, true)
+
+    failing_file = File.join(@temp_source, "fail.mp3")
+    File.write(failing_file, "copy failure")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+
+    FileUtils.stub(:mv, ->(*) { raise Errno::EACCES, "permission denied" }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert @request.reload.attention_needed?
+    assert File.exist?(failing_file), "Failing file should remain in source after failure"
+  end
+
+  test "moves ebook directory imports and removes nested source entries when enabled" do
+    FileUtils.rm_rf(@temp_source)
+    nested_source = File.join(@temp_source, "Calibre Export")
+    FileUtils.mkdir_p(nested_source)
+    write_valid_ebook_file(File.join(nested_source, "Jurassic Park by Michael Crichton.epub"))
+    File.binwrite(File.join(nested_source, "cover.jpg"), "\xFF\xD8\xFFvalid cover content".b)
+
+    @book.update!(
+      title: "Jurassic Park",
+      author: "Michael Crichton",
+      book_type: :ebook,
+      year: 1990
+    )
+
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:ebook_path_template, "{author}/{title}")
+    SettingsService.set(:ebook_filename_template, "{author} - {title} ({year})")
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:move_completed_downloads, true)
+
+    FileCopyService.stub(:cp, ->(*) { flunk "Move imports should not copy ebook files" }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    expected_dest = File.join(@temp_dest_base, "Michael Crichton", "Jurassic Park")
+    assert @request.reload.completed?
+    assert File.exist?(File.join(expected_dest, "Michael Crichton - Jurassic Park (1990).epub"))
+    assert File.exist?(File.join(expected_dest, "cover.jpg"))
+    assert_not File.exist?(nested_source), "Nested ebook source folder should be removed after a move import"
+    assert_not File.exist?(@temp_source), "Empty ebook source folder should be removed after a move import"
   end
 
   test "updates book file_path after processing" do

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -121,14 +121,14 @@ class PostProcessingJobTest < ActiveJob::TestCase
     original_file = File.join(@temp_source, "audiobook.mp3")
     assert File.exist?(original_file), "Source file should exist before processing"
 
-    FileCopyService.stub(:cp_r, ->(*) { flunk "Move imports should not copy directory entries" }) do
+    FileCopyService.stub(:mv, ->(*) { flunk "Directory imports should copy entries, not move them individually" }) do
       PostProcessingJob.perform_now(@download.id)
     end
 
     expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
     assert File.exist?(File.join(expected_dest, "audiobook.mp3")), "Destination file should exist"
-    assert_not File.exist?(original_file), "Source file should be moved out of the download folder"
-    assert_not File.exist?(@temp_source), "Empty source download folder should be removed"
+    assert_not File.exist?(original_file), "Source file should be removed after successful import"
+    assert_not File.exist?(@temp_source), "Source download folder should be removed after successful import"
   end
 
   test "moves and renames single file imports when enabled" do
@@ -141,7 +141,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     SettingsService.set(:audiobook_filename_template, "{author} - {title}")
     SettingsService.set(:move_completed_downloads, true)
 
-    FileCopyService.stub(:cp, ->(*) { flunk "Move imports should not copy files" }) do
+    FileCopyService.stub(:cp, ->(*) { flunk "Single-file move imports should not copy files" }) do
       PostProcessingJob.perform_now(@download.id)
     end
 
@@ -150,13 +150,33 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_not File.exist?(source_file), "Source file should no longer exist after move import"
   end
 
-  test "keeps source file when move import fails" do
+  test "falls back to buffered move when NFS copy_file_range fails for single files" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.write(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+
     SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
     SettingsService.set(:move_completed_downloads, true)
 
+    FileUtils.stub(:mv, ->(*) { raise Errno::EACCES, "copy_file_range" }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert @request.reload.completed?
+    assert File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.m4b"))
+    assert_not File.exist?(source_file), "Source file should be removed after buffered move fallback"
+  end
+
+  test "keeps source file when move import fails" do
     failing_file = File.join(@temp_source, "fail.mp3")
     File.write(failing_file, "copy failure")
-    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: failing_file)
+
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:move_completed_downloads, true)
 
     FileUtils.stub(:mv, ->(*) { raise Errno::EACCES, "permission denied" }) do
       PostProcessingJob.perform_now(@download.id)
@@ -186,7 +206,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:move_completed_downloads, true)
 
-    FileCopyService.stub(:cp, ->(*) { flunk "Move imports should not copy ebook files" }) do
+    FileCopyService.stub(:mv, ->(*) { flunk "Ebook directory imports should copy files, not move them individually" }) do
       PostProcessingJob.perform_now(@download.id)
     end
 
@@ -195,7 +215,42 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert File.exist?(File.join(expected_dest, "Michael Crichton - Jurassic Park (1990).epub"))
     assert File.exist?(File.join(expected_dest, "cover.jpg"))
     assert_not File.exist?(nested_source), "Nested ebook source folder should be removed after a move import"
-    assert_not File.exist?(@temp_source), "Empty ebook source folder should be removed after a move import"
+    assert_not File.exist?(@temp_source), "Ebook source folder should be removed after a move import"
+  end
+
+  test "keeps source directory intact when directory import fails with move enabled" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:move_completed_downloads, true)
+
+    File.write(File.join(@temp_source, "second.mp3"), "second file")
+    original_file = File.join(@temp_source, "audiobook.mp3")
+
+    FileCopyService.stub(:cp_r, ->(source, _destination) {
+      raise "import failed" if File.basename(source) == "second.mp3"
+    }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert @request.reload.attention_needed?
+    assert File.exist?(original_file), "First source file should remain when a later import fails"
+    assert File.exist?(File.join(@temp_source, "second.mp3")), "Failing source file should remain after partial import"
+    assert File.exist?(@temp_source), "Source download folder should remain after failed import"
+  end
+
+  test "completes request when import source removal fails non-fatally" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:move_completed_downloads, true)
+
+    FileUtils.stub(:rm_rf, ->(*) { raise Errno::EACCES, "permission denied" }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    @request.reload
+    assert @request.completed?
+    assert_not @request.attention_needed?
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    assert File.exist?(File.join(expected_dest, "audiobook.mp3"))
   end
 
   test "updates book file_path after processing" do

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -110,6 +110,55 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal "nested file", File.read(File.join(copied_dir, "subdir", "nested.txt"))
   end
 
+  test "mv moves a file normally" do
+    dest_file = File.join(@dest_dir, "output.txt")
+    FileCopyService.mv(@src_file, dest_file)
+
+    assert File.exist?(dest_file)
+    assert_equal "test content", File.read(dest_file)
+    assert_not File.exist?(@src_file)
+  end
+
+  test "mv falls back to buffered copy on NFS copy_file_range EACCES" do
+    dest_file = File.join(@dest_dir, "output.txt")
+
+    FileUtils.stub(:mv, ->(_s, _d) { raise Errno::EACCES, "copy_file_range" }) do
+      FileCopyService.mv(@src_file, dest_file)
+    end
+
+    assert File.exist?(dest_file)
+    assert_equal "test content", File.read(dest_file)
+    assert_not File.exist?(@src_file)
+  end
+
+  test "mv re-raises EACCES when not from copy_file_range" do
+    dest_file = File.join(@dest_dir, "output.txt")
+
+    FileUtils.stub(:mv, ->(_s, _d) { raise Errno::EACCES, "some other permission error" }) do
+      assert_raises(Errno::EACCES) do
+        FileCopyService.mv(@src_file, dest_file)
+      end
+    end
+
+    assert File.exist?(@src_file)
+  end
+
+  test "mv tolerates source removal failure when destination copy exists" do
+    dest_file = File.join(@dest_dir, "output.txt")
+
+    FileUtils.stub(:mv, ->(_s, _d) { raise Errno::EACCES, "copy_file_range" }) do
+      FileUtils.stub(:rm_f, ->(_path) { raise Errno::EACCES, "permission denied" }) do
+        assert_nothing_raised do
+          FileCopyService.mv(@src_file, dest_file)
+        end
+      end
+    end
+
+    assert File.exist?(dest_file)
+    assert_equal "test content", File.read(dest_file)
+    assert File.exist?(@src_file), "Source should remain when removal fails after a verified copy"
+  end
+
   test "cp_r fallback copies hidden files" do
     src_dir = File.join(@tmp_dir, "src_dir")
     FileUtils.mkdir_p(src_dir)

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled]).delete_all
+    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types move_completed_downloads zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -102,6 +102,10 @@ class SettingsServiceTest < ActiveSupport::TestCase
     Setting.where(key: "post_processing_source_path_retries").delete_all
 
     assert_equal 10, SettingsService.get(:post_processing_source_path_retries)
+  end
+
+  test "move completed downloads defaults to disabled" do
+    assert_equal false, SettingsService.get(:move_completed_downloads)
   end
 
   test "zlibrary_configured? requires enabled flag and credentials" do


### PR DESCRIPTION
## Summary
- Add a move_completed_downloads setting under Download Settings.
- Keep copy as the default behavior to preserve torrent seeding.
- When enabled, stage imports first and remove source files only after successful post-processing.
- Document the setting in the configuration reference.

Closes #316

## Test plan
- bin/rails test test/jobs/post_processing_job_test.rb
- bin/rails test test/services/settings_service_test.rb
- bin/rails test test/controllers/admin/settings_controller_test.rb
- bin/rails test
- git diff --check