### PR TITLE
feat: add BookOrbit library support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Think Jellyseerr, but for books. Your users request ebooks and audiobooks; Shelf
 - **Smart Acquisition** — Search Prowlarr, Jackett or Newznab/NZBHydra2 indexers; download via qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet
 - **Direct Downloads** — Ebooks from Anna's Archive and Z-Library, public-domain audiobooks from LibriVox — no torrent client needed
 - **Auto-Selection & Format Preferences** — Pick the best release automatically, scored by your preferred formats, bitrate and language
-- **Auto-Processing** — Rename and organize files with path/filename templates, then deliver to Audiobookshelf
-- **Library Sync** — Automatic Audiobookshelf scans after downloads complete
+- **Auto-Processing** — Rename and organize files with path/filename templates, then deliver to Audiobookshelf or BookOrbit watched folders
+- **Library Sync** — Automatic Audiobookshelf or BookOrbit scans after downloads complete
 - **Manual Uploads** — Upload your own files to fulfill a request
 - **Multi-User** — Role-based access with user requests and admin controls
 - **Authentication** — TOTP-based 2FA with backup codes, plus OIDC/SSO (Authentik, Authelia, Keycloak, etc.)
@@ -107,7 +107,7 @@ After logging in, go to **Admin → Settings**:
 | Indexer | Prowlarr, Jackett or Newznab/NZBHydra2 URL + API key for searches |
 | Download Clients | qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet (Admin → Download Clients) |
 | Output Paths | Where to place completed audiobooks/ebooks |
-| Audiobookshelf | URL + API key for library integration (optional) |
+| Library Platform | Audiobookshelf URL + API key, or BookOrbit URL + username/password for library integration (optional) |
 
 📖 **[Read the docs](https://shelfarr.org/getting-started.html)** for a full install and setup walkthrough, plus a **[settings reference](https://shelfarr.org/configuration.html)** describing every option, its type and default.
 
@@ -145,7 +145,7 @@ Shelfarr supports OpenID Connect for single sign-on with identity providers like
 | **SABnzbd**, **NZBGet** | Usenet downloads |
 | **Anna's Archive** / **Z-Library** | Direct ebook downloads |
 | **LibriVox** | Public-domain audiobook downloads |
-| **Audiobookshelf** | Library management |
+| **Audiobookshelf** / **BookOrbit** | Library management |
 | **Discord** / **Telegram** / **Webhooks** | Notifications |
 
 ## Requirements
@@ -154,7 +154,9 @@ Shelfarr supports OpenID Connect for single sign-on with identity providers like
 - At least one way to find books:
   - An indexer — Prowlarr, Jackett or Newznab/NZBHydra2 — plus a download client (qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet), **and/or**
   - A direct source — Anna's Archive or Z-Library (ebooks), LibriVox (audiobooks)
-- Audiobookshelf (optional, for library integration)
+- Audiobookshelf or BookOrbit (optional, for library integration)
+
+BookOrbit support uses BookOrbit's current `/api/v1` endpoints for library listing, inventory sync, and scan triggers. Shelfarr still delivers files through configured output paths; direct Book Dock upload/finalize is not implemented because BookOrbit does not currently publish a stable external API for that workflow.
 
 ## Development
 

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -13,9 +13,11 @@ module Admin
       key = params[:id]
       value = params[:setting][:value]
 
-      validate_path_template!(key, value)
-      SettingsService.set(key, value)
-      handle_settings_side_effects([ key.to_s ])
+      unless preserve_blank_secret?(key, value)
+        validate_path_template!(key, value)
+        SettingsService.set(key, value)
+        handle_settings_side_effects([ key.to_s ])
+      end
 
       respond_to do |format|
         format.html { redirect_to admin_settings_path, notice: "Setting updated." }
@@ -27,17 +29,20 @@ module Admin
 
     def bulk_update
       errors = []
+      changed_keys = []
 
       params[:settings]&.each do |key, value|
+        next if preserve_blank_secret?(key, value)
+
         error = validate_path_template(key, value)
         if error
           errors << "#{key.to_s.titleize}: #{error}"
         else
           SettingsService.set(key, value)
+          changed_keys << key.to_s
         end
       end
 
-      changed_keys = params[:settings]&.keys&.map(&:to_s) || []
       handle_settings_side_effects(changed_keys)
 
       @settings_by_category = SettingsService.all_by_category
@@ -112,32 +117,32 @@ module Admin
     def test_audiobookshelf
       health = SystemHealth.for_service("audiobookshelf")
 
-      unless AudiobookshelfClient.configured?
+      unless LibraryPlatformClient.configured?
         health.mark_not_configured!
-        respond_with_flash(alert: "#{AudiobookshelfClient.display_name} is not configured. Enter connection details first.")
+        respond_with_flash(alert: "#{LibraryPlatformClient.display_name} is not configured. Enter connection details first.")
         return
       end
 
-      if AudiobookshelfClient.test_connection
+      if LibraryPlatformClient.test_connection
         health.check_succeeded!(message: "Connection successful")
-        respond_with_flash(notice: "#{AudiobookshelfClient.display_name} connection successful!")
+        respond_with_flash(notice: "#{LibraryPlatformClient.display_name} connection successful!")
       else
-        health.check_failed!(message: "Failed to connect to #{AudiobookshelfClient.display_name}")
-        respond_with_flash(alert: "#{AudiobookshelfClient.display_name} connection failed.")
+        health.check_failed!(message: "Failed to connect to #{LibraryPlatformClient.display_name}")
+        respond_with_flash(alert: "#{LibraryPlatformClient.display_name} connection failed.")
       end
-    rescue AudiobookshelfClient::Error => e
+    rescue LibraryPlatformClient::Error => e
       health&.check_failed!(message: e.message)
-      respond_with_flash(alert: "#{AudiobookshelfClient.display_name} error: #{e.message}")
+      respond_with_flash(alert: "#{LibraryPlatformClient.display_name} error: #{e.message}")
     end
 
     def sync_audiobookshelf_library
-      unless AudiobookshelfClient.configured?
-        redirect_to admin_settings_path, alert: "#{AudiobookshelfClient.display_name} is not configured. Enter connection details first."
+      unless LibraryPlatformClient.configured?
+        redirect_to admin_settings_path, alert: "#{LibraryPlatformClient.display_name} is not configured. Enter connection details first."
         return
       end
 
       AudiobookshelfLibrarySyncJob.perform_later
-      redirect_to admin_settings_path, notice: "#{AudiobookshelfClient.display_name} library sync started."
+      redirect_to admin_settings_path, notice: "#{LibraryPlatformClient.display_name} library sync started."
     end
 
     # FlareSolverr is not tracked in SystemHealth::SERVICES, so no SystemHealth sync here
@@ -409,8 +414,8 @@ module Admin
       return if changed_keys.blank?
 
       if changed_keys.any? { |k| library_platform_setting_key?(k) }
-        AudiobookshelfClient.reset_connection!
-        AudiobookshelfLibrarySyncJob.perform_later if AudiobookshelfClient.configured?
+        LibraryPlatformClient.reset_connections!
+        AudiobookshelfLibrarySyncJob.perform_later if LibraryPlatformClient.configured?
         run_service_health_check("audiobookshelf")
       end
       if changed_keys.any? { |k| indexer_setting_key?(k) }
@@ -476,11 +481,11 @@ module Admin
     end
 
     def fetch_audiobookshelf_libraries
-      return [] unless AudiobookshelfClient.configured?
+      return [] unless LibraryPlatformClient.configured?
 
-      AudiobookshelfClient.libraries
-    rescue AudiobookshelfClient::Error => e
-      Rails.logger.warn "[SettingsController] Failed to fetch #{AudiobookshelfClient.display_name} libraries: #{e.message}"
+      LibraryPlatformClient.libraries
+    rescue LibraryPlatformClient::Error => e
+      Rails.logger.warn "[SettingsController] Failed to fetch #{LibraryPlatformClient.display_name} libraries: #{e.message}"
       []
     end
 
@@ -501,10 +506,11 @@ module Admin
     end
 
     def load_audiobookshelf_cache_summary
-      @audiobookshelf_library_items = LibraryItem.by_synced_at_desc.limit(50)
-      @audiobookshelf_library_items_count = LibraryItem.count
+      active_library_items = LibraryItem.for_active_platform
+      @audiobookshelf_library_items = active_library_items.by_synced_at_desc.limit(50)
+      @audiobookshelf_library_items_count = active_library_items.count
       @audiobookshelf_available_library_items_count = LibraryItem.available_for_matching.count
-      @audiobookshelf_missing_library_items_count = LibraryItem.where(missing: true).count
+      @audiobookshelf_missing_library_items_count = active_library_items.where(missing: true).count
       @audiobookshelf_library_items_last_synced_at = @audiobookshelf_library_items.maximum(:synced_at)
     end
 
@@ -522,6 +528,15 @@ module Admin
 
     def library_platform_setting_key?(key)
       key.start_with?("audiobookshelf") || key.start_with?("bookorbit") || key == "library_platform"
+    end
+
+    def preserve_blank_secret?(key, value)
+      secret_setting_key?(key) && value.blank? && SettingsService.get(key).present?
+    end
+
+    def secret_setting_key?(key)
+      key = key.to_s
+      key == "discord_webhook_url" || key.include?("password") || key.include?("api_key") || key.include?("token") || key.include?("secret")
     end
   end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -114,30 +114,30 @@ module Admin
 
       unless AudiobookshelfClient.configured?
         health.mark_not_configured!
-        respond_with_flash(alert: "Audiobookshelf is not configured. Enter URL and API key first.")
+        respond_with_flash(alert: "#{AudiobookshelfClient.display_name} is not configured. Enter connection details first.")
         return
       end
 
       if AudiobookshelfClient.test_connection
         health.check_succeeded!(message: "Connection successful")
-        respond_with_flash(notice: "Audiobookshelf connection successful!")
+        respond_with_flash(notice: "#{AudiobookshelfClient.display_name} connection successful!")
       else
-        health.check_failed!(message: "Failed to connect to Audiobookshelf")
-        respond_with_flash(alert: "Audiobookshelf connection failed.")
+        health.check_failed!(message: "Failed to connect to #{AudiobookshelfClient.display_name}")
+        respond_with_flash(alert: "#{AudiobookshelfClient.display_name} connection failed.")
       end
     rescue AudiobookshelfClient::Error => e
       health&.check_failed!(message: e.message)
-      respond_with_flash(alert: "Audiobookshelf error: #{e.message}")
+      respond_with_flash(alert: "#{AudiobookshelfClient.display_name} error: #{e.message}")
     end
 
     def sync_audiobookshelf_library
       unless AudiobookshelfClient.configured?
-        redirect_to admin_settings_path, alert: "Audiobookshelf is not configured. Enter URL and API key first."
+        redirect_to admin_settings_path, alert: "#{AudiobookshelfClient.display_name} is not configured. Enter connection details first."
         return
       end
 
       AudiobookshelfLibrarySyncJob.perform_later
-      redirect_to admin_settings_path, notice: "Audiobookshelf library sync started."
+      redirect_to admin_settings_path, notice: "#{AudiobookshelfClient.display_name} library sync started."
     end
 
     # FlareSolverr is not tracked in SystemHealth::SERVICES, so no SystemHealth sync here
@@ -408,7 +408,7 @@ module Admin
     def handle_settings_side_effects(changed_keys)
       return if changed_keys.blank?
 
-      if changed_keys.any? { |k| k.start_with?("audiobookshelf") }
+      if changed_keys.any? { |k| library_platform_setting_key?(k) }
         AudiobookshelfClient.reset_connection!
         AudiobookshelfLibrarySyncJob.perform_later if AudiobookshelfClient.configured?
         run_service_health_check("audiobookshelf")
@@ -480,7 +480,7 @@ module Admin
 
       AudiobookshelfClient.libraries
     rescue AudiobookshelfClient::Error => e
-      Rails.logger.warn "[SettingsController] Failed to fetch Audiobookshelf libraries: #{e.message}"
+      Rails.logger.warn "[SettingsController] Failed to fetch #{AudiobookshelfClient.display_name} libraries: #{e.message}"
       []
     end
 
@@ -518,6 +518,10 @@ module Admin
 
     def metadata_provider_setting?(key)
       MetadataProviderStatus.provider_for_setting(key).present?
+    end
+
+    def library_platform_setting_key?(key)
+      key.start_with?("audiobookshelf") || key.start_with?("bookorbit") || key == "library_platform"
     end
   end
 end

--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -48,10 +48,10 @@ class LibraryController < ApplicationController
       remove_associated_torrents(@book)
     end
 
-    # Delete book files from disk if requested
-    # Also removes from Audiobookshelf if configured
+    # Delete book files from disk if requested.
+    # Also asks the active library platform to remove its item if supported.
     if params[:delete_files] == "1" && @book.file_path.present?
-      delete_from_audiobookshelf(@book)
+      delete_from_library_platform(@book)
       delete_book_files(@book)
     end
 
@@ -125,16 +125,16 @@ class LibraryController < ApplicationController
     end
   end
 
-  def delete_from_audiobookshelf(book)
-    return unless AudiobookshelfClient.configured?
+  def delete_from_library_platform(book)
+    return unless LibraryPlatformClient.configured?
     return unless book.file_path.present?
 
-    if AudiobookshelfClient.delete_item_by_path(book.file_path)
-      Rails.logger.info "[LibraryController] Deleted book from Audiobookshelf: #{book.file_path}"
+    if LibraryPlatformClient.delete_item_by_path(book.file_path)
+      Rails.logger.info "[LibraryController] Deleted book from #{LibraryPlatformClient.display_name}: #{book.file_path}"
     else
-      Rails.logger.warn "[LibraryController] Book not found in Audiobookshelf: #{book.file_path}"
+      Rails.logger.warn "[LibraryController] Book not found in #{LibraryPlatformClient.display_name}: #{book.file_path}"
     end
-  rescue AudiobookshelfClient::Error => e
-    Rails.logger.error "[LibraryController] Failed to delete from Audiobookshelf: #{e.message}"
+  rescue LibraryPlatformClient::Error => e
+    Rails.logger.error "[LibraryController] Failed to delete from #{LibraryPlatformClient.display_name}: #{e.message}"
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -131,7 +131,7 @@ class SearchController < ApplicationController
   end
 
   def audiobookshelf_matches_for(results)
-    if results.any? && LibraryItem.exists?
+    if results.any? && LibraryItem.available_for_matching.exists?
       AudiobookshelfLibraryMatcherService.matches_for_many(results, limit_per_result: 3)
     else
       Array.new(results.size) { [] }

--- a/app/jobs/audiobookshelf_library_sync_job.rb
+++ b/app/jobs/audiobookshelf_library_sync_job.rb
@@ -4,7 +4,7 @@ class AudiobookshelfLibrarySyncJob < ApplicationJob
   queue_as :default
 
   def perform
-    return unless AudiobookshelfClient.configured?
+    return unless LibraryPlatformClient.configured?
 
     AudiobookshelfLibrarySyncService.new.sync!
   ensure
@@ -14,7 +14,7 @@ class AudiobookshelfLibrarySyncJob < ApplicationJob
   private
 
   def schedule_next_run
-    return unless AudiobookshelfClient.configured?
+    return unless LibraryPlatformClient.configured?
 
     interval = SettingsService.get(:audiobookshelf_library_sync_interval, default: 3600).to_i
     return if interval <= 0

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -231,7 +231,7 @@ class DownloadJob < ApplicationJob
 
     book.update!(file_path: destination_dir)
     download.request.complete!
-    trigger_library_scan(book) if AudiobookshelfClient.configured?
+    trigger_library_scan(book) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
@@ -264,7 +264,7 @@ class DownloadJob < ApplicationJob
 
     book.update!(file_path: destination_dir)
     download.request.complete!
-    trigger_library_scan(book) if AudiobookshelfClient.configured?
+    trigger_library_scan(book) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
@@ -309,7 +309,7 @@ class DownloadJob < ApplicationJob
     download.request.complete!
 
     # Trigger library scan if configured
-    trigger_library_scan(book) if AudiobookshelfClient.configured?
+    trigger_library_scan(book) if LibraryPlatformClient.configured?
 
     # Send notification
     NotificationService.request_completed(download.request)
@@ -672,9 +672,9 @@ class DownloadJob < ApplicationJob
 
     return unless lib_id.present?
 
-    AudiobookshelfClient.scan_library(lib_id)
-    Rails.logger.info "[DownloadJob] Triggered Audiobookshelf library scan for #{book.book_type}"
-  rescue AudiobookshelfClient::Error => e
+    LibraryPlatformClient.scan_library(lib_id)
+    Rails.logger.info "[DownloadJob] Triggered #{LibraryPlatformClient.display_name} library scan for #{book.book_type}"
+  rescue LibraryPlatformClient::Error => e
     Rails.logger.warn "[DownloadJob] Failed to trigger scan: #{e.message}"
   end
 

--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -109,11 +109,11 @@ class HealthCheckJob < ApplicationJob
 
     clients.each do |client|
       # Check client-specific download_path if set
-      if client.download_path.present? 
+      if client.download_path.present?
         if !Dir.exist?(client.download_path)
           issues << "#{client.name}: configured download path '#{client.download_path}' does not exist"
         end
-      else 
+      else
         # No client-specific download_path set, try the default pattern that qbittorrent will set
         # Check category subfolder only for qBittorrent-compatible clients
         if client.qbittorrent_compatible? && client.category.present?
@@ -192,7 +192,7 @@ class HealthCheckJob < ApplicationJob
     if AudiobookshelfClient.test_connection
       health.check_succeeded!(message: "Connection successful")
     else
-      health.check_failed!(message: "Failed to connect to Audiobookshelf")
+      health.check_failed!(message: "Failed to connect to #{AudiobookshelfClient.display_name}")
     end
   rescue AudiobookshelfClient::AuthenticationError => e
     health.check_failed!(message: "Authentication failed: #{e.message}")
@@ -200,7 +200,7 @@ class HealthCheckJob < ApplicationJob
     health.check_failed!(message: "Connection error: #{e.message}")
   rescue => e
     health.check_failed!(message: "Error: #{e.message}")
-    Rails.logger.error "[HealthCheckJob] Audiobookshelf check failed: #{e.message}"
+    Rails.logger.error "[HealthCheckJob] #{AudiobookshelfClient.display_name} check failed: #{e.message}"
   end
 
   def check_hardcover

--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -184,23 +184,23 @@ class HealthCheckJob < ApplicationJob
   def check_audiobookshelf
     health = SystemHealth.for_service("audiobookshelf")
 
-    unless AudiobookshelfClient.configured?
+    unless LibraryPlatformClient.configured?
       health.mark_not_configured!
       return
     end
 
-    if AudiobookshelfClient.test_connection
+    if LibraryPlatformClient.test_connection
       health.check_succeeded!(message: "Connection successful")
     else
-      health.check_failed!(message: "Failed to connect to #{AudiobookshelfClient.display_name}")
+      health.check_failed!(message: "Failed to connect to #{LibraryPlatformClient.display_name}")
     end
-  rescue AudiobookshelfClient::AuthenticationError => e
+  rescue LibraryPlatformClient::AuthenticationError => e
     health.check_failed!(message: "Authentication failed: #{e.message}")
-  rescue AudiobookshelfClient::ConnectionError => e
+  rescue LibraryPlatformClient::ConnectionError => e
     health.check_failed!(message: "Connection error: #{e.message}")
   rescue => e
     health.check_failed!(message: "Error: #{e.message}")
-    Rails.logger.error "[HealthCheckJob] #{AudiobookshelfClient.display_name} check failed: #{e.message}"
+    Rails.logger.error "[HealthCheckJob] #{LibraryPlatformClient.display_name} check failed: #{e.message}"
   end
 
   def check_hardcover

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -39,7 +39,7 @@ class PostProcessingJob < ApplicationJob
       # Pre-create zip for directories (audiobooks) so download is instant
       pre_create_download_zip(book, destination) if File.directory?(destination)
 
-      trigger_library_scan(book) if AudiobookshelfClient.configured?
+      trigger_library_scan(book) if LibraryPlatformClient.configured?
 
       NotificationService.request_completed(request)
 
@@ -103,8 +103,8 @@ class PostProcessingJob < ApplicationJob
 
   def get_base_path(book)
     # Always use Shelfarr's configured output paths.
-    # Audiobookshelf library paths are from ABS's container perspective,
-    # not ours, so we can't use them for file operations.
+    # External library paths are from that service's container perspective,
+    # not ours, so they cannot drive file operations.
     if book.ebook?
       SettingsService.get(:ebook_output_path, default: "/ebooks")
     else
@@ -496,10 +496,10 @@ class PostProcessingJob < ApplicationJob
     lib_id = library_id_for(book)
     return unless lib_id.present?
 
-    AudiobookshelfClient.scan_library(lib_id)
-    Rails.logger.info "[PostProcessingJob] Triggered Audiobookshelf library scan for #{book.book_type}"
-  rescue AudiobookshelfClient::Error => e
+    LibraryPlatformClient.scan_library(lib_id)
+    Rails.logger.info "[PostProcessingJob] Triggered #{LibraryPlatformClient.display_name} library scan for #{book.book_type}"
+  rescue LibraryPlatformClient::Error => e
     Rails.logger.warn "[PostProcessingJob] Failed to trigger scan: #{e.message}"
-    # Non-fatal - Audiobookshelf will pick up files on next auto-scan
+    # Non-fatal - the library platform will pick up files on next auto-scan.
   end
 end

--- a/app/jobs/upload_processing_job.rb
+++ b/app/jobs/upload_processing_job.rb
@@ -97,8 +97,8 @@ class UploadProcessingJob < ApplicationJob
         completed_request = complete_target_request!(target_request, upload) if target_request
       end
 
-      # Step 8: Trigger Audiobookshelf scan if configured (outside transaction)
-      trigger_library_scan(book) if book && AudiobookshelfClient.configured?
+      # Step 8: Trigger library platform scan if configured (outside transaction)
+      trigger_library_scan(book) if book && LibraryPlatformClient.configured?
       NotificationService.request_completed(completed_request) if completed_request
 
       Rails.logger.info "[UploadProcessingJob] Completed processing upload #{upload.id}"
@@ -431,9 +431,9 @@ class UploadProcessingJob < ApplicationJob
 
     return unless library_id.present?
 
-    AudiobookshelfClient.scan_library(library_id)
-    Rails.logger.info "[UploadProcessingJob] Triggered Audiobookshelf library scan for #{book.book_type}"
-  rescue AudiobookshelfClient::Error => e
+    LibraryPlatformClient.scan_library(library_id)
+    Rails.logger.info "[UploadProcessingJob] Triggered #{LibraryPlatformClient.display_name} library scan for #{book.book_type}"
+  rescue LibraryPlatformClient::Error => e
     Rails.logger.warn "[UploadProcessingJob] Failed to trigger scan: #{e.message}"
   end
 end

--- a/app/models/library_item.rb
+++ b/app/models/library_item.rb
@@ -1,27 +1,23 @@
 # frozen_string_literal: true
 
 class LibraryItem < ApplicationRecord
+  validates :library_platform, presence: true, inclusion: { in: SettingsService::LIBRARY_PLATFORMS }
   validates :library_id, presence: true
   validates :audiobookshelf_id, presence: true
-  validates :library_id, uniqueness: { scope: :audiobookshelf_id }
+  validates :library_id, uniqueness: { scope: [ :library_platform, :audiobookshelf_id ] }
 
   scope :by_synced_at_desc, -> { order(synced_at: :desc, title: :asc) }
+  scope :for_platform, ->(platform) { where(library_platform: platform) }
+  scope :for_active_platform, -> { for_platform(SettingsService.active_library_platform) }
   scope :for_libraries, ->(ids) { where(library_id: ids) }
-  scope :available_for_matching, -> { where.not(missing: true) }
+  scope :available_for_matching, -> { for_active_platform.where.not(missing: true) }
+
+  def library_url
+    LibraryPlatformClient.item_url(self)
+  end
 
   def audiobookshelf_url
-    base_url = if SettingsService.bookorbit_library_platform?
-      SettingsService.get(:bookorbit_url)
-    else
-      SettingsService.get(:audiobookshelf_url)
-    end
-    return nil if base_url.blank? || audiobookshelf_id.blank?
-
-    if SettingsService.bookorbit_library_platform?
-      "#{base_url.to_s.chomp("/")}/book/#{audiobookshelf_id}"
-    else
-      "#{base_url.to_s.chomp("/")}/item/#{audiobookshelf_id}"
-    end
+    library_url
   end
 
   def display_title

--- a/app/models/library_item.rb
+++ b/app/models/library_item.rb
@@ -10,10 +10,18 @@ class LibraryItem < ApplicationRecord
   scope :available_for_matching, -> { where.not(missing: true) }
 
   def audiobookshelf_url
-    base_url = SettingsService.get(:audiobookshelf_url)
+    base_url = if SettingsService.bookorbit_library_platform?
+      SettingsService.get(:bookorbit_url)
+    else
+      SettingsService.get(:audiobookshelf_url)
+    end
     return nil if base_url.blank? || audiobookshelf_id.blank?
 
-    "#{base_url.to_s.chomp("/")}/item/#{audiobookshelf_id}"
+    if SettingsService.bookorbit_library_platform?
+      "#{base_url.to_s.chomp("/")}/book/#{audiobookshelf_id}"
+    else
+      "#{base_url.to_s.chomp("/")}/item/#{audiobookshelf_id}"
+    end
   end
 
   def display_title

--- a/app/services/audiobookshelf_client.rb
+++ b/app/services/audiobookshelf_client.rb
@@ -10,7 +10,7 @@ class AudiobookshelfClient
 
   Library = Data.define(:id, :name, :folders, :media_type) do
     def folder_paths
-      folders.map { |f| f["fullPath"] }
+      folders.map { |f| f["fullPath"] || f["path"] }.compact
     end
 
     def audiobook_library?
@@ -25,6 +25,8 @@ class AudiobookshelfClient
   class << self
     # GET /api/libraries - List all libraries with folder paths
     def libraries
+      return translate_bookorbit_errors { ::BookOrbitClient.libraries } if bookorbit?
+
       ensure_configured!
 
       response = request { connection.get("/api/libraries") }
@@ -35,6 +37,8 @@ class AudiobookshelfClient
 
     # GET /api/libraries/:id - Get single library
     def library(id)
+      return translate_bookorbit_errors { ::BookOrbitClient.library(id) } if bookorbit?
+
       ensure_configured!
 
       response = request { connection.get("/api/libraries/#{id}") }
@@ -43,6 +47,8 @@ class AudiobookshelfClient
 
     # POST /api/libraries/:id/scan - Trigger library scan
     def scan_library(id)
+      return translate_bookorbit_errors { ::BookOrbitClient.scan_library(id) } if bookorbit?
+
       ensure_configured!
 
       response = request { connection.post("/api/libraries/#{id}/scan") }
@@ -51,6 +57,8 @@ class AudiobookshelfClient
 
     # GET /api/libraries/:id/items - List all items in a library
     def library_items(id, page_size: 500)
+      return translate_bookorbit_errors { ::BookOrbitClient.library_items(id, page_size: page_size) } if bookorbit?
+
       ensure_configured!
 
       items = []
@@ -71,6 +79,8 @@ class AudiobookshelfClient
 
     # GET /api/libraries/:id/items - Find item by path
     def find_item_by_path(path)
+      return nil if bookorbit?
+
       ensure_configured!
 
       # Normalize path for comparison
@@ -103,6 +113,8 @@ class AudiobookshelfClient
 
     # DELETE /api/library-items/:id - Delete a library item
     def delete_item(item_id)
+      return false if bookorbit?
+
       ensure_configured!
 
       response = request { connection.delete("/api/library-items/#{item_id}") }
@@ -111,6 +123,8 @@ class AudiobookshelfClient
 
     # Find and delete item by path
     def delete_item_by_path(path)
+      return translate_bookorbit_errors { ::BookOrbitClient.delete_item_by_path(path) } if bookorbit?
+
       item = find_item_by_path(path)
       return false unless item
 
@@ -122,6 +136,8 @@ class AudiobookshelfClient
     end
 
     def test_connection
+      return translate_bookorbit_errors { ::BookOrbitClient.test_connection } if bookorbit?
+
       ensure_configured!
       libraries.any?
     rescue Error
@@ -130,12 +146,33 @@ class AudiobookshelfClient
 
     def reset_connection!
       @connection = nil
+      ::BookOrbitClient.reset_connection!
+    end
+
+    def display_name
+      bookorbit? ? "BookOrbit" : "Audiobookshelf"
     end
 
     private
 
+    def bookorbit?
+      SettingsService.bookorbit_library_platform?
+    end
+
+    def translate_bookorbit_errors
+      yield
+    rescue ::BookOrbitClient::AuthenticationError => e
+      raise AuthenticationError, e.message
+    rescue ::BookOrbitClient::ConnectionError => e
+      raise ConnectionError, e.message
+    rescue ::BookOrbitClient::NotConfiguredError => e
+      raise NotConfiguredError, e.message
+    rescue ::BookOrbitClient::Error => e
+      raise Error, e.message
+    end
+
     def ensure_configured!
-      raise NotConfiguredError, "Audiobookshelf is not configured" unless configured?
+      raise NotConfiguredError, "#{display_name} is not configured" unless configured?
     end
 
     def request

--- a/app/services/audiobookshelf_client.rb
+++ b/app/services/audiobookshelf_client.rb
@@ -25,8 +25,6 @@ class AudiobookshelfClient
   class << self
     # GET /api/libraries - List all libraries with folder paths
     def libraries
-      return translate_bookorbit_errors { ::BookOrbitClient.libraries } if bookorbit?
-
       ensure_configured!
 
       response = request { connection.get("/api/libraries") }
@@ -37,8 +35,6 @@ class AudiobookshelfClient
 
     # GET /api/libraries/:id - Get single library
     def library(id)
-      return translate_bookorbit_errors { ::BookOrbitClient.library(id) } if bookorbit?
-
       ensure_configured!
 
       response = request { connection.get("/api/libraries/#{id}") }
@@ -47,8 +43,6 @@ class AudiobookshelfClient
 
     # POST /api/libraries/:id/scan - Trigger library scan
     def scan_library(id)
-      return translate_bookorbit_errors { ::BookOrbitClient.scan_library(id) } if bookorbit?
-
       ensure_configured!
 
       response = request { connection.post("/api/libraries/#{id}/scan") }
@@ -57,8 +51,6 @@ class AudiobookshelfClient
 
     # GET /api/libraries/:id/items - List all items in a library
     def library_items(id, page_size: 500)
-      return translate_bookorbit_errors { ::BookOrbitClient.library_items(id, page_size: page_size) } if bookorbit?
-
       ensure_configured!
 
       items = []
@@ -79,8 +71,6 @@ class AudiobookshelfClient
 
     # GET /api/libraries/:id/items - Find item by path
     def find_item_by_path(path)
-      return nil if bookorbit?
-
       ensure_configured!
 
       # Normalize path for comparison
@@ -113,8 +103,6 @@ class AudiobookshelfClient
 
     # DELETE /api/library-items/:id - Delete a library item
     def delete_item(item_id)
-      return false if bookorbit?
-
       ensure_configured!
 
       response = request { connection.delete("/api/library-items/#{item_id}") }
@@ -123,8 +111,6 @@ class AudiobookshelfClient
 
     # Find and delete item by path
     def delete_item_by_path(path)
-      return translate_bookorbit_errors { ::BookOrbitClient.delete_item_by_path(path) } if bookorbit?
-
       item = find_item_by_path(path)
       return false unless item
 
@@ -132,12 +118,10 @@ class AudiobookshelfClient
     end
 
     def configured?
-      SettingsService.audiobookshelf_configured?
+      SettingsService.audiobookshelf_credentials_configured?
     end
 
     def test_connection
-      return translate_bookorbit_errors { ::BookOrbitClient.test_connection } if bookorbit?
-
       ensure_configured!
       libraries.any?
     rescue Error
@@ -146,30 +130,13 @@ class AudiobookshelfClient
 
     def reset_connection!
       @connection = nil
-      ::BookOrbitClient.reset_connection!
     end
 
     def display_name
-      bookorbit? ? "BookOrbit" : "Audiobookshelf"
+      "Audiobookshelf"
     end
 
     private
-
-    def bookorbit?
-      SettingsService.bookorbit_library_platform?
-    end
-
-    def translate_bookorbit_errors
-      yield
-    rescue ::BookOrbitClient::AuthenticationError => e
-      raise AuthenticationError, e.message
-    rescue ::BookOrbitClient::ConnectionError => e
-      raise ConnectionError, e.message
-    rescue ::BookOrbitClient::NotConfiguredError => e
-      raise NotConfiguredError, e.message
-    rescue ::BookOrbitClient::Error => e
-      raise Error, e.message
-    end
 
     def ensure_configured!
       raise NotConfiguredError, "#{display_name} is not configured" unless configured?

--- a/app/services/audiobookshelf_library_sync_service.rb
+++ b/app/services/audiobookshelf_library_sync_service.rb
@@ -19,19 +19,20 @@ class AudiobookshelfLibrarySyncService
         success: false,
         items_synced: 0,
         libraries_synced: 0,
-        errors: [ "No Audiobookshelf library IDs configured or available." ]
+        errors: [ "No #{LibraryPlatformClient.display_name} library IDs configured or available." ]
       )
     end
 
+    library_platform = LibraryPlatformClient.active_platform
     library_ids.each do |library_id|
       begin
-        items = AudiobookshelfClient.library_items(library_id)
-        sync_library_items(library_id, items, synced_at: now)
+        items = LibraryPlatformClient.library_items(library_id)
+        sync_library_items(library_platform, library_id, items, synced_at: now)
         libraries_synced += 1
         items_synced += items.size
-      rescue AudiobookshelfClient::Error, StandardError => e
+      rescue LibraryPlatformClient::Error, StandardError => e
         errors << "#{library_id}: #{e.message}"
-        Rails.logger.warn "[AudiobookshelfLibrarySyncService] Failed to sync library #{library_id}: #{e.message}"
+        Rails.logger.warn "[AudiobookshelfLibrarySyncService] Failed to sync #{LibraryPlatformClient.display_name} library #{library_id}: #{e.message}"
       end
     end
 
@@ -63,7 +64,7 @@ class AudiobookshelfLibrarySyncService
 
   private
 
-  def sync_library_items(library_id, items, synced_at:)
+  def sync_library_items(library_platform, library_id, items, synced_at:)
     item_ids = []
     now = synced_at
 
@@ -71,7 +72,11 @@ class AudiobookshelfLibrarySyncService
       audiobookshelf_id = item["audiobookshelf_id"]
       next if audiobookshelf_id.blank?
 
-      cached = LibraryItem.find_or_initialize_by(library_id: library_id, audiobookshelf_id: audiobookshelf_id)
+      cached = LibraryItem.find_or_initialize_by(
+        library_platform: library_platform,
+        library_id: library_id,
+        audiobookshelf_id: audiobookshelf_id
+      )
       cached.title = item["title"]
       cached.subtitle = item["subtitle"]
       cached.author = item["author"]
@@ -90,13 +95,13 @@ class AudiobookshelfLibrarySyncService
       item_ids << audiobookshelf_id
     end
 
-    LibraryItem.where(library_id: library_id).where.not(audiobookshelf_id: item_ids).delete_all
+    LibraryItem.where(library_platform: library_platform, library_id: library_id).where.not(audiobookshelf_id: item_ids).delete_all
   end
 
   def load_library_ids_from_configured_client
-    return [] unless AudiobookshelfClient.configured?
+    return [] unless LibraryPlatformClient.configured?
 
-    libraries = AudiobookshelfClient.libraries
+    libraries = LibraryPlatformClient.libraries
     libraries.select(&:audiobook_library?).map(&:id)
   end
 end

--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -78,7 +78,7 @@ class BookOrbitClient
     end
 
     def configured?
-      SettingsService.bookorbit_library_platform? && SettingsService.audiobookshelf_configured?
+      SettingsService.bookorbit_configured?
     end
 
     def test_connection

--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+# Client for BookOrbit's current internal API. BookOrbit does not publish stable
+# API docs yet, so this intentionally covers only library inventory and scans.
+class BookOrbitClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class AuthenticationError < Error; end
+  class NotConfiguredError < Error; end
+
+  Library = Data.define(:id, :name, :folders, :media_type) do
+    def folder_paths
+      folders.map { |folder| folder["fullPath"] || folder["path"] }.compact
+    end
+
+    def audiobook_library?
+      true
+    end
+
+    def podcast_library?
+      false
+    end
+  end
+
+  class << self
+    def libraries
+      ensure_configured!
+
+      response = request { connection.get("/api/v1/libraries") }
+      handle_response(response) do |data|
+        Array(data).map { |library| parse_library(library) }
+      end
+    end
+
+    def library(id)
+      ensure_configured!
+
+      response = request { connection.get("/api/v1/libraries/#{id}") }
+      handle_response(response) { |data| parse_library(data) }
+    end
+
+    def scan_library(id)
+      ensure_configured!
+
+      response = request { connection.post("/api/v1/scanner/libraries/#{id}/scan") }
+      response.status.in?([ 200, 201, 202, 204 ])
+    end
+
+    def library_items(id, page_size: 200)
+      ensure_configured!
+
+      items = []
+      page = 0
+      query_page_size = [ page_size.to_i, 200 ].min
+      query_page_size = 200 if query_page_size <= 0
+
+      loop do
+        response = request do
+          connection.post("/api/v1/libraries/#{id}/books", {
+            sort: [],
+            pagination: { page: page, size: query_page_size },
+            collapseSeries: false
+          })
+        end
+        break unless response.status == 200
+
+        page_items = extract_library_items(response.body)
+        items.concat(page_items)
+        break if end_of_items?(page_items, response.body, query_page_size, page)
+        page += 1
+      end
+
+      items
+    end
+
+    def delete_item_by_path(_path)
+      false
+    end
+
+    def configured?
+      SettingsService.bookorbit_library_platform? && SettingsService.audiobookshelf_configured?
+    end
+
+    def test_connection
+      ensure_configured!
+      libraries.any?
+    rescue Error
+      false
+    end
+
+    def reset_connection!
+      @connection = nil
+      @access_token = nil
+    end
+
+    private
+
+    def ensure_configured!
+      raise NotConfiguredError, "BookOrbit is not configured" unless configured?
+    end
+
+    def request
+      yield
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError, URI::Error => e
+      raise ConnectionError, "Failed to connect to BookOrbit: #{e.message}"
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: base_url) do |f|
+        f.request :json
+        f.response :json, parser_options: { symbolize_names: false }
+        f.adapter Faraday.default_adapter
+        f.headers["Authorization"] = "Bearer #{access_token}"
+        f.options.timeout = 15
+        f.options.open_timeout = 5
+      end
+    end
+
+    def auth_connection
+      Faraday.new(url: base_url) do |f|
+        f.request :json
+        f.response :json, parser_options: { symbolize_names: false }
+        f.adapter Faraday.default_adapter
+        f.options.timeout = 15
+        f.options.open_timeout = 5
+      end
+    end
+
+    def access_token
+      @access_token ||= begin
+        response = request do
+          auth_connection.post("/api/v1/auth/login", {
+            username: SettingsService.get(:bookorbit_username),
+            password: SettingsService.get(:bookorbit_password)
+          })
+        end
+        handle_response(response) do |data|
+          token = data["accessToken"]
+          raise AuthenticationError, "BookOrbit login did not return an access token" if token.blank?
+
+          token
+        end
+      end
+    end
+
+    def base_url
+      url = SettingsService.get(:bookorbit_url).to_s.strip
+      parsed_url = URI.parse(url)
+
+      unless parsed_url.is_a?(URI::HTTP) && parsed_url.host.present?
+        raise URI::InvalidURIError, "BookOrbit URL must include http:// or https://"
+      end
+
+      url
+    end
+
+    def handle_response(response)
+      case response.status
+      when 200, 201, 202, 204
+        yield(response.body.presence || {})
+      when 401, 403
+        raise AuthenticationError, "Invalid BookOrbit credentials or permissions"
+      when 404
+        raise Error, "BookOrbit resource not found"
+      else
+        raise Error, "BookOrbit API error: #{response.status}"
+      end
+    end
+
+    def parse_library(data)
+      Library.new(
+        id: data["id"].to_s,
+        name: data["name"],
+        folders: data["folders"] || [],
+        media_type: "bookorbit"
+      )
+    end
+
+    def extract_library_items(data)
+      Array(data["items"]).filter_map do |raw_item|
+        next unless raw_item.is_a?(Hash)
+
+        {
+          "audiobookshelf_id" => raw_item["id"].to_s,
+          "title" => raw_item["title"],
+          "subtitle" => raw_item["subtitle"],
+          "author" => Array(raw_item["authors"]).join(", ").presence,
+          "narrator" => Array(raw_item["narrators"]).join(", ").presence,
+          "series" => raw_item["seriesName"],
+          "series_position" => raw_item["seriesIndex"]&.to_s,
+          "publisher" => raw_item["publisher"],
+          "language" => raw_item["language"],
+          "description" => nil,
+          "isbn" => raw_item["isbn13"],
+          "asin" => nil,
+          "published_year" => raw_item["publishedYear"],
+          "missing" => raw_item["status"] == "missing"
+        }
+      end
+    end
+
+    def end_of_items?(page_items, data, page_size, page)
+      return true if page_items.empty?
+      return true if page_items.length < page_size
+
+      total = data["total"]
+      total.present? && total <= ((page + 1) * page_size)
+    end
+  end
+end

--- a/app/services/library_platform_client.rb
+++ b/app/services/library_platform_client.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+class LibraryPlatformClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class AuthenticationError < Error; end
+  class NotConfiguredError < Error; end
+
+  DISPLAY_NAMES = {
+    "audiobookshelf" => "Audiobookshelf",
+    "bookorbit" => "BookOrbit"
+  }.freeze
+
+  class << self
+    def active_platform
+      SettingsService.active_library_platform
+    end
+
+    def display_name(platform = active_platform)
+      DISPLAY_NAMES.fetch(platform, platform.to_s.titleize)
+    end
+
+    def configured?
+      client.configured?
+    end
+
+    def libraries
+      translate_errors { client.libraries }
+    end
+
+    def library(id)
+      translate_errors { client.library(id) }
+    end
+
+    def library_items(id, page_size: 500)
+      translate_errors { client.library_items(id, page_size: page_size) }
+    end
+
+    def scan_library(id)
+      translate_errors { client.scan_library(id) }
+    end
+
+    def delete_item_by_path(path)
+      translate_errors { client.delete_item_by_path(path) }
+    end
+
+    def test_connection
+      translate_errors { client.test_connection }
+    end
+
+    def reset_connections!
+      AudiobookshelfClient.reset_connection!
+      BookOrbitClient.reset_connection!
+    end
+
+    def reset_connection!
+      reset_connections!
+    end
+
+    def item_url(item)
+      item_url_for(
+        platform: item.library_platform.presence || active_platform,
+        external_id: item.audiobookshelf_id
+      )
+    end
+
+    def item_url_for(platform:, external_id:)
+      return nil if external_id.blank?
+
+      base_url = base_url_for(platform)
+      return nil if base_url.blank?
+
+      path_segment = platform.to_s == "audiobookshelf" ? "item" : "book"
+      "#{base_url.to_s.chomp("/")}/#{path_segment}/#{external_id}"
+    end
+
+    private
+
+    def client
+      client_for(active_platform)
+    end
+
+    def client_for(platform)
+      case platform.to_s
+      when "bookorbit"
+        BookOrbitClient
+      else
+        AudiobookshelfClient
+      end
+    end
+
+    def base_url_for(platform)
+      case platform.to_s
+      when "bookorbit"
+        SettingsService.get(:bookorbit_url)
+      else
+        SettingsService.get(:audiobookshelf_url)
+      end
+    end
+
+    def translate_errors
+      active_client = client
+      yield
+    rescue active_client::AuthenticationError => e
+      raise AuthenticationError, e.message
+    rescue active_client::ConnectionError => e
+      raise ConnectionError, e.message
+    rescue active_client::NotConfiguredError => e
+      raise NotConfiguredError, e.message
+    rescue active_client::Error => e
+      raise Error, e.message
+    end
+  end
+end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -230,7 +230,23 @@ class SettingsService
     "oidc" => "OIDC/SSO Authentication"
   }.freeze
 
+  LABELS = {
+    library_platform: "Active Library Platform",
+    audiobookshelf_url: "Audiobookshelf URL",
+    audiobookshelf_api_key: "Audiobookshelf API Key",
+    bookorbit_url: "BookOrbit URL",
+    bookorbit_username: "BookOrbit Username",
+    bookorbit_password: "BookOrbit Password",
+    audiobookshelf_audiobook_library_id: "Audiobook Library",
+    audiobookshelf_ebook_library_id: "Ebook Library",
+    audiobookshelf_library_sync_interval: "Library Sync Interval"
+  }.freeze
+
   class << self
+    def label_for(key)
+      LABELS.fetch(key.to_sym, key.to_s.titleize)
+    end
+
     # Primary getter with default fallback
     def get(key, default: nil)
       key = key.to_sym

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -65,12 +65,16 @@ class SettingsService
     move_completed_downloads: { type: "boolean", default: false, category: "download", description: "Move completed download files into the library instead of copying them. Disable to preserve torrent seeding." },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
-    # Audiobookshelf Integration
+    # Library Platform Integration
+    library_platform: { type: "string", default: "audiobookshelf", category: "audiobookshelf", description: "Library platform to sync and scan: audiobookshelf or bookorbit" },
     audiobookshelf_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for Audiobookshelf (e.g., http://localhost:13378)" },
     audiobookshelf_api_key: { type: "string", default: "", category: "audiobookshelf", description: "API token from Audiobookshelf user settings" },
-    audiobookshelf_audiobook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for audiobooks" },
-    audiobookshelf_ebook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for ebooks" },
-    audiobookshelf_library_sync_interval: { type: "integer", default: 3600, category: "audiobookshelf", description: "Seconds between automatic Audiobookshelf library sync jobs" },
+    bookorbit_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for BookOrbit (e.g., http://localhost:3000)" },
+    bookorbit_username: { type: "string", default: "", category: "audiobookshelf", description: "BookOrbit username with library access and scan permissions" },
+    bookorbit_password: { type: "string", default: "", category: "audiobookshelf", description: "BookOrbit password used to obtain an API access token" },
+    audiobookshelf_audiobook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for audiobooks on the active library platform" },
+    audiobookshelf_ebook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for ebooks on the active library platform" },
+    audiobookshelf_library_sync_interval: { type: "integer", default: 3600, category: "audiobookshelf", description: "Seconds between automatic library inventory sync jobs" },
 
     # Output Paths
     audiobook_output_path: { type: "string", default: "/audiobooks", category: "paths", description: "Directory for completed audiobooks" },
@@ -203,7 +207,7 @@ class SettingsService
   CATEGORIES = {
     "indexer" => "Indexer",
     "download" => "Download Settings",
-    "audiobookshelf" => "Audiobookshelf",
+    "audiobookshelf" => "Library Platform",
     "anna_archive" => "Anna's Archive",
     "zlibrary" => "Z-Library",
     "gutenberg" => "Project Gutenberg",
@@ -362,7 +366,20 @@ class SettingsService
     end
 
     def audiobookshelf_configured?
-      configured?(:audiobookshelf_url) && configured?(:audiobookshelf_api_key)
+      if bookorbit_library_platform?
+        configured?(:bookorbit_url) && configured?(:bookorbit_username) && configured?(:bookorbit_password)
+      else
+        configured?(:audiobookshelf_url) && configured?(:audiobookshelf_api_key)
+      end
+    end
+
+    def active_library_platform
+      platform = get(:library_platform).to_s.strip.downcase
+      %w[audiobookshelf bookorbit].include?(platform) ? platform : "audiobookshelf"
+    end
+
+    def bookorbit_library_platform?
+      active_library_platform == "bookorbit"
     end
 
     def anna_archive_configured?

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -2,6 +2,7 @@ class SettingsService
   DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
 
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
+  LIBRARY_PLATFORMS = %w[audiobookshelf bookorbit].freeze
   INDEXER_SEARCH_SCOPES = %w[broad strict unrestricted custom].freeze
   INDEXER_SEARCH_SCOPE_OPTIONS = {
     "broad" => {
@@ -366,16 +367,28 @@ class SettingsService
     end
 
     def audiobookshelf_configured?
+      library_platform_configured?
+    end
+
+    def library_platform_configured?
       if bookorbit_library_platform?
-        configured?(:bookorbit_url) && configured?(:bookorbit_username) && configured?(:bookorbit_password)
+        bookorbit_configured?
       else
-        configured?(:audiobookshelf_url) && configured?(:audiobookshelf_api_key)
+        audiobookshelf_credentials_configured?
       end
+    end
+
+    def audiobookshelf_credentials_configured?
+      configured?(:audiobookshelf_url) && configured?(:audiobookshelf_api_key)
+    end
+
+    def bookorbit_configured?
+      configured?(:bookorbit_url) && configured?(:bookorbit_username) && configured?(:bookorbit_password)
     end
 
     def active_library_platform
       platform = get(:library_platform).to_s.strip.downcase
-      %w[audiobookshelf bookorbit].include?(platform) ? platform : "audiobookshelf"
+      LIBRARY_PLATFORMS.include?(platform) ? platform : "audiobookshelf"
     end
 
     def bookorbit_library_platform?

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -84,9 +84,10 @@
       </div>
       <% SystemHealth::SERVICES.each do |service| %>
         <% health = @system_health[service] %>
+        <% service_label = service == "audiobookshelf" ? "Library Platform" : service.titleize %>
         <div class="flex items-center justify-between py-3 border-b border-gray-700 last:border-b-0">
           <div>
-            <span class="font-medium text-gray-200"><%= service.titleize %></span>
+            <span class="font-medium text-gray-200"><%= service_label %></span>
             <% if health&.last_check_at %>
               <span class="text-xs text-gray-500 block">
                 Checked <%= time_ago_in_words(health.last_check_at) %> ago

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -100,12 +100,14 @@
                         <%= form.text_field "settings[#{key}]", value: data[:value].is_a?(Array) ? data[:value].join(', ') : data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <p class="mt-1 text-xs text-gray-500">For multiple values, use comma-separated format (e.g., en, fr, de)</p>
                       <% else %>
-                        <% if key.to_s.end_with?("_library_id") && @audiobookshelf_libraries.any? %>
+                        <% if key.to_s == "library_platform" %>
+                          <%= form.select "settings[#{key}]", options_for_select([["Audiobookshelf", "audiobookshelf"], ["BookOrbit", "bookorbit"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                        <% elsif key.to_s.end_with?("_library_id") && @audiobookshelf_libraries.any? %>
                           <% library_options = @audiobookshelf_libraries.map { |lib| ["#{lib.name} (#{lib.media_type})", lib.id] } %>
                           <%= form.select "settings[#{key}]", options_for_select([["Select a library...", ""]] + library_options, data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s.end_with?("_library_id") %>
-                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure Audiobookshelf URL and API key first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
-                          <p class="mt-1 text-xs text-yellow-500">Enter Audiobookshelf URL and API key above to select from available libraries</p>
+                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure library platform connection details first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <p class="mt-1 text-xs text-yellow-500">Enter active platform connection details above to select from available libraries</p>
                         <% elsif key.to_s == "oidc_default_role" %>
                           <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s == "metadata_source" %>
@@ -200,7 +202,7 @@
                           No cached items yet. Run a sync to populate.
                         </p>
                       <% end %>
-                      <%= link_to "Sync Audiobookshelf Library", sync_audiobookshelf_library_admin_settings_path, data: { turbo_method: :post }, class: "inline-block rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm cursor-pointer" %>
+                      <%= link_to "Sync Library Platform", sync_audiobookshelf_library_admin_settings_path, data: { turbo_method: :post }, class: "inline-block rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm cursor-pointer" %>
                     </div>
                     <div>
                       <% if @audiobookshelf_library_items.any? %>
@@ -235,10 +237,10 @@
                   <div class="flex flex-col md:flex-row md:items-start gap-4 pt-4 border-t border-gray-800">
                     <div class="md:w-1/3">
                       <span class="font-medium text-gray-300">Test Connection</span>
-                      <p class="text-sm text-gray-500">Verify Audiobookshelf is reachable</p>
+                      <p class="text-sm text-gray-500">Verify the active library platform is reachable</p>
                     </div>
                     <div class="md:w-2/3">
-                      <%= link_to "Test Audiobookshelf Connection", test_audiobookshelf_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
+                      <%= link_to "Test Library Platform Connection", test_audiobookshelf_admin_settings_path, data: { turbo_method: :post, turbo_preserve_scroll: true }, class: "inline-block rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm cursor-pointer" %>
                     </div>
                   </div>
                 <% elsif category == "hardcover" %>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -115,7 +115,7 @@
                         <% elsif key.to_s == "telegram_update_mode" %>
                           <%= form.select "settings[#{key}]", options_for_select([["Polling", "polling"], ["Webhook", "webhook"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s == "discord_webhook_url" %>
-                          <%= form.password_field "settings[#{key}]", value: data[:value], placeholder: data[:value].present? ? "********" : "https://discord.com/api/webhooks/...", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.password_field "settings[#{key}]", value: "", placeholder: data[:value].present? ? "********" : "https://discord.com/api/webhooks/...", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif %w[anna_archive_url zlibrary_url].include?(key.to_s) %>
                           <% url_list_urls = data[:value].to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?).uniq %>
                           <% url_list_name = key.to_s == "zlibrary_url" ? "Z-Library" : "Anna's Archive" %>
@@ -165,7 +165,7 @@
                             <p class="hidden text-xs text-red-400" data-url-list-error></p>
                           </div>
                         <% elsif key.to_s.include?("password") || key.to_s.include?("api_key") || key.to_s.include?("token") || key.to_s.include?("secret") %>
-                          <%= form.password_field "settings[#{key}]", value: data[:value], placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.password_field "settings[#{key}]", value: "", placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% else %>
                           <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% end %>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -75,7 +75,7 @@
                 <% settings.each do |key, data| %>
                   <div class="flex flex-col md:flex-row md:items-start gap-4">
                     <div class="md:w-1/3">
-                      <label for="settings_<%= key %>" class="font-medium text-gray-300"><%= key.to_s.titleize %></label>
+                      <label for="settings_<%= key %>" class="font-medium text-gray-300"><%= SettingsService.label_for(key) %></label>
                       <p class="text-sm text-gray-500"><%= data[:definition][:description] %></p>
                     </div>
                     <div class="md:w-2/3">

--- a/app/views/admin/settings/_indexer_section.html.erb
+++ b/app/views/admin/settings/_indexer_section.html.erb
@@ -75,7 +75,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:prowlarr_api_key, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.password_field "settings[prowlarr_api_key]", value: settings.dig(:prowlarr_api_key, :value), placeholder: settings.dig(:prowlarr_api_key, :value).present? ? "********" : "", id: "settings_prowlarr_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.password_field "settings[prowlarr_api_key]", value: "", placeholder: settings.dig(:prowlarr_api_key, :value).present? ? "********" : "", id: "settings_prowlarr_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
         </div>
       </div>
 
@@ -107,7 +107,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:jackett_api_key, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.password_field "settings[jackett_api_key]", value: settings.dig(:jackett_api_key, :value), placeholder: settings.dig(:jackett_api_key, :value).present? ? "********" : "", id: "settings_jackett_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.password_field "settings[jackett_api_key]", value: "", placeholder: settings.dig(:jackett_api_key, :value).present? ? "********" : "", id: "settings_jackett_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
         </div>
       </div>
 
@@ -139,7 +139,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:newznab_api_key, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.password_field "settings[newznab_api_key]", value: settings.dig(:newznab_api_key, :value), placeholder: settings.dig(:newznab_api_key, :value).present? ? "********" : "", id: "settings_newznab_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.password_field "settings[newznab_api_key]", value: "", placeholder: settings.dig(:newznab_api_key, :value).present? ? "********" : "", id: "settings_newznab_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
         </div>
       </div>
     </div>

--- a/app/views/library/show.html.erb
+++ b/app/views/library/show.html.erb
@@ -110,7 +110,7 @@
                     <label class="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
                       <input type="checkbox" name="delete_files" value="1"
                              class="w-4 h-4 rounded border-gray-600 bg-gray-800 text-red-600 focus:ring-red-500">
-                      <span>Delete book files from disk<%= " and Audiobookshelf" if AudiobookshelfClient.configured? %></span>
+                      <span>Delete book files from disk<%= " and #{LibraryPlatformClient.display_name}" if LibraryPlatformClient.configured? %></span>
                     </label>
                   <% end %>
 

--- a/db/migrate/20260622000000_add_library_platform_to_library_items.rb
+++ b/db/migrate/20260622000000_add_library_platform_to_library_items.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLibraryPlatformToLibraryItems < ActiveRecord::Migration[8.1]
+  def change
+    add_column :library_items, :library_platform, :string, null: false, default: "audiobookshelf"
+
+    remove_index :library_items, [ :library_id, :audiobookshelf_id ]
+    add_index :library_items, [ :library_platform, :library_id, :audiobookshelf_id ], unique: true
+    add_index :library_items, :library_platform
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_000000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -156,6 +156,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
     t.string "isbn"
     t.string "language"
     t.string "library_id", null: false
+    t.string "library_platform", default: "audiobookshelf", null: false
     t.boolean "missing", default: false, null: false
     t.string "narrator"
     t.integer "published_year"
@@ -167,8 +168,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.index ["isbn"], name: "index_library_items_on_isbn"
-    t.index ["library_id", "audiobookshelf_id"], name: "index_library_items_on_library_id_and_audiobookshelf_id", unique: true
     t.index ["library_id"], name: "index_library_items_on_library_id"
+    t.index ["library_platform", "library_id", "audiobookshelf_id"], name: "idx_on_library_platform_library_id_audiobookshelf_i_c1fd6c7905", unique: true
+    t.index ["library_platform"], name: "index_library_items_on_library_platform"
     t.index ["missing"], name: "index_library_items_on_missing"
     t.index ["synced_at"], name: "index_library_items_on_synced_at"
   end

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -190,6 +190,23 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "index shows neutral and brand-correct library platform labels" do
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label[for='settings_library_platform']", text: "Active Library Platform"
+    assert_select "label[for='settings_audiobookshelf_url']", text: "Audiobookshelf URL"
+    assert_select "label[for='settings_audiobookshelf_api_key']", text: "Audiobookshelf API Key"
+    assert_select "label[for='settings_bookorbit_url']", text: "BookOrbit URL"
+    assert_select "label[for='settings_bookorbit_username']", text: "BookOrbit Username"
+    assert_select "label[for='settings_bookorbit_password']", text: "BookOrbit Password"
+    assert_select "label[for='settings_audiobookshelf_audiobook_library_id']", text: "Audiobook Library"
+    assert_select "label[for='settings_audiobookshelf_ebook_library_id']", text: "Ebook Library"
+    assert_select "label[for='settings_audiobookshelf_library_sync_interval']", text: "Library Sync Interval"
+    assert_no_match /Bookorbit/, @response.body
+    assert_no_match /Audiobookshelf Audiobook Library/, @response.body
+  end
+
   test "index shows text input when audiobookshelf not configured" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:audiobookshelf_api_key, "")

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -6,7 +6,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @admin = users(:two)
     sign_in_as(@admin)
-    AudiobookshelfClient.reset_connection!
+    LibraryPlatformClient.reset_connections!
     ProwlarrClient.reset_connection!
     FlaresolverrClient.reset_connection!
     GoogleBooksClient.reset_connection!
@@ -15,7 +15,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    AudiobookshelfClient.reset_connection!
+    LibraryPlatformClient.reset_connections!
     ProwlarrClient.reset_connection!
     FlaresolverrClient.reset_connection!
     GoogleBooksClient.reset_connection!
@@ -50,6 +50,8 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index shows indexer provider dropdown" do
+    SettingsService.set(:prowlarr_api_key, "stored-prowlarr-secret")
+
     get admin_settings_url
 
     assert_response :success
@@ -59,6 +61,8 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "option[value='newznab']", text: "NZBHydra2 / Newznab"
     assert_select "input[name='settings[newznab_url]']"
     assert_select "input[name='settings[newznab_api_key]']"
+    assert_select "input[type='password'][name='settings[prowlarr_api_key]'][value='']"
+    assert_no_match /stored-prowlarr-secret/, @response.body
   end
 
   test "index shows google books and open library test buttons" do
@@ -267,6 +271,33 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 7, SettingsService.get(:max_retries)
   end
 
+  test "update preserves existing secret when blank secret value submitted" do
+    SettingsService.set(:prowlarr_api_key, "existing-secret")
+
+    patch admin_setting_url("prowlarr_api_key"), params: {
+      setting: { value: "" }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal "existing-secret", SettingsService.get(:prowlarr_api_key)
+  end
+
+  test "bulk_update preserves existing secrets when blank secret values submitted" do
+    SettingsService.set(:prowlarr_api_key, "existing-prowlarr-secret")
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        prowlarr_api_key: "",
+        discord_webhook_url: ""
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal "existing-prowlarr-secret", SettingsService.get(:prowlarr_api_key)
+    assert_equal "https://discord.com/api/webhooks/123/token", SettingsService.get(:discord_webhook_url)
+  end
+
   test "update rejects invalid single path template" do
     patch admin_setting_url("audiobook_path_template"), params: {
       setting: { value: "{invalid_var}" }
@@ -288,13 +319,16 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index shows Discord notification settings" do
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
+
     get admin_settings_url
 
     assert_response :success
     assert_select "label", text: "Discord Enabled"
     assert_select "input[name='settings[discord_enabled]']"
-    assert_select "input[type='password'][name='settings[discord_webhook_url]']"
+    assert_select "input[type='password'][name='settings[discord_webhook_url]'][value='']"
     assert_select "input[name='settings[discord_events]']"
+    assert_no_match %r{https://discord\.com/api/webhooks/123/token}, @response.body
     assert_select "a", text: "Send Test Discord"
   end
 
@@ -934,7 +968,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
     SettingsService.set(:audiobookshelf_api_key, "test-api-key")
 
-    AudiobookshelfClient.stub(:test_connection, -> { raise AudiobookshelfClient::Error, "abs boom" }) do
+    LibraryPlatformClient.stub(:test_connection, -> { raise LibraryPlatformClient::Error, "abs boom" }) do
       post test_audiobookshelf_admin_settings_url
     end
 

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class PostProcessingJobTest < ActiveJob::TestCase
   setup do
-    AudiobookshelfClient.reset_connection!
+    LibraryPlatformClient.reset_connections!
 
     # Create an audiobook for testing (not ebook)
     @book = Book.create!(
@@ -50,7 +50,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
   end
 
   teardown do
-    AudiobookshelfClient.reset_connection!
+    LibraryPlatformClient.reset_connections!
     FileUtils.rm_rf(@temp_source) if @temp_source && File.exist?(@temp_source)
     FileUtils.rm_rf(@temp_dest_base) if @temp_dest_base && File.exist?(@temp_dest_base)
   end

--- a/test/jobs/upload_processing_job_test.rb
+++ b/test/jobs/upload_processing_job_test.rb
@@ -516,13 +516,13 @@ class UploadProcessingJobTest < ActiveJob::TestCase
     book = books(:audiobook_acquired)
     scanned = []
 
-    AudiobookshelfClient.stub(:scan_library, ->(library_id) { scanned << library_id }) do
+    LibraryPlatformClient.stub(:scan_library, ->(library_id) { scanned << library_id }) do
       UploadProcessingJob.new.send(:trigger_library_scan, book)
     end
 
     assert_equal [ "audio-lib" ], scanned
 
-    AudiobookshelfClient.stub(:scan_library, ->(*) { raise AudiobookshelfClient::Error, "scan failed" }) do
+    LibraryPlatformClient.stub(:scan_library, ->(*) { raise LibraryPlatformClient::Error, "scan failed" }) do
       assert_nothing_raised { UploadProcessingJob.new.send(:trigger_library_scan, book) }
     end
   end

--- a/test/models/library_item_test.rb
+++ b/test/models/library_item_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LibraryItemTest < ActiveSupport::TestCase
+  setup do
+    Setting.where(key: %w[library_platform audiobookshelf_url bookorbit_url]).delete_all
+  end
+
+  test "audiobookshelf_url uses Audiobookshelf item route by default" do
+    SettingsService.set(:audiobookshelf_url, "http://abs.example")
+    item = LibraryItem.new(audiobookshelf_id: "abs-item-1")
+
+    assert_equal "http://abs.example/item/abs-item-1", item.audiobookshelf_url
+  end
+
+  test "audiobookshelf_url uses BookOrbit book route when BookOrbit is active" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:bookorbit_url, "http://bookorbit.example")
+    item = LibraryItem.new(audiobookshelf_id: "42")
+
+    assert_equal "http://bookorbit.example/book/42", item.audiobookshelf_url
+  end
+end

--- a/test/models/library_item_test.rb
+++ b/test/models/library_item_test.rb
@@ -17,7 +17,16 @@ class LibraryItemTest < ActiveSupport::TestCase
   test "audiobookshelf_url uses BookOrbit book route when BookOrbit is active" do
     SettingsService.set(:library_platform, "bookorbit")
     SettingsService.set(:bookorbit_url, "http://bookorbit.example")
-    item = LibraryItem.new(audiobookshelf_id: "42")
+    item = LibraryItem.new(library_platform: "bookorbit", audiobookshelf_id: "42")
+
+    assert_equal "http://bookorbit.example/book/42", item.audiobookshelf_url
+  end
+
+  test "audiobookshelf_url uses item platform rather than active platform" do
+    SettingsService.set(:library_platform, "audiobookshelf")
+    SettingsService.set(:audiobookshelf_url, "http://abs.example")
+    SettingsService.set(:bookorbit_url, "http://bookorbit.example")
+    item = LibraryItem.new(library_platform: "bookorbit", audiobookshelf_id: "42")
 
     assert_equal "http://bookorbit.example/book/42", item.audiobookshelf_url
   end

--- a/test/services/audiobookshelf_library_matcher_service_test.rb
+++ b/test/services/audiobookshelf_library_matcher_service_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
   setup do
     LibraryItem.destroy_all
+    SettingsService.set(:library_platform, "audiobookshelf")
 
     LibraryItem.create!(
       library_id: "lib-audio",
@@ -100,5 +101,17 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
     )
 
     assert_equal [ "ab-1" ], matches.map { |match| match.item.audiobookshelf_id }
+  end
+
+  test "ignores cached items from inactive library platforms" do
+    SettingsService.set(:library_platform, "bookorbit")
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 5
+    )
+
+    assert_empty matches
   end
 end

--- a/test/services/audiobookshelf_library_sync_service_test.rb
+++ b/test/services/audiobookshelf_library_sync_service_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
   setup do
     LibraryItem.destroy_all
+    SettingsService.set(:library_platform, "audiobookshelf")
     SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
     SettingsService.set(:audiobookshelf_api_key, "test-api-key")
     SettingsService.set(:audiobookshelf_audiobook_library_id, "lib-audio")
@@ -168,5 +169,51 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
       assert item.missing?
       assert_equal 0, LibraryItem.available_for_matching.count
     end
+  end
+
+  test "sync scopes cached items to the active library platform" do
+    LibraryItem.create!(
+      library_platform: "audiobookshelf",
+      library_id: "42",
+      audiobookshelf_id: "101",
+      title: "Audiobookshelf Copy",
+      author: "Original Author",
+      synced_at: 1.day.ago
+    )
+
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:bookorbit_url, "http://localhost:3000")
+    SettingsService.set(:bookorbit_username, "admin")
+    SettingsService.set(:bookorbit_password, "secret")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "42")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    LibraryPlatformClient.reset_connections!
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: { accessToken: "bookorbit-token" }.to_json)
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            items: [
+              { id: 101, status: "present", title: "BookOrbit Copy", authors: [ "New Author" ] }
+            ],
+            total: 1
+          }.to_json
+        )
+
+      result = AudiobookshelfLibrarySyncService.new.sync!
+
+      assert result.success?
+      assert_equal 2, LibraryItem.count
+      assert_equal "Audiobookshelf Copy", LibraryItem.find_by!(library_platform: "audiobookshelf", library_id: "42", audiobookshelf_id: "101").title
+      assert_equal "BookOrbit Copy", LibraryItem.find_by!(library_platform: "bookorbit", library_id: "42", audiobookshelf_id: "101").title
+      assert_equal [ "BookOrbit Copy" ], LibraryItem.available_for_matching.pluck(:title)
+    end
+  ensure
+    LibraryPlatformClient.reset_connections!
   end
 end

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BookOrbitClientTest < ActiveSupport::TestCase
+  setup do
+    AudiobookshelfClient.reset_connection!
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:bookorbit_url, "http://localhost:3000")
+    SettingsService.set(:bookorbit_username, "admin")
+    SettingsService.set(:bookorbit_password, "secret")
+  end
+
+  teardown do
+    AudiobookshelfClient.reset_connection!
+    SettingsService.set(:library_platform, "audiobookshelf")
+  end
+
+  test "configured? returns true when BookOrbit is selected and credentials are present" do
+    assert BookOrbitClient.configured?
+    assert AudiobookshelfClient.configured?
+    assert_equal "BookOrbit", AudiobookshelfClient.display_name
+  end
+
+  test "libraries logs in and returns BookOrbit libraries" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer bookorbit-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [
+            {
+              "id" => 42,
+              "name" => "Kobo Books",
+              "folders" => [ { "id" => 7, "path" => "/books/kobo" } ]
+            }
+          ].to_json
+        )
+
+      libraries = AudiobookshelfClient.libraries
+
+      assert_equal 1, libraries.size
+      assert_equal "42", libraries.first.id
+      assert_equal "Kobo Books", libraries.first.name
+      assert_equal [ "/books/kobo" ], libraries.first.folder_paths
+      assert libraries.first.audiobook_library?
+    end
+  end
+
+  test "library_items maps BookOrbit book cards into Shelfarr library item attributes" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(
+          headers: { "Authorization" => "Bearer bookorbit-token" },
+          body: hash_including(
+            "sort" => [],
+            "collapseSeries" => false,
+            "pagination" => { "page" => 0, "size" => 200 }
+          )
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "items" => [
+              {
+                "id" => 101,
+                "status" => "present",
+                "title" => "The Left Hand of Darkness",
+                "subtitle" => "A Novel",
+                "authors" => [ "Ursula K. Le Guin" ],
+                "narrators" => [ "George Guidall" ],
+                "seriesName" => "Hainish Cycle",
+                "seriesIndex" => 4,
+                "publisher" => "Ace",
+                "language" => "en",
+                "isbn13" => "9780441478125",
+                "publishedYear" => 1969
+              },
+              {
+                "id" => 102,
+                "status" => "missing",
+                "title" => "Missing Book",
+                "authors" => []
+              }
+            ],
+            "total" => 2,
+            "page" => 0,
+            "size" => 200
+          }.to_json
+        )
+
+      items = AudiobookshelfClient.library_items("42")
+
+      assert_equal 2, items.size
+      assert_equal "101", items.first["audiobookshelf_id"]
+      assert_equal "The Left Hand of Darkness", items.first["title"]
+      assert_equal "A Novel", items.first["subtitle"]
+      assert_equal "Ursula K. Le Guin", items.first["author"]
+      assert_equal "George Guidall", items.first["narrator"]
+      assert_equal "Hainish Cycle", items.first["series"]
+      assert_equal "4", items.first["series_position"]
+      assert_equal "9780441478125", items.first["isbn"]
+      assert_equal 1969, items.first["published_year"]
+      assert_equal false, items.first["missing"]
+      assert_equal true, items.last["missing"]
+    end
+  end
+
+  test "scan_library calls BookOrbit scanner endpoint" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/scanner/libraries/42/scan")
+        .with(headers: { "Authorization" => "Bearer bookorbit-token" })
+        .to_return(status: 202, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+
+      assert AudiobookshelfClient.scan_library("42")
+    end
+  end
+
+  test "facade translates BookOrbit authentication errors" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .to_return(status: 401, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+
+      assert_raises AudiobookshelfClient::AuthenticationError do
+        AudiobookshelfClient.libraries
+      end
+    end
+  end
+
+  private
+
+  def stub_login
+    stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+      .with(body: { username: "admin", password: "secret" }.to_json)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { accessToken: "bookorbit-token" }.to_json
+      )
+  end
+end

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class BookOrbitClientTest < ActiveSupport::TestCase
   setup do
-    AudiobookshelfClient.reset_connection!
+    LibraryPlatformClient.reset_connections!
     SettingsService.set(:library_platform, "bookorbit")
     SettingsService.set(:bookorbit_url, "http://localhost:3000")
     SettingsService.set(:bookorbit_username, "admin")
@@ -12,14 +12,14 @@ class BookOrbitClientTest < ActiveSupport::TestCase
   end
 
   teardown do
-    AudiobookshelfClient.reset_connection!
+    LibraryPlatformClient.reset_connections!
     SettingsService.set(:library_platform, "audiobookshelf")
   end
 
   test "configured? returns true when BookOrbit is selected and credentials are present" do
     assert BookOrbitClient.configured?
-    assert AudiobookshelfClient.configured?
-    assert_equal "BookOrbit", AudiobookshelfClient.display_name
+    assert LibraryPlatformClient.configured?
+    assert_equal "BookOrbit", LibraryPlatformClient.display_name
   end
 
   test "libraries logs in and returns BookOrbit libraries" do
@@ -39,7 +39,7 @@ class BookOrbitClientTest < ActiveSupport::TestCase
           ].to_json
         )
 
-      libraries = AudiobookshelfClient.libraries
+      libraries = LibraryPlatformClient.libraries
 
       assert_equal 1, libraries.size
       assert_equal "42", libraries.first.id
@@ -93,7 +93,7 @@ class BookOrbitClientTest < ActiveSupport::TestCase
           }.to_json
         )
 
-      items = AudiobookshelfClient.library_items("42")
+      items = LibraryPlatformClient.library_items("42")
 
       assert_equal 2, items.size
       assert_equal "101", items.first["audiobookshelf_id"]
@@ -117,7 +117,7 @@ class BookOrbitClientTest < ActiveSupport::TestCase
         .with(headers: { "Authorization" => "Bearer bookorbit-token" })
         .to_return(status: 202, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
 
-      assert AudiobookshelfClient.scan_library("42")
+      assert LibraryPlatformClient.scan_library("42")
     end
   end
 
@@ -126,8 +126,8 @@ class BookOrbitClientTest < ActiveSupport::TestCase
       stub_request(:post, "http://localhost:3000/api/v1/auth/login")
         .to_return(status: 401, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
 
-      assert_raises AudiobookshelfClient::AuthenticationError do
-        AudiobookshelfClient.libraries
+      assert_raises LibraryPlatformClient::AuthenticationError do
+        LibraryPlatformClient.libraries
       end
     end
   end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -189,6 +189,12 @@ class SettingsServiceTest < ActiveSupport::TestCase
     assert SettingsService.bookorbit_library_platform?
   end
 
+  test "label_for uses brand and neutral library platform labels" do
+    assert_equal "BookOrbit URL", SettingsService.label_for(:bookorbit_url)
+    assert_equal "Audiobook Library", SettingsService.label_for(:audiobookshelf_audiobook_library_id)
+    assert_equal "Max Retries", SettingsService.label_for(:max_retries)
+  end
+
   test "audiobookshelf_configured? checks active platform credentials" do
     SettingsService.set(:library_platform, "audiobookshelf")
     SettingsService.set(:audiobookshelf_url, "http://localhost:13378")

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types move_completed_downloads zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled]).delete_all
+    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types move_completed_downloads zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled library_platform audiobookshelf_url audiobookshelf_api_key bookorbit_url bookorbit_username bookorbit_password]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -175,5 +175,34 @@ class SettingsServiceTest < ActiveSupport::TestCase
     SettingsService.set(:open_library_enabled, false)
 
     assert_equal [], SettingsService.enabled_metadata_providers
+  end
+
+  test "active_library_platform defaults to audiobookshelf" do
+    assert_equal "audiobookshelf", SettingsService.active_library_platform
+    assert_not SettingsService.bookorbit_library_platform?
+  end
+
+  test "active_library_platform supports bookorbit" do
+    SettingsService.set(:library_platform, "bookorbit")
+
+    assert_equal "bookorbit", SettingsService.active_library_platform
+    assert SettingsService.bookorbit_library_platform?
+  end
+
+  test "audiobookshelf_configured? checks active platform credentials" do
+    SettingsService.set(:library_platform, "audiobookshelf")
+    SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
+    SettingsService.set(:audiobookshelf_api_key, "abs-key")
+
+    assert SettingsService.audiobookshelf_configured?
+
+    SettingsService.set(:library_platform, "bookorbit")
+    assert_not SettingsService.audiobookshelf_configured?
+
+    SettingsService.set(:bookorbit_url, "http://localhost:3000")
+    SettingsService.set(:bookorbit_username, "admin")
+    SettingsService.set(:bookorbit_password, "secret")
+
+    assert SettingsService.audiobookshelf_configured?
   end
 end


### PR DESCRIPTION
## Summary
- Add BookOrbit as an optional library platform alongside Audiobookshelf.
- Add BookOrbit settings, connection testing, library listing, inventory sync, and scan triggering.
- Route existing library sync behavior through the active platform while keeping Audiobookshelf as the default.
- Document BookOrbit support and current limitations.

Closes #299

## Test plan
- bundle exec rails test test/services/bookorbit_client_test.rb test/services/settings_service_test.rb test/services/audiobookshelf_client_test.rb test/services/audiobookshelf_library_sync_service_test.rb test/controllers/admin/settings_controller_test.rb
- bundle exec rails test test/jobs/audiobookshelf_library_sync_job_test.rb test/jobs/download_job_test.rb test/jobs/post_processing_job_test.rb test/jobs/upload_processing_job_test.rb test/jobs/health_check_job_test.rb
- bundle exec rubocop app/controllers/admin/settings_controller.rb app/jobs/health_check_job.rb app/models/library_item.rb app/services/audiobookshelf_client.rb app/services/book_orbit_client.rb app/services/settings_service.rb test/models/library_item_test.rb test/services/bookorbit_client_test.rb test/services/settings_service_test.rb
- bundle exec rails test