### PR TITLE
feat: add Grimmory library support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Think Jellyseerr, but for books. Your users request ebooks and audiobooks; Shelf
 - **Smart Acquisition** — Search Prowlarr, Jackett or Newznab/NZBHydra2 indexers; download via qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet
 - **Direct Downloads** — Ebooks from Anna's Archive and Z-Library, public-domain audiobooks from LibriVox — no torrent client needed
 - **Auto-Selection & Format Preferences** — Pick the best release automatically, scored by your preferred formats, bitrate and language
-- **Auto-Processing** — Rename and organize files with path/filename templates, then deliver to Audiobookshelf or BookOrbit watched folders
-- **Library Sync** — Automatic Audiobookshelf or BookOrbit scans after downloads complete
+- **Auto-Processing** — Rename and organize files with path/filename templates, then deliver to Audiobookshelf, BookOrbit or Grimmory watched folders
+- **Library Sync** — Automatic Audiobookshelf, BookOrbit or Grimmory scans after downloads complete
 - **Manual Uploads** — Upload your own files to fulfill a request
 - **Multi-User** — Role-based access with user requests and admin controls
 - **Authentication** — TOTP-based 2FA with backup codes, plus OIDC/SSO (Authentik, Authelia, Keycloak, etc.)
@@ -107,7 +107,7 @@ After logging in, go to **Admin → Settings**:
 | Indexer | Prowlarr, Jackett or Newznab/NZBHydra2 URL + API key for searches |
 | Download Clients | qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet (Admin → Download Clients) |
 | Output Paths | Where to place completed audiobooks/ebooks |
-| Library Platform | Audiobookshelf URL + API key, or BookOrbit URL + username/password for library integration (optional) |
+| Library Platform | Audiobookshelf URL + API key, or BookOrbit/Grimmory URL + username/password for library integration (optional) |
 
 📖 **[Read the docs](https://shelfarr.org/getting-started.html)** for a full install and setup walkthrough, plus a **[settings reference](https://shelfarr.org/configuration.html)** describing every option, its type and default.
 
@@ -145,7 +145,7 @@ Shelfarr supports OpenID Connect for single sign-on with identity providers like
 | **SABnzbd**, **NZBGet** | Usenet downloads |
 | **Anna's Archive** / **Z-Library** | Direct ebook downloads |
 | **LibriVox** | Public-domain audiobook downloads |
-| **Audiobookshelf** / **BookOrbit** | Library management |
+| **Audiobookshelf** / **BookOrbit** / **Grimmory** | Library management |
 | **Discord** / **Telegram** / **Webhooks** | Notifications |
 
 ## Requirements
@@ -154,9 +154,11 @@ Shelfarr supports OpenID Connect for single sign-on with identity providers like
 - At least one way to find books:
   - An indexer — Prowlarr, Jackett or Newznab/NZBHydra2 — plus a download client (qBittorrent, Decypharr, Deluge, Transmission, SABnzbd or NZBGet), **and/or**
   - A direct source — Anna's Archive or Z-Library (ebooks), LibriVox (audiobooks)
-- Audiobookshelf or BookOrbit (optional, for library integration)
+- Audiobookshelf, BookOrbit or Grimmory (optional, for library integration)
 
 BookOrbit support uses BookOrbit's current `/api/v1` endpoints for library listing, inventory sync, and scan triggers. Shelfarr still delivers files through configured output paths; direct Book Dock upload/finalize is not implemented because BookOrbit does not currently publish a stable external API for that workflow.
+
+Grimmory support uses Grimmory's `/api/v1` endpoints for library listing, inventory sync and refresh triggers. Shelfarr delivers files to its configured output paths and asks Grimmory to rescan; Grimmory BookDrop upload/finalize is not used.
 
 ## Development
 

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -527,7 +527,7 @@ module Admin
     end
 
     def library_platform_setting_key?(key)
-      key.start_with?("audiobookshelf") || key.start_with?("bookorbit") || key == "library_platform"
+      key.start_with?("audiobookshelf") || key.start_with?("bookorbit") || key.start_with?("grimmory") || key == "library_platform"
     end
 
     def preserve_blank_secret?(key, value)

--- a/app/services/grimmory_client.rb
+++ b/app/services/grimmory_client.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+# Client for Grimmory's documented /api/v1 endpoints.
+class GrimmoryClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class AuthenticationError < Error; end
+  class NotConfiguredError < Error; end
+
+  Library = Data.define(:id, :name, :paths, :media_type) do
+    def folder_paths
+      paths.map { |path| path["path"] || path["fullPath"] }.compact
+    end
+
+    def audiobook_library?
+      true
+    end
+
+    def podcast_library?
+      false
+    end
+
+    def folders
+      paths
+    end
+  end
+
+  class << self
+    def libraries
+      ensure_configured!
+
+      response = authenticated_request { connection.get("/api/v1/libraries") }
+      handle_response(response) do |data|
+        extract_collection(data, "libraries").map { |library| parse_library(library) }
+      end
+    end
+
+    def library(id)
+      ensure_configured!
+
+      response = authenticated_request { connection.get("/api/v1/libraries/#{id}") }
+      handle_response(response) { |data| parse_library(data) }
+    end
+
+    def library_items(id, page_size: 200)
+      ensure_configured!
+
+      response = authenticated_request { connection.get("/api/v1/libraries/#{id}/book") }
+      handle_response(response) do |data|
+        extract_collection(data, "books").filter_map { |item| parse_item(item) }
+      end
+    end
+
+    def scan_library(id)
+      ensure_configured!
+
+      response = authenticated_request { connection.put("/api/v1/libraries/#{id}/refresh") }
+      response.status.in?([ 200, 201, 202, 204 ])
+    end
+
+    def delete_item_by_path(_path)
+      false
+    end
+
+    def configured?
+      SettingsService.grimmory_configured?
+    end
+
+    def test_connection
+      ensure_configured!
+      libraries.any?
+    rescue Error
+      false
+    end
+
+    def reset_connection!
+      @connection = nil
+      @access_token = nil
+    end
+
+    private
+
+    def ensure_configured!
+      raise NotConfiguredError, "Grimmory is not configured" unless configured?
+    end
+
+    def request
+      yield
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError, URI::Error => e
+      raise ConnectionError, "Failed to connect to Grimmory: #{e.message}"
+    end
+
+    def authenticated_request
+      response = request { yield }
+      return response unless response.status.in?([ 401, 403 ]) && @access_token.present?
+
+      reset_connection!
+      request { yield }
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: base_url) do |f|
+        f.request :json
+        f.response :json, parser_options: { symbolize_names: false }
+        f.adapter Faraday.default_adapter
+        f.headers["Authorization"] = "Bearer #{access_token}"
+        f.options.timeout = 15
+        f.options.open_timeout = 5
+      end
+    end
+
+    def auth_connection
+      Faraday.new(url: base_url) do |f|
+        f.request :json
+        f.response :json, parser_options: { symbolize_names: false }
+        f.adapter Faraday.default_adapter
+        f.options.timeout = 15
+        f.options.open_timeout = 5
+      end
+    end
+
+    def access_token
+      @access_token ||= begin
+        response = request do
+          auth_connection.post("/api/v1/auth/login", {
+            username: SettingsService.get(:grimmory_username),
+            password: SettingsService.get(:grimmory_password)
+          })
+        end
+        handle_response(response) do |data|
+          token = data["accessToken"]
+          raise AuthenticationError, "Grimmory login did not return an access token" if token.blank?
+
+          token
+        end
+      end
+    end
+
+    def base_url
+      url = SettingsService.get(:grimmory_url).to_s.strip
+      parsed_url = URI.parse(url)
+
+      unless parsed_url.is_a?(URI::HTTP) && parsed_url.host.present?
+        raise URI::InvalidURIError, "Grimmory URL must include http:// or https://"
+      end
+
+      url
+    end
+
+    def handle_response(response)
+      case response.status
+      when 200, 201, 202, 204
+        yield(response.body.presence || {})
+      when 401, 403
+        raise AuthenticationError, "Invalid Grimmory credentials or permissions"
+      when 404
+        raise Error, "Grimmory resource not found"
+      else
+        raise Error, "Grimmory API error: #{response.status}"
+      end
+    end
+
+    def parse_library(data)
+      Library.new(
+        id: data["id"].to_s,
+        name: data["name"],
+        paths: data["paths"] || [],
+        media_type: infer_media_type(data["allowedFormats"])
+      )
+    end
+
+    def infer_media_type(allowed_formats)
+      formats = Array(allowed_formats).map { |format| format.to_s.downcase.delete_prefix(".") }
+      return "grimmory" if formats.empty?
+
+      ebook_formats = %w[azw azw3 cbx cbz cbr epub fb2 lit lrf mobi pdf txt]
+      audiobook_formats = %w[aac aiff alac audiobook flac m4a m4b mp3 ogg opus wav wma]
+
+      has_ebooks = formats.any? { |format| ebook_formats.include?(format) }
+      has_audiobooks = formats.any? { |format| audiobook_formats.include?(format) }
+
+      return "audiobook" if has_audiobooks && !has_ebooks
+      return "ebook" if has_ebooks && !has_audiobooks
+
+      "grimmory"
+    end
+
+    def extract_collection(data, preferred_key)
+      return data if data.is_a?(Array)
+      return [] unless data.is_a?(Hash)
+
+      data[preferred_key] || data["items"] || data["results"] || data["data"] || []
+    end
+
+    def parse_item(raw_item)
+      return unless raw_item.is_a?(Hash)
+
+      {
+        "audiobookshelf_id" => item_id(raw_item),
+        "title" => raw_item["title"] || raw_item.dig("metadata", "title"),
+        "subtitle" => raw_item["subtitle"] || raw_item.dig("metadata", "subtitle"),
+        "author" => extract_author(raw_item),
+        "narrator" => extract_narrator(raw_item),
+        "series" => extract_series_name(raw_item),
+        "series_position" => extract_series_position(raw_item)&.to_s,
+        "publisher" => extract_named_value(raw_item["publisher"] || raw_item.dig("metadata", "publisher")),
+        "language" => raw_item["language"] || raw_item.dig("metadata", "language"),
+        "description" => raw_item["description"] || raw_item.dig("metadata", "description"),
+        "isbn" => extract_isbn(raw_item),
+        "asin" => raw_item["asin"] || raw_item.dig("metadata", "asin"),
+        "published_year" => extract_published_year(raw_item),
+        "missing" => missing?(raw_item)
+      }
+    end
+
+    def item_id(raw_item)
+      (raw_item["id"] || raw_item["bookId"] || raw_item.dig("book", "id")).to_s
+    end
+
+    def extract_author(raw_item)
+      return raw_item["author"] if raw_item["author"].present?
+      return raw_item["authorName"] if raw_item["authorName"].present?
+      return raw_item.dig("metadata", "author") if raw_item.dig("metadata", "author").present?
+      return raw_item.dig("metadata", "authorName") if raw_item.dig("metadata", "authorName").present?
+
+      join_people(raw_item["authors"] || raw_item.dig("metadata", "authors"))
+    end
+
+    def extract_narrator(raw_item)
+      return raw_item["narrator"] if raw_item["narrator"].present?
+      return raw_item["narratorName"] if raw_item["narratorName"].present?
+      return raw_item.dig("metadata", "narrator") if raw_item.dig("metadata", "narrator").present?
+      return raw_item.dig("metadata", "narratorName") if raw_item.dig("metadata", "narratorName").present?
+
+      join_people(raw_item["narrators"] || raw_item.dig("metadata", "narrators"))
+    end
+
+    def extract_series_name(raw_item)
+      return raw_item["seriesName"] if raw_item["seriesName"].present?
+      return raw_item.dig("metadata", "seriesName") if raw_item.dig("metadata", "seriesName").present?
+
+      extract_named_value(first_series_entry(raw_item))
+    end
+
+    def extract_series_position(raw_item)
+      series = first_series_entry(raw_item)
+
+      raw_item["seriesPosition"] ||
+        raw_item["seriesIndex"] ||
+        raw_item["seriesSequence"] ||
+        raw_item.dig("metadata", "seriesPosition") ||
+        raw_item.dig("metadata", "seriesIndex") ||
+        raw_item.dig("metadata", "seriesNumber") ||
+        raw_item.dig("metadata", "seriesSequence") ||
+        (series.is_a?(Hash) ? series["position"] || series["sequence"] : nil)
+    end
+
+    def first_series_entry(raw_item)
+      series = raw_item["series"] || raw_item.dig("metadata", "series")
+      series.is_a?(Array) ? series.first : series
+    end
+
+    def extract_isbn(raw_item)
+      raw_item["isbn13"].presence ||
+        raw_item.dig("metadata", "isbn13").presence ||
+        raw_item["isbn10"].presence ||
+        raw_item.dig("metadata", "isbn10").presence ||
+        normalize_identifier(raw_item["isbn"] || raw_item.dig("metadata", "isbn"))
+    end
+
+    def extract_published_year(raw_item)
+      value = raw_item["publishedYear"] ||
+        raw_item.dig("metadata", "publishedYear") ||
+        raw_item["publishedDate"] ||
+        raw_item.dig("metadata", "publishedDate")
+      return nil if value.blank?
+
+      match = value.to_s.match(/\A\d{4}\z|(\d{4})/)
+      return nil unless match
+
+      (match[0] || match[1]).to_i
+    end
+
+    def missing?(raw_item)
+      raw_item["missing"] == true || raw_item["isMissing"] == true || raw_item["status"].to_s.downcase == "missing"
+    end
+
+    def join_people(values)
+      return nil if values.blank?
+      return values.join(", ") if values.is_a?(Array) && values.all?(String)
+
+      if values.is_a?(Array)
+        names = values.map { |value| extract_named_value(value) }.compact_blank
+        return names.join(", ") if names.any?
+      end
+
+      extract_named_value(values)
+    end
+
+    def extract_named_value(value)
+      return nil if value.blank?
+      return value if value.is_a?(String)
+
+      if value.is_a?(Hash)
+        return value["name"] || value["fullName"] || value["title"] || value.dig("series", "name")
+      end
+
+      value.to_s
+    end
+
+    def normalize_identifier(value)
+      return nil if value.blank?
+      return value.compact_blank.first.to_s if value.is_a?(Array)
+
+      value.to_s
+    end
+  end
+end

--- a/app/services/library_platform_client.rb
+++ b/app/services/library_platform_client.rb
@@ -8,7 +8,8 @@ class LibraryPlatformClient
 
   DISPLAY_NAMES = {
     "audiobookshelf" => "Audiobookshelf",
-    "bookorbit" => "BookOrbit"
+    "bookorbit" => "BookOrbit",
+    "grimmory" => "Grimmory"
   }.freeze
 
   class << self
@@ -51,6 +52,7 @@ class LibraryPlatformClient
     def reset_connections!
       AudiobookshelfClient.reset_connection!
       BookOrbitClient.reset_connection!
+      GrimmoryClient.reset_connection!
     end
 
     def reset_connection!
@@ -84,6 +86,8 @@ class LibraryPlatformClient
       case platform.to_s
       when "bookorbit"
         BookOrbitClient
+      when "grimmory"
+        GrimmoryClient
       else
         AudiobookshelfClient
       end
@@ -93,6 +97,8 @@ class LibraryPlatformClient
       case platform.to_s
       when "bookorbit"
         SettingsService.get(:bookorbit_url)
+      when "grimmory"
+        SettingsService.get(:grimmory_url)
       else
         SettingsService.get(:audiobookshelf_url)
       end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -2,7 +2,7 @@ class SettingsService
   DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
 
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
-  LIBRARY_PLATFORMS = %w[audiobookshelf bookorbit].freeze
+  LIBRARY_PLATFORMS = %w[audiobookshelf bookorbit grimmory].freeze
   INDEXER_SEARCH_SCOPES = %w[broad strict unrestricted custom].freeze
   INDEXER_SEARCH_SCOPE_OPTIONS = {
     "broad" => {
@@ -67,12 +67,15 @@ class SettingsService
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
     # Library Platform Integration
-    library_platform: { type: "string", default: "audiobookshelf", category: "audiobookshelf", description: "Library platform to sync and scan: audiobookshelf or bookorbit" },
+    library_platform: { type: "string", default: "audiobookshelf", category: "audiobookshelf", description: "Library platform to sync and scan: audiobookshelf, bookorbit, or grimmory" },
     audiobookshelf_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for Audiobookshelf (e.g., http://localhost:13378)" },
     audiobookshelf_api_key: { type: "string", default: "", category: "audiobookshelf", description: "API token from Audiobookshelf user settings" },
     bookorbit_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for BookOrbit (e.g., http://localhost:3000)" },
     bookorbit_username: { type: "string", default: "", category: "audiobookshelf", description: "BookOrbit username with library access and scan permissions" },
     bookorbit_password: { type: "string", default: "", category: "audiobookshelf", description: "BookOrbit password used to obtain an API access token" },
+    grimmory_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for Grimmory (e.g., http://localhost:5173)" },
+    grimmory_username: { type: "string", default: "", category: "audiobookshelf", description: "Grimmory username with library access and refresh permissions" },
+    grimmory_password: { type: "string", default: "", category: "audiobookshelf", description: "Grimmory password used to obtain an API access token" },
     audiobookshelf_audiobook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for audiobooks on the active library platform" },
     audiobookshelf_ebook_library_id: { type: "string", default: "", category: "audiobookshelf", description: "Library ID for ebooks on the active library platform" },
     audiobookshelf_library_sync_interval: { type: "integer", default: 3600, category: "audiobookshelf", description: "Seconds between automatic library inventory sync jobs" },
@@ -237,6 +240,9 @@ class SettingsService
     bookorbit_url: "BookOrbit URL",
     bookorbit_username: "BookOrbit Username",
     bookorbit_password: "BookOrbit Password",
+    grimmory_url: "Grimmory URL",
+    grimmory_username: "Grimmory Username",
+    grimmory_password: "Grimmory Password",
     audiobookshelf_audiobook_library_id: "Audiobook Library",
     audiobookshelf_ebook_library_id: "Ebook Library",
     audiobookshelf_library_sync_interval: "Library Sync Interval"
@@ -387,8 +393,11 @@ class SettingsService
     end
 
     def library_platform_configured?
-      if bookorbit_library_platform?
+      case active_library_platform
+      when "bookorbit"
         bookorbit_configured?
+      when "grimmory"
+        grimmory_configured?
       else
         audiobookshelf_credentials_configured?
       end
@@ -402,6 +411,10 @@ class SettingsService
       configured?(:bookorbit_url) && configured?(:bookorbit_username) && configured?(:bookorbit_password)
     end
 
+    def grimmory_configured?
+      configured?(:grimmory_url) && configured?(:grimmory_username) && configured?(:grimmory_password)
+    end
+
     def active_library_platform
       platform = get(:library_platform).to_s.strip.downcase
       LIBRARY_PLATFORMS.include?(platform) ? platform : "audiobookshelf"
@@ -409,6 +422,10 @@ class SettingsService
 
     def bookorbit_library_platform?
       active_library_platform == "bookorbit"
+    end
+
+    def grimmory_library_platform?
+      active_library_platform == "grimmory"
     end
 
     def anna_archive_configured?

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -101,7 +101,7 @@
                         <p class="mt-1 text-xs text-gray-500">For multiple values, use comma-separated format (e.g., en, fr, de)</p>
                       <% else %>
                         <% if key.to_s == "library_platform" %>
-                          <%= form.select "settings[#{key}]", options_for_select([["Audiobookshelf", "audiobookshelf"], ["BookOrbit", "bookorbit"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.select "settings[#{key}]", options_for_select([["Audiobookshelf", "audiobookshelf"], ["BookOrbit", "bookorbit"], ["Grimmory", "grimmory"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s.end_with?("_library_id") && @audiobookshelf_libraries.any? %>
                           <% library_options = @audiobookshelf_libraries.map { |lib| ["#{lib.name} (#{lib.media_type})", lib.id] } %>
                           <%= form.select "settings[#{key}]", options_for_select([["Select a library...", ""]] + library_options, data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -200,6 +200,9 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "label[for='settings_bookorbit_url']", text: "BookOrbit URL"
     assert_select "label[for='settings_bookorbit_username']", text: "BookOrbit Username"
     assert_select "label[for='settings_bookorbit_password']", text: "BookOrbit Password"
+    assert_select "label[for='settings_grimmory_url']", text: "Grimmory URL"
+    assert_select "label[for='settings_grimmory_username']", text: "Grimmory Username"
+    assert_select "label[for='settings_grimmory_password']", text: "Grimmory Password"
     assert_select "label[for='settings_audiobookshelf_audiobook_library_id']", text: "Audiobook Library"
     assert_select "label[for='settings_audiobookshelf_ebook_library_id']", text: "Ebook Library"
     assert_select "label[for='settings_audiobookshelf_library_sync_interval']", text: "Library Sync Interval"
@@ -276,6 +279,60 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_settings_path
     assert_equal true, SettingsService.auto_approve_requests?
+  end
+
+  test "bulk_update preserves existing secret settings when left blank" do
+    SettingsService.set(:grimmory_password, "existing-secret")
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/existing")
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        grimmory_password: "",
+        discord_webhook_url: ""
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal "existing-secret", SettingsService.get(:grimmory_password)
+    assert_equal "https://discord.com/api/webhooks/existing", SettingsService.get(:discord_webhook_url)
+  end
+
+  test "bulk_update skips side effects when preserving blank secret settings" do
+    SettingsService.set(:library_platform, "grimmory")
+    SettingsService.set(:grimmory_url, "http://localhost:5173")
+    SettingsService.set(:grimmory_username, "admin")
+    SettingsService.set(:grimmory_password, "existing-secret")
+
+    reset_called = false
+    sync_called = false
+
+    LibraryPlatformClient.stub(:reset_connections!, -> { reset_called = true }) do
+      AudiobookshelfLibrarySyncJob.stub(:perform_later, -> { sync_called = true }) do
+        patch bulk_update_admin_settings_url, params: {
+          settings: {
+            grimmory_password: ""
+          }
+        }
+      end
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_equal "existing-secret", SettingsService.get(:grimmory_password)
+    assert_not reset_called
+    assert_not sync_called
+  end
+
+  test "index does not render saved secret setting values" do
+    SettingsService.set(:grimmory_password, "existing-secret")
+    SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/existing")
+
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "input[type='password'][name='settings[grimmory_password]'][value='']"
+    assert_select "input[type='password'][name='settings[discord_webhook_url]'][value='']"
+    assert_no_match "existing-secret", response.body
+    assert_no_match "https://discord.com/api/webhooks/existing", response.body
   end
 
   test "update stores a single setting" do

--- a/test/models/library_item_test.rb
+++ b/test/models/library_item_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class LibraryItemTest < ActiveSupport::TestCase
   setup do
-    Setting.where(key: %w[library_platform audiobookshelf_url bookorbit_url]).delete_all
+    Setting.where(key: %w[library_platform audiobookshelf_url bookorbit_url grimmory_url]).delete_all
   end
 
   test "audiobookshelf_url uses Audiobookshelf item route by default" do
@@ -29,5 +29,13 @@ class LibraryItemTest < ActiveSupport::TestCase
     item = LibraryItem.new(library_platform: "bookorbit", audiobookshelf_id: "42")
 
     assert_equal "http://bookorbit.example/book/42", item.audiobookshelf_url
+  end
+
+  test "audiobookshelf_url uses Grimmory book route when Grimmory is active" do
+    SettingsService.set(:library_platform, "grimmory")
+    SettingsService.set(:grimmory_url, "http://grimmory.example")
+    item = LibraryItem.new(library_platform: "grimmory", audiobookshelf_id: "book-1")
+
+    assert_equal "http://grimmory.example/book/book-1", item.audiobookshelf_url
   end
 end

--- a/test/services/audiobookshelf_library_sync_service_test.rb
+++ b/test/services/audiobookshelf_library_sync_service_test.rb
@@ -216,4 +216,49 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
   ensure
     LibraryPlatformClient.reset_connections!
   end
+
+  test "syncs library items through Grimmory facade" do
+    SettingsService.set(:library_platform, "grimmory")
+    SettingsService.set(:grimmory_url, "http://localhost:5173")
+    SettingsService.set(:grimmory_username, "admin")
+    SettingsService.set(:grimmory_password, "secret")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "grim-lib")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    LibraryPlatformClient.reset_connections!
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:5173/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { accessToken: "grimmory-token" }.to_json
+        )
+      stub_request(:get, "http://localhost:5173/api/v1/libraries/grim-lib/book")
+        .with(headers: { "Authorization" => "Bearer grimmory-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [
+            {
+              "id" => "grim-1",
+              "title" => "Nettle & Bone",
+              "authors" => [ "T. Kingfisher" ],
+              "publishedYear" => 2022
+            }
+          ].to_json
+        )
+
+      result = AudiobookshelfLibrarySyncService.new.sync!
+
+      assert result.success?
+      assert_equal 1, result.items_synced
+      item = LibraryItem.find_by!(library_platform: "grimmory", library_id: "grim-lib", audiobookshelf_id: "grim-1")
+      assert_equal "Nettle & Bone", item.title
+      assert_equal "T. Kingfisher", item.author
+      assert_equal 2022, item.published_year
+    end
+  ensure
+    LibraryPlatformClient.reset_connections!
+  end
 end

--- a/test/services/grimmory_client_test.rb
+++ b/test/services/grimmory_client_test.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GrimmoryClientTest < ActiveSupport::TestCase
+  setup do
+    LibraryPlatformClient.reset_connections!
+    SettingsService.set(:library_platform, "grimmory")
+    SettingsService.set(:grimmory_url, "http://localhost:5173")
+    SettingsService.set(:grimmory_username, "admin")
+    SettingsService.set(:grimmory_password, "secret")
+  end
+
+  teardown do
+    LibraryPlatformClient.reset_connections!
+    SettingsService.set(:library_platform, "audiobookshelf")
+  end
+
+  test "configured? returns true when Grimmory is selected and credentials are present" do
+    assert GrimmoryClient.configured?
+    assert LibraryPlatformClient.configured?
+    assert_equal "Grimmory", LibraryPlatformClient.display_name
+  end
+
+  test "libraries logs in and returns Grimmory libraries" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:get, "http://localhost:5173/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer grimmory-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [
+            {
+              "id" => "lib-1",
+              "name" => "Ebooks",
+              "paths" => [ { "id" => "path-1", "path" => "/books/ebooks" } ],
+              "allowedFormats" => [ "EPUB", "CBX" ]
+            },
+            {
+              "id" => "lib-2",
+              "name" => "Audiobooks",
+              "paths" => [ { "id" => "path-2", "path" => "/books/audiobooks" } ],
+              "allowedFormats" => [ "AUDIOBOOK" ]
+            }
+          ].to_json
+        )
+
+      libraries = LibraryPlatformClient.libraries
+
+      assert_equal 2, libraries.size
+      assert_equal "lib-1", libraries.first.id
+      assert_equal "Ebooks", libraries.first.name
+      assert_equal [ "/books/ebooks" ], libraries.first.folder_paths
+      assert_equal "ebook", libraries.first.media_type
+      assert libraries.first.audiobook_library?
+      assert_equal "audiobook", libraries.second.media_type
+    end
+  end
+
+  test "library_items maps Grimmory books into Shelfarr library item attributes" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:get, "http://localhost:5173/api/v1/libraries/lib-1/book")
+        .with(headers: { "Authorization" => "Bearer grimmory-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [
+            {
+              "id" => "book-1",
+              "status" => "present",
+              "title" => "The Left Hand of Darkness",
+              "subtitle" => "A Novel",
+              "authors" => [ { "name" => "Ursula K. Le Guin" } ],
+              "narrators" => [ "George Guidall" ],
+              "series" => { "name" => "Hainish Cycle", "position" => 4 },
+              "publisher" => { "name" => "Ace" },
+              "language" => "en",
+              "description" => "A winter planet story.",
+              "isbn13" => "9780441478125",
+              "publishedDate" => "1969-03-01"
+            },
+            {
+              "id" => "book-2",
+              "status" => "missing",
+              "title" => "Missing Book",
+              "authors" => []
+            }
+          ].to_json
+        )
+
+      items = LibraryPlatformClient.library_items("lib-1")
+
+      assert_equal 2, items.size
+      assert_equal "book-1", items.first["audiobookshelf_id"]
+      assert_equal "The Left Hand of Darkness", items.first["title"]
+      assert_equal "A Novel", items.first["subtitle"]
+      assert_equal "Ursula K. Le Guin", items.first["author"]
+      assert_equal "George Guidall", items.first["narrator"]
+      assert_equal "Hainish Cycle", items.first["series"]
+      assert_equal "4", items.first["series_position"]
+      assert_equal "Ace", items.first["publisher"]
+      assert_equal "en", items.first["language"]
+      assert_equal "A winter planet story.", items.first["description"]
+      assert_equal "9780441478125", items.first["isbn"]
+      assert_equal 1969, items.first["published_year"]
+      assert_equal false, items.first["missing"]
+      assert_equal true, items.last["missing"]
+    end
+  end
+
+  test "library_items maps Grimmory native metadata fields" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:get, "http://localhost:5173/api/v1/libraries/lib-1/book")
+        .with(headers: { "Authorization" => "Bearer grimmory-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [
+            {
+              "id" => "book-1",
+              "title" => "Caliban's War",
+              "metadata" => {
+                "authors" => [ "James S. A. Corey" ],
+                "seriesName" => "The Expanse",
+                "seriesNumber" => 2.0,
+                "publishedDate" => "2012-06-26"
+              }
+            }
+          ].to_json
+        )
+
+      item = LibraryPlatformClient.library_items("lib-1").first
+
+      assert_equal "James S. A. Corey", item["author"]
+      assert_equal "The Expanse", item["series"]
+      assert_equal "2.0", item["series_position"]
+      assert_equal 2012, item["published_year"]
+    end
+  end
+
+  test "scan_library calls Grimmory refresh endpoint" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:put, "http://localhost:5173/api/v1/libraries/lib-1/refresh")
+        .with(headers: { "Authorization" => "Bearer grimmory-token" })
+        .to_return(status: 204)
+
+      assert LibraryPlatformClient.scan_library("lib-1")
+    end
+  end
+
+  test "facade translates Grimmory authentication errors" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:5173/api/v1/auth/login")
+        .to_return(status: 401, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+
+      assert_raises LibraryPlatformClient::AuthenticationError do
+        LibraryPlatformClient.libraries
+      end
+    end
+  end
+
+  test "relogs in once when cached Grimmory token is rejected" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:5173/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "expired-token" }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "fresh-token" }.to_json
+          }
+        )
+      stub_request(:get, "http://localhost:5173/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer expired-token" })
+        .to_return(status: 401, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+      stub_request(:get, "http://localhost:5173/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer fresh-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "id" => "lib-1", "name" => "Ebooks", "paths" => [], "allowedFormats" => [ "epub" ] } ].to_json
+        )
+
+      libraries = LibraryPlatformClient.libraries
+
+      assert_equal [ "lib-1" ], libraries.map(&:id)
+    end
+  end
+
+  private
+
+  def stub_login
+    stub_request(:post, "http://localhost:5173/api/v1/auth/login")
+      .with(body: { username: "admin", password: "secret" }.to_json)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { accessToken: "grimmory-token" }.to_json
+      )
+  end
+end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types move_completed_downloads zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled library_platform audiobookshelf_url audiobookshelf_api_key bookorbit_url bookorbit_username bookorbit_password]).delete_all
+    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types move_completed_downloads zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled library_platform audiobookshelf_url audiobookshelf_api_key bookorbit_url bookorbit_username bookorbit_password grimmory_url grimmory_username grimmory_password]).delete_all
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -191,8 +191,16 @@ class SettingsServiceTest < ActiveSupport::TestCase
 
   test "label_for uses brand and neutral library platform labels" do
     assert_equal "BookOrbit URL", SettingsService.label_for(:bookorbit_url)
+    assert_equal "Grimmory URL", SettingsService.label_for(:grimmory_url)
     assert_equal "Audiobook Library", SettingsService.label_for(:audiobookshelf_audiobook_library_id)
     assert_equal "Max Retries", SettingsService.label_for(:max_retries)
+  end
+
+  test "active_library_platform supports grimmory" do
+    SettingsService.set(:library_platform, "grimmory")
+
+    assert_equal "grimmory", SettingsService.active_library_platform
+    assert SettingsService.grimmory_library_platform?
   end
 
   test "audiobookshelf_configured? checks active platform credentials" do
@@ -208,6 +216,15 @@ class SettingsServiceTest < ActiveSupport::TestCase
     SettingsService.set(:bookorbit_url, "http://localhost:3000")
     SettingsService.set(:bookorbit_username, "admin")
     SettingsService.set(:bookorbit_password, "secret")
+
+    assert SettingsService.audiobookshelf_configured?
+
+    SettingsService.set(:library_platform, "grimmory")
+    assert_not SettingsService.audiobookshelf_configured?
+
+    SettingsService.set(:grimmory_url, "http://localhost:5173")
+    SettingsService.set(:grimmory_username, "admin")
+    SettingsService.set(:grimmory_password, "secret")
 
     assert SettingsService.audiobookshelf_configured?
   end


### PR DESCRIPTION
## Summary
- Add Grimmory as a third library platform option alongside Audiobookshelf and BookOrbit.
- Add Grimmory connection settings, JWT login, library listing, inventory sync, and refresh-trigger support.
- Map Grimmory book payloads into Shelfarr cached library items and link to Grimmory book pages.
- Harden settings secret fields so saved passwords, API keys, tokens, secrets, and Discord webhook URLs are not rendered or cleared by blank submissions.

Stacked on #321 because it introduces the multi-library-platform abstraction this branch extends.

## Test plan
- bundle exec rails test
- bundle exec rubocop app/controllers/admin/settings_controller.rb app/models/library_item.rb app/services/audiobookshelf_client.rb app/services/book_orbit_client.rb app/services/grimmory_client.rb app/services/settings_service.rb test/controllers/admin/settings_controller_test.rb test/models/library_item_test.rb test/services/audiobookshelf_library_sync_service_test.rb test/services/grimmory_client_test.rb test/services/settings_service_test.rb
- git diff --check