### PR TITLE
feat(settings): allow any setting to be overridden from the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ environment:
   - RAILS_RELATIVE_URL_ROOT=/shelfarr
 ```
 
+#### Settings as environment variables (config-as-code)
+
+Any setting from **Admin → Settings** can also be supplied from the environment,
+which is useful for declarative/GitOps deployments and for keeping secrets out of
+the app database. Set `SHELFARR_SETTING_<KEY>` (the uppercased setting key) and it
+overrides the stored value:
+
+```yaml
+environment:
+  # OIDC, sourced from the environment instead of the admin UI
+  - SHELFARR_SETTING_OIDC_ENABLED=true
+  - SHELFARR_SETTING_OIDC_ISSUER=https://auth.example.com/application/o/shelfarr/
+  - SHELFARR_SETTING_OIDC_CLIENT_ID=shelfarr
+  - SHELFARR_SETTING_OIDC_CLIENT_SECRET=...   # inject from a secret store
+  # Outbound webhook
+  - SHELFARR_SETTING_WEBHOOK_ENABLED=true
+  - SHELFARR_SETTING_WEBHOOK_URL=http://my-listener:9000/
+```
+
+Semantics: **the environment is the source of truth and the database is a cache.**
+A managed key shows up read-only in the settings page (with the controlling
+variable named) and is reconciled on every boot, so it survives a database wipe or
+restore with no manual re-entry. Booleans (`true`/`false`), integers and JSON-array
+values are parsed to the setting's type. Keys you don't set stay fully editable in
+the UI as before. See the [settings reference](https://shelfarr.org/configuration.html)
+for the full list of keys.
+
 ### Configuration
 
 After logging in, go to **Admin → Settings**:

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -13,6 +13,11 @@ module Admin
       key = params[:id]
       value = params[:setting][:value]
 
+      if SettingsService.env_managed?(key)
+        return redirect_to admin_settings_path,
+          alert: "#{key.to_s.titleize} is managed by the environment and cannot be changed here."
+      end
+
       validate_path_template!(key, value)
       SettingsService.set(key, value)
       handle_settings_side_effects([ key.to_s ])
@@ -29,6 +34,11 @@ module Admin
       errors = []
 
       params[:settings]&.each do |key, value|
+        # Env-managed settings are read-only; the env override wins on read, so
+        # never persist a shadowed value (the field isn't rendered, but guard the
+        # raw params too).
+        next if SettingsService.env_managed?(key)
+
         error = validate_path_template(key, value)
         if error
           errors << "#{key.to_s.titleize}: #{error}"

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -1,4 +1,17 @@
 class SettingsService
+  # Config-as-code surface. Any setting can be overridden from the environment
+  # with SHELFARR_SETTING_<KEY> (uppercased key). When the variable is present it
+  # takes precedence over the database value, cast to the setting's declared type
+  # (booleans/integers/json strings are parsed the same way a stored value is).
+  #
+  # Semantics: the environment is the source of truth and the database is a
+  # cache. An env-managed setting is read-only in the admin UI and survives a
+  # database wipe/restore with no manual re-entry — which makes secrets (OIDC
+  # client secret) and integration wiring (webhook URL/events) declarable from a
+  # mounted Secret/ConfigMap and reconcilable by tools like Flux. Keys left out
+  # of the environment stay fully UI-managed as before.
+  ENV_OVERRIDE_PREFIX = "SHELFARR_SETTING_"
+
   DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
 
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
@@ -229,6 +242,8 @@ class SettingsService
     # Primary getter with default fallback
     def get(key, default: nil)
       key = key.to_sym
+
+      return env_override_value(key) if env_managed?(key)
       return preferred_download_types if key == :preferred_download_types
 
       value = raw_setting_value(key)
@@ -236,6 +251,22 @@ class SettingsService
 
       definition = DEFINITIONS[key]
       definition ? definition[:default] : default
+    end
+
+    # Environment variable name that overrides a given setting key.
+    def env_override_name(key)
+      "#{ENV_OVERRIDE_PREFIX}#{key.to_s.upcase}"
+    end
+
+    # True when the setting is being supplied from the environment. Such keys are
+    # read-only in the admin UI (editing the DB row has no effect).
+    def env_managed?(key)
+      ENV.key?(env_override_name(key))
+    end
+
+    # All known settings currently sourced from the environment.
+    def env_managed_keys
+      DEFINITIONS.keys.select { |key| env_managed?(key) }
     end
 
     # Primary setter
@@ -276,7 +307,9 @@ class SettingsService
         keys.each_with_object({}) do |key, hash|
           hash[key] = {
             value: get(key),
-            definition: DEFINITIONS[key]
+            definition: DEFINITIONS[key],
+            env_managed: env_managed?(key),
+            env_var: env_override_name(key)
           }
         end
       end
@@ -518,6 +551,17 @@ class SettingsService
       return setting.typed_value if setting
 
       DEFINITIONS[key.to_sym]&.dig(:default)
+    end
+
+    # Value of an env override, cast to the key's declared type. Reuses the
+    # Setting model's type casting so booleans/integers/json parse identically to
+    # a stored value. Unknown keys fall back to the raw string.
+    def env_override_value(key)
+      raw = ENV[env_override_name(key)]
+      definition = DEFINITIONS[key.to_sym]
+      return raw unless definition
+
+      Setting.new(value_type: definition[:type], value: raw).typed_value
     end
 
     def normalize_download_types(values)

--- a/app/views/admin/settings/_env_managed_field.html.erb
+++ b/app/views/admin/settings/_env_managed_field.html.erb
@@ -1,0 +1,23 @@
+<%# Read-only display for a setting sourced from the environment.
+    Editing the DB row would have no effect (the env override wins in
+    SettingsService.get), so we render the effective value instead of an input
+    and surface the controlling variable behind a hover tooltip on the lock
+    icon — keeping the row as compact as a normal field. No form field is
+    emitted, so a Save All never writes a shadowed value back to the database. %>
+<% secret = key.to_s.include?("password") || key.to_s.include?("api_key") || key.to_s.include?("token") || key.to_s.include?("secret") %>
+<% display = data[:value].is_a?(Array) ? data[:value].join(", ") : data[:value].to_s %>
+<% display = display.present? ? display : "(empty)" %>
+<% display = "********" if secret && data[:value].to_s.present? %>
+<% display = (display == "true" ? "true" : "false") if data[:definition][:type] == "boolean" %>
+<div class="relative">
+  <div class="w-full rounded-md border border-gray-700 bg-gray-950/60 px-3 py-2 pr-10 text-gray-400 font-mono text-sm break-all">
+    <%= display %>
+  </div>
+  <span class="absolute inset-y-0 right-0 flex items-center pr-3 text-amber-400/80 cursor-help"
+        title="Managed by environment variable <%= data[:env_var] %> — read-only">
+    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+    </svg>
+    <span class="sr-only">Managed by environment variable <%= data[:env_var] %>, read-only</span>
+  </span>
+</div>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -79,7 +79,9 @@
                       <p class="text-sm text-gray-500"><%= data[:definition][:description] %></p>
                     </div>
                     <div class="md:w-2/3">
-                      <% if key.to_s == "preferred_download_types" %>
+                      <% if data[:env_managed] %>
+                        <%= render "admin/settings/env_managed_field", key: key, data: data %>
+                      <% elsif key.to_s == "preferred_download_types" %>
                         <%= render "admin/settings/download_type_preferences_field", form: form, key: key, ordered_types: SettingsService.preferred_download_types %>
                       <% else %>
                       <% case data[:definition][:type] %>

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -176,4 +176,91 @@ class SettingsServiceTest < ActiveSupport::TestCase
 
     assert_equal [], SettingsService.enabled_metadata_providers
   end
+
+  test "env override takes precedence over a stored string value" do
+    SettingsService.set(:oidc_issuer, "https://db.example.com")
+
+    with_env("SHELFARR_SETTING_OIDC_ISSUER" => "https://env.example.com") do
+      assert_equal "https://env.example.com", SettingsService.get(:oidc_issuer)
+      assert SettingsService.env_managed?(:oidc_issuer)
+    end
+
+    # Reverts to the database value once the variable is gone.
+    assert_equal "https://db.example.com", SettingsService.get(:oidc_issuer)
+    assert_not SettingsService.env_managed?(:oidc_issuer)
+  end
+
+  test "env override supplies a value when no row exists (survives a DB wipe)" do
+    Setting.where(key: "oidc_client_secret").delete_all
+
+    with_env("SHELFARR_SETTING_OIDC_CLIENT_SECRET" => "from-secret") do
+      assert_equal "from-secret", SettingsService.get(:oidc_client_secret)
+    end
+  end
+
+  test "env override casts booleans, integers, and json to the declared type" do
+    with_env(
+      "SHELFARR_SETTING_OIDC_ENABLED" => "true",
+      "SHELFARR_SETTING_QUEUE_BATCH_SIZE" => "12",
+      "SHELFARR_SETTING_ENABLED_LANGUAGES" => '["en","fr"]'
+    ) do
+      assert_equal true, SettingsService.get(:oidc_enabled)
+      assert_equal 12, SettingsService.get(:queue_batch_size)
+      assert_equal %w[en fr], SettingsService.get(:enabled_languages)
+    end
+  end
+
+  test "env override can disable a setting enabled in the database" do
+    SettingsService.set(:oidc_enabled, true)
+
+    with_env("SHELFARR_SETTING_OIDC_ENABLED" => "false") do
+      assert_equal false, SettingsService.get(:oidc_enabled)
+    end
+  end
+
+  test "oidc and webhook configured? honor env overrides without any DB rows" do
+    Setting.where(key: %w[oidc_enabled oidc_issuer oidc_client_id oidc_client_secret webhook_enabled webhook_url]).delete_all
+
+    with_env(
+      "SHELFARR_SETTING_OIDC_ENABLED" => "true",
+      "SHELFARR_SETTING_OIDC_ISSUER" => "https://auth.example.com",
+      "SHELFARR_SETTING_OIDC_CLIENT_ID" => "shelfarr",
+      "SHELFARR_SETTING_OIDC_CLIENT_SECRET" => "s3cret",
+      "SHELFARR_SETTING_WEBHOOK_ENABLED" => "true",
+      "SHELFARR_SETTING_WEBHOOK_URL" => "http://hook.example.com:9000/"
+    ) do
+      assert SettingsService.oidc_configured?
+      assert SettingsService.configured?(:webhook_url)
+    end
+  end
+
+  test "env_managed_keys lists only keys present in the environment" do
+    with_env("SHELFARR_SETTING_WEBHOOK_URL" => "http://hook.example.com/") do
+      assert_includes SettingsService.env_managed_keys, :webhook_url
+      assert_not_includes SettingsService.env_managed_keys, :oidc_issuer
+    end
+  end
+
+  test "env_override_name builds the SHELFARR_SETTING_ variable name" do
+    assert_equal "SHELFARR_SETTING_OIDC_CLIENT_SECRET", SettingsService.env_override_name(:oidc_client_secret)
+  end
+
+  private
+
+  def with_env(vars)
+    previous = {}
+    vars.each do |name, value|
+      previous[name] = ENV.key?(name) ? ENV[name] : :__absent__
+      ENV[name] = value
+    end
+    yield
+  ensure
+    previous.each do |name, value|
+      if value == :__absent__
+        ENV.delete(name)
+      else
+        ENV[name] = value
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds a config-as-code surface so any setting can be supplied from the environment instead of (only) the admin UI. Setting `SHELFARR_SETTING_<KEY>` (uppercased setting key) overrides the stored value of `<key>`, cast to its declared type.

```yaml
environment:
  - SHELFARR_SETTING_OIDC_ENABLED=true
  - SHELFARR_SETTING_OIDC_ISSUER=https://auth.example.com/application/o/shelfarr/
  - SHELFARR_SETTING_OIDC_CLIENT_ID=shelfarr
  - SHELFARR_SETTING_OIDC_CLIENT_SECRET=...   # from a secret store
  - SHELFARR_SETTING_WEBHOOK_ENABLED=true
  - SHELFARR_SETTING_WEBHOOK_URL=http://my-listener:9000/
```

## Why

Today every setting (including OIDC issuer/client-id/**client-secret** and the outbound webhook config) lives only in the app's SQLite `settings` table, written through the admin UI. For declarative / GitOps deployments (Kubernetes, Compose-with-secrets, Kamal) that has two pain points:

- **Secrets in the DB.** The OIDC client secret can't be injected from a secret manager; it has to be typed into the UI and then lives in the database.
- **Lost on a wipe/restore.** A fresh or restored DB silently drops the configuration, so auth + integrations have to be re-entered by hand.

This makes the environment the source of truth and the database a cache: an env-managed key is reconciled on every boot, so it survives a DB wipe/restore with no manual re-entry.

## How

- `SettingsService.get` consults `SHELFARR_SETTING_<KEY>` first, reusing the `Setting` model's type casting so booleans (`true`/`false`), integers, and JSON-array values parse exactly like a stored value. Because OIDC already reads live via `SettingsService.get`, this needs no boot ordering or restart.
- New helpers: `env_managed?`, `env_managed_keys`, `env_override_name`.
- **Admin → Settings** renders an env-managed key as a single read-only row, with the controlling variable behind a hover tooltip on a lock icon. The settings controller refuses to persist env-managed keys (so a stray POST can't write a shadowed value).
- Keys you don't set in the environment stay fully UI-managed, exactly as before — this is purely additive and opt-in.

## Tests

- Added `SettingsServiceTest` coverage: precedence over a stored value, supplying a value with no DB row (the wipe/restore case), boolean/integer/json casting, disabling a DB-enabled setting, `oidc_configured?` / `configured?` honoring env with no rows, and `env_managed_keys` / `env_override_name`.
- `bin/rails test test/services/settings_service_test.rb test/controllers/admin/settings_controller_test.rb` → 123 runs, 0 failures.

## Notes

- `DISABLE_AUTH` precedent already existed for one setting; this generalizes the idea to all of them under a consistent `SHELFARR_SETTING_*` prefix.
- Documented under "Settings as environment variables (config-as-code)" in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
