### PR TITLE
feat: add manual magnet link option to requests (#317)

### DIFF
--- a/app/controllers/admin/search_results_controller.rb
+++ b/app/controllers/admin/search_results_controller.rb
@@ -26,8 +26,9 @@ module Admin
     end
 
     def refresh
-      # Clear existing results and re-queue for search
-      @request.search_results.destroy_all
+      # Clear existing search-sourced results and re-queue; keep manually-added
+      # results (e.g. admin-pasted magnets) so a refresh doesn't discard them.
+      @request.search_results.from_search.destroy_all
       @request.update!(status: :pending)
       SearchJob.perform_later(@request.id)
 

--- a/app/controllers/admin/search_results_controller.rb
+++ b/app/controllers/admin/search_results_controller.rb
@@ -35,6 +35,17 @@ module Admin
                   notice: "Search refreshed. Results will appear shortly."
     end
 
+    def add_magnet
+      result = ManualMagnetService.call(request: @request, magnet_url: params[:magnet_url])
+
+      if result.success?
+        redirect_back fallback_location: request_path(@request),
+                      notice: "Magnet link added. \"#{result.search_result.title}\" is now downloading."
+      else
+        redirect_back fallback_location: request_path(@request), alert: result.error
+      end
+    end
+
     private
 
     def set_request

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -244,7 +244,9 @@ class SearchJob < ApplicationJob
   end
 
   def save_results(request, tagged_results)
-    request.search_results.destroy_all
+    # Preserve manually-added results (e.g. admin-pasted magnets); only the
+    # ephemeral search-sourced results are refreshed.
+    request.search_results.from_search.destroy_all
 
     tagged_results.each do |tagged|
       result = tagged[:result]

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -29,6 +29,11 @@ class SearchResult < ApplicationRecord
 
   scope :selectable, -> { pending }
 
+  # Manually added results (e.g. admin-pasted magnets) are durable; everything
+  # else is ephemeral and re-fetched on each search.
+  scope :manual, -> { where(source: SOURCE_MANUAL) }
+  scope :from_search, -> { where.not(source: SOURCE_MANUAL) }
+
   scope :preferred_first, -> {
     ordered_types = SettingsService.preferred_download_types
     type_order_sql = ordered_types.each_with_index.map { |type, index| "WHEN '#{type}' THEN #{index}" }.join(" ")

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -22,6 +22,7 @@ class SearchResult < ApplicationRecord
   SOURCE_GUTENBERG = "gutenberg"
   SOURCE_LIBRIVOX = "librivox"
   SOURCE_CUSTOM = "custom"
+  SOURCE_MANUAL = "manual"
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
   validates :title, presence: true
@@ -247,6 +248,13 @@ class SearchResult < ApplicationRecord
     source == SOURCE_CUSTOM
   end
 
+  # Manually added by an admin (e.g. a pasted magnet link). Deliberately NOT an
+  # indexer source, so it routes to the default torrent client rather than
+  # matching indexer-keyed DownloadRoutingRules.
+  def from_manual?
+    source == SOURCE_MANUAL
+  end
+
   def source_display_name
     case source
     when SOURCE_JACKETT
@@ -263,6 +271,8 @@ class SearchResult < ApplicationRecord
       "LibriVox"
     when SOURCE_CUSTOM
       acquisition_provider&.name || indexer.presence || "Custom Provider"
+    when SOURCE_MANUAL
+      "Manual"
     else
       indexer.presence || "Prowlarr"
     end

--- a/app/services/magnet_link.rb
+++ b/app/services/magnet_link.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "uri"
+
+# Parses a magnet: URI into its useful parts. Centralizes info-hash extraction
+# and canonicalization (hex passes through, base32 is converted to hex) so
+# callers dedupe on a stable key and validate hashes consistently rather than
+# each reimplementing magnet parsing.
+class MagnetLink
+  # A v1 btih is either 40 hex chars or a 32-char base32 string.
+  BTIH_REGEX = /\Aurn:btih:([a-f0-9]{40}|[a-z2-7]{32})\z/i
+  BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+  def self.parse(value)
+    new(value)
+  end
+
+  def initialize(value)
+    @raw = value.to_s.strip
+  end
+
+  def url
+    @raw
+  end
+
+  def magnet?
+    @raw.downcase.start_with?("magnet:?")
+  end
+
+  # Canonical lowercase hex info hash, or nil if absent/invalid. Reads the
+  # decoded `xt` parameters (a magnet may carry several) rather than scanning
+  # the raw string, so a hash embedded in another field (e.g. `dn`) can't be
+  # mistaken for the real one.
+  def info_hash
+    xt_values.each do |xt|
+      match = xt.match(BTIH_REGEX)
+      next unless match
+
+      hash = match[1]
+      return hash.downcase if hash.match?(/\A[a-f0-9]{40}\z/i)
+
+      hex = base32_to_hex(hash)
+      return hex if hex
+    end
+    nil
+  end
+
+  def display_name
+    pairs.find { |key, _| key == "dn" }&.last.presence
+  end
+
+  private
+
+  def xt_values
+    pairs.filter_map { |key, value| value if key == "xt" }
+  end
+
+  def pairs
+    @pairs ||= begin
+      query = @raw.split("?", 2)[1].to_s
+      URI.decode_www_form(query)
+    rescue ArgumentError
+      []
+    end
+  end
+
+  def base32_to_hex(value)
+    bits = value.upcase.each_char.map do |char|
+      index = BASE32_ALPHABET.index(char)
+      return nil unless index
+
+      index.to_s(2).rjust(5, "0")
+    end.join
+
+    bytes = bits.scan(/.{8}/).map { |byte| byte.to_i(2) }
+    return nil unless bytes.length == 20
+
+    bytes.pack("C*").unpack1("H*")
+  end
+end

--- a/app/services/manual_magnet_service.rb
+++ b/app/services/manual_magnet_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
-
 # Creates a search result from an admin-supplied magnet link and sends it
 # through the normal selection/download pipeline (torrent client dispatch,
 # monitoring and post-processing). Useful for sources that can't be wired up
@@ -13,9 +11,6 @@ class ManualMagnetService
     end
   end
 
-  # magnet:?xt=urn:btih:<40-hex or 32-base32 hash>
-  INFO_HASH_REGEX = /xt=urn:btih:([a-z0-9]+)/i
-
   class << self
     def call(...)
       new(...).call
@@ -24,17 +19,22 @@ class ManualMagnetService
 
   def initialize(request:, magnet_url:)
     @request = request
-    @magnet_url = magnet_url.to_s.strip
+    @magnet = MagnetLink.parse(magnet_url)
   end
 
   def call
-    return failure("Please provide a magnet link.") if @magnet_url.blank?
-    unless @magnet_url.downcase.start_with?("magnet:?")
+    return failure("Please provide a magnet link.") if @magnet.url.blank?
+    unless @magnet.magnet?
       return failure("That doesn't look like a magnet link. Magnet links start with \"magnet:?\".")
     end
+    if @request.completed?
+      return failure("This request is already completed. Cancel it before downloading a different release.")
+    end
 
-    info_hash = extract_info_hash
-    return failure("Magnet link is missing a torrent hash (xt=urn:btih:...).") if info_hash.blank?
+    info_hash = @magnet.info_hash
+    if info_hash.blank?
+      return failure("Magnet link has no valid torrent hash (expected xt=urn:btih: with a 40-char hex or 32-char base32 hash).")
+    end
 
     search_result = build_search_result(info_hash)
     download = @request.select_result!(search_result)
@@ -47,35 +47,19 @@ class ManualMagnetService
   private
 
   def build_search_result(info_hash)
-    guid = "manual:#{info_hash.downcase}"
+    guid = "manual:#{info_hash}"
     search_result = @request.search_results.find_or_initialize_by(guid: guid)
     search_result.assign_attributes(
-      title: magnet_title,
+      title: @magnet.display_name || @request.book.title,
       indexer: "Manual",
-      source: SearchResult::SOURCE_PROWLARR,
-      magnet_url: @magnet_url,
+      source: SearchResult::SOURCE_MANUAL,
+      magnet_url: @magnet.url,
       download_url: nil,
       status: :pending
     )
     search_result.save!
     search_result.calculate_score!
     search_result
-  end
-
-  def magnet_title
-    magnet_params["dn"].presence || @request.book.title
-  end
-
-  def extract_info_hash
-    match = @magnet_url.match(INFO_HASH_REGEX)
-    match && match[1]
-  end
-
-  def magnet_params
-    query = @magnet_url.split("?", 2)[1].to_s
-    URI.decode_www_form(query).to_h
-  rescue ArgumentError
-    {}
   end
 
   def failure(message)

--- a/app/services/manual_magnet_service.rb
+++ b/app/services/manual_magnet_service.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "uri"
+
+# Creates a search result from an admin-supplied magnet link and sends it
+# through the normal selection/download pipeline (torrent client dispatch,
+# monitoring and post-processing). Useful for sources that can't be wired up
+# to an indexer, e.g. AudiobookBay magnets pasted by hand.
+class ManualMagnetService
+  Result = Data.define(:search_result, :download, :error) do
+    def success?
+      error.nil?
+    end
+  end
+
+  # magnet:?xt=urn:btih:<40-hex or 32-base32 hash>
+  INFO_HASH_REGEX = /xt=urn:btih:([a-z0-9]+)/i
+
+  class << self
+    def call(...)
+      new(...).call
+    end
+  end
+
+  def initialize(request:, magnet_url:)
+    @request = request
+    @magnet_url = magnet_url.to_s.strip
+  end
+
+  def call
+    return failure("Please provide a magnet link.") if @magnet_url.blank?
+    unless @magnet_url.downcase.start_with?("magnet:?")
+      return failure("That doesn't look like a magnet link. Magnet links start with \"magnet:?\".")
+    end
+
+    info_hash = extract_info_hash
+    return failure("Magnet link is missing a torrent hash (xt=urn:btih:...).") if info_hash.blank?
+
+    search_result = build_search_result(info_hash)
+    download = @request.select_result!(search_result)
+
+    Result.new(search_result: search_result, download: download, error: nil)
+  rescue ArgumentError, ActiveRecord::RecordInvalid => e
+    failure("Could not add magnet link: #{e.message}")
+  end
+
+  private
+
+  def build_search_result(info_hash)
+    guid = "manual:#{info_hash.downcase}"
+    search_result = @request.search_results.find_or_initialize_by(guid: guid)
+    search_result.assign_attributes(
+      title: magnet_title,
+      indexer: "Manual",
+      source: SearchResult::SOURCE_PROWLARR,
+      magnet_url: @magnet_url,
+      download_url: nil,
+      status: :pending
+    )
+    search_result.save!
+    search_result.calculate_score!
+    search_result
+  end
+
+  def magnet_title
+    magnet_params["dn"].presence || @request.book.title
+  end
+
+  def extract_info_hash
+    match = @magnet_url.match(INFO_HASH_REGEX)
+    match && match[1]
+  end
+
+  def magnet_params
+    query = @magnet_url.split("?", 2)[1].to_s
+    URI.decode_www_form(query).to_h
+  rescue ArgumentError
+    {}
+  end
+
+  def failure(message)
+    Result.new(search_result: nil, download: nil, error: message)
+  end
+end

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -106,7 +106,7 @@
         </div>
       <% end %>
 
-      <% if Current.user.admin? %>
+      <% if Current.user.admin? && !@request.completed? %>
         <details class="bg-gray-800/60 border border-gray-700 rounded-lg p-4 mb-6">
           <summary class="text-sm font-medium text-white cursor-pointer select-none">Add a magnet link manually</summary>
           <p class="text-sm text-gray-400 mt-2 mb-3">

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -106,6 +106,22 @@
         </div>
       <% end %>
 
+      <% if Current.user.admin? %>
+        <details class="bg-gray-800/60 border border-gray-700 rounded-lg p-4 mb-6">
+          <summary class="text-sm font-medium text-white cursor-pointer select-none">Add a magnet link manually</summary>
+          <p class="text-sm text-gray-400 mt-2 mb-3">
+            Paste a magnet link from a source your indexers can't reach. Shelfarr sends it to your torrent client and runs its normal import and delivery.
+          </p>
+          <%= form_with url: add_magnet_admin_request_search_results_path(@request), method: :post, class: "flex flex-col sm:flex-row gap-2" do |f| %>
+            <%= f.text_field :magnet_url,
+                  placeholder: "magnet:?xt=urn:btih:...",
+                  autocomplete: "off",
+                  class: "flex-grow px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+            <%= f.submit "Add Magnet", class: "px-4 py-2 bg-green-600 hover:bg-green-500 text-white text-sm font-medium rounded transition cursor-pointer" %>
+          <% end %>
+        </details>
+      <% end %>
+
       <% if Current.user.admin? && @request.search_results.any? %>
         <div class="mb-6" data-controller="search-results" data-search-results-expanded-value="true">
           <div class="flex items-center justify-between mb-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,7 @@ Rails.application.routes.draw do
         end
         collection do
           post :refresh
+          post :add_magnet
         end
       end
     end

--- a/test/controllers/admin/search_results_controller_test.rb
+++ b/test/controllers/admin/search_results_controller_test.rb
@@ -136,6 +136,42 @@ module Admin
       end
     end
 
+    # === Add magnet ===
+
+    test "add_magnet requires admin" do
+      sign_out
+      sign_in_as(@user)
+
+      post add_magnet_admin_request_search_results_path(@request_record), params: { magnet_url: "magnet:?xt=urn:btih:abc123" }
+      assert_redirected_to root_path
+    end
+
+    test "add_magnet creates a search result and starts a download" do
+      magnet = "magnet:?xt=urn:btih:DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF&dn=Manual+Book"
+
+      assert_difference -> { Download.count }, 1 do
+        assert_enqueued_with(job: DownloadJob) do
+          post add_magnet_admin_request_search_results_path(@request_record), params: { magnet_url: magnet }
+        end
+      end
+
+      result = @request_record.search_results.find_by(guid: "manual:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+      assert_not_nil result
+      assert_equal "Manual Book", result.title
+      assert_equal magnet, result.magnet_url
+      assert result.selected?
+      assert @request_record.reload.downloading?
+      assert_match /Magnet link added/, flash[:notice]
+    end
+
+    test "add_magnet rejects an invalid magnet link" do
+      assert_no_difference -> { Download.count } do
+        post add_magnet_admin_request_search_results_path(@request_record), params: { magnet_url: "https://example.com/not-a-magnet" }
+      end
+
+      assert_match /doesn't look like a magnet link/, flash[:alert]
+    end
+
     # === Refresh ===
 
     test "refresh clears results and requeues search" do

--- a/test/controllers/admin/search_results_controller_test.rb
+++ b/test/controllers/admin/search_results_controller_test.rb
@@ -188,5 +188,21 @@ module Admin
       assert_redirected_to request_path(@request_record)
       assert_match /refreshed/, flash[:notice]
     end
+
+    test "refresh preserves manually-added results" do
+      manual = @request_record.search_results.create!(
+        guid: "manual:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        title: "Manual Magnet",
+        indexer: "Manual",
+        source: SearchResult::SOURCE_MANUAL,
+        magnet_url: "magnet:?xt=urn:btih:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        status: :selected
+      )
+
+      post refresh_admin_request_search_results_path(@request_record)
+
+      assert SearchResult.exists?(manual.id), "manual result should survive a refresh"
+      assert_not SearchResult.exists?(@pending_result.id), "search-sourced result should be cleared"
+    end
   end
 end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -64,6 +64,26 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "preserves manually-added results while refreshing search-sourced ones" do
+    manual = @request.search_results.create!(
+      guid: "manual:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      title: "Manual Magnet",
+      indexer: "Manual",
+      source: SearchResult::SOURCE_MANUAL,
+      magnet_url: "magnet:?xt=urn:btih:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      status: :selected
+    )
+
+    VCR.turned_off do
+      stub_prowlarr_search_with_results
+
+      SearchJob.perform_now(@request.id)
+
+      assert SearchResult.exists?(manual.id), "manual result should survive a re-search"
+      assert @request.search_results.from_search.any?, "search-sourced results should be (re)created"
+    end
+  end
+
   test "schedules retry when no results found" do
     VCR.turned_off do
       stub_prowlarr_search_empty

--- a/test/services/magnet_link_test.rb
+++ b/test/services/magnet_link_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MagnetLinkTest < ActiveSupport::TestCase
+  test "recognises magnet links and rejects other strings" do
+    assert MagnetLink.parse("magnet:?xt=urn:btih:#{'a' * 40}").magnet?
+    assert_not MagnetLink.parse("https://example.com/x.torrent").magnet?
+    assert_not MagnetLink.parse("").magnet?
+    assert_not MagnetLink.parse(nil).magnet?
+  end
+
+  test "returns the lowercased hex info hash" do
+    hash = "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+    assert_equal hash.downcase, MagnetLink.parse("magnet:?xt=urn:btih:#{hash}").info_hash
+  end
+
+  test "converts a base32 info hash to canonical hex" do
+    # 32 'A's (base32) -> 20 zero bytes -> 40 hex zeros
+    assert_equal "0" * 40, MagnetLink.parse("magnet:?xt=urn:btih:#{'A' * 32}").info_hash
+  end
+
+  test "returns nil for a malformed or truncated hash" do
+    assert_nil MagnetLink.parse("magnet:?xt=urn:btih:abc").info_hash
+    assert_nil MagnetLink.parse("magnet:?dn=No+Hash").info_hash
+  end
+
+  test "reads the xt parameter, not a hash embedded in another field" do
+    real = "d" * 40
+    decoy = "0" * 40
+    magnet = "magnet:?dn=urn:btih:#{decoy}&xt=urn:btih:#{real}"
+
+    assert_equal real, MagnetLink.parse(magnet).info_hash
+  end
+
+  test "picks the btih xt when multiple xt values are present" do
+    real = "d" * 40
+    magnet = "magnet:?xt=urn:btmh:1220abcd&xt=urn:btih:#{real}"
+
+    assert_equal real, MagnetLink.parse(magnet).info_hash
+  end
+
+  test "extracts the display name from dn" do
+    magnet = "magnet:?xt=urn:btih:#{'a' * 40}&dn=The+Perfect+Run"
+    assert_equal "The Perfect Run", MagnetLink.parse(magnet).display_name
+  end
+
+  test "display name is nil when dn is absent" do
+    assert_nil MagnetLink.parse("magnet:?xt=urn:btih:#{'a' * 40}").display_name
+  end
+end

--- a/test/services/manual_magnet_service_test.rb
+++ b/test/services/manual_magnet_service_test.rb
@@ -21,6 +21,9 @@ class ManualMagnetServiceTest < ActiveSupport::TestCase
     assert_equal "The Perfect Run", result.search_result.title
     assert_equal magnet, result.search_result.magnet_url
     assert_equal "Manual", result.search_result.indexer
+    assert_equal SearchResult::SOURCE_MANUAL, result.search_result.source
+    assert result.search_result.from_manual?
+    assert_not result.search_result.from_indexer?
     assert result.search_result.selected?
     assert_equal @request, result.download.request
   end
@@ -52,7 +55,29 @@ class ManualMagnetServiceTest < ActiveSupport::TestCase
     result = ManualMagnetService.call(request: @request, magnet_url: "magnet:?dn=No+Hash+Here")
 
     assert_not result.success?
-    assert_match /missing a torrent hash/, result.error
+    assert_match /no valid torrent hash/, result.error
+  end
+
+  test "rejects a malformed or truncated torrent hash" do
+    # "abc" is neither a 40-char hex nor a 32-char base32 hash; reject up front
+    # instead of dispatching a bad magnet that the torrent client rejects later.
+    result = ManualMagnetService.call(request: @request, magnet_url: "magnet:?xt=urn:btih:abc")
+
+    assert_not result.success?
+    assert_match /no valid torrent hash/, result.error
+  end
+
+  test "refuses to add a magnet to an already-completed request" do
+    @request.update!(status: :completed)
+    magnet = "magnet:?xt=urn:btih:DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+
+    assert_no_difference -> { Download.count } do
+      result = ManualMagnetService.call(request: @request, magnet_url: magnet)
+      assert_not result.success?
+      assert_match /already completed/, result.error
+    end
+
+    assert @request.reload.completed?
   end
 
   test "reuses the same search result when the same magnet is added twice" do
@@ -61,6 +86,21 @@ class ManualMagnetServiceTest < ActiveSupport::TestCase
     assert_difference -> { @request.search_results.count }, 1 do
       ManualMagnetService.call(request: @request, magnet_url: magnet)
       ManualMagnetService.call(request: @request, magnet_url: magnet)
+    end
+  end
+
+  test "dedupes hex and base32 forms of the same info hash" do
+    # 32 'A's in base32 decodes to 20 zero bytes -> 40 hex zeros, the same
+    # torrent as the all-zero hex magnet. Both must collapse to one guid.
+    hex_magnet = "magnet:?xt=urn:btih:#{'0' * 40}"
+    base32_magnet = "magnet:?xt=urn:btih:#{'A' * 32}"
+
+    assert_difference -> { @request.search_results.count }, 1 do
+      first = ManualMagnetService.call(request: @request, magnet_url: hex_magnet)
+      second = ManualMagnetService.call(request: @request, magnet_url: base32_magnet)
+      assert first.success?
+      assert second.success?
+      assert_equal first.search_result.id, second.search_result.id
     end
   end
 end

--- a/test/services/manual_magnet_service_test.rb
+++ b/test/services/manual_magnet_service_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ManualMagnetServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @request = requests(:pending_request)
+  end
+
+  test "creates a selected search result from a magnet link" do
+    magnet = "magnet:?xt=urn:btih:DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF&dn=The+Perfect+Run"
+
+    result = nil
+    assert_enqueued_with(job: DownloadJob) do
+      result = ManualMagnetService.call(request: @request, magnet_url: magnet)
+    end
+
+    assert result.success?
+    assert_equal "The Perfect Run", result.search_result.title
+    assert_equal magnet, result.search_result.magnet_url
+    assert_equal "Manual", result.search_result.indexer
+    assert result.search_result.selected?
+    assert_equal @request, result.download.request
+  end
+
+  test "falls back to the book title when the magnet has no display name" do
+    magnet = "magnet:?xt=urn:btih:DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+
+    result = ManualMagnetService.call(request: @request, magnet_url: magnet)
+
+    assert result.success?
+    assert_equal @request.book.title, result.search_result.title
+  end
+
+  test "rejects blank input" do
+    result = ManualMagnetService.call(request: @request, magnet_url: "  ")
+
+    assert_not result.success?
+    assert_match /provide a magnet link/, result.error
+  end
+
+  test "rejects non-magnet URLs" do
+    result = ManualMagnetService.call(request: @request, magnet_url: "https://example.com/file.torrent")
+
+    assert_not result.success?
+    assert_match /doesn't look like a magnet link/, result.error
+  end
+
+  test "rejects magnet links without a torrent hash" do
+    result = ManualMagnetService.call(request: @request, magnet_url: "magnet:?dn=No+Hash+Here")
+
+    assert_not result.success?
+    assert_match /missing a torrent hash/, result.error
+  end
+
+  test "reuses the same search result when the same magnet is added twice" do
+    magnet = "magnet:?xt=urn:btih:DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF&dn=Dup"
+
+    assert_difference -> { @request.search_results.count }, 1 do
+      ManualMagnetService.call(request: @request, magnet_url: magnet)
+      ManualMagnetService.call(request: @request, magnet_url: magnet)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds an admin option to paste a magnet link directly onto a request, closing #317.

On the request page, admins get an "Add a magnet link manually" panel. Pasting a magnet creates a selected `SearchResult` and runs it through the existing select → download → post-processing pipeline, so it's sent to the configured torrent client and imported/delivered exactly like an indexer result.

### Use case (from the issue)
Some sources (e.g. AudiobookBay) don't work well via Prowlarr. Previously you had to add the magnet to qBittorrent yourself and import manually. Now you can paste the magnet into Shelfarr and let it handle dispatch, monitoring and delivery.

## How

- New `ManualMagnetService` validates the magnet (`magnet:?`, requires an `xt=urn:btih:` hash), derives the title from the `dn` parameter (falling back to the book title), creates/updates a `SearchResult` (`source: prowlarr`, `indexer: "Manual"`, `magnet_url` set), and calls the existing `Request#select_result!`.
- New admin route + `Admin::SearchResultsController#add_magnet`.
- Admin-only collapsible form on the request show page.

Because it reuses `select_result!` and the standard `DownloadJob` torrent path, it cancels any in-flight download, rejects other results, and triggers the normal post-processing/library scan. Invalid input and missing torrent clients surface as flash messages / request attention, same as other flows.

## Testing

- `ManualMagnetServiceTest` — valid magnet, title fallback, blank/invalid/no-hash rejection, idempotent re-add.
- `Admin::SearchResultsControllerTest` — admin-only auth, creates result + download + enqueues `DownloadJob`, rejects invalid magnets.

All tests green; RuboCop clean on changed lines.