### PR TITLE
[codex] allow env-managed settings allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ environment:
   - RAILS_RELATIVE_URL_ROOT=/shelfarr
 ```
 
+#### Settings Environment Overrides
+
+OIDC and webhook settings can be managed by environment variables. Use `SHELFARR_SETTING_` plus the uppercased setting key, for example `SHELFARR_SETTING_OIDC_CLIENT_SECRET` or `SHELFARR_SETTING_WEBHOOK_URL`.
+
+Supported setting keys:
+
+`oidc_enabled`, `oidc_auto_redirect`, `oidc_provider_name`, `oidc_issuer`, `oidc_client_id`, `oidc_client_secret`, `oidc_scopes`, `oidc_link_existing_users`, `oidc_auto_create_users`, `oidc_default_role`, `webhook_enabled`, `webhook_url`, `webhook_token`, `webhook_events`, `webhook_topic`.
+
+Example with the client secret supplied by your deployment secret store:
+```yaml
+services:
+  shelfarr:
+    environment:
+      SHELFARR_SETTING_OIDC_ENABLED: "true"
+      SHELFARR_SETTING_OIDC_ISSUER: "https://auth.example.com"
+      SHELFARR_SETTING_OIDC_CLIENT_ID: "shelfarr"
+      SHELFARR_SETTING_OIDC_CLIENT_SECRET: "${OIDC_CLIENT_SECRET}"
+```
+
+The env value takes precedence while set and is cast using the setting type. Nothing is written back to the database; removing the variable falls back to the stored value, or the default if none exists. Env-managed keys are read-only in Admin -> Settings. Other settings are not overridable, and unsupported `SHELFARR_SETTING_*` variables are ignored with a boot-time warning.
+
 ### Configuration
 
 After logging in, go to **Admin → Settings**:

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -11,6 +11,12 @@ module Admin
 
     def update
       key = params[:id]
+
+      if SettingsService.env_managed?(key)
+        redirect_to admin_settings_path, alert: "#{SettingsService.label_for(key)} is managed by the environment and cannot be changed here."
+        return
+      end
+
       value = params[:setting][:value]
 
       unless preserve_blank_secret?(key, value)
@@ -32,6 +38,7 @@ module Admin
       changed_keys = []
 
       params[:settings]&.each do |key, value|
+        next if SettingsService.env_managed?(key)
         next if preserve_blank_secret?(key, value)
 
         error = validate_path_template(key, value)
@@ -535,8 +542,7 @@ module Admin
     end
 
     def secret_setting_key?(key)
-      key = key.to_s
-      key == "discord_webhook_url" || key.include?("password") || key.include?("api_key") || key.include?("token") || key.include?("secret")
+      SettingsService.secret_setting_key?(key)
     end
   end
 end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -1,5 +1,6 @@
 class SettingsService
   DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
+  ENV_OVERRIDE_PREFIX = "SHELFARR_SETTING_"
 
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
   LIBRARY_PLATFORMS = %w[audiobookshelf bookorbit grimmory].freeze
@@ -174,11 +175,11 @@ class SettingsService
     hardcover_search_limit: { type: "integer", default: 10, category: "hardcover", description: "Maximum number of search results from Hardcover" },
 
     # Webhook Notifications
-    webhook_enabled: { type: "boolean", default: false, category: "webhook", description: "Send outbound webhook notifications for request lifecycle events" },
-    webhook_url: { type: "string", default: "", category: "webhook", description: "Webhook endpoint URL. Shelfarr sends a JSON payload for each enabled event." },
-    webhook_token: { type: "string", default: "", category: "webhook", description: "Optional Bearer token for webhook authentication" },
-    webhook_events: { type: "string", default: "request_created,request_completed,request_failed,request_attention", category: "webhook", description: "Comma-separated webhook events to send" },
-    webhook_topic: { type: "string", default: "", category: "webhook", description: "Optional topic field included in webhook JSON payload (required by ntfy when posting to the server base URL)" },
+    webhook_enabled: { type: "boolean", default: false, category: "webhook", description: "Send outbound webhook notifications for request lifecycle events", env_overridable: true },
+    webhook_url: { type: "string", default: "", category: "webhook", description: "Webhook endpoint URL. Shelfarr sends a JSON payload for each enabled event.", env_overridable: true },
+    webhook_token: { type: "string", default: "", category: "webhook", description: "Optional Bearer token for webhook authentication", env_overridable: true },
+    webhook_events: { type: "string", default: "request_created,request_completed,request_failed,request_attention", category: "webhook", description: "Comma-separated webhook events to send", env_overridable: true },
+    webhook_topic: { type: "string", default: "", category: "webhook", description: "Optional topic field included in webhook JSON payload (required by ntfy when posting to the server base URL)", env_overridable: true },
 
     # Discord Notifications
     discord_enabled: { type: "boolean", default: false, category: "discord", description: "Send native Discord webhook notifications for request lifecycle events" },
@@ -196,16 +197,16 @@ class SettingsService
     telegram_notification_events: { type: "string", default: "request_completed,request_failed,request_attention", category: "telegram", description: "Comma-separated request lifecycle events sent back to the authorized Telegram group that created the request" },
 
     # OIDC/SSO Authentication
-    oidc_enabled: { type: "boolean", default: false, category: "oidc", description: "Enable OpenID Connect (OIDC) single sign-on authentication" },
-    oidc_auto_redirect: { type: "boolean", default: false, category: "oidc", description: "Automatically start OIDC sign-in for unauthenticated users. Use /session/new?local=1 to access the local login form." },
-    oidc_provider_name: { type: "string", default: "SSO", category: "oidc", description: "Display name for the OIDC provider (shown on login button)" },
-    oidc_issuer: { type: "string", default: "", category: "oidc", description: "OIDC issuer URL (e.g., https://auth.example.com/realms/master)" },
-    oidc_client_id: { type: "string", default: "", category: "oidc", description: "OIDC client ID from your identity provider" },
-    oidc_client_secret: { type: "string", default: "", category: "oidc", description: "OIDC client secret from your identity provider" },
-    oidc_scopes: { type: "string", default: "openid profile email", category: "oidc", description: "OIDC scopes to request (space-separated)" },
-    oidc_link_existing_users: { type: "boolean", default: false, category: "oidc", description: "When enabled, OIDC sign-in will link an unlinked local user whose username matches the OIDC preferred username or email prefix." },
-    oidc_auto_create_users: { type: "boolean", default: false, category: "oidc", description: "Automatically create new users on first OIDC login" },
-    oidc_default_role: { type: "string", default: "user", category: "oidc", description: "Default role for auto-created OIDC users (user or admin)" }
+    oidc_enabled: { type: "boolean", default: false, category: "oidc", description: "Enable OpenID Connect (OIDC) single sign-on authentication", env_overridable: true },
+    oidc_auto_redirect: { type: "boolean", default: false, category: "oidc", description: "Automatically start OIDC sign-in for unauthenticated users. Use /session/new?local=1 to access the local login form.", env_overridable: true },
+    oidc_provider_name: { type: "string", default: "SSO", category: "oidc", description: "Display name for the OIDC provider (shown on login button)", env_overridable: true },
+    oidc_issuer: { type: "string", default: "", category: "oidc", description: "OIDC issuer URL (e.g., https://auth.example.com/realms/master)", env_overridable: true },
+    oidc_client_id: { type: "string", default: "", category: "oidc", description: "OIDC client ID from your identity provider", env_overridable: true },
+    oidc_client_secret: { type: "string", default: "", category: "oidc", description: "OIDC client secret from your identity provider", env_overridable: true },
+    oidc_scopes: { type: "string", default: "openid profile email", category: "oidc", description: "OIDC scopes to request (space-separated)", env_overridable: true },
+    oidc_link_existing_users: { type: "boolean", default: false, category: "oidc", description: "When enabled, OIDC sign-in will link an unlinked local user whose username matches the OIDC preferred username or email prefix.", env_overridable: true },
+    oidc_auto_create_users: { type: "boolean", default: false, category: "oidc", description: "Automatically create new users on first OIDC login", env_overridable: true },
+    oidc_default_role: { type: "string", default: "user", category: "oidc", description: "Default role for auto-created OIDC users (user or admin)", env_overridable: true }
   }.freeze
 
   CATEGORIES = {
@@ -253,9 +254,28 @@ class SettingsService
       LABELS.fetch(key.to_sym, key.to_s.titleize)
     end
 
+    def env_override_name(key)
+      "#{ENV_OVERRIDE_PREFIX}#{key.to_s.upcase}"
+    end
+
+    def env_managed?(key)
+      key = key.to_sym
+      DEFINITIONS[key]&.fetch(:env_overridable, false) == true && ENV.key?(env_override_name(key))
+    end
+
+    def env_managed_keys
+      DEFINITIONS.keys.select { |key| env_managed?(key) }
+    end
+
+    def secret_setting_key?(key)
+      key = key.to_s
+      key == "discord_webhook_url" || key.include?("password") || key.include?("api_key") || key.include?("token") || key.include?("secret")
+    end
+
     # Primary getter with default fallback
     def get(key, default: nil)
       key = key.to_sym
+      return env_override_value(key) if env_managed?(key)
       return preferred_download_types if key == :preferred_download_types
 
       value = raw_setting_value(key)
@@ -303,7 +323,9 @@ class SettingsService
         keys.each_with_object({}) do |key, hash|
           hash[key] = {
             value: get(key),
-            definition: DEFINITIONS[key]
+            definition: DEFINITIONS[key],
+            env_managed: env_managed?(key),
+            env_var: env_override_name(key)
           }
         end
       end
@@ -547,6 +569,11 @@ class SettingsService
     end
 
     private
+
+    def env_override_value(key)
+      raw = ENV.fetch(env_override_name(key))
+      Setting.new(value_type: DEFINITIONS.fetch(key)[:type], value: raw).typed_value
+    end
 
     def provider_enabled?(provider)
       case provider.to_s

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -267,6 +267,18 @@ class SettingsService
       DEFINITIONS.keys.select { |key| env_managed?(key) }
     end
 
+    # SHELFARR_SETTING_* variables that do not control any setting, either
+    # because the key is unknown, the setting is not env-overridable, or the
+    # variable name is not the exact uppercased form env_managed? looks up.
+    def unrecognized_env_override_names
+      ENV.keys.select do |env_name|
+        next false unless env_name.start_with?(ENV_OVERRIDE_PREFIX)
+
+        key = env_name.delete_prefix(ENV_OVERRIDE_PREFIX).downcase.to_sym
+        DEFINITIONS[key]&.fetch(:env_overridable, false) != true || env_name != env_override_name(key)
+      end
+    end
+
     def secret_setting_key?(key)
       key = key.to_s
       key == "discord_webhook_url" || key.include?("password") || key.include?("api_key") || key.include?("token") || key.include?("secret")

--- a/app/views/admin/settings/_env_managed_field.html.erb
+++ b/app/views/admin/settings/_env_managed_field.html.erb
@@ -1,0 +1,28 @@
+<%
+  display_value = if SettingsService.secret_setting_key?(key) && data[:value].present?
+    "********"
+  elsif data[:value].is_a?(Array)
+    data[:value].join(", ")
+  else
+    data[:value].to_s
+  end
+
+  display_value = "Not set" if display_value.blank?
+%>
+
+<div class="rounded-md border border-yellow-800/60 bg-yellow-950/20 px-3 py-2 text-gray-200">
+  <div class="flex items-start justify-between gap-3">
+    <span id="settings_<%= key %>_env_value" class="min-w-0 break-all"><%= display_value %></span>
+    <span class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-yellow-700/60 bg-yellow-900/30 text-yellow-300"
+          title="Managed by <%= data[:env_var] %>"
+          aria-label="Managed by <%= data[:env_var] %>">
+      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2Zm10-10V7a4 4 0 0 0-8 0v4h8Z" />
+      </svg>
+      <span class="sr-only">Managed by environment variable <%= data[:env_var] %></span>
+    </span>
+  </div>
+  <p class="mt-1 text-xs text-yellow-300">
+    Managed by <code class="rounded bg-yellow-950/70 px-1 py-0.5 text-yellow-200"><%= data[:env_var] %></code>
+  </p>
+</div>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -79,7 +79,9 @@
                       <p class="text-sm text-gray-500"><%= data[:definition][:description] %></p>
                     </div>
                     <div class="md:w-2/3">
-                      <% if key.to_s == "preferred_download_types" %>
+                      <% if data[:env_managed] %>
+                        <%= render "admin/settings/env_managed_field", key: key, data: data %>
+                      <% elsif key.to_s == "preferred_download_types" %>
                         <%= render "admin/settings/download_type_preferences_field", form: form, key: key, ordered_types: SettingsService.preferred_download_types %>
                       <% else %>
                       <% case data[:definition][:type] %>
@@ -164,7 +166,7 @@
                             </div>
                             <p class="hidden text-xs text-red-400" data-url-list-error></p>
                           </div>
-                        <% elsif key.to_s.include?("password") || key.to_s.include?("api_key") || key.to_s.include?("token") || key.to_s.include?("secret") %>
+                        <% elsif SettingsService.secret_setting_key?(key) %>
                           <%= form.password_field "settings[#{key}]", value: "", placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% else %>
                           <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>

--- a/config/initializers/settings_env_overrides.rb
+++ b/config/initializers/settings_env_overrides.rb
@@ -1,0 +1,15 @@
+Rails.application.config.after_initialize do
+  env_names = ENV.keys.select { |name| name.start_with?(SettingsService::ENV_OVERRIDE_PREFIX) }
+
+  env_names.each do |env_name|
+    setting_key = env_name.delete_prefix(SettingsService::ENV_OVERRIDE_PREFIX).downcase.to_sym
+    definition = SettingsService::DEFINITIONS[setting_key]
+
+    next if definition&.fetch(:env_overridable, false) == true && env_name == SettingsService.env_override_name(setting_key)
+
+    Rails.logger.warn "[Shelfarr] #{env_name} does not match an env-overridable setting and has no effect."
+  end
+
+  managed_keys = SettingsService.env_managed_keys.map(&:to_s).sort
+  Rails.logger.info "[Shelfarr] Env-managed settings in effect: #{managed_keys.join(', ')}" if managed_keys.any?
+end

--- a/config/initializers/settings_env_overrides.rb
+++ b/config/initializers/settings_env_overrides.rb
@@ -1,12 +1,5 @@
 Rails.application.config.after_initialize do
-  env_names = ENV.keys.select { |name| name.start_with?(SettingsService::ENV_OVERRIDE_PREFIX) }
-
-  env_names.each do |env_name|
-    setting_key = env_name.delete_prefix(SettingsService::ENV_OVERRIDE_PREFIX).downcase.to_sym
-    definition = SettingsService::DEFINITIONS[setting_key]
-
-    next if definition&.fetch(:env_overridable, false) == true && env_name == SettingsService.env_override_name(setting_key)
-
+  SettingsService.unrecognized_env_override_names.each do |env_name|
     Rails.logger.warn "[Shelfarr] #{env_name} does not match an env-overridable setting and has no effect."
   end
 

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    clear_settings_env!
     @admin = users(:two)
     sign_in_as(@admin)
     LibraryPlatformClient.reset_connections!
@@ -12,6 +13,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     GoogleBooksClient.reset_connection!
     OpenLibraryClient.reset_connection!
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
+    restore_settings_env!
   end
 
   teardown do
@@ -335,6 +337,22 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match "https://discord.com/api/webhooks/existing", response.body
   end
 
+  test "index renders env managed settings as read-only and masks secret values" do
+    SettingsService.set(:oidc_client_secret, "stored-secret")
+
+    with_env("SHELFARR_SETTING_OIDC_CLIENT_SECRET" => "env-secret") do
+      get admin_settings_url
+
+      assert_response :success
+      assert_select "input[name='settings[oidc_client_secret]']", count: 0
+      assert_select "[title='Managed by SHELFARR_SETTING_OIDC_CLIENT_SECRET']"
+      assert_select "code", text: "SHELFARR_SETTING_OIDC_CLIENT_SECRET"
+      assert_match "********", response.body
+      assert_no_match "env-secret", response.body
+      assert_no_match "stored-secret", response.body
+    end
+  end
+
   test "update stores a single setting" do
     patch admin_setting_url("max_retries"), params: {
       setting: { value: "7" }
@@ -356,6 +374,21 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "existing-secret", SettingsService.get(:prowlarr_api_key)
   end
 
+  test "update refuses to persist env managed setting" do
+    SettingsService.set(:oidc_client_secret, "stored-secret")
+
+    with_env("SHELFARR_SETTING_OIDC_CLIENT_SECRET" => "env-secret") do
+      patch admin_setting_url("oidc_client_secret"), params: {
+        setting: { value: "attempted-secret" }
+      }
+
+      assert_redirected_to admin_settings_path
+      assert_match /managed by the environment/, flash[:alert]
+      assert_equal "stored-secret", Setting.find_by(key: "oidc_client_secret").typed_value
+      assert_equal "env-secret", SettingsService.get(:oidc_client_secret)
+    end
+  end
+
   test "bulk_update preserves existing secrets when blank secret values submitted" do
     SettingsService.set(:prowlarr_api_key, "existing-prowlarr-secret")
     SettingsService.set(:discord_webhook_url, "https://discord.com/api/webhooks/123/token")
@@ -370,6 +403,25 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_settings_path
     assert_equal "existing-prowlarr-secret", SettingsService.get(:prowlarr_api_key)
     assert_equal "https://discord.com/api/webhooks/123/token", SettingsService.get(:discord_webhook_url)
+  end
+
+  test "bulk_update skips env managed keys but persists other settings" do
+    SettingsService.set(:oidc_client_secret, "stored-secret")
+    SettingsService.set(:max_retries, 10)
+
+    with_env("SHELFARR_SETTING_OIDC_CLIENT_SECRET" => "env-secret") do
+      patch bulk_update_admin_settings_url, params: {
+        settings: {
+          oidc_client_secret: "attempted-secret",
+          max_retries: "22"
+        }
+      }
+
+      assert_redirected_to admin_settings_path
+      assert_equal "stored-secret", Setting.find_by(key: "oidc_client_secret").typed_value
+      assert_equal "env-secret", SettingsService.get(:oidc_client_secret)
+      assert_equal 22, SettingsService.get(:max_retries)
+    end
   end
 
   test "update rejects invalid single path template" do

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -13,10 +13,10 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     GoogleBooksClient.reset_connection!
     OpenLibraryClient.reset_connection!
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
-    restore_settings_env!
   end
 
   teardown do
+    restore_settings_env!
     LibraryPlatformClient.reset_connections!
     ProwlarrClient.reset_connection!
     FlaresolverrClient.reset_connection!

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -342,4 +342,33 @@ class SettingsServiceTest < ActiveSupport::TestCase
       assert_not SettingsService.env_managed?(:api_token)
     end
   end
+
+  test "env override with empty string yields blank value instead of default" do
+    with_env("SHELFARR_SETTING_OIDC_PROVIDER_NAME" => "") do
+      assert SettingsService.env_managed?(:oidc_provider_name)
+      assert_equal "", SettingsService.get(:oidc_provider_name)
+      assert_not SettingsService.configured?(:oidc_provider_name)
+    end
+  end
+
+  test "unrecognized_env_override_names flags unknown and non-overridable keys" do
+    with_env(
+      "SHELFARR_SETTING_OIDC_ENABLED" => "true",
+      "SHELFARR_SETTING_NO_SUCH_SETTING" => "value",
+      "SHELFARR_SETTING_AUDIOBOOK_PATH_TEMPLATE" => "{title}"
+    ) do
+      names = SettingsService.unrecognized_env_override_names
+
+      assert_includes names, "SHELFARR_SETTING_NO_SUCH_SETTING"
+      assert_includes names, "SHELFARR_SETTING_AUDIOBOOK_PATH_TEMPLATE"
+      assert_not_includes names, "SHELFARR_SETTING_OIDC_ENABLED"
+    end
+  end
+
+  test "unrecognized_env_override_names flags variables that are not fully uppercased" do
+    with_env("SHELFARR_SETTING_oidc_enabled" => "true") do
+      assert_includes SettingsService.unrecognized_env_override_names, "SHELFARR_SETTING_oidc_enabled"
+      assert_not SettingsService.env_managed?(:oidc_enabled)
+    end
+  end
 end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -6,7 +6,23 @@ class SettingsServiceTest < ActiveSupport::TestCase
   cover "SettingsService*"
 
   setup do
-    Setting.where(key: %w[indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key preferred_download_type preferred_download_types move_completed_downloads zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled library_platform audiobookshelf_url audiobookshelf_api_key bookorbit_url bookorbit_username bookorbit_password grimmory_url grimmory_username grimmory_password]).delete_all
+    clear_settings_env!
+    Setting.where(key: %w[
+      indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories
+      prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key
+      preferred_download_type preferred_download_types move_completed_downloads audiobook_path_template api_token
+      zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url
+      metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled
+      library_platform audiobookshelf_url audiobookshelf_api_key bookorbit_url bookorbit_username bookorbit_password
+      grimmory_url grimmory_username grimmory_password
+      oidc_enabled oidc_auto_redirect oidc_provider_name oidc_issuer oidc_client_id oidc_client_secret oidc_scopes
+      oidc_link_existing_users oidc_auto_create_users oidc_default_role
+      webhook_enabled webhook_url webhook_token webhook_events webhook_topic
+    ]).delete_all
+  end
+
+  teardown do
+    restore_settings_env!
   end
 
   test "active_indexer_provider falls back to prowlarr for legacy installs" do
@@ -227,5 +243,103 @@ class SettingsServiceTest < ActiveSupport::TestCase
     SettingsService.set(:grimmory_password, "secret")
 
     assert SettingsService.audiobookshelf_configured?
+  end
+
+  test "env override name uses setting prefix and uppercased key" do
+    assert_equal "SHELFARR_SETTING_OIDC_CLIENT_SECRET", SettingsService.env_override_name(:oidc_client_secret)
+  end
+
+  test "env value takes precedence over stored value and reverts when removed" do
+    SettingsService.set(:oidc_client_id, "stored-client")
+
+    with_env("SHELFARR_SETTING_OIDC_CLIENT_ID" => "env-client") do
+      assert_equal "env-client", SettingsService.get(:oidc_client_id)
+      assert SettingsService.env_managed?(:oidc_client_id)
+    end
+
+    assert_equal "stored-client", SettingsService.get(:oidc_client_id)
+    assert_not SettingsService.env_managed?(:oidc_client_id)
+  end
+
+  test "env supplies a value when no database row exists" do
+    Setting.where(key: "oidc_client_secret").delete_all
+
+    with_env("SHELFARR_SETTING_OIDC_CLIENT_SECRET" => "env-secret") do
+      assert_equal "env-secret", SettingsService.get(:oidc_client_secret)
+      assert_equal [ :oidc_client_secret ], SettingsService.env_managed_keys
+    end
+  end
+
+  test "env boolean values use setting type casting" do
+    with_env(
+      "SHELFARR_SETTING_OIDC_ENABLED" => "true",
+      "SHELFARR_SETTING_OIDC_AUTO_CREATE_USERS" => "false"
+    ) do
+      assert_equal true, SettingsService.get(:oidc_enabled)
+      assert_equal false, SettingsService.get(:oidc_auto_create_users)
+    end
+  end
+
+  test "env string values use setting type casting" do
+    with_env("SHELFARR_SETTING_WEBHOOK_EVENTS" => "request_created,request_completed") do
+      assert_equal "request_created,request_completed", SettingsService.get(:webhook_events)
+    end
+  end
+
+  test "env can force a stored enabled setting off" do
+    SettingsService.set(:oidc_enabled, true)
+
+    with_env("SHELFARR_SETTING_OIDC_ENABLED" => "false") do
+      assert_equal false, SettingsService.get(:oidc_enabled)
+    end
+  end
+
+  test "oidc_configured? honors env with no database rows" do
+    Setting.where(key: %w[oidc_enabled oidc_issuer oidc_client_id oidc_client_secret]).delete_all
+
+    with_env(
+      "SHELFARR_SETTING_OIDC_ENABLED" => "true",
+      "SHELFARR_SETTING_OIDC_ISSUER" => "https://auth.example.com",
+      "SHELFARR_SETTING_OIDC_CLIENT_ID" => "client-id",
+      "SHELFARR_SETTING_OIDC_CLIENT_SECRET" => "client-secret"
+    ) do
+      assert SettingsService.oidc_configured?
+    end
+  end
+
+  test "configured? honors env with no database rows" do
+    Setting.where(key: "webhook_url").delete_all
+
+    with_env("SHELFARR_SETTING_WEBHOOK_URL" => "https://hooks.example.com/shelfarr") do
+      assert SettingsService.configured?(:webhook_url)
+    end
+  end
+
+  test "all_by_category includes env management metadata" do
+    with_env("SHELFARR_SETTING_WEBHOOK_URL" => "https://hooks.example.com/shelfarr") do
+      webhook_url = SettingsService.all_by_category.dig("webhook", :webhook_url)
+
+      assert_equal true, webhook_url[:env_managed]
+      assert_equal "SHELFARR_SETTING_WEBHOOK_URL", webhook_url[:env_var]
+    end
+  end
+
+  test "non-allowlisted path template env key is inert" do
+    SettingsService.set(:audiobook_path_template, "{author}/{title}")
+
+    with_env("SHELFARR_SETTING_AUDIOBOOK_PATH_TEMPLATE" => "{title}") do
+      assert_equal "{author}/{title}", SettingsService.get(:audiobook_path_template)
+      assert_not SettingsService.env_managed?(:audiobook_path_template)
+    end
+  end
+
+  test "non-allowlisted api token env key is inert" do
+    SettingsService.set(:api_token, "stored-api-token")
+
+    with_env("SHELFARR_SETTING_API_TOKEN" => "env-api-token") do
+      assert_equal "stored-api-token", SettingsService.get(:api_token)
+      assert_equal "stored-api-token", SettingsService.api_token
+      assert_not SettingsService.env_managed?(:api_token)
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,33 @@ module ActiveSupport
         )
     end
 
+    def with_env(overrides)
+      original = overrides.each_key.to_h { |key| [ key, ENV.key?(key) ? ENV[key] : :__unset__ ] }
+
+      overrides.each do |key, value|
+        value.nil? ? ENV.delete(key) : ENV[key] = value
+      end
+
+      yield
+    ensure
+      original&.each do |key, value|
+        value == :__unset__ ? ENV.delete(key) : ENV[key] = value
+      end
+    end
+
+    def clear_settings_env!
+      @settings_env_backup = ENV.to_h.select { |key, _| key.start_with?(SettingsService::ENV_OVERRIDE_PREFIX) }
+      @settings_env_backup.each_key { |key| ENV.delete(key) }
+    end
+
+    def restore_settings_env!
+      return unless defined?(@settings_env_backup) && @settings_env_backup
+
+      ENV.delete_if { |key, _| key.start_with?(SettingsService::ENV_OVERRIDE_PREFIX) }
+      @settings_env_backup.each { |key, value| ENV[key] = value }
+      @settings_env_backup = nil
+    end
+
     # Add more helper methods to be used by all tests here...
   end
 end


### PR DESCRIPTION
## What changed

- Added an explicit `env_overridable: true` allowlist for OIDC and webhook settings.
- Made `SettingsService.get` prefer typed `SHELFARR_SETTING_<KEY>` values only for allowlisted settings.
- Added boot-time warnings for unsupported `SHELFARR_SETTING_*` variables and info logging for active env-managed keys.
- Rendered env-managed settings as read-only in Admin -> Settings and guarded controller persistence.
- Documented supported variables and read-through semantics.

## Why

A blanket env override would bypass validation, miss readers that do not use `SettingsService.get`, and skip controller side effects. This keeps env management scoped to plain OIDC and webhook settings that are safe to read through `get` today.

## Impact

Operators can keep OIDC and webhook credentials in deployment secrets while the UI shows which values are environment-managed. Removing an env var falls back to the stored database value or the default; unsupported settings remain UI/DB managed.

## Validation

- `bin/rails test test/services/settings_service_test.rb test/controllers/admin/settings_controller_test.rb`
- `bin/quality fast`
- `bin/quality commit --staged`
