### PR TITLE
feat: blocklist failed releases

### DIFF
--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -206,6 +206,8 @@ class API::V1::RequestsController < API::V1::ApplicationController
     result = @request.search_results.find(params[:search_result_id])
     @request.select_result!(result)
     render json: request_payload_with_selected_result(@request.reload)
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: [ "Search result not found" ] }, status: :not_found
   rescue ArgumentError => e
     render json: { errors: [ e.message ] }, status: :unprocessable_entity
   end

--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class API::V1::RequestsController < API::V1::ApplicationController
-  before_action -> { require_scope!("requests:read") }, only: [ :index, :show ]
+  before_action -> { require_scope!("requests:read") }, only: [ :index, :show, :search_results ]
   before_action -> { require_scope!("requests:write") }, only: [ :create, :destroy ]
-  before_action -> { require_scope!("requests:admin") }, only: :retry
-  before_action :set_request, only: [ :show, :destroy, :retry ]
+  before_action -> { require_scope!("requests:admin") }, only: [ :retry, :blocklist_and_next ]
+  before_action :set_request, only: [ :show, :destroy, :retry, :search_results, :blocklist_and_next ]
 
   def index
     requests = request_scope.includes(:book, :user).order(created_at: :desc)
@@ -68,6 +68,28 @@ class API::V1::RequestsController < API::V1::ApplicationController
 
     @request.retry_now!
     render json: request_payload(@request.reload)
+  end
+
+  def search_results
+    render json: {
+      search_results: @request.search_results.best_first.map { |result| search_result_payload(result) }
+    }
+  end
+
+  def blocklist_and_next
+    if params[:search_result_id].present?
+      grab_search_result
+      return
+    end
+
+    case @request.blocklist_and_select_next!(reason: "Blocklisted via API")
+    when :no_selected_result
+      render json: { errors: [ "No selected result to blocklist" ] }, status: :unprocessable_entity
+    when :exhausted
+      render json: request_payload(@request.reload)
+    else
+      render json: request_payload_with_selected_result(@request.reload)
+    end
   end
 
   private
@@ -153,5 +175,38 @@ class API::V1::RequestsController < API::V1::ApplicationController
         username: request.user.username
       }
     }
+  end
+
+  def request_payload_with_selected_result(request)
+    request_payload(request).merge(
+      selected_result: request.search_results.selected.first.then { |result| result && search_result_payload(result) }
+    )
+  end
+
+  def search_result_payload(result)
+    {
+      id: result.id,
+      title: result.title,
+      source: result.source,
+      indexer: result.indexer,
+      seeders: result.seeders,
+      leechers: result.leechers,
+      size_bytes: result.size_bytes,
+      confidence_score: result.confidence_score,
+      detected_language: result.detected_language,
+      status: result.status,
+      downloadable: result.downloadable?,
+      blocklisted: result.blocklisted?,
+      blocklisted_at: result.blocklisted_at&.iso8601,
+      blocklist_reason: result.blocklist_reason
+    }
+  end
+
+  def grab_search_result
+    result = @request.search_results.find(params[:search_result_id])
+    @request.select_result!(result)
+    render json: request_payload_with_selected_result(@request.reload)
+  rescue ArgumentError => e
+    render json: { errors: [ e.message ] }, status: :unprocessable_entity
   end
 end

--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -72,7 +72,7 @@ class API::V1::RequestsController < API::V1::ApplicationController
 
   def search_results
     render json: {
-      search_results: @request.search_results.best_first.map { |result| search_result_payload(result) }
+      search_results: @request.search_results.includes(:acquisition_provider).best_first.map { |result| search_result_payload(result) }
     }
   end
 

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "uri"
 require "tempfile"
+require "timeout"
 
 class DownloadJob < ApplicationJob
   queue_as :default
@@ -131,7 +132,7 @@ class DownloadJob < ApplicationJob
 
   def transient_direct_download_error?(error)
     case error
-    when SocketError, IOError, EOFError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
+    when SocketError, IOError, EOFError, Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
       true
     else
       error.message.to_s.include?("Direct download request failed:")
@@ -596,7 +597,7 @@ class DownloadJob < ApplicationJob
 
     file_size = File.size(destination)
     Rails.logger.info "[DownloadJob] Downloaded #{(file_size / 1024.0 / 1024.0).round(2)} MB"
-  rescue SocketError, IOError, EOFError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
+  rescue SocketError, IOError, EOFError, Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
     raise "Direct download request failed: #{e.message}"
   end
 

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -6,6 +6,10 @@ require "tempfile"
 require "timeout"
 
 class DownloadJob < ApplicationJob
+  # Wraps network-level failures during a direct HTTP download so failure
+  # handling can classify them as transient without message matching.
+  class DirectDownloadError < StandardError; end
+
   queue_as :default
 
   MAX_DIRECT_DOWNLOAD_BYTES = 512.megabytes
@@ -132,10 +136,11 @@ class DownloadJob < ApplicationJob
 
   def transient_direct_download_error?(error)
     case error
-    when SocketError, IOError, EOFError, Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
+    when DirectDownloadError,
+         SocketError, IOError, EOFError, Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
       true
     else
-      error.message.to_s.include?("Direct download request failed:")
+      false
     end
   end
 
@@ -158,22 +163,13 @@ class DownloadJob < ApplicationJob
          GutenbergClient::ConnectionError,
          GutenbergClient::NotConfiguredError,
          GutenbergClient::ConfigurationError,
-         CustomAcquisitionProviderClient::ConnectionError
+         CustomAcquisitionProviderClient::ConnectionError,
+         CustomAcquisitionProviderClient::NotConfiguredError,
+         CustomAcquisitionProviderClient::ResponseError
       true
-    when CustomAcquisitionProviderClient::ResponseError
-      transient_custom_provider_response_error?(error)
     else
       false
     end
-  end
-
-  def transient_custom_provider_response_error?(error)
-    message = error.message.to_s
-    message.include?("returned HTTP") ||
-      message.include?("returned invalid JSON") ||
-      message.include?("returned an invalid acquire response") ||
-      message.include?("response exceeds") ||
-      message.include?("missing its provider")
   end
 
   def handle_anna_archive_download(download, search_result)
@@ -227,7 +223,7 @@ class DownloadJob < ApplicationJob
 
   def handle_custom_provider_download(download, search_result)
     provider = search_result.acquisition_provider
-    raise CustomAcquisitionProviderClient::ResponseError, "Selected custom provider result is missing its provider" unless provider&.enabled?
+    raise CustomAcquisitionProviderClient::NotConfiguredError, "Selected custom provider result is missing its provider" unless provider&.enabled?
 
     Rails.logger.info "[DownloadJob] Acquiring custom provider result from #{provider.name}"
     acquisition = provider.client.acquire(search_result)
@@ -246,7 +242,7 @@ class DownloadJob < ApplicationJob
       nzb_url = acquisition.nzb_url.presence || acquisition.direct_url
       send_to_usenet_client(download, search_result, validate_dispatch_url!(nzb_url, search_result))
     else
-      raise CustomAcquisitionProviderClient::ResponseError, "Unsupported custom provider artifact type: #{acquisition.download_type}"
+      raise CustomAcquisitionProviderClient::UnusableArtifactError, "Unsupported custom provider artifact type: #{acquisition.download_type}"
     end
   rescue CustomAcquisitionProviderClient::Error
     raise
@@ -598,7 +594,7 @@ class DownloadJob < ApplicationJob
     file_size = File.size(destination)
     Rails.logger.info "[DownloadJob] Downloaded #{(file_size / 1024.0 / 1024.0).round(2)} MB"
   rescue SocketError, IOError, EOFError, Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
-    raise "Direct download request failed: #{e.message}"
+    raise DirectDownloadError, "Direct download request failed: #{e.message}"
   end
 
   def validate_direct_download_url!(url, search_result = nil)
@@ -622,7 +618,7 @@ class DownloadJob < ApplicationJob
     OutboundUrlGuard.validate!(url, allow_private: allow_private_download?(search_result))
     url
   rescue OutboundUrlGuard::BlockedUrlError => e
-    raise CustomAcquisitionProviderClient::ResponseError, "Refused download URL from custom provider: #{e.message}"
+    raise CustomAcquisitionProviderClient::UnusableArtifactError, "Refused download URL from custom provider: #{e.message}"
   end
 
   def normalize_direct_download_url(url)

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -45,6 +45,7 @@ class DownloadJob < ApplicationJob
       download.request.mark_for_attention!("No search result selected for download")
       return
     end
+    download.update!(search_result: search_result) unless download.search_result_id
 
     begin
       # Handle Anna's Archive downloads differently
@@ -80,36 +81,81 @@ class DownloadJob < ApplicationJob
       Rails.logger.error "[DownloadJob] Download client error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Download client error: #{e.message}")
+      download.request.handle_download_failure!(download, reason: "Download client error: #{e.message}")
     rescue AnnaArchiveClient::Error => e
       Rails.logger.error "[DownloadJob] Anna's Archive error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Anna's Archive error: #{e.message}")
+      handle_download_source_failure(download, e, "Anna's Archive error: #{e.message}")
     rescue ZLibraryClient::Error => e
       Rails.logger.error "[DownloadJob] Z-Library error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Z-Library error: #{e.message}")
+      handle_download_source_failure(download, e, "Z-Library error: #{e.message}")
     rescue LibrivoxClient::Error => e
       Rails.logger.error "[DownloadJob] LibriVox error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
-      download.request.mark_for_attention!("LibriVox error: #{e.message}")
+      handle_download_source_failure(download, e, "LibriVox error: #{e.message}")
     rescue GutenbergClient::Error => e
       Rails.logger.error "[DownloadJob] Project Gutenberg error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Project Gutenberg error: #{e.message}")
+      handle_download_source_failure(download, e, "Project Gutenberg error: #{e.message}")
     rescue CustomAcquisitionProviderClient::Error => e
       Rails.logger.error "[DownloadJob] Custom provider error for download ##{download.id}: #{e.message}"
       track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Custom provider error: #{e.message}")
+      handle_download_source_failure(download, e, "Custom provider error: #{e.message}")
     end
   end
 
   private
+
+  def handle_download_source_failure(download, error, message)
+    if transient_download_source_error?(error)
+      download.request.mark_for_attention!(message)
+    else
+      download.request.handle_download_failure!(download, reason: message)
+    end
+  end
+
+  def transient_download_source_error?(error)
+    case error
+    when AnnaArchiveClient::ConnectionError,
+         AnnaArchiveClient::AuthenticationError,
+         AnnaArchiveClient::NotConfiguredError,
+         AnnaArchiveClient::ConfigurationError,
+         AnnaArchiveClient::BotProtectionError,
+         AnnaArchiveClient::RetryableError,
+         ZLibraryClient::ConnectionError,
+         ZLibraryClient::AuthenticationError,
+         ZLibraryClient::NotConfiguredError,
+         ZLibraryClient::RateLimitError,
+         ZLibraryClient::ConfigurationError,
+         LibrivoxClient::ConnectionError,
+         LibrivoxClient::NotConfiguredError,
+         LibrivoxClient::ConfigurationError,
+         GutenbergClient::ConnectionError,
+         GutenbergClient::NotConfiguredError,
+         GutenbergClient::ConfigurationError,
+         CustomAcquisitionProviderClient::ConnectionError
+      true
+    when CustomAcquisitionProviderClient::ResponseError
+      transient_custom_provider_response_error?(error)
+    else
+      false
+    end
+  end
+
+  def transient_custom_provider_response_error?(error)
+    message = error.message.to_s
+    message.include?("returned HTTP") ||
+      message.include?("returned invalid JSON") ||
+      message.include?("returned an invalid acquire response") ||
+      message.include?("response exceeds") ||
+      message.include?("missing its provider")
+  end
 
   def handle_anna_archive_download(download, search_result)
     # Fetch actual download URL from Anna's Archive API
@@ -155,7 +201,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.error e.backtrace.first(5).join("\n")
     track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
     download.update!(status: :failed)
-    download.request.mark_for_attention!("LibriVox download failed: #{e.message}")
+    download.request.handle_download_failure!(download, reason: "LibriVox download failed: #{e.message}")
   end
 
   def handle_custom_provider_download(download, search_result)
@@ -188,7 +234,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.error e.backtrace.first(5).join("\n")
     track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
     download.update!(status: :failed)
-    download.request.mark_for_attention!("Custom provider download failed: #{e.message}")
+    download.request.handle_download_failure!(download, reason: "Custom provider download failed: #{e.message}")
   end
 
   def handle_direct_audiobook_download(download, search_result, download_url, source_name:)
@@ -325,7 +371,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.error e.backtrace.first(5).join("\n")
     track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
     download.update!(status: :failed)
-    download.request.mark_for_attention!("Direct download failed: #{e.message}")
+    download.request.handle_download_failure!(download, reason: "Direct download failed: #{e.message}")
   end
 
   def infer_filename_from_url(url, search_result)
@@ -724,7 +770,7 @@ class DownloadJob < ApplicationJob
         details: { client_name: client_record.name }
       )
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Failed to add to #{client_record.name}")
+      download.request.handle_download_failure!(download, reason: "Failed to add to #{client_record.name}")
       Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
     end
   end
@@ -769,7 +815,7 @@ class DownloadJob < ApplicationJob
         details: { client_name: client_record.name, download_type: "usenet" }
       )
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Failed to add to #{client_record.name}")
+      download.request.handle_download_failure!(download, reason: "Failed to add to #{client_record.name}")
     end
   end
 
@@ -778,7 +824,7 @@ class DownloadJob < ApplicationJob
       Rails.logger.error "[DownloadJob] Search result has no download link for download ##{download.id}"
       track_request_event(download.request, "dispatch_failed", download: download, message: "Selected result has no download link", level: :error)
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Selected result has no download link")
+      download.request.handle_download_failure!(download, reason: "Selected result has no download link")
       return
     end
 
@@ -840,7 +886,7 @@ class DownloadJob < ApplicationJob
         }
       )
       download.update!(status: :failed)
-      download.request.mark_for_attention!("Failed to add to #{client_record.name}")
+      download.request.handle_download_failure!(download, reason: "Failed to add to #{client_record.name}")
       Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
     end
   end

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -120,6 +120,24 @@ class DownloadJob < ApplicationJob
     end
   end
 
+  def handle_direct_download_failure(download, error)
+    message = "Direct download failed: #{error.message}"
+    if transient_direct_download_error?(error)
+      download.request.mark_for_attention!(message)
+    else
+      download.request.handle_download_failure!(download, reason: message)
+    end
+  end
+
+  def transient_direct_download_error?(error)
+    case error
+    when SocketError, IOError, EOFError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
+      true
+    else
+      error.message.to_s.include?("Direct download request failed:")
+    end
+  end
+
   def transient_download_source_error?(error)
     case error
     when AnnaArchiveClient::ConnectionError,
@@ -196,6 +214,8 @@ class DownloadJob < ApplicationJob
     raise LibrivoxClient::Error, "Selected LibriVox result is missing a download URL" if search_result.download_url.blank?
 
     handle_direct_audiobook_archive_download(download, search_result, search_result.download_url, source_name: "LibriVox")
+  rescue LibrivoxClient::Error
+    raise
   rescue => e
     Rails.logger.error "[DownloadJob] LibriVox download failed: #{e.message}"
     Rails.logger.error e.backtrace.first(5).join("\n")
@@ -371,7 +391,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.error e.backtrace.first(5).join("\n")
     track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
     download.update!(status: :failed)
-    download.request.handle_download_failure!(download, reason: "Direct download failed: #{e.message}")
+    handle_direct_download_failure(download, e)
   end
 
   def infer_filename_from_url(url, search_result)

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -120,8 +120,8 @@ class DownloadJob < ApplicationJob
     end
   end
 
-  def handle_direct_download_failure(download, error)
-    message = "Direct download failed: #{error.message}"
+  def handle_direct_download_failure(download, error, message: nil)
+    message ||= "Direct download failed: #{error.message}"
     if transient_direct_download_error?(error)
       download.request.mark_for_attention!(message)
     else
@@ -221,7 +221,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.error e.backtrace.first(5).join("\n")
     track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
     download.update!(status: :failed)
-    download.request.handle_download_failure!(download, reason: "LibriVox download failed: #{e.message}")
+    handle_direct_download_failure(download, e, message: "LibriVox download failed: #{e.message}")
   end
 
   def handle_custom_provider_download(download, search_result)
@@ -254,7 +254,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.error e.backtrace.first(5).join("\n")
     track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
     download.update!(status: :failed)
-    download.request.handle_download_failure!(download, reason: "Custom provider download failed: #{e.message}")
+    handle_direct_download_failure(download, e, message: "Custom provider download failed: #{e.message}")
   end
 
   def handle_direct_audiobook_download(download, search_result, download_url, source_name:)

--- a/app/jobs/download_monitor_job.rb
+++ b/app/jobs/download_monitor_job.rb
@@ -109,7 +109,7 @@ class DownloadMonitorJob < ApplicationJob
 
     track_request_event(download.request, "failed", download: download, message: "Download failed in client", level: :error)
     download.update!(status: :failed)
-    download.request.mark_for_attention!("Download failed in client")
+    download.request.handle_download_failure!(download, reason: "Download failed in client")
   end
 
   def handle_missing(download)
@@ -128,7 +128,7 @@ class DownloadMonitorJob < ApplicationJob
         details: { client_name: client_name }
       )
       download.update!(status: :failed, not_found_count: new_count)
-      download.request.mark_for_attention!("Download not found in client '#{client_name}' (hash: #{download.external_id})")
+      download.request.handle_download_failure!(download, reason: "Download not found in client '#{client_name}' (hash: #{download.external_id})")
     else
       Rails.logger.warn "[DownloadMonitorJob] Download #{download.id} (hash: #{download.external_id}) not found in client '#{client_name}' (attempt #{new_count}/#{NOT_FOUND_THRESHOLD})"
 

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -244,6 +244,12 @@ class SearchJob < ApplicationJob
   end
 
   def save_results(request, tagged_results)
+    blocklisted_by_guid = request.search_results
+      .where.not(source: SearchResult::SOURCE_MANUAL_MAGNET)
+      .blocklisted
+      .pluck(:guid, :blocklisted_at, :blocklist_reason)
+      .to_h { |guid, blocklisted_at, blocklist_reason| [ guid, { blocklisted_at: blocklisted_at, blocklist_reason: blocklist_reason } ] }
+
     request.search_results.where.not(source: SearchResult::SOURCE_MANUAL_MAGNET).destroy_all
 
     tagged_results.each do |tagged|
@@ -265,7 +271,12 @@ class SearchJob < ApplicationJob
         save_indexer_result(request, result, source)
       end
 
-      search_result.calculate_score! if search_result
+      if search_result
+        if (blocklist_attrs = blocklisted_by_guid[search_result.guid])
+          search_result.update!(blocklist_attrs.merge(status: :rejected))
+        end
+        search_result.calculate_score!
+      end
     end
   end
 

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -250,7 +250,7 @@ class SearchJob < ApplicationJob
       .pluck(:guid, :blocklisted_at, :blocklist_reason)
       .to_h { |guid, blocklisted_at, blocklist_reason| [ guid, { blocklisted_at: blocklisted_at, blocklist_reason: blocklist_reason } ] }
 
-    request.search_results.where.not(source: SearchResult::SOURCE_MANUAL_MAGNET).destroy_all
+    request.search_results.where.not(source: SearchResult::SOURCE_MANUAL_MAGNET).not_blocklisted.destroy_all
 
     tagged_results.each do |tagged|
       result = tagged[:result]
@@ -281,8 +281,8 @@ class SearchJob < ApplicationJob
   end
 
   def save_indexer_result(request, result, source)
-    request.search_results.create!(
-      guid: result.guid,
+    search_result = request.search_results.find_or_initialize_by(guid: result.guid)
+    search_result.assign_attributes(
       title: result.title,
       indexer: result.indexer,
       size_bytes: result.size_bytes,
@@ -294,6 +294,9 @@ class SearchJob < ApplicationJob
       published_at: result.published_at,
       source: source
     )
+    search_result.status = :pending unless search_result.blocklisted? || search_result.selected?
+    search_result.save!
+    search_result
   end
 
   def save_anna_archive_result(request, result)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -250,7 +250,17 @@ class SearchJob < ApplicationJob
       .pluck(:guid, :blocklisted_at, :blocklist_reason)
       .to_h { |guid, blocklisted_at, blocklist_reason| [ guid, { blocklisted_at: blocklisted_at, blocklist_reason: blocklist_reason } ] }
 
-    request.search_results.where.not(source: SearchResult::SOURCE_MANUAL_MAGNET).not_blocklisted.destroy_all
+    active_download_result_ids = request.downloads
+      .where(status: [ :queued, :downloading, :paused ])
+      .where.not(search_result_id: nil)
+      .distinct
+      .pluck(:search_result_id)
+
+    request.search_results
+      .where.not(source: SearchResult::SOURCE_MANUAL_MAGNET)
+      .where.not(id: active_download_result_ids)
+      .not_blocklisted
+      .destroy_all
 
     tagged_results.each do |tagged|
       result = tagged[:result]

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -99,52 +99,61 @@ class Request < ApplicationRecord
     update!(status: :pending, next_retry_at: nil)
   end
 
-  # Retry now - reset for immediate processing
-  # If there's a selected result with a failed download, retry the download
-  # Otherwise, restart the search process
+  # Retry now - reset for immediate processing.
+  # If a selected release already failed, keep it blocklisted and try the next
+  # eligible candidate before falling back to a fresh search.
   def retry_now!
     selected_result = search_results.selected.first
-    failed_download = downloads.where(status: :failed).order(created_at: :desc).first
+    failed_download = selected_result && downloads.where(status: :failed, search_result: selected_result).order(created_at: :desc).first
 
     if selected_result && failed_download
-      # Retry the download - create a new download and queue the job
-      download = nil
-      ActiveRecord::Base.transaction do
-        download = downloads.create!(
-          name: selected_result.title,
-          size_bytes: selected_result.size_bytes,
-          search_result: selected_result,
-          status: :queued
-        )
+      reason = "Failed download (manual retry)"
+      blocklist_result!(selected_result, reason: reason, download: failed_download)
 
-        update!(
-          status: :downloading,
-          next_retry_at: nil,
-          attention_needed: false,
-          issue_description: nil
-        )
+      if auto_select_enabled? && attempt_next_candidate!(failure_reason: reason, mark_exhausted: false) == :selected_next
+        return
+      end
+    end
+
+    update!(
+      status: :pending,
+      next_retry_at: nil,
+      attention_needed: false,
+      issue_description: nil
+    )
+  end
+
+  def handle_download_failure!(download, reason:)
+    download.update!(status: :failed) unless download.failed?
+
+    blocklisted = blocklist_result!(download.search_result, reason: reason, download: download)
+
+    unless auto_select_enabled?
+      manual_message = if blocklisted
+        "Download failed: #{reason}. The failed release was blocklisted. Select another release manually."
+      else
+        "Download failed: #{reason}. Select another release manually."
+      end
+      mark_for_attention!(manual_message)
+      return :manual_review
+    end
+
+    attempt_next_candidate!(failure_reason: reason)
+  end
+
+  def blocklist_and_select_next!(reason:, search_result: nil)
+    target = search_result || search_results.selected.first
+    return :no_selected_result unless target
+
+    ActiveRecord::Base.transaction do
+      downloads.where(status: [ :queued, :downloading, :paused ]).find_each do |download|
+        cancel_download(download)
       end
 
-      track_diagnostic(
-        "download_queued",
-        download: download,
-        message: "Download queued for retry from selected result",
-        details: {
-          search_result_id: selected_result.id,
-          title: selected_result.title,
-          trigger: "retry"
-        }
-      )
-      DownloadJob.perform_later(download.id)
-    else
-      # No selected result or failed download - restart search
-      update!(
-        status: :pending,
-        next_retry_at: nil,
-        attention_needed: false,
-        issue_description: nil
-      )
+      blocklist_result!(target, reason: reason)
     end
+
+    attempt_next_candidate!(failure_reason: reason)
   end
 
   # Cancel/fail request permanently
@@ -221,6 +230,20 @@ class Request < ApplicationRecord
     ActiveRecord::Base.transaction do
       downloads.where(status: [ :queued, :downloading, :paused ]).find_each do |download|
         cancel_download(download)
+      end
+
+      if search_result.blocklisted?
+        search_result.clear_blocklist!
+        track_diagnostic(
+          "blocklist_overridden",
+          message: "Blocklist overridden for selected release",
+          level: :warn,
+          user_visible: true,
+          details: {
+            search_result_id: search_result.id,
+            title: search_result.title
+          }
+        )
       end
 
       search_results.where.not(id: search_result.id).update_all(status: :rejected)
@@ -312,7 +335,67 @@ class Request < ApplicationRecord
     broadcast_show_refresh_later if (previous_changes.keys & SHOW_PAGE_BROADCAST_ATTRIBUTES).any?
   end
 
-  def track_diagnostic(event_type, message: nil, level: :info, download: nil, details: {})
+  def attempt_next_candidate!(failure_reason:, mark_exhausted: true)
+    search_results.rejected.not_blocklisted.update_all(
+      status: SearchResult.statuses[:pending],
+      updated_at: Time.current
+    )
+
+    selection = AutoSelectService.call(self)
+    if selection.success?
+      track_diagnostic(
+        "fallback_selected",
+        message: "Selected the next eligible release after a failed download",
+        user_visible: true,
+        details: {
+          search_result_id: selection.search_result&.id,
+          title: selection.search_result&.title,
+          failure_reason: failure_reason
+        }
+      )
+      return :selected_next
+    end
+
+    mark_candidate_exhausted!(failure_reason, selection.reason) if mark_exhausted
+    :exhausted
+  end
+
+  def mark_candidate_exhausted!(failure_reason, selection_reason)
+    blocklisted_count = search_results.blocklisted.count
+    remaining_reason = selection_reason.to_s.humanize.downcase
+    mark_for_attention!(
+      "Download failed: #{failure_reason}. No suitable alternative release found - " \
+        "#{blocklisted_count} release(s) blocklisted, remaining results #{remaining_reason}. " \
+        "Select a release manually or refresh the search.",
+      status: :not_found
+    )
+  end
+
+  def blocklist_result!(search_result, reason:, download: nil)
+    return false unless search_result
+    return false if search_result.blocklisted?
+
+    search_result.blocklist!(reason)
+    track_diagnostic(
+      "release_blocklisted",
+      download: download,
+      message: "Blocklisted release after failed download",
+      level: :warn,
+      user_visible: true,
+      details: {
+        search_result_id: search_result.id,
+        title: search_result.title,
+        reason: reason
+      }
+    )
+    true
+  end
+
+  def auto_select_enabled?
+    SettingsService.get(:auto_select_enabled, default: false)
+  end
+
+  def track_diagnostic(event_type, message: nil, level: :info, download: nil, details: {}, user_visible: false)
     RequestEvent.record!(
       request: self,
       download: download,
@@ -320,7 +403,8 @@ class Request < ApplicationRecord
       source: "request",
       message: message,
       level: level,
-      details: details
+      details: details,
+      user_visible: user_visible
     )
   end
 

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -28,6 +28,8 @@ class SearchResult < ApplicationRecord
   validates :title, presence: true
 
   scope :selectable, -> { pending }
+  scope :blocklisted, -> { where.not(blocklisted_at: nil) }
+  scope :not_blocklisted, -> { where(blocklisted_at: nil) }
 
   scope :preferred_first, -> {
     ordered_types = SettingsService.preferred_download_types
@@ -88,6 +90,24 @@ class SearchResult < ApplicationRecord
     return true if direct_download?
 
     download_url.present? || magnet_url.present?
+  end
+
+  def blocklisted?
+    blocklisted_at.present?
+  end
+
+  def blocklist!(reason)
+    attributes = {
+      blocklisted_at: Time.current,
+      blocklist_reason: reason.to_s.truncate(255)
+    }
+    attributes[:status] = :rejected if selected?
+
+    update!(attributes)
+  end
+
+  def clear_blocklist!
+    update!(blocklisted_at: nil, blocklist_reason: nil)
   end
 
   def download_link

--- a/app/services/auto_select_service.rb
+++ b/app/services/auto_select_service.rb
@@ -65,6 +65,7 @@ class AutoSelectService
   def find_matching_results
     @request.search_results
       .pending
+      .not_blocklisted
       .auto_selectable(@confidence_threshold)
       .matches_language(@requested_language)
       .best_first

--- a/app/services/custom_acquisition_provider_client.rb
+++ b/app/services/custom_acquisition_provider_client.rb
@@ -8,6 +8,8 @@ class CustomAcquisitionProviderClient
   class Error < StandardError; end
   class ConnectionError < Error; end
   class ResponseError < Error; end
+  class NotConfiguredError < Error; end
+  class UnusableArtifactError < Error; end
 
   MAX_RESPONSE_BYTES = 10.megabytes
   HEALTH_CHECK_TIMEOUT_SECONDS = 10

--- a/app/views/admin/search_results/index.html.erb
+++ b/app/views/admin/search_results/index.html.erb
@@ -84,6 +84,11 @@
                       Manual review
                     </span>
                   <% end %>
+                  <% if result.blocklisted? %>
+                    <span title="<%= result.blocklist_reason %>" class="inline-flex items-center rounded-full bg-red-500/10 px-2 py-0.5 font-medium text-red-400 ring-1 ring-inset ring-red-500/20">
+                      Blocklisted
+                    </span>
+                  <% end %>
                 </div>
               </div>
 
@@ -95,7 +100,7 @@
                 <% if result.selected? %>
                   <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
                 <% elsif result.downloadable? %>
-                  <%= button_to result.rejected? ? "Select Instead" : "Select", select_admin_request_search_result_path(@request, result),
+                  <%= button_to result.blocklisted? ? "Retry Anyway" : (result.rejected? ? "Select Instead" : "Select"), select_admin_request_search_result_path(@request, result),
                       method: :post,
                       class: "px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
                 <% elsif result.rejected? %>

--- a/app/views/requests/_search_result_row.html.erb
+++ b/app/views/requests/_search_result_row.html.erb
@@ -41,6 +41,9 @@
       <% if Current.user.admin? && !result.auto_select_allowed_by_preferences? %>
         <span class="text-red-400 font-medium">Manual review</span>
       <% end %>
+      <% if result.blocklisted? %>
+        <span class="text-red-400 font-medium" title="<%= result.blocklist_reason %>">Blocklisted</span>
+      <% end %>
     </div>
   </div>
   <div class="flex-shrink-0 flex items-center gap-2">
@@ -52,7 +55,7 @@
       <% if result.selected? %>
         <span class="px-2 py-1 text-xs bg-green-600/20 text-green-400 rounded font-medium">Selected</span>
       <% elsif result.downloadable? %>
-        <%= button_to result.rejected? ? "Select Instead" : "Select", select_admin_request_search_result_path(request, result),
+        <%= button_to result.blocklisted? ? "Retry Anyway" : (result.rejected? ? "Select Instead" : "Select"), select_admin_request_search_result_path(request, result),
             method: :post,
             class: "px-2 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded font-medium transition" %>
       <% elsif result.rejected? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,8 @@ Rails.application.routes.draw do
       get "search", to: "search#index"
       resources :requests, only: [ :index, :create, :show, :destroy ] do
         member do
+          get :search_results
+          post :blocklist_and_next
           post :retry
         end
       end

--- a/db/migrate/20260703000000_add_blocklist_to_search_results.rb
+++ b/db/migrate/20260703000000_add_blocklist_to_search_results.rb
@@ -1,0 +1,7 @@
+class AddBlocklistToSearchResults < ActiveRecord::Migration[8.1]
+  def change
+    add_column :search_results, :blocklisted_at, :datetime
+    add_column :search_results, :blocklist_reason, :string
+    add_index :search_results, [ :request_id, :blocklisted_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_000000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -250,6 +250,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_000000) do
 
   create_table "search_results", force: :cascade do |t|
     t.integer "acquisition_provider_id"
+    t.string "blocklist_reason"
+    t.datetime "blocklisted_at"
     t.integer "confidence_score"
     t.datetime "created_at", null: false
     t.string "detected_language"
@@ -272,6 +274,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_000000) do
     t.datetime "updated_at", null: false
     t.index ["acquisition_provider_id", "provider_result_id"], name: "index_search_results_on_provider_result"
     t.index ["acquisition_provider_id"], name: "index_search_results_on_acquisition_provider_id"
+    t.index ["request_id", "blocklisted_at"], name: "index_search_results_on_request_id_and_blocklisted_at"
     t.index ["request_id", "guid"], name: "index_search_results_on_request_id_and_guid", unique: true
     t.index ["request_id"], name: "index_search_results_on_request_id"
     t.index ["status"], name: "index_search_results_on_status"

--- a/test/controllers/admin/search_results_controller_test.rb
+++ b/test/controllers/admin/search_results_controller_test.rb
@@ -79,6 +79,18 @@ module Admin
       end
     end
 
+    test "index labels blocklisted results and offers retry anyway" do
+      blocklisted = search_results(:blocklisted_result)
+
+      get admin_request_search_results_path(@request_record)
+      assert_response :success
+
+      assert_select "span[title='#{blocklisted.blocklist_reason}']", text: "Blocklisted"
+      assert_select "form[action='#{select_admin_request_search_result_path(@request_record, blocklisted)}']" do
+        assert_select "button", text: "Retry Anyway"
+      end
+    end
+
     # === Select ===
 
     test "select creates download and updates statuses" do
@@ -106,6 +118,18 @@ module Admin
 
       assert @pending_result.reload.selected?
       assert @selected_result.reload.rejected?
+    end
+
+    test "selecting a blocklisted result clears blocklist and starts download" do
+      blocklisted = search_results(:blocklisted_result)
+
+      assert_difference -> { Download.count }, 1 do
+        post select_admin_request_search_result_path(@request_record, blocklisted)
+      end
+
+      assert blocklisted.reload.selected?
+      assert_not blocklisted.blocklisted?
+      assert_nil blocklisted.blocklist_reason
     end
 
     test "select marks other results as rejected" do

--- a/test/controllers/api/v1/requests_controller_test.rb
+++ b/test/controllers/api/v1/requests_controller_test.rb
@@ -380,6 +380,22 @@ class API::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_includes JSON.parse(response.body)["errors"].join, "No selected result"
   end
 
+  test "blocklist_and_next with unknown search_result_id returns 404" do
+    _token, raw = APIToken.issue!(
+      name: "Admin",
+      user: users(:two),
+      scopes: %w[requests:admin]
+    )
+    request = requests(:pending_request)
+
+    post blocklist_and_next_api_v1_request_path(request),
+      headers: { "Authorization" => "Bearer #{raw}" },
+      params: { search_result_id: 0 }
+
+    assert_response :not_found
+    assert_includes JSON.parse(response.body)["errors"].join, "Search result not found"
+  end
+
   test "blocklist_and_next with search_result_id returns 422 for undownloadable result" do
     _token, raw = APIToken.issue!(
       name: "Admin",

--- a/test/controllers/api/v1/requests_controller_test.rb
+++ b/test/controllers/api/v1/requests_controller_test.rb
@@ -3,9 +3,12 @@
 require "test_helper"
 
 class API::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     SettingsService.set(:api_token, "apitoken")
     @user = users(:one)
+    clear_enqueued_jobs
   end
 
   test "creates a request for an existing Shelfarr user" do
@@ -246,5 +249,163 @@ class API::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     assert_includes JSON.parse(response.body)["errors"].join, "cannot be retried"
+  end
+
+  test "lists search results with blocklist fields for scoped reader" do
+    _token, raw = APIToken.issue!(
+      name: "Reader",
+      user: @user,
+      scopes: %w[requests:read]
+    )
+    blocklisted = search_results(:blocklisted_result)
+
+    get search_results_api_v1_request_path(requests(:pending_request)),
+      headers: { "Authorization" => "Bearer #{raw}" }
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    payload = body["search_results"].find { |result| result["id"] == blocklisted.id }
+    assert payload
+    assert_equal true, payload["blocklisted"]
+    assert_equal "Previous download failed", payload["blocklist_reason"]
+    assert payload.key?("downloadable")
+  end
+
+  test "search results endpoint requires read scope" do
+    _token, raw = APIToken.issue!(
+      name: "Writer",
+      user: @user,
+      scopes: %w[requests:write]
+    )
+
+    get search_results_api_v1_request_path(requests(:pending_request)),
+      headers: { "Authorization" => "Bearer #{raw}" }
+
+    assert_response :forbidden
+  end
+
+  test "blocklist_and_next blocklists selected release and returns new selected result" do
+    SettingsService.set(:auto_select_enabled, true)
+    SettingsService.set(:auto_select_confidence_threshold, 50)
+    SettingsService.set(:auto_select_min_seeders, 1)
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    _token, raw = APIToken.issue!(
+      name: "Admin",
+      user: users(:two),
+      scopes: %w[requests:admin]
+    )
+    request = requests(:pending_request)
+    selected = search_results(:selected_result)
+    fallback = search_results(:pending_result)
+    fallback.update!(confidence_score: 95, detected_language: "en")
+
+    assert_enqueued_with(job: DownloadJob) do
+      post blocklist_and_next_api_v1_request_path(request),
+        headers: { "Authorization" => "Bearer #{raw}" }
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal fallback.id, body.dig("selected_result", "id")
+    assert selected.reload.blocklisted?
+    assert fallback.reload.selected?
+  end
+
+  test "blocklist_and_next returns exhausted request payload" do
+    SettingsService.set(:auto_select_enabled, true)
+    SettingsService.set(:auto_select_confidence_threshold, 50)
+    _token, raw = APIToken.issue!(
+      name: "Admin",
+      user: users(:two),
+      scopes: %w[requests:admin]
+    )
+    book = Book.create!(title: "API Exhausted", book_type: :ebook, open_library_work_id: "OL_API_EXHAUSTED")
+    request = Request.create!(book: book, user: @user, status: :downloading, language: "en")
+    request.search_results.create!(
+      guid: "api-selected-only",
+      title: "API Exhausted EPUB",
+      status: :selected,
+      confidence_score: 95,
+      detected_language: "en",
+      download_url: "http://example.com/api-exhausted.nzb"
+    )
+
+    post blocklist_and_next_api_v1_request_path(request),
+      headers: { "Authorization" => "Bearer #{raw}" }
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal "not_found", body["status"]
+    assert_equal true, body["attention_needed"]
+    assert_includes body["issue_description"], "No suitable alternative"
+  end
+
+  test "blocklist_and_next can grab a specific search result and clear its blocklist" do
+    _token, raw = APIToken.issue!(
+      name: "Admin",
+      user: users(:two),
+      scopes: %w[requests:admin]
+    )
+    request = requests(:pending_request)
+    result = search_results(:blocklisted_result)
+
+    assert_enqueued_with(job: DownloadJob) do
+      post blocklist_and_next_api_v1_request_path(request),
+        headers: { "Authorization" => "Bearer #{raw}" },
+        params: { search_result_id: result.id }
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal result.id, body.dig("selected_result", "id")
+    assert_not result.reload.blocklisted?
+    assert result.selected?
+  end
+
+  test "blocklist_and_next returns 422 for no selected result" do
+    _token, raw = APIToken.issue!(
+      name: "Admin",
+      user: users(:two),
+      scopes: %w[requests:admin]
+    )
+    book = Book.create!(title: "API No Selection", book_type: :ebook, open_library_work_id: "OL_API_NO_SELECTION")
+    request = Request.create!(book: book, user: @user, status: :searching)
+
+    post blocklist_and_next_api_v1_request_path(request),
+      headers: { "Authorization" => "Bearer #{raw}" }
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "No selected result"
+  end
+
+  test "blocklist_and_next with search_result_id returns 422 for undownloadable result" do
+    _token, raw = APIToken.issue!(
+      name: "Admin",
+      user: users(:two),
+      scopes: %w[requests:admin]
+    )
+    request = requests(:pending_request)
+
+    post blocklist_and_next_api_v1_request_path(request),
+      headers: { "Authorization" => "Bearer #{raw}" },
+      params: { search_result_id: search_results(:no_link_result).id }
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "not downloadable"
+  end
+
+  test "blocklist_and_next requires admin scope" do
+    _token, raw = APIToken.issue!(
+      name: "Reader",
+      user: @user,
+      scopes: %w[requests:read]
+    )
+
+    post blocklist_and_next_api_v1_request_path(requests(:pending_request)),
+      headers: { "Authorization" => "Bearer #{raw}" }
+
+    assert_response :forbidden
   end
 end

--- a/test/fixtures/search_results.yml
+++ b/test/fixtures/search_results.yml
@@ -27,3 +27,15 @@ no_link_result:
   size_bytes: 104857600
   seeders: 5
   status: 0
+
+blocklisted_result:
+  request: pending_request
+  guid: "test-guid-4"
+  title: "The Pending Ebook - Failed Release"
+  indexer: "FailedIndexer"
+  size_bytes: 734003200
+  seeders: 30
+  magnet_url: "magnet:?xt=urn:btih:failedrelease123"
+  status: 2
+  blocklisted_at: <%= 1.hour.ago %>
+  blocklist_reason: "Previous download failed"

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -258,6 +258,35 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_not @selected_result.reload.blocklisted?
   end
 
+  test "does not blocklist on LibriVox transient connection error" do
+    @selected_result.update!(
+      source: SearchResult::SOURCE_LIBRIVOX,
+      download_url: "https://archive.org/compress/test_librivox/formats=64KBPS%20MP3"
+    )
+    job = DownloadJob.new
+
+    job.stub(:handle_librivox_download, ->(*) { raise LibrivoxClient::ConnectionError, "offline" }) do
+      job.perform(@download.id)
+    end
+
+    assert @download.reload.failed?
+    assert @request.reload.attention_needed?
+    assert_not @selected_result.reload.blocklisted?
+  end
+
+  test "does not blocklist on transient direct download network error" do
+    @selected_result.update!(source: SearchResult::SOURCE_GUTENBERG, download_url: "https://example.com/book.epub")
+    job = DownloadJob.new
+
+    job.stub(:download_file_via_http, ->(*) { raise Net::OpenTimeout, "execution expired" }) do
+      job.perform(@download.id)
+    end
+
+    assert @download.reload.failed?
+    assert @request.reload.attention_needed?
+    assert_not @selected_result.reload.blocklisted?
+  end
+
   test "does not blocklist on custom provider system response error" do
     @selected_result.update!(source: SearchResult::SOURCE_CUSTOM)
     job = DownloadJob.new

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -281,10 +281,11 @@ class DownloadJobTest < ActiveJob::TestCase
       blocklisted_at: nil,
       blocklist_reason: nil
     )
-    job = DownloadJob.new
 
-    job.stub(:download_file_via_http, ->(*) { raise Net::OpenTimeout, "execution expired" }) do
-      job.perform(@download.id)
+    VCR.turned_off do
+      stub_request(:get, "https://example.com/book.epub").to_timeout
+
+      DownloadJob.perform_now(@download.id)
     end
 
     assert @download.reload.failed?

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -283,7 +283,8 @@ class DownloadJobTest < ActiveJob::TestCase
     )
 
     VCR.turned_off do
-      stub_request(:get, "https://example.com/book.epub").to_timeout
+      stub_request(:get, "https://example.com/book.epub")
+        .to_raise(Timeout::Error.new("execution expired"))
 
       DownloadJob.perform_now(@download.id)
     end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -117,7 +117,22 @@ class DownloadJobTest < ActiveJob::TestCase
       @download.reload
 
       assert @download.downloading?
+      assert_equal @selected_result, @download.search_result
     end
+  end
+
+  test "legacy download without association blocklists resolved selected result on release failure" do
+    SettingsService.set(:auto_select_enabled, false)
+    @download.update!(search_result: nil)
+    job = DownloadJob.new
+
+    job.stub(:handle_standard_download, ->(*) { raise DownloadClients::Base::Error, "client rejected release" }) do
+      job.perform(@download.id)
+    end
+
+    assert @download.reload.failed?
+    assert_equal @selected_result, @download.search_result
+    assert @selected_result.reload.blocklisted?
   end
 
   test "marks for attention when no download client configured" do
@@ -130,6 +145,7 @@ class DownloadJobTest < ActiveJob::TestCase
     assert @download.failed?
     assert @request.attention_needed?
     assert_includes @request.issue_description, "No torrent download client configured"
+    assert_not @selected_result.reload.blocklisted?
   end
 
   test "marks for attention on download client authentication error" do
@@ -141,6 +157,7 @@ class DownloadJobTest < ActiveJob::TestCase
 
     assert @download.reload.failed?
     assert_includes @request.reload.issue_description, "authentication failed"
+    assert_not @selected_result.reload.blocklisted?
   end
 
   test "marks for attention on download client connection error" do
@@ -152,6 +169,7 @@ class DownloadJobTest < ActiveJob::TestCase
 
     assert @download.reload.failed?
     assert_includes @request.reload.issue_description, "Failed to connect"
+    assert_not @selected_result.reload.blocklisted?
   end
 
   test "marks for attention on generic download client error" do
@@ -163,6 +181,31 @@ class DownloadJobTest < ActiveJob::TestCase
 
     assert @download.reload.failed?
     assert_includes @request.reload.issue_description, "Download client error"
+    assert @selected_result.reload.blocklisted?
+  end
+
+  test "generic download client error blocklists release and selects next candidate when auto-select is enabled" do
+    SettingsService.set(:auto_select_enabled, true)
+    SettingsService.set(:auto_select_confidence_threshold, 50)
+    SettingsService.set(:auto_select_min_seeders, 1)
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    fallback = search_results(:pending_result)
+    fallback.update!(confidence_score: 95, detected_language: "en")
+    job = DownloadJob.new
+
+    assert_enqueued_with(job: DownloadJob) do
+      job.stub(:handle_standard_download, ->(*) { raise DownloadClients::Base::Error, "client rejected release" }) do
+        job.perform(@download.id)
+      end
+    end
+
+    assert @download.reload.failed?
+    assert @selected_result.reload.blocklisted?
+    assert fallback.reload.selected?
+    assert @request.reload.downloading?
+    assert_not @request.attention_needed?
   end
 
   test "marks for attention on anna archive error" do
@@ -177,6 +220,19 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_includes @request.reload.issue_description, "Anna's Archive error"
   end
 
+  test "does not blocklist on Anna's Archive transient connection error" do
+    @selected_result.update!(source: SearchResult::SOURCE_ANNA_ARCHIVE, guid: "md5")
+    job = DownloadJob.new
+
+    job.stub(:handle_anna_archive_download, ->(*) { raise AnnaArchiveClient::ConnectionError, "offline" }) do
+      job.perform(@download.id)
+    end
+
+    assert @download.reload.failed?
+    assert @request.reload.attention_needed?
+    assert_not @selected_result.reload.blocklisted?
+  end
+
   test "marks for attention on z-library error" do
     @selected_result.update!(source: SearchResult::SOURCE_ZLIBRARY, guid: "missing")
     job = DownloadJob.new
@@ -187,6 +243,32 @@ class DownloadJobTest < ActiveJob::TestCase
 
     assert @download.reload.failed?
     assert_includes @request.reload.issue_description, "Z-Library error"
+  end
+
+  test "does not blocklist on Z-Library rate limit error" do
+    @selected_result.update!(source: SearchResult::SOURCE_ZLIBRARY, guid: "missing")
+    job = DownloadJob.new
+
+    job.stub(:handle_zlibrary_download, ->(*) { raise ZLibraryClient::RateLimitError, "slow down" }) do
+      job.perform(@download.id)
+    end
+
+    assert @download.reload.failed?
+    assert @request.reload.attention_needed?
+    assert_not @selected_result.reload.blocklisted?
+  end
+
+  test "does not blocklist on custom provider system response error" do
+    @selected_result.update!(source: SearchResult::SOURCE_CUSTOM)
+    job = DownloadJob.new
+
+    job.stub(:handle_custom_provider_download, ->(*) { raise CustomAcquisitionProviderClient::ResponseError, "Provider returned HTTP 500" }) do
+      job.perform(@download.id)
+    end
+
+    assert @download.reload.failed?
+    assert @request.reload.attention_needed?
+    assert_not @selected_result.reload.blocklisted?
   end
 
   test "skips non-queued downloads" do

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -287,6 +287,53 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_not @selected_result.reload.blocklisted?
   end
 
+  test "does not blocklist on LibriVox direct audiobook transient download error" do
+    Dir.mktmpdir do |dir|
+      setup_librivox_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:get, "https://archive.org/compress/test_librivox/formats=64KBPS%20MP3")
+          .to_timeout
+
+        DownloadJob.perform_now(@librivox_download.id)
+      end
+
+      @librivox_download.reload
+      @librivox_request.reload
+      assert @librivox_download.failed?
+      assert @librivox_request.attention_needed?
+      assert_includes @librivox_request.issue_description, "LibriVox download failed"
+      assert_not @librivox_download.search_result.reload.blocklisted?
+    end
+  end
+
+  test "does not blocklist on custom provider direct audiobook transient download error" do
+    Dir.mktmpdir do |dir|
+      setup_custom_provider_audiobook_download(output_path: dir)
+
+      VCR.turned_off do
+        stub_request(:post, "http://provider.test/acquire")
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { download_type: "direct", direct_url: "https://files.test/custom-audiobook.m4b" }.to_json
+          )
+
+        stub_request(:get, "https://files.test/custom-audiobook.m4b")
+          .to_timeout
+
+        DownloadJob.perform_now(@custom_provider_audiobook_download.id)
+      end
+
+      @custom_provider_audiobook_download.reload
+      @custom_provider_audiobook_request.reload
+      assert @custom_provider_audiobook_download.failed?
+      assert @custom_provider_audiobook_request.attention_needed?
+      assert_includes @custom_provider_audiobook_request.issue_description, "Custom provider download failed"
+      assert_not @custom_provider_audiobook_download.search_result.reload.blocklisted?
+    end
+  end
+
   test "does not blocklist on custom provider system response error" do
     @selected_result.update!(source: SearchResult::SOURCE_CUSTOM)
     job = DownloadJob.new

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 require "base64"
 require "bencode"
 require "digest/sha1"
+require "securerandom"
 require "tempfile"
 
 class DownloadJobTest < ActiveJob::TestCase
@@ -275,23 +276,37 @@ class DownloadJobTest < ActiveJob::TestCase
   end
 
   test "does not blocklist on transient direct download network error" do
-    @selected_result.update!(
+    book = Book.create!(
+      title: "Transient Direct Ebook",
+      author: "Network Author",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :downloading)
+    download_url = "https://example.com/#{SecureRandom.hex(8)}.epub"
+    result = request.search_results.create!(
+      guid: "gutenberg-timeout-#{SecureRandom.hex(8)}",
+      title: "Transient Direct Ebook - Network Author [EPUB]",
+      indexer: "Project Gutenberg",
       source: SearchResult::SOURCE_GUTENBERG,
-      download_url: "https://example.com/book.epub",
-      blocklisted_at: nil,
-      blocklist_reason: nil
+      download_url: download_url,
+      status: :selected
+    )
+    download = request.downloads.create!(
+      name: result.title,
+      search_result: result,
+      status: :queued
     )
 
     VCR.turned_off do
-      stub_request(:get, "https://example.com/book.epub")
+      stub_request(:get, download_url)
         .to_raise(Timeout::Error.new("execution expired"))
 
-      DownloadJob.perform_now(@download.id)
+      DownloadJob.perform_now(download.id)
     end
 
-    assert @download.reload.failed?
-    assert @request.reload.attention_needed?
-    assert_not @selected_result.reload.blocklisted?
+    assert download.reload.failed?
+    assert request.reload.attention_needed?
+    assert_not result.reload.blocklisted?
   end
 
   test "does not blocklist on LibriVox direct audiobook transient download error" do

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -275,7 +275,12 @@ class DownloadJobTest < ActiveJob::TestCase
   end
 
   test "does not blocklist on transient direct download network error" do
-    @selected_result.update!(source: SearchResult::SOURCE_GUTENBERG, download_url: "https://example.com/book.epub")
+    @selected_result.update!(
+      source: SearchResult::SOURCE_GUTENBERG,
+      download_url: "https://example.com/book.epub",
+      blocklisted_at: nil,
+      blocklist_reason: nil
+    )
     job = DownloadJob.new
 
     job.stub(:download_file_via_http, ->(*) { raise Net::OpenTimeout, "execution expired" }) do

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -306,7 +306,11 @@ class DownloadJobTest < ActiveJob::TestCase
 
     assert download.reload.failed?
     assert request.reload.attention_needed?
-    assert_not result.reload.blocklisted?
+    result.reload
+    request.reload
+    assert_not result.blocklisted?,
+      "expected transient direct timeout not to blocklist; " \
+      "blocklist_reason=#{result.blocklist_reason.inspect}; issue=#{request.issue_description.inspect}"
   end
 
   test "does not blocklist on LibriVox direct audiobook transient download error" do

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -276,41 +276,44 @@ class DownloadJobTest < ActiveJob::TestCase
   end
 
   test "does not blocklist on transient direct download network error" do
-    book = Book.create!(
-      title: "Transient Direct Ebook",
-      author: "Network Author",
-      book_type: :ebook
-    )
-    request = Request.create!(book: book, user: users(:one), status: :downloading)
-    download_url = "https://example.com/#{SecureRandom.hex(8)}.epub"
-    result = request.search_results.create!(
-      guid: "gutenberg-timeout-#{SecureRandom.hex(8)}",
-      title: "Transient Direct Ebook - Network Author [EPUB]",
-      indexer: "Project Gutenberg",
-      source: SearchResult::SOURCE_GUTENBERG,
-      download_url: download_url,
-      status: :selected
-    )
-    download = request.downloads.create!(
-      name: result.title,
-      search_result: result,
-      status: :queued
-    )
+    Dir.mktmpdir do |dir|
+      SettingsService.set(:ebook_output_path, dir)
+      book = Book.create!(
+        title: "Transient Direct Ebook",
+        author: "Network Author",
+        book_type: :ebook
+      )
+      request = Request.create!(book: book, user: users(:one), status: :downloading)
+      download_url = "https://example.com/#{SecureRandom.hex(8)}.epub"
+      result = request.search_results.create!(
+        guid: "gutenberg-timeout-#{SecureRandom.hex(8)}",
+        title: "Transient Direct Ebook - Network Author [EPUB]",
+        indexer: "Project Gutenberg",
+        source: SearchResult::SOURCE_GUTENBERG,
+        download_url: download_url,
+        status: :selected
+      )
+      download = request.downloads.create!(
+        name: result.title,
+        search_result: result,
+        status: :queued
+      )
 
-    VCR.turned_off do
-      stub_request(:get, download_url)
-        .to_raise(Timeout::Error.new("execution expired"))
+      VCR.turned_off do
+        stub_request(:get, download_url)
+          .to_raise(Timeout::Error.new("execution expired"))
 
-      DownloadJob.perform_now(download.id)
+        DownloadJob.perform_now(download.id)
+      end
+
+      assert download.reload.failed?
+      assert request.reload.attention_needed?
+      result.reload
+      request.reload
+      assert_not result.blocklisted?,
+        "expected transient direct timeout not to blocklist; " \
+        "blocklist_reason=#{result.blocklist_reason.inspect}; issue=#{request.issue_description.inspect}"
     end
-
-    assert download.reload.failed?
-    assert request.reload.attention_needed?
-    result.reload
-    request.reload
-    assert_not result.blocklisted?,
-      "expected transient direct timeout not to blocklist; " \
-      "blocklist_reason=#{result.blocklist_reason.inspect}; issue=#{request.issue_description.inspect}"
   end
 
   test "does not blocklist on LibriVox direct audiobook transient download error" do

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -134,6 +134,36 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     end
   end
 
+  test "missing download after threshold blocklists release and selects next candidate" do
+    SettingsService.set(:auto_select_enabled, true)
+    SettingsService.set(:auto_select_confidence_threshold, 50)
+    SettingsService.set(:auto_select_min_seeders, 1)
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    selected = search_results(:selected_result)
+    fallback = search_results(:pending_result)
+    fallback.update!(confidence_score: 95, detected_language: "en")
+    @download.update!(
+      search_result: selected,
+      not_found_count: DownloadMonitorJob::NOT_FOUND_THRESHOLD - 1
+    )
+
+    VCR.turned_off do
+      stub_qbittorrent_auth
+      stub_qbittorrent_torrent_not_found
+
+      assert_enqueued_with(job: DownloadJob) do
+        DownloadMonitorJob.perform_now
+      end
+    end
+
+    assert @download.reload.failed?
+    assert selected.reload.blocklisted?
+    assert fallback.reload.selected?
+    assert @request.reload.downloading?
+  end
+
   test "resets not_found_count when download is found again" do
     @download.update!(not_found_count: 2)
 
@@ -162,6 +192,33 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
       assert @request.attention_needed?
       assert_includes @request.issue_description, "failed in client"
     end
+  end
+
+  test "client-reported failure blocklists release and selects next candidate" do
+    SettingsService.set(:auto_select_enabled, true)
+    SettingsService.set(:auto_select_confidence_threshold, 50)
+    SettingsService.set(:auto_select_min_seeders, 1)
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    selected = search_results(:selected_result)
+    fallback = search_results(:pending_result)
+    fallback.update!(confidence_score: 95, detected_language: "en")
+    @download.update!(search_result: selected)
+
+    VCR.turned_off do
+      stub_qbittorrent_auth
+      stub_qbittorrent_torrent_info(progress: 0, state: "error")
+
+      assert_enqueued_with(job: DownloadJob) do
+        DownloadMonitorJob.perform_now
+      end
+    end
+
+    assert @download.reload.failed?
+    assert selected.reload.blocklisted?
+    assert fallback.reload.selected?
+    assert @request.reload.downloading?
   end
 
   test "marks transmission download as failed when client reports local error" do
@@ -355,10 +412,12 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
   end
 
   test "flags queued downloads that never reached a client" do
+    selected = search_results(:selected_result)
     @download.update_columns(
       status: Download.statuses[:queued],
       external_id: nil,
       download_client_id: nil,
+      search_result_id: selected.id,
       created_at: 10.minutes.ago,
       updated_at: 10.minutes.ago
     )
@@ -375,6 +434,7 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     assert @download.failed?
     assert @request.attention_needed?
     assert_includes @request.issue_description, "never sent to the download client"
+    assert_not selected.reload.blocklisted?
   end
 
   test "skips downloads with disabled client" do

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -85,6 +85,33 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "save_results carries blocklist forward by guid" do
+    blocklisted = search_results(:blocklisted_result)
+    blocklisted.update!(blocklisted_at: 2.days.ago, blocklist_reason: "Bad release")
+    tagged_result = {
+      source: SearchResult::SOURCE_PROWLARR,
+      result: OpenStruct.new(
+        guid: blocklisted.guid,
+        title: "The Pending Ebook Another Author EPUB",
+        indexer: "TestIndexer",
+        size_bytes: 123_456,
+        seeders: 10,
+        leechers: 1,
+        download_url: nil,
+        magnet_url: "magnet:?xt=urn:btih:carried",
+        info_url: nil,
+        published_at: nil
+      )
+    }
+
+    SearchJob.new.send(:save_results, @request, [ tagged_result ])
+
+    carried = @request.search_results.find_by!(guid: blocklisted.guid)
+    assert carried.blocklisted?
+    assert_equal "Bad release", carried.blocklist_reason
+    assert carried.rejected?
+  end
+
   test "schedules retry when no results found" do
     VCR.turned_off do
       stub_prowlarr_search_empty

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class SearchJobTest < ActiveJob::TestCase
   setup do
     @request = requests(:pending_request)
+    @request.search_results.blocklisted.destroy_all
     SettingsService.set(:prowlarr_url, "http://localhost:9696")
     SettingsService.set(:prowlarr_api_key, "test-key")
     SettingsService.set(:zlibrary_enabled, false)
@@ -85,13 +86,39 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "save_results preserves blocklist for guid absent from refreshed search" do
+    blocklisted = @request.search_results.create!(
+      guid: "persist-blocklist-guid",
+      title: "Failed Release",
+      indexer: "FailedIndexer",
+      magnet_url: "magnet:?xt=urn:btih:persist",
+      status: :rejected,
+      blocklisted_at: 2.days.ago,
+      blocklist_reason: "Bad release"
+    )
+
+    SearchJob.new.send(:save_results, @request, [])
+
+    carried = @request.search_results.find_by!(guid: blocklisted.guid)
+    assert carried.blocklisted?
+    assert_equal "Bad release", carried.blocklist_reason
+    assert carried.rejected?
+  end
+
   test "save_results carries blocklist forward by guid" do
-    blocklisted = search_results(:blocklisted_result)
-    blocklisted.update!(blocklisted_at: 2.days.ago, blocklist_reason: "Bad release")
+    blocklisted = @request.search_results.create!(
+      guid: "carry-blocklist-guid",
+      title: "Failed Release",
+      indexer: "FailedIndexer",
+      magnet_url: "magnet:?xt=urn:btih:carry",
+      status: :rejected,
+      blocklisted_at: 2.days.ago,
+      blocklist_reason: "Bad release"
+    )
     tagged_result = {
       source: SearchResult::SOURCE_PROWLARR,
       result: OpenStruct.new(
-        guid: blocklisted.guid,
+        guid: "carry-blocklist-guid",
         title: "The Pending Ebook Another Author EPUB",
         indexer: "TestIndexer",
         size_bytes: 123_456,
@@ -106,7 +133,7 @@ class SearchJobTest < ActiveJob::TestCase
 
     SearchJob.new.send(:save_results, @request, [ tagged_result ])
 
-    carried = @request.search_results.find_by!(guid: blocklisted.guid)
+    carried = @request.search_results.find_by!(guid: "carry-blocklist-guid")
     assert carried.blocklisted?
     assert_equal "Bad release", carried.blocklist_reason
     assert carried.rejected?

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -105,6 +105,22 @@ class SearchJobTest < ActiveJob::TestCase
     assert carried.rejected?
   end
 
+  test "save_results preserves selected result absent from refreshed search" do
+    selected = @request.search_results.create!(
+      guid: "persist-selected-guid",
+      title: "Downloading Release",
+      indexer: "TestIndexer",
+      magnet_url: "magnet:?xt=urn:btih:selected",
+      status: :selected
+    )
+    download = @request.downloads.create!(name: selected.title, search_result: selected, status: :downloading)
+
+    SearchJob.new.send(:save_results, @request, [])
+
+    assert selected.reload.selected?
+    assert_equal selected.id, download.reload.search_result_id
+  end
+
   test "save_results carries blocklist forward by guid" do
     blocklisted = @request.search_results.create!(
       guid: "carry-blocklist-guid",

--- a/test/models/request_download_failure_test.rb
+++ b/test/models/request_download_failure_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RequestDownloadFailureTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    SettingsService.set(:auto_select_confidence_threshold, 50)
+    SettingsService.set(:auto_select_min_seeders, 1)
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    SettingsService.set(:preferred_download_types, %w[torrent usenet direct])
+    clear_enqueued_jobs
+  end
+
+  test "handle_download_failure blocklists selected release and selects next candidate" do
+    SettingsService.set(:auto_select_enabled, true)
+    request = build_request
+    selected = create_result(request, guid: "failed", status: :selected, seeders: 100)
+    fallback = create_result(request, guid: "fallback", status: :rejected, seeders: 20)
+    failed_download = request.downloads.create!(name: selected.title, search_result: selected, status: :failed)
+
+    outcome = nil
+    assert_difference -> { request.request_events.where(event_type: "release_blocklisted").count }, 1 do
+      assert_difference -> { request.downloads.count }, 1 do
+        assert_enqueued_with(job: DownloadJob) do
+          outcome = request.handle_download_failure!(failed_download, reason: "Dead torrent")
+        end
+      end
+    end
+
+    assert_equal :selected_next, outcome
+    assert selected.reload.blocklisted?
+    assert selected.rejected?
+    assert_equal "Dead torrent", selected.blocklist_reason
+    assert fallback.reload.selected?
+    assert request.reload.downloading?
+    assert_not request.attention_needed?
+  end
+
+  test "handle_download_failure never reselects a blocklisted candidate" do
+    SettingsService.set(:auto_select_enabled, true)
+    request = build_request
+    selected = create_result(request, guid: "failed", status: :selected, seeders: 100)
+    blocklisted = create_result(request, guid: "blocked", status: :rejected, seeders: 90)
+    blocklisted.blocklist!("Already failed")
+    fallback = create_result(request, guid: "fallback", status: :rejected, seeders: 10)
+    failed_download = request.downloads.create!(name: selected.title, search_result: selected, status: :failed)
+
+    request.handle_download_failure!(failed_download, reason: "Rejected by client")
+
+    assert blocklisted.reload.rejected?
+    assert fallback.reload.selected?
+  end
+
+  test "handle_download_failure marks not_found when alternatives are exhausted" do
+    SettingsService.set(:auto_select_enabled, true)
+    request = build_request
+    selected = create_result(request, guid: "failed", status: :selected, seeders: 100)
+    blocked = create_result(request, guid: "blocked", status: :rejected, seeders: 20)
+    blocked.blocklist!("Already failed")
+    failed_download = request.downloads.create!(name: selected.title, search_result: selected, status: :failed)
+
+    outcome = request.handle_download_failure!(failed_download, reason: "Dead torrent")
+
+    assert_equal :exhausted, outcome
+    assert request.reload.not_found?
+    assert request.attention_needed?
+    assert_includes request.issue_description, "2 release(s) blocklisted"
+    assert_includes request.issue_description, "No suitable alternative"
+  end
+
+  test "handle_download_failure with auto-select disabled blocklists and flags manual review" do
+    SettingsService.set(:auto_select_enabled, false)
+    request = build_request
+    selected = create_result(request, guid: "failed", status: :selected, seeders: 100)
+    create_result(request, guid: "fallback", status: :rejected, seeders: 20)
+    failed_download = request.downloads.create!(name: selected.title, search_result: selected, status: :failed)
+
+    assert_no_difference -> { request.downloads.count } do
+      outcome = request.handle_download_failure!(failed_download, reason: "Dead torrent")
+      assert_equal :manual_review, outcome
+    end
+
+    assert selected.reload.blocklisted?
+    assert request.reload.attention_needed?
+    assert_includes request.issue_description, "Select another release manually"
+  end
+
+  test "handle_download_failure skips nil search result without crashing" do
+    SettingsService.set(:auto_select_enabled, false)
+    request = build_request
+    failed_download = request.downloads.create!(name: "Legacy download", search_result: nil, status: :failed)
+
+    outcome = request.handle_download_failure!(failed_download, reason: "Legacy failure")
+
+    assert_equal :manual_review, outcome
+    assert request.reload.attention_needed?
+    assert_equal 0, request.search_results.blocklisted.count
+  end
+
+  test "handle_download_failure is idempotent for an already blocklisted release" do
+    SettingsService.set(:auto_select_enabled, false)
+    request = build_request
+    selected = create_result(request, guid: "failed", status: :selected, seeders: 100)
+    failed_download = request.downloads.create!(name: selected.title, search_result: selected, status: :failed)
+
+    request.handle_download_failure!(failed_download, reason: "First failure")
+
+    assert_no_difference -> { request.request_events.where(event_type: "release_blocklisted").count } do
+      request.handle_download_failure!(failed_download, reason: "Second failure")
+    end
+
+    assert_equal "First failure", selected.reload.blocklist_reason
+  end
+
+  test "blocklist_and_select_next cancels active downloads and runs selection even when auto-select is disabled" do
+    SettingsService.set(:auto_select_enabled, false)
+    request = build_request
+    selected = create_result(request, guid: "failed", status: :selected, seeders: 100)
+    fallback = create_result(request, guid: "fallback", status: :rejected, seeders: 20)
+    active_download = request.downloads.create!(name: selected.title, search_result: selected, status: :queued)
+
+    outcome = nil
+    assert_difference -> { request.downloads.count }, 1 do
+      assert_enqueued_with(job: DownloadJob) do
+        outcome = request.blocklist_and_select_next!(reason: "Blocklisted manually")
+      end
+    end
+
+    assert_equal :selected_next, outcome
+    assert active_download.reload.failed?
+    assert selected.reload.blocklisted?
+    assert fallback.reload.selected?
+  end
+
+  test "blocklist_and_select_next returns no_selected_result without a selection" do
+    SettingsService.set(:auto_select_enabled, true)
+    request = build_request(status: :searching)
+
+    assert_equal :no_selected_result, request.blocklist_and_select_next!(reason: "No selected release")
+  end
+
+  private
+
+  def build_request(status: :downloading)
+    book = Book.create!(title: "Fallback Book", author: "Fallback Author", book_type: :ebook, open_library_work_id: SecureRandom.uuid)
+    Request.create!(book: book, user: users(:one), status: status, language: "en")
+  end
+
+  def create_result(request, attrs)
+    request.search_results.create!({
+      guid: SecureRandom.uuid,
+      title: "Fallback Book Fallback Author EPUB",
+      indexer: "TestIndexer",
+      status: :pending,
+      confidence_score: 95,
+      detected_language: "en",
+      magnet_url: "magnet:?xt=urn:btih:#{SecureRandom.hex(20)}"
+    }.merge(attrs))
+  end
+end

--- a/test/models/request_retry_test.rb
+++ b/test/models/request_retry_test.rb
@@ -209,7 +209,13 @@ class RequestRetryTest < ActiveSupport::TestCase
     assert_equal [ request ], attention_requests
   end
 
-  test "retry_now! retries download when there is a selected result and failed download" do
+  test "retry_now! blocklists failed selected result and grabs next candidate" do
+    SettingsService.set(:auto_select_enabled, true)
+    SettingsService.set(:auto_select_confidence_threshold, 50)
+    SettingsService.set(:auto_select_min_seeders, 1)
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
     book = Book.create!(title: "Test Book", book_type: :ebook, open_library_work_id: "OL_RETRY_DL")
     request = Request.create!(
       book: book,
@@ -226,14 +232,22 @@ class RequestRetryTest < ActiveSupport::TestCase
       status: :selected,
       download_url: "http://example.com/test.nzb"
     )
+    fallback_result = request.search_results.create!(
+      guid: "test-guid-retry-next",
+      title: "Test Result Next",
+      status: :rejected,
+      confidence_score: 95,
+      detected_language: "en",
+      download_url: "http://example.com/test-next.nzb"
+    )
 
     # Create a failed download
-    failed_download = request.downloads.create!(
+    request.downloads.create!(
       name: "Test Download",
+      search_result: search_result,
       status: :failed
     )
 
-    # Retry should create a new download and queue the job
     assert_difference -> { request.downloads.count }, 1 do
       assert_enqueued_with(job: DownloadJob) do
         request.retry_now!
@@ -245,10 +259,69 @@ class RequestRetryTest < ActiveSupport::TestCase
     assert_not request.attention_needed?
     assert_nil request.issue_description
 
-    # New download should be queued
+    assert search_result.reload.blocklisted?
+    assert search_result.rejected?
+    assert fallback_result.reload.selected?
+
     new_download = request.downloads.order(created_at: :desc).first
     assert new_download.queued?
-    assert_equal search_result.title, new_download.name
+    assert_equal fallback_result.title, new_download.name
+  end
+
+  test "retry_now! blocklists failed selected result and restarts search when auto-select is disabled" do
+    SettingsService.set(:auto_select_enabled, false)
+    book = Book.create!(title: "Test Book Retry Off", book_type: :ebook, open_library_work_id: "OL_RETRY_OFF")
+    request = Request.create!(
+      book: book,
+      user: users(:one),
+      status: :downloading,
+      attention_needed: true,
+      issue_description: "Download failed"
+    )
+    search_result = request.search_results.create!(
+      guid: "test-guid-retry-off",
+      title: "Test Result",
+      status: :selected,
+      download_url: "http://example.com/test.nzb"
+    )
+    request.downloads.create!(name: "Test Download", search_result: search_result, status: :failed)
+
+    request.retry_now!
+
+    assert request.reload.pending?
+    assert search_result.reload.blocklisted?
+    assert_not request.attention_needed?
+  end
+
+  test "retry_now! does not blocklist selected result because of an older unrelated failed download" do
+    SettingsService.set(:auto_select_enabled, true)
+    book = Book.create!(title: "Test Book Retry Stale", book_type: :ebook, open_library_work_id: "OL_RETRY_STALE")
+    request = Request.create!(
+      book: book,
+      user: users(:one),
+      status: :downloading,
+      attention_needed: true,
+      issue_description: "Old failure"
+    )
+    old_result = request.search_results.create!(
+      guid: "test-guid-old-failed",
+      title: "Old failed result",
+      status: :rejected,
+      download_url: "http://example.com/old.nzb"
+    )
+    selected_result = request.search_results.create!(
+      guid: "test-guid-new-selected",
+      title: "New selected result",
+      status: :selected,
+      download_url: "http://example.com/new.nzb"
+    )
+    request.downloads.create!(name: old_result.title, search_result: old_result, status: :failed)
+
+    request.retry_now!
+
+    assert request.reload.pending?
+    assert_not selected_result.reload.blocklisted?
+    assert_not old_result.reload.blocklisted?
   end
 
   test "retry_now! restarts search when there is a selected result but no failed download" do

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -52,6 +52,15 @@ class SearchResultTest < ActiveSupport::TestCase
     assert_not_includes selectable, @selected_result
   end
 
+  test "blocklisted scopes split eligible and blocklisted results" do
+    blocklisted = search_results(:blocklisted_result)
+
+    assert_includes SearchResult.blocklisted, blocklisted
+    assert_not_includes SearchResult.blocklisted, @pending_result
+    assert_includes SearchResult.not_blocklisted, @pending_result
+    assert_not_includes SearchResult.not_blocklisted, blocklisted
+  end
+
   test "best_first orders by seeders desc then size asc" do
     request = requests(:pending_request)
     request.search_results.destroy_all
@@ -210,6 +219,29 @@ class SearchResultTest < ActiveSupport::TestCase
 
   test "downloadable? returns true when magnet_url present" do
     assert @pending_result.downloadable?
+  end
+
+  test "blocklist! records timestamp and reason and rejects selected result" do
+    long_reason = "x" * 300
+
+    freeze_time do
+      @selected_result.blocklist!(long_reason)
+
+      assert @selected_result.reload.blocklisted?
+      assert_equal Time.current, @selected_result.blocklisted_at
+      assert_equal 255, @selected_result.blocklist_reason.length
+      assert @selected_result.rejected?
+    end
+  end
+
+  test "clear_blocklist! removes blocklist fields" do
+    result = search_results(:blocklisted_result)
+
+    result.clear_blocklist!
+
+    assert_not result.reload.blocklisted?
+    assert_nil result.blocklisted_at
+    assert_nil result.blocklist_reason
   end
 
   test "downloadable? returns true when download_url present" do

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -182,6 +182,30 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert_equal high_seeder, selection.search_result
   end
 
+  test "skips blocklisted best candidate and selects next eligible result" do
+    blocklisted = create_search_result(seeders: 100, magnet_url: "magnet:?blocked")
+    blocklisted.blocklist!("Previous failure")
+    fallback = create_search_result(seeders: 10, magnet_url: "magnet:?fallback")
+
+    selection = AutoSelectService.call(@request)
+
+    assert selection.success?
+    assert_equal fallback, selection.search_result
+    assert blocklisted.reload.blocklisted?
+    assert fallback.reload.selected?
+  end
+
+  test "returns no matching results when all matching candidates are blocklisted" do
+    blocklisted = create_search_result(seeders: 100, magnet_url: "magnet:?blocked")
+    blocklisted.blocklist!("Previous failure")
+
+    selection = AutoSelectService.call(@request)
+
+    refute selection.success?
+    assert_equal :no_matching_results, selection.reason
+    assert_equal 0, @request.downloads.count
+  end
+
   test "rejects other results when selecting" do
     selected = create_search_result(seeders: 100, magnet_url: "magnet:?best")
     other1 = create_search_result(seeders: 50, magnet_url: "magnet:?other1")


### PR DESCRIPTION
## Summary

- Add per-request release blocklisting on `SearchResult` and exclude blocklisted rows from auto-select.
- On release-attributable download failures, blocklist the failed release, revive non-blocklisted candidates, and grab the next eligible result until exhaustion.
- Add API endpoints to list candidate releases and blocklist-and-next or explicitly grab a result.
- Preserve blocklists across normal search result replacement by matching release GUIDs, while admin refresh still resets search results.

Fixes #329

## Validation

- `bin/rails db:migrate`
- `bin/rails test`
- `bin/quality commit --staged`
- `bin/quality push`