### PR TITLE
[codex] Improve indexer search broadening

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -3,6 +3,35 @@
 class SearchJob < ApplicationJob
   queue_as :default
 
+  SearchAttempt = Data.define(:name, :query, :score_penalty)
+
+  GENERIC_SEARCH_ATTEMPT_PENALTIES = {
+    exact_title: 0,
+    title_author: 5,
+    author_title: 8,
+    normalized_title: 10,
+    number_variant: 12
+  }.freeze
+
+  ROMAN_NUMERALS = {
+    "I" => "1",
+    "II" => "2",
+    "III" => "3",
+    "IV" => "4",
+    "V" => "5",
+    "VI" => "6",
+    "VII" => "7",
+    "VIII" => "8",
+    "IX" => "9",
+    "X" => "10",
+    "XI" => "11",
+    "XII" => "12",
+    "XIII" => "13",
+    "XIV" => "14",
+    "XV" => "15"
+  }.freeze
+  ARABIC_NUMERALS = ROMAN_NUMERALS.invert.freeze
+
   def perform(request_id)
     request = Request.find_by(id: request_id)
     return unless request
@@ -105,13 +134,13 @@ class SearchJob < ApplicationJob
 
   def search_indexer(request)
     if IndexerClient.provider == SearchResult::SOURCE_PROWLARR
-      results = search_prowlarr(request)
+      tagged_results = search_prowlarr(request)
     else
-      results = search_generic_indexer(request)
+      tagged_results = search_generic_indexer(request)
     end
 
-    results.map do |r|
-      { result: r, source: IndexerClient.provider }
+    tagged_results.map do |tagged|
+      tagged.merge(source: IndexerClient.provider)
     end
   end
 
@@ -122,12 +151,15 @@ class SearchJob < ApplicationJob
 
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} book query for title='#{book.title}' author='#{book.author}' extra='#{query}' (type: #{book.book_type})"
 
-    structured_results = IndexerClient.search(
-      query,
-      book_type: book.book_type,
-      categories: categories,
-      title: book.title,
-      author: book.author
+    structured_results = tag_indexer_results(
+      IndexerClient.search(
+        query,
+        book_type: book.book_type,
+        categories: categories,
+        title: book.title,
+        author: book.author
+      ),
+      attempt: SearchAttempt.new(name: :structured_book, query: query, score_penalty: 0)
     )
 
     fallback_query = generic_indexer_query(request)
@@ -135,13 +167,13 @@ class SearchJob < ApplicationJob
 
     if structured_results.empty?
       Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search returned no results for request ##{request.id}; retrying with generic query '#{fallback_query}'"
-      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type, categories: categories))
+      results = merge_indexer_results(results, search_generic_indexer_attempts(request, categories: categories, starting_results: results))
     elsif book.ebook?
       Rails.logger.info "[SearchJob] #{IndexerClient.display_name} ebook search found #{structured_results.count} structured results for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
-      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type, categories: categories))
+      results = merge_indexer_results(results, search_generic_indexer_attempts(request, categories: categories, starting_results: results))
     elsif !strong_indexer_match?(results, request)
       Rails.logger.info "[SearchJob] #{IndexerClient.display_name} book search found no strong match for request ##{request.id}; supplementing with generic query '#{fallback_query}'"
-      results = merge_indexer_results(results, IndexerClient.search(fallback_query, book_type: book.book_type, categories: categories))
+      results = merge_indexer_results(results, search_generic_indexer_attempts(request, categories: categories, starting_results: results))
     end
 
     finalize_indexer_results(request, results)
@@ -153,7 +185,7 @@ class SearchJob < ApplicationJob
     categories = primary_indexer_categories(request)
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} for: #{query} (type: #{book.book_type})"
 
-    results = IndexerClient.search(query, book_type: book.book_type, categories: categories)
+    results = search_generic_indexer_attempts(request, categories: categories)
     finalize_indexer_results(request, results)
   end
 
@@ -286,6 +318,7 @@ class SearchJob < ApplicationJob
           search_result.update!(blocklist_attrs.merge(status: :rejected))
         end
         search_result.calculate_score!
+        apply_search_attempt_penalty!(search_result, tagged)
       end
     end
   end
@@ -489,12 +522,13 @@ class SearchJob < ApplicationJob
   def merge_indexer_results(*result_groups)
     seen = {}
 
-    result_groups.flatten.each_with_object([]) do |result, merged|
+    result_groups.flatten.compact.each_with_object([]) do |tagged_result, merged|
+      result = indexer_result_from(tagged_result)
       key = result.guid.presence || [ result.indexer, result.title, result.download_link ].join("|")
       next if seen[key]
 
       seen[key] = true
-      merged << result
+      merged << normalize_tagged_indexer_result(tagged_result)
     end
   end
 
@@ -506,10 +540,10 @@ class SearchJob < ApplicationJob
   def supplement_with_broad_search(request, results)
     return results unless SettingsService.broad_indexer_search_scope?
 
-    query = generic_indexer_query(request)
-    Rails.logger.info "[SearchJob] Supplementing #{IndexerClient.display_name} search for request ##{request.id} without category restrictions using '#{query}'"
+    attempts = generic_indexer_attempts(request)
+    Rails.logger.info "[SearchJob] Supplementing #{IndexerClient.display_name} search for request ##{request.id} without category restrictions using '#{attempts.first.query}'"
 
-    broad_results = IndexerClient.search(query, categories: [])
+    broad_results = search_generic_indexer_attempts(request, categories: [], starting_results: results, attempts: attempts)
     merge_indexer_results(results, filter_broad_results(broad_results, request))
   rescue IndexerClients::Base::Error => e
     Rails.logger.warn "[SearchJob] #{IndexerClient.display_name} broad search failed for request ##{request.id}: #{e.message}"
@@ -524,6 +558,7 @@ class SearchJob < ApplicationJob
     threshold = SettingsService.get(:min_match_confidence)
 
     Array(results).any? do |result|
+      result = indexer_result_from(result)
       next false if SettingsService.unrestricted_indexer_search_scope? &&
         !compatible_result_categories?(result, request.book.book_type)
 
@@ -545,8 +580,9 @@ class SearchJob < ApplicationJob
     threshold = SettingsService.get(:min_match_confidence)
 
     Array(results).select do |result|
-      compatible_result_categories?(result, request.book.book_type) &&
-        ReleaseScorer.score(search_result_for_scoring(result), request).total >= threshold
+      indexer_result = indexer_result_from(result)
+      compatible_result_categories?(indexer_result, request.book.book_type) &&
+        ReleaseScorer.score(search_result_for_scoring(indexer_result), request).total >= threshold
     end
   end
 
@@ -563,5 +599,126 @@ class SearchJob < ApplicationJob
     else
       true
     end
+  end
+
+  def search_generic_indexer_attempts(request, categories:, starting_results: [], attempts: nil)
+    attempts ||= generic_indexer_attempts(request)
+
+    attempts.each_with_object([]) do |attempt, results|
+      Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} generic query '#{attempt.query}' for request ##{request.id} (attempt: #{attempt.name})"
+
+      attempt_results = tag_indexer_results(
+        IndexerClient.search(attempt.query, book_type: request.book.book_type, categories: categories),
+        attempt: attempt
+      )
+      results.replace(merge_indexer_results(results, attempt_results))
+
+      combined_results = merge_indexer_results(starting_results, results)
+      break results if strong_indexer_match?(combined_results, request)
+    end
+  end
+
+  def generic_indexer_attempts(request)
+    book = request.book
+    language_hint = indexer_language_hint(request)
+    attempts = [
+      build_search_attempt(:exact_title, [ book.title, language_hint ]),
+      build_search_attempt(:title_author, [ book.title, book.author, language_hint ]),
+      build_search_attempt(:author_title, [ book.author, book.title, language_hint ]),
+      build_search_attempt(:normalized_title, [ normalized_search_title(book.title), language_hint ])
+    ]
+
+    numeric_title_variants(book.title).each do |title_variant|
+      attempts << build_search_attempt(:number_variant, [ title_variant, language_hint ])
+      attempts << build_search_attempt(:number_variant, [ title_variant, book.author, language_hint ])
+    end
+
+    deduplicate_search_attempts(attempts)
+  end
+
+  def build_search_attempt(name, parts)
+    query = parts.compact_blank.join(" ").squish
+    SearchAttempt.new(
+      name: name,
+      query: query,
+      score_penalty: GENERIC_SEARCH_ATTEMPT_PENALTIES.fetch(name, 0)
+    )
+  end
+
+  def deduplicate_search_attempts(attempts)
+    seen = {}
+    attempts.select do |attempt|
+      normalized_query = attempt.query.downcase
+      next false if attempt.query.blank? || seen[normalized_query]
+
+      seen[normalized_query] = true
+    end
+  end
+
+  def normalized_search_title(title)
+    title.to_s
+      .gsub(/\([^)]*\)|\[[^\]]*\]/, " ")
+      .gsub(/\b(?:volume|vol\.?|book|part)\s+(\d+)\b/i, "\\1")
+      .gsub(/[[:punct:]]+/, " ")
+      .squish
+  end
+
+  def numeric_title_variants(title)
+    values = Set.new
+    text = title.to_s
+
+    ROMAN_NUMERALS.each do |roman, number|
+      values << text.gsub(/\b#{Regexp.escape(roman)}\b/i, number) if text.match?(/\b#{Regexp.escape(roman)}\b/i)
+    end
+
+    ARABIC_NUMERALS.each do |number, roman|
+      values << text.gsub(/\b#{Regexp.escape(number)}\b/, roman) if text.match?(/\b#{Regexp.escape(number)}\b/)
+    end
+
+    values.delete(text)
+    values.first(6)
+  end
+
+  def tag_indexer_results(results, attempt:)
+    Array(results).map do |result|
+      {
+        result: result,
+        score_penalty: attempt.score_penalty,
+        search_attempt: attempt.name.to_s,
+        search_query: attempt.query
+      }
+    end
+  end
+
+  def normalize_tagged_indexer_result(tagged_result)
+    return tagged_result if tagged_result.is_a?(Hash) && tagged_result.key?(:result)
+
+    {
+      result: tagged_result,
+      score_penalty: 0,
+      search_attempt: "unknown",
+      search_query: nil
+    }
+  end
+
+  def indexer_result_from(tagged_result)
+    tagged_result.is_a?(Hash) && tagged_result.key?(:result) ? tagged_result[:result] : tagged_result
+  end
+
+  def apply_search_attempt_penalty!(search_result, tagged)
+    penalty = tagged[:score_penalty].to_i
+    attempt = tagged[:search_attempt]
+    query = tagged[:search_query]
+    return if penalty <= 0 && attempt.blank? && query.blank?
+
+    breakdown = search_result.score_breakdown || {}
+    breakdown["search_attempt"] = attempt
+    breakdown["search_query"] = query
+    breakdown["search_penalty"] = penalty
+
+    search_result.update!(
+      confidence_score: [ search_result.confidence_score.to_i - penalty, 0 ].max,
+      score_breakdown: breakdown
+    )
   end
 end

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -31,6 +31,9 @@ class SearchJob < ApplicationJob
     "XV" => "15"
   }.freeze
   ARABIC_NUMERALS = ROMAN_NUMERALS.invert.freeze
+  # Standalone "I" is almost always the pronoun ("I, Robot"), not a series number,
+  # so it is excluded when generating roman -> arabic query variants.
+  ROMAN_VARIANT_NUMERALS = ROMAN_NUMERALS.except("I").freeze
 
   def perform(request_id)
     request = Request.find_by(id: request_id)
@@ -541,6 +544,8 @@ class SearchJob < ApplicationJob
     return results unless SettingsService.broad_indexer_search_scope?
 
     attempts = generic_indexer_attempts(request)
+    return results if attempts.empty?
+
     Rails.logger.info "[SearchJob] Supplementing #{IndexerClient.display_name} search for request ##{request.id} without category restrictions using '#{attempts.first.query}'"
 
     broad_results = search_generic_indexer_attempts(request, categories: [], starting_results: results, attempts: attempts)
@@ -557,14 +562,24 @@ class SearchJob < ApplicationJob
   def strong_indexer_match?(results, request)
     threshold = SettingsService.get(:min_match_confidence)
 
-    Array(results).any? do |result|
-      result = indexer_result_from(result)
+    Array(results).any? do |tagged_result|
+      result = indexer_result_from(tagged_result)
       next false if SettingsService.unrestricted_indexer_search_scope? &&
         !compatible_result_categories?(result, request.book.book_type)
 
-      score_result = ReleaseScorer.score(search_result_for_scoring(result), request)
-      score_result.total >= threshold
+      penalized_indexer_score(tagged_result, request) >= threshold
     end
+  end
+
+  # Scores a result the same way save_results will persist it: the raw
+  # ReleaseScorer total minus the search attempt penalty. Keeping threshold
+  # checks on the penalized score prevents broadened attempts from stopping
+  # the search with a result that ends up stored below the confidence threshold.
+  def penalized_indexer_score(tagged_result, request)
+    result = indexer_result_from(tagged_result)
+    score = ReleaseScorer.score(search_result_for_scoring(result), request).total
+    penalty = tagged_result.is_a?(Hash) ? tagged_result[:score_penalty].to_i : 0
+    [ score - penalty, 0 ].max
   end
 
   def search_result_for_scoring(result)
@@ -579,10 +594,10 @@ class SearchJob < ApplicationJob
   def filter_broad_results(results, request)
     threshold = SettingsService.get(:min_match_confidence)
 
-    Array(results).select do |result|
-      indexer_result = indexer_result_from(result)
+    Array(results).select do |tagged_result|
+      indexer_result = indexer_result_from(tagged_result)
       compatible_result_categories?(indexer_result, request.book.book_type) &&
-        ReleaseScorer.score(search_result_for_scoring(indexer_result), request).total >= threshold
+        penalized_indexer_score(tagged_result, request) >= threshold
     end
   end
 
@@ -603,19 +618,34 @@ class SearchJob < ApplicationJob
 
   def search_generic_indexer_attempts(request, categories:, starting_results: [], attempts: nil)
     attempts ||= generic_indexer_attempts(request)
+    results = []
+    last_error = nil
 
-    attempts.each_with_object([]) do |attempt, results|
+    attempts.each do |attempt|
       Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} generic query '#{attempt.query}' for request ##{request.id} (attempt: #{attempt.name})"
 
-      attempt_results = tag_indexer_results(
-        IndexerClient.search(attempt.query, book_type: request.book.book_type, categories: categories),
-        attempt: attempt
-      )
-      results.replace(merge_indexer_results(results, attempt_results))
+      begin
+        attempt_results = tag_indexer_results(
+          IndexerClient.search(attempt.query, book_type: request.book.book_type, categories: categories),
+          attempt: attempt
+        )
+        results = merge_indexer_results(results, attempt_results)
+      rescue IndexerClients::Base::AuthenticationError
+        # Every remaining attempt would fail the same way; let the caller surface it.
+        raise
+      rescue IndexerClients::Base::Error => e
+        Rails.logger.warn "[SearchJob] #{IndexerClient.display_name} generic query '#{attempt.query}' failed for request ##{request.id}: #{e.message}"
+        last_error = e
+      end
 
-      combined_results = merge_indexer_results(starting_results, results)
-      break results if strong_indexer_match?(combined_results, request)
+      break if strong_indexer_match?(merge_indexer_results(starting_results, results), request)
     end
+
+    # If nothing was found anywhere and at least one attempt errored, propagate
+    # so the caller treats this as an indexer failure rather than an empty search.
+    raise last_error if last_error && results.empty? && Array(starting_results).empty?
+
+    results
   end
 
   def generic_indexer_attempts(request)
@@ -659,6 +689,7 @@ class SearchJob < ApplicationJob
     title.to_s
       .gsub(/\([^)]*\)|\[[^\]]*\]/, " ")
       .gsub(/\b(?:volume|vol\.?|book|part)\s+(\d+)\b/i, "\\1")
+      .gsub(/['’]/, "")
       .gsub(/[[:punct:]]+/, " ")
       .squish
   end
@@ -667,7 +698,7 @@ class SearchJob < ApplicationJob
     values = Set.new
     text = title.to_s
 
-    ROMAN_NUMERALS.each do |roman, number|
+    ROMAN_VARIANT_NUMERALS.each do |roman, number|
       values << text.gsub(/\b#{Regexp.escape(roman)}\b/i, number) if text.match?(/\b#{Regexp.escape(roman)}\b/i)
     end
 

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -8,10 +8,16 @@ class SearchJob < ApplicationJob
   GENERIC_SEARCH_ATTEMPT_PENALTIES = {
     exact_title: 0,
     title_author: 5,
+    short_title: 6,
     author_title: 8,
     normalized_title: 10,
     number_variant: 12
   }.freeze
+
+  # How many below-threshold broad results to keep when a search would
+  # otherwise come back empty, so users see low-confidence candidates
+  # instead of no results at all.
+  LOW_CONFIDENCE_FALLBACK_LIMIT = 5
 
   ROMAN_NUMERALS = {
     "I" => "1",
@@ -536,7 +542,10 @@ class SearchJob < ApplicationJob
   end
 
   def finalize_indexer_results(request, results)
-    results = filter_broad_results(results, request) if SettingsService.unrestricted_indexer_search_scope?
+    if SettingsService.unrestricted_indexer_search_scope?
+      filtered = filter_broad_results(results, request)
+      results = filtered.any? ? filtered : low_confidence_fallback_results(results, request)
+    end
     supplement_with_broad_search(request, results)
   end
 
@@ -549,7 +558,10 @@ class SearchJob < ApplicationJob
     Rails.logger.info "[SearchJob] Supplementing #{IndexerClient.display_name} search for request ##{request.id} without category restrictions using '#{attempts.first.query}'"
 
     broad_results = search_generic_indexer_attempts(request, categories: [], starting_results: results, attempts: attempts)
-    merge_indexer_results(results, filter_broad_results(broad_results, request))
+    merged = merge_indexer_results(results, filter_broad_results(broad_results, request))
+    return merged if merged.any?
+
+    low_confidence_fallback_results(broad_results, request)
   rescue IndexerClients::Base::Error => e
     Rails.logger.warn "[SearchJob] #{IndexerClient.display_name} broad search failed for request ##{request.id}: #{e.message}"
     results
@@ -564,6 +576,7 @@ class SearchJob < ApplicationJob
 
     Array(results).any? do |tagged_result|
       result = indexer_result_from(tagged_result)
+      next false if ReleaseParserService.video_release?(result.title)
       next false if SettingsService.unrestricted_indexer_search_scope? &&
         !compatible_result_categories?(result, request.book.book_type)
 
@@ -595,10 +608,33 @@ class SearchJob < ApplicationJob
     threshold = SettingsService.get(:min_match_confidence)
 
     Array(results).select do |tagged_result|
-      indexer_result = indexer_result_from(tagged_result)
-      compatible_result_categories?(indexer_result, request.book.book_type) &&
+      broad_result_candidate?(tagged_result, request) &&
         penalized_indexer_score(tagged_result, request) >= threshold
     end
+  end
+
+  # Baseline sanity check for results found without category restrictions:
+  # category tags (when present) must be compatible with the book type, and
+  # the release name must not look like video content.
+  def broad_result_candidate?(tagged_result, request)
+    result = indexer_result_from(tagged_result)
+    compatible_result_categories?(result, request.book.book_type) &&
+      !ReleaseParserService.video_release?(result.title)
+  end
+
+  # When every result was filtered out, an empty list hides that the broad
+  # search did retrieve plausible candidates. Keep the best few below the
+  # confidence threshold — clearly penalized and ranked last — so users can
+  # judge them instead of resorting to manual searches.
+  def low_confidence_fallback_results(results, request)
+    candidates = Array(results).select { |tagged_result| broad_result_candidate?(tagged_result, request) }
+    return [] if candidates.empty?
+
+    kept = candidates
+      .sort_by { |tagged_result| -penalized_indexer_score(tagged_result, request) }
+      .first(LOW_CONFIDENCE_FALLBACK_LIMIT)
+    Rails.logger.info "[SearchJob] No results met the confidence threshold for request ##{request.id}; keeping #{kept.count} low-confidence candidates"
+    kept
   end
 
   def compatible_result_categories?(result, book_type)
@@ -653,10 +689,14 @@ class SearchJob < ApplicationJob
     language_hint = indexer_language_hint(request)
     attempts = [
       build_search_attempt(:exact_title, [ book.title, language_hint ]),
-      build_search_attempt(:title_author, [ book.title, book.author, language_hint ]),
-      build_search_attempt(:author_title, [ book.author, book.title, language_hint ]),
-      build_search_attempt(:normalized_title, [ normalized_search_title(book.title), language_hint ])
+      build_search_attempt(:title_author, [ book.title, book.author, language_hint ])
     ]
+
+    short_title = short_search_title(book.title)
+    attempts << build_search_attempt(:short_title, [ short_title, book.author, language_hint ]) if short_title.present?
+
+    attempts << build_search_attempt(:author_title, [ book.author, book.title, language_hint ])
+    attempts << build_search_attempt(:normalized_title, [ normalized_search_title(book.title), language_hint ])
 
     numeric_title_variants(book.title).each do |title_variant|
       attempts << build_search_attempt(:number_variant, [ title_variant, language_hint ])
@@ -683,6 +723,18 @@ class SearchJob < ApplicationJob
 
       seen[normalized_query] = true
     end
+  end
+
+  # Book metadata often carries subtitles that release names omit
+  # ("Mistborn: The Final Empire", "Project Hail Mary: A Novel").
+  # Returns the title up to the first subtitle separator, or nil when the
+  # title has no subtitle or the remainder is too short to search safely.
+  def short_search_title(title)
+    short = title.to_s.split(/\s*(?::|;|–|—|\s-\s)\s*/, 2).first.to_s.squish
+    return nil if short.blank? || short.casecmp?(title.to_s.squish)
+    return nil if short.length < 4
+
+    short
   end
 
   def normalized_search_title(title)

--- a/app/services/indexer_clients/jackett.rb
+++ b/app/services/indexer_clients/jackett.rb
@@ -80,14 +80,14 @@ module IndexerClients
         when 200
           yield response.body
         when 401, 403
-          raise AuthenticationError, "Invalid #{display_name} API key"
+          raise Base::AuthenticationError, "Invalid #{display_name} API key"
         when 404
-          raise Error, "#{display_name} endpoint not found"
+          raise Base::Error, "#{display_name} endpoint not found"
         else
-          raise Error, "#{display_name} API error: #{response.status}"
+          raise Base::Error, "#{display_name} API error: #{response.status}"
         end
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-        raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
+        raise Base::ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
       end
 
       def parse_results(xml, limit:)
@@ -98,7 +98,7 @@ module IndexerClients
 
         doc.xpath("//rss/channel/item").first(limit).map { |item| parse_item(item) }
       rescue Nokogiri::XML::SyntaxError => e
-        raise Error, "Failed to parse #{display_name} response: #{e.message}"
+        raise Base::Error, "Failed to parse #{display_name} response: #{e.message}"
       end
 
       def parse_item(item)

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -145,14 +145,14 @@ module IndexerClients
         when 200
           yield response.body
         when 401, 403
-          raise AuthenticationError, "Invalid Prowlarr API key"
+          raise Base::AuthenticationError, "Invalid Prowlarr API key"
         when 404
-          raise Error, "Prowlarr endpoint not found"
+          raise Base::Error, "Prowlarr endpoint not found"
         else
-          raise Error, "Prowlarr API error: #{response.status}"
+          raise Base::Error, "Prowlarr API error: #{response.status}"
         end
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-        raise ConnectionError, "Failed to connect to Prowlarr: #{e.message}"
+        raise Base::ConnectionError, "Failed to connect to Prowlarr: #{e.message}"
       end
 
       def parse_result(item)

--- a/app/services/release_parser_service.rb
+++ b/app/services/release_parser_service.rb
@@ -258,6 +258,19 @@ class ReleaseParserService
 
   BITRATE_PATTERN = /(?<!\d)(\d{2,3})\s?kbps\b/i
 
+  # Markers that only appear in video (movie/TV) release names. Used to reject
+  # non-book content from category-less indexer searches, where category tags
+  # are unavailable or unreliable.
+  VIDEO_RELEASE_PATTERNS = [
+    /\b(?:480|576|720|1080|2160)[pi]\b/i,
+    /\bs\d{1,2}e\d{1,3}\b/i,
+    /\b[xh]\.?26[45]\b/i,
+    /\bhevc\b/i,
+    /\bxvid\b/i,
+    /\bdivx\b/i,
+    /\b(?:blu-?ray|bd-?rip|br-?rip|web-?dl|web-?rip|hd-?tv|dvd-?rip|hd-?rip|cam-?rip|telesync|remux)\b/i
+  ].freeze
+
   class << self
     # Parse a release title and extract metadata
     # @param title [String] The release title to parse
@@ -336,6 +349,19 @@ class ReleaseParserService
         end
         .min_by(&:last)
         &.first
+    end
+
+    # Check whether a release name looks like video (movie/TV) content.
+    # Explicit book markers (formats or extensions) veto the video markers so
+    # this stays high-precision: it only rejects titles that carry video
+    # signals and no book signals at all.
+    # @param title [String] The release title
+    # @return [Boolean]
+    def video_release?(title)
+      return false if title.blank?
+      return false if detect_format(title).present? || detect_extensions(title).any?
+
+      VIDEO_RELEASE_PATTERNS.any? { |pattern| title.match?(pattern) }
     end
 
     def detect_audio_bitrate(title)

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -3,6 +3,23 @@
 # Scores search results based on how well they match a request.
 # Returns a confidence score (0-100) with a detailed breakdown.
 class ReleaseScorer
+  ROMAN_NUMBER_TOKENS = {
+    "II" => "2",
+    "III" => "3",
+    "IV" => "4",
+    "V" => "5",
+    "VI" => "6",
+    "VII" => "7",
+    "VIII" => "8",
+    "IX" => "9",
+    "X" => "10",
+    "XI" => "11",
+    "XII" => "12",
+    "XIII" => "13",
+    "XIV" => "14",
+    "XV" => "15"
+  }.freeze
+
   # Weight configuration for each scoring factor
   WEIGHTS = {
     title: 40,      # How well does the release title match the book title?
@@ -193,11 +210,18 @@ class ReleaseScorer
   def normalize_for_matching(text)
     return "" if text.blank?
 
-    text
+    normalized = text
       .downcase
       .gsub(/[^a-z0-9\s]/, "")  # Remove special characters
       .gsub(/\s+/, " ")         # Collapse whitespace
       .strip
+
+    normalize_number_tokens(normalized)
+  end
+
+  def normalize_number_tokens(text)
+    tokens = text.split
+    tokens.map { |token| ROMAN_NUMBER_TOKENS.fetch(token.upcase, token) }.join(" ")
   end
 
   # Trigram-based similarity score (0-100)

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -8,7 +8,7 @@ class SettingsService
   INDEXER_SEARCH_SCOPE_OPTIONS = {
     "broad" => {
       label: "Broad (recommended)",
-      description: "Search Shelfarr's book categories, then supplement with an unrestricted search filtered by match quality."
+      description: "Search Shelfarr's book categories, then supplement with a category-less search that filters out non-book releases and keeps matches by quality."
     },
     "strict" => {
       label: "Strict",
@@ -16,7 +16,7 @@ class SettingsService
     },
     "unrestricted" => {
       label: "Unrestricted",
-      description: "Search without category filters and rely on match quality filtering."
+      description: "Search without category filters and rely on non-book detection and match quality filtering."
     },
     "custom" => {
       label: "Custom",
@@ -132,7 +132,7 @@ class SettingsService
     # Language Settings
     default_language: { type: "string", default: "en", category: "language", description: "Default language for new requests" },
     enabled_languages: { type: "json", default: '["en"]', category: "language", description: "Languages available for selection when creating requests" },
-    min_match_confidence: { type: "integer", default: 50, category: "language", description: "Minimum confidence score (0-100) to display a search result" },
+    min_match_confidence: { type: "integer", default: 50, category: "language", description: "Minimum confidence score (0-100) for keeping results from category-less indexer searches. When nothing clears it, the best few low-confidence results are kept for manual review instead of returning an empty search." },
 
     # Updates
     github_repo: { type: "string", default: "Pedro-Revez-Silva/shelfarr", category: "updates", description: "GitHub repository for update notifications" },

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -520,11 +520,13 @@
 
         <h2 id="indexers">Indexers <a class="anchor" href="#indexers" aria-label="Link to Indexers">#</a></h2>
         <p class="section-desc">Shelfarr searches indexers through Prowlarr, Jackett or Newznab/NZBHydra2. Pick one provider with <code>indexer_provider</code>.</p>
+        <p class="section-desc">Searches broaden automatically: Shelfarr starts with a structured book search, then tries progressively looser name-based queries &mdash; exact title, title + author, subtitle-stripped title, author-first ordering, and roman/arabic series-number variants (<code>III</code> &harr; <code>3</code>) &mdash; until a strong match is found. Results found by broader queries carry a small confidence penalty and record the query that found them in their score breakdown. With the default <em>broad</em> scope a category-less pass runs as well: releases that look like video content (resolution tags, <code>S01E05</code> markers, video codecs) are rejected, and when nothing clears <code>min_match_confidence</code> the best few low-confidence candidates are kept for manual review instead of returning an empty search.</p>
         <div class="table-wrap">
           <table>
             <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
             <tbody>
               <tr><td class="key"><code>indexer_provider</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Active provider: <code>prowlarr</code>, <code>jackett</code>, <code>newznab</code> or <code>none</code>. Leave unset on upgrades to keep legacy Prowlarr config.</td></tr>
+              <tr><td class="key"><code>indexer_search_scope</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>broad</code></td><td class="desc">Category strategy: <code>broad</code> (book categories plus a filtered category-less pass), <code>strict</code> (book categories only), <code>unrestricted</code> (no category filters, quality filtering only) or <code>custom</code> (only the category IDs configured in the admin UI).</td></tr>
               <tr><td class="key"><code>prowlarr_url</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Base URL for Prowlarr (e.g. <code>http://localhost:9696</code>).</td></tr>
               <tr><td class="key"><code>prowlarr_api_key</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">API key from Prowlarr &rarr; Settings &rarr; General.</td></tr>
               <tr><td class="key"><code>prowlarr_tags</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>(empty)</code></td><td class="desc">Comma-separated tag IDs or names to filter indexers (empty = all).</td></tr>
@@ -722,7 +724,7 @@
             <tbody>
               <tr><td class="key"><code>default_language</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>en</code></td><td class="desc">Default language for new requests.</td></tr>
               <tr><td class="key"><code>enabled_languages</code></td><td><span class="badge t-json">json</span></td><td class="default"><code>["en"]</code></td><td class="desc">Languages selectable when creating requests.</td></tr>
-              <tr><td class="key"><code>min_match_confidence</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>50</code></td><td class="desc">Minimum confidence score (0&ndash;100) to display a search result.</td></tr>
+              <tr><td class="key"><code>min_match_confidence</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>50</code></td><td class="desc">Minimum confidence score (0&ndash;100) for keeping results from category-less indexer searches. When nothing clears it, the best few low-confidence results are kept for manual review instead of returning an empty search.</td></tr>
             </tbody>
           </table>
         </div>

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -468,6 +468,128 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "tries numeric title variants when Prowlarr exact title searches are empty" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "The Perfect Run III",
+      author: "Maxime Durand",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    numeric_payload = prowlarr_result_payload.merge(
+      "guid" => "perfect-run-3",
+      "title" => "The Perfect Run 3 Maxime Durand Audiobook M4B",
+      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      exact_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "The Perfect Run III" &&
+            category_query_param?(req)
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      title_author_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "The Perfect Run III Maxime Durand" &&
+            category_query_param?(req)
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      author_title_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Maxime Durand The Perfect Run III" &&
+            category_query_param?(req)
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      numeric_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "The Perfect Run 3" &&
+            category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ numeric_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested structured_stub
+      assert_requested exact_stub
+      assert_requested title_author_stub
+      assert_requested author_title_stub
+      assert_requested numeric_stub
+      assert_equal numeric_payload["title"], request.search_results.first.title
+      assert_equal "number_variant", request.search_results.first.score_breakdown["search_attempt"]
+      assert_equal 12, request.search_results.first.score_breakdown["search_penalty"]
+    end
+  end
+
+  test "tries author title Prowlarr query when title first queries are empty" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "Awkward Indexer Title",
+      author: "Specific Author",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    author_title_payload = prowlarr_result_payload.merge(
+      "guid" => "author-title-match",
+      "title" => "Specific Author Awkward Indexer Title Audiobook M4B",
+      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+    )
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            [ "Awkward Indexer Title", "Awkward Indexer Title Specific Author" ].include?(req.uri.query_values["query"]) &&
+            category_query_param?(req)
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      author_title_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Specific Author Awkward Indexer Title" &&
+            category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ author_title_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested author_title_stub
+      assert_equal author_title_payload["title"], request.search_results.first.title
+      assert_equal "author_title", request.search_results.first.score_breakdown["search_attempt"]
+      assert_equal 8, request.search_results.first.score_breakdown["search_penalty"]
+    end
+  end
+
   test "uses categoryless Prowlarr fallback when categorized results are weak" do
     broad_payload = prowlarr_result_payload.merge(
       "guid" => "broad-strong-match",
@@ -515,7 +637,7 @@ class SearchJobTest < ActiveJob::TestCase
       @request.reload
 
       assert_requested structured_stub
-      assert_requested categorized_stub
+      assert_requested categorized_stub, times: 3
       assert_requested broad_stub
       assert_includes @request.search_results.pluck(:title), broad_payload["title"]
       assert_not_includes @request.search_results.pluck(:title), movie_payload["title"]
@@ -833,7 +955,31 @@ class SearchJobTest < ActiveJob::TestCase
       stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] != "Frieren: Beyond Journey's End, Vol. 1" &&
+            category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
             req.uri.query_values["query"] == "Frieren: Beyond Journey's End, Vol. 1" &&
+            !category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] != "Frieren: Beyond Journey's End, Vol. 1" &&
             !category_query_param?(req)
         end
         .to_return(
@@ -887,17 +1033,15 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
-  test "uses title-only generic text search for Jackett" do
+  test "starts generic text search with title-only query for Jackett" do
     SettingsService.set(:indexer_provider, "jackett")
     SettingsService.set(:jackett_url, "http://localhost:9117")
     SettingsService.set(:jackett_api_key, "jackett-key")
 
-    body = <<~XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
-        <channel></channel>
-      </rss>
-    XML
+    body = jackett_result_xml(
+      title: "#{@request.book.title} #{@request.book.author} EPUB",
+      guid: "jackett-title-first"
+    )
 
     VCR.turned_off do
       stub_request(:get, %r{localhost:9117/api/v2\.0/indexers/all/results/torznab/api})
@@ -949,7 +1093,7 @@ class SearchJobTest < ActiveJob::TestCase
       SearchJob.perform_now(@request.id)
       @request.reload
 
-      assert_requested categorized_stub
+      assert_requested categorized_stub, times: 3
       assert_requested broad_stub
       assert_equal "#{@request.book.title} #{@request.book.author} EPUB", @request.search_results.first.title
     end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -527,6 +527,16 @@ class SearchJobTest < ActiveJob::TestCase
           body: [ numeric_payload ].to_json
         )
 
+      # The numeric result lands below the confidence threshold once its
+      # attempt penalty is applied, so the search keeps broadening.
+      numeric_author_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "The Perfect Run 3 Maxime Durand" &&
+            category_query_param?(req)
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
       SearchJob.perform_now(request.id)
       request.reload
 
@@ -535,6 +545,7 @@ class SearchJobTest < ActiveJob::TestCase
       assert_requested title_author_stub
       assert_requested author_title_stub
       assert_requested numeric_stub
+      assert_requested numeric_author_stub
       assert_equal numeric_payload["title"], request.search_results.first.title
       assert_equal "number_variant", request.search_results.first.score_breakdown["search_attempt"]
       assert_equal 12, request.search_results.first.score_breakdown["search_penalty"]
@@ -587,6 +598,202 @@ class SearchJobTest < ActiveJob::TestCase
       assert_equal author_title_payload["title"], request.search_results.first.title
       assert_equal "author_title", request.search_results.first.score_breakdown["search_attempt"]
       assert_equal 8, request.search_results.first.score_breakdown["search_penalty"]
+    end
+  end
+
+  test "stops issuing generic queries once a strong match is found" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "Strong First Attempt",
+      author: "Solid Author",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    strong_payload = prowlarr_result_payload.merge(
+      "guid" => "strong-exact-title",
+      "title" => "Strong First Attempt Solid Author English Audiobook M4B",
+      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+    )
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      exact_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Strong First Attempt"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ strong_payload ].to_json
+        )
+
+      later_attempts_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] != "Strong First Attempt"
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested exact_stub
+      assert_not_requested later_attempts_stub
+      assert_equal strong_payload["title"], request.search_results.first.title
+    end
+  end
+
+  test "keeps broadening when a penalized match falls below the confidence threshold" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "The Perfect Run III",
+      author: "Maxime Durand",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    weak_payload = prowlarr_result_payload.merge(
+      "guid" => "perfect-run-3-weak",
+      "title" => "The Perfect Run 3",
+      "seeders" => 0,
+      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+    )
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] != "The Perfect Run 3" &&
+            req.uri.query_values["query"] != "The Perfect Run 3 Maxime Durand"
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      weak_variant_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "The Perfect Run 3"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ weak_payload ].to_json
+        )
+
+      variant_with_author_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "The Perfect Run 3 Maxime Durand"
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      threshold = SettingsService.get(:min_match_confidence)
+      saved = request.search_results.find_by!(guid: weak_payload["guid"])
+      raw_score = saved.confidence_score + saved.score_breakdown["search_penalty"]
+
+      # Sanity-check the scenario: strong before the penalty, weak after it.
+      assert_operator raw_score, :>=, threshold
+      assert_operator saved.confidence_score, :<, threshold
+
+      assert_requested weak_variant_stub
+      assert_requested variant_with_author_stub
+    end
+  end
+
+  test "keeps results from later attempts when an earlier generic query fails" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "Flaky Indexer Book",
+      author: "Retry Author",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    title_author_payload = prowlarr_result_payload.merge(
+      "guid" => "title-author-after-failure",
+      "title" => "Flaky Indexer Book Retry Author English Audiobook M4B",
+      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+    )
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      failing_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Flaky Indexer Book"
+        end
+        .to_return(status: 500, headers: { "Content-Type" => "application/json" }, body: "")
+
+      title_author_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Flaky Indexer Book Retry Author"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ title_author_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested failing_stub
+      assert_requested title_author_stub
+      assert_equal title_author_payload["title"], request.search_results.first.title
+      assert_equal "title_author", request.search_results.first.score_breakdown["search_attempt"]
+    end
+  end
+
+  test "marks for attention when generic queries fail authentication" do
+    SettingsService.set(:indexer_search_scope, "strict")
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "search" }
+        .to_return(status: 401, headers: { "Content-Type" => "application/json" }, body: "")
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert @request.attention_needed?
+      assert_match(/authentication failed/i, @request.issue_description)
+    end
+  end
+
+  test "does not generate numeric variants for standalone I in titles" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "I Am Legend",
+      author: "Richard Matheson",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      SearchJob.perform_now(request.id)
+
+      assert_not_requested(:get, %r{localhost:9696/api/v1/search}) do |req|
+        req.uri.query_values["query"].to_s.include?("1 Am Legend")
+      end
     end
   end
 

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -797,6 +797,142 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "tries subtitle-stripped query when full title searches are empty" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "Mistborn: The Final Empire",
+      author: "Brandon Sanderson",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    short_title_payload = prowlarr_result_payload.merge(
+      "guid" => "mistborn-short-title",
+      "title" => "Mistborn The Final Empire Brandon Sanderson English Audiobook M4B",
+      "categories" => [ { "id" => 3030, "name" => "Audio/Audiobook" } ]
+    )
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] != "Mistborn Brandon Sanderson"
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      short_title_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Mistborn Brandon Sanderson"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ short_title_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      assert_requested short_title_stub
+      assert_equal short_title_payload["title"], request.search_results.first.title
+      assert_equal "short_title", request.search_results.first.score_breakdown["search_attempt"]
+      assert_equal 6, request.search_results.first.score_breakdown["search_penalty"]
+    end
+  end
+
+  test "keeps low-confidence broad results instead of returning an empty search" do
+    book = Book.create!(
+      title: "Signal Path",
+      author: "Casey Vernon",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    weak_payload = prowlarr_result_payload.merge(
+      "guid" => "signal-path-weak",
+      "title" => "Signal Path [German]",
+      "seeders" => 0
+    )
+    video_payload = prowlarr_result_payload.merge(
+      "guid" => "signal-path-video",
+      "title" => "Signal Path S01E03 1080p WEB-DL x264"
+    )
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "search" && category_query_param?(req) }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "search" && !category_query_param?(req) }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ weak_payload, video_payload ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+      request.reload
+
+      threshold = SettingsService.get(:min_match_confidence)
+      titles = request.search_results.pluck(:title)
+
+      assert_includes titles, weak_payload["title"]
+      assert_not_includes titles, video_payload["title"]
+      assert_operator request.search_results.find_by!(guid: weak_payload["guid"]).confidence_score, :<, threshold
+    end
+  end
+
+  test "video releases never count as strong matches" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "Signal Path",
+      author: "Casey Vernon",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    video_payload = prowlarr_result_payload.merge(
+      "guid" => "signal-path-video-strong",
+      "title" => "Signal Path Casey Vernon S01E03 1080p WEB-DL x264"
+    )
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      exact_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == "Signal Path"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ video_payload ].to_json
+        )
+
+      later_attempts_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] != "Signal Path"
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      SearchJob.perform_now(request.id)
+
+      assert_requested exact_stub
+      assert_requested later_attempts_stub, at_least_times: 1
+    end
+  end
+
   test "uses categoryless Prowlarr fallback when categorized results are weak" do
     broad_payload = prowlarr_result_payload.merge(
       "guid" => "broad-strong-match",

--- a/test/services/release_parser_service_test.rb
+++ b/test/services/release_parser_service_test.rb
@@ -180,4 +180,33 @@ class ReleaseParserServiceTest < ActiveSupport::TestCase
   test "detects flemish as Dutch" do
     assert_includes ReleaseParserService.detect_languages("Book.Title.Flemish.Audiobook"), "nl"
   end
+
+  test "detects video releases from resolution markers" do
+    assert ReleaseParserService.video_release?("The Matrix 1999 1080p BluRay x264-GROUP")
+    assert ReleaseParserService.video_release?("Some.Documentary.2023.2160p.REMUX")
+  end
+
+  test "detects video releases from episode markers" do
+    assert ReleaseParserService.video_release?("Great Show S02E05 720p WEB-DL")
+  end
+
+  test "detects video releases from codec and source markers" do
+    assert ReleaseParserService.video_release?("Old Film DVDRip XviD")
+    assert ReleaseParserService.video_release?("Feature.HEVC.WEBRip")
+  end
+
+  test "does not flag plain book releases as video" do
+    assert_not ReleaseParserService.video_release?("The Name of the Wind - Patrick Rothfuss")
+    assert_not ReleaseParserService.video_release?("The Perfect Run 3 Maxime Durand")
+  end
+
+  test "book format markers veto video markers" do
+    assert_not ReleaseParserService.video_release?("Filmmaking Basics 1080p Explained EPUB")
+    assert_not ReleaseParserService.video_release?("History of Television HDTV Era Audiobook MP3")
+  end
+
+  test "video_release? is false for blank titles" do
+    assert_not ReleaseParserService.video_release?(nil)
+    assert_not ReleaseParserService.video_release?("")
+  end
 end

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -165,6 +165,25 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     assert result.breakdown[:author] == 80
   end
 
+  test "treats roman and arabic series numbers as equivalent in title matching" do
+    book = Book.create!(
+      title: "The Perfect Run III",
+      author: "Maxime Durand",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+    search_result = request.search_results.create!(
+      guid: "perfect-run-3",
+      title: "The Perfect Run 3 - Maxime Durand - English Audiobook M4B",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, request)
+
+    assert_equal 100, result.breakdown[:title]
+    assert result.total >= 80
+  end
+
   test "scores health based on seeders" do
     search_result = @request.search_results.create!(
       guid: "test-9",

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -184,6 +184,24 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     assert result.total >= 80
   end
 
+  test "treats arabic book numbers and roman release numbers as equivalent in title matching" do
+    book = Book.create!(
+      title: "The Perfect Run 3",
+      author: "Maxime Durand",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+    search_result = request.search_results.create!(
+      guid: "perfect-run-iii",
+      title: "The Perfect Run III - Maxime Durand - English Audiobook M4B",
+      seeders: 50
+    )
+
+    result = ReleaseScorer.score(search_result, request)
+
+    assert_equal 100, result.breakdown[:title]
+  end
+
   test "scores health based on seeders" do
     search_result = @request.search_results.create!(
       guid: "test-9",


### PR DESCRIPTION
## Summary

Fixes #327 by making indexer search broaden automatically instead of adding a manual query input.

This keeps the search UX simple while covering the reported cases where provider metadata is more precise than indexer release naming. Shelfarr now tries additional generic indexer queries when structured or exact-title searches are empty or weak — `title author`, `author title`, subtitle-stripped titles, normalized titles, and roman numeral / arabic number variants such as `III` and `3` — and it no longer returns an empty result list when the broad pass retrieved plausible candidates.

## Why

Issue #327 asked for editable retry queries because releases such as `The Perfect Run II` / `The Perfect Run III` may exist under numeric naming in indexers, and a commenter reported success with `author title` ordering. Rather than shifting that work to the user, this PR improves the automatic search strategy and keeps broader matches ranked with lower confidence. The goal is that manual queries never feel necessary.

## Changes

### Search broadening
- Add ordered generic indexer search attempts after the structured Prowlarr search: exact title, title + author, subtitle-stripped title (`Mistborn: The Final Empire` → `Mistborn`), author-first ordering, normalized title, and roman/arabic number variants.
- Apply confidence penalties to broader attempts and record the search attempt/query in `score_breakdown`.
- Normalize roman numerals during title scoring so `III` and `3` match strongly regardless of which query found the release.
- Standalone `I` is excluded from numeric variants (it is almost always the pronoun).

### Robustness
- Threshold checks now use the penalized score, so a broadened match cannot stop the search while being stored below the confidence threshold.
- A single failing generic query no longer discards results from other attempts; authentication errors still surface immediately.
- Fix indexer error constants in `Prowlarr`/`Jackett` singleton classes that raised `NameError` instead of typed errors on non-200 responses.

### Better category-less searching
- Releases that look like video content (resolution tags, `S01E05` markers, video codecs/sources) are rejected from category-less searches. Explicit book markers (EPUB, M4B, Audiobook, …) veto the detection so it stays high-precision.
- When nothing clears `min_match_confidence`, the best few low-confidence candidates are kept for manual review instead of returning an empty search.

### Documentation
- Document the search broadening behavior and `indexer_search_scope` in `docs/configuration.html`, and correct the `min_match_confidence` description.

## Validation

- `bundle exec rails test` (full suite, 1619 runs, 0 failures)
- `bundle exec rubocop` on all changed files
- Verified the issue scenarios end to end: `The Perfect Run II/III` generate `The Perfect Run 2/3` queries and score `title=100`; `author title` ordering is attempted when title-first queries are empty.
