### PR TITLE
fix: skip unsupported files in ebook imports

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -189,14 +189,16 @@ class PostProcessingJob < ApplicationJob
   end
 
   def import_ebook_directory_entry(source_file, destination, book)
-    if File.directory?(source_file)
+    if File.directory?(source_file) && !File.symlink?(source_file)
       Dir.entries(source_file).reject { |f| f.start_with?(".") }.each do |file|
         import_ebook_directory_entry(File.join(source_file, file), destination, book)
       end
-    elsif ebook_file?(source_file)
+    elsif allowed_ebook_import_file?(source_file) && ebook_file?(source_file)
       import_renamed_file(source_file, destination, book)
-    else
+    elsif allowed_ebook_import_file?(source_file)
       import_sidecar_file(source_file, destination)
+    else
+      Rails.logger.info "[PostProcessingJob] Skipping unsupported ebook import file: #{File.basename(source_file)}"
     end
   end
 
@@ -205,17 +207,31 @@ class PostProcessingJob < ApplicationJob
   end
 
   def validate_ebook_source!(source)
-    paths = if File.directory?(source)
-      ebook_directory_files(source)
-    else
-      [ source ]
+    unless File.directory?(source)
+      return if ebook_file?(source) && allowed_ebook_import_file?(source)
+
+      raise "Unsupported ebook import file type: #{File.basename(source)}"
     end
+
+    supported_ebook_found = false
+    paths = ebook_directory_files(source)
 
     paths.each do |path|
-      next if allowed_ebook_import_file?(path)
+      if File.symlink?(path)
+        raise "Unsupported ebook import file type: #{File.basename(path)}"
+      end
 
-      raise "Unsupported ebook import file type: #{File.basename(path)}"
+      extension = File.extname(path).delete_prefix(".").downcase
+      next unless EBOOK_ALLOWED_EXTENSIONS.include?(extension)
+
+      unless allowed_ebook_import_file?(path)
+        raise "Unsupported ebook import file type: #{File.basename(path)}"
+      end
+
+      supported_ebook_found ||= EBOOK_FILE_EXTENSIONS.include?(extension)
     end
+
+    raise "No supported ebook files found in download" unless supported_ebook_found
   end
 
   def ebook_directory_files(source)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -902,12 +902,31 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_match /source path not found/i, @request.issue_description
   end
 
-  test "marks ebook directory import for attention when it contains unsupported files" do
+  test "imports supported ebook files and skips unsupported files in the directory" do
     FileUtils.rm_rf(@temp_source)
     nested_source = File.join(@temp_source, "Nested")
     FileUtils.mkdir_p(nested_source)
     write_valid_ebook_file(File.join(@temp_source, "Valid Book.epub"))
-    File.write(File.join(nested_source, "payload.exe"), "bad executable content")
+    File.write(File.join(nested_source, "alternate.rtf"), "unsupported alternate format")
+
+    @book.update!(book_type: :ebook)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    @request.reload
+    assert @request.completed?
+    assert_not @request.attention_needed?
+    assert File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
+    assert_not File.exist?(File.join(expected_dest, "alternate.rtf"))
+  end
+
+  test "marks ebook directory import for attention when it has no supported ebook files" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    File.write(File.join(@temp_source, "alternate.rtf"), "unsupported alternate format")
 
     @book.update!(book_type: :ebook)
     SettingsService.set(:ebook_output_path, @temp_dest_base)
@@ -918,9 +937,8 @@ class PostProcessingJobTest < ActiveJob::TestCase
     expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
     @request.reload
     assert @request.attention_needed?
-    assert_match /unsupported ebook import file type/i, @request.issue_description
-    assert_not File.exist?(File.join(expected_dest, "payload.exe"))
-    assert_not File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
+    assert_match /no supported ebook files found/i, @request.issue_description
+    assert_not File.exist?(File.join(expected_dest, "alternate.rtf"))
   end
 
   test "marks single file ebook import for attention when extension is unsupported" do


### PR DESCRIPTION
## Summary

- import supported ebook and comic files even when the download directory also contains unsupported formats
- skip unsupported directory entries instead of copying them into the library
- keep single-file imports strict and preserve content-signature and symlink validation
- fail clearly when a directory contains no supported ebook files

## Why

Ebook directory imports were validated as all-or-nothing. A valid EPUB beside an unrelated RTF caused post-processing to fail before any supported file could be imported.

Closes #341

## Validation

- `bundle exec rails test test/jobs/post_processing_job_test.rb` (50 runs, 139 assertions)
- `bundle exec rails test` (1,727 runs, 5,333 assertions)
- `bundle exec rubocop app/jobs/post_processing_job.rb test/jobs/post_processing_job_test.rb`
- `bin/quality commit --staged`
- `bin/quality push`
