### PR TITLE
feat: add manual NZB URL downloads

### DIFF
--- a/app/controllers/admin/search_results_controller.rb
+++ b/app/controllers/admin/search_results_controller.rb
@@ -26,8 +26,8 @@ module Admin
     end
 
     def refresh
-      # Clear existing results and re-queue for search, keeping manually added magnets
-      @request.search_results.where.not(source: SearchResult::SOURCE_MANUAL_MAGNET).destroy_all
+      # Clear existing results and re-queue for search, keeping manually added downloads.
+      @request.search_results.where.not(source: SearchResult::MANUAL_SOURCES).destroy_all
       @request.update!(status: :pending)
       SearchJob.perform_later(@request.id)
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RequestsController < ApplicationController
-  before_action :set_request, only: [ :show, :destroy, :retry, :manual_magnet ]
+  before_action :set_request, only: [ :show, :destroy, :retry, :manual_magnet, :manual_nzb ]
   before_action :set_request_for_download, only: [ :download ]
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
@@ -155,6 +155,20 @@ class RequestsController < ApplicationController
     redirect_to @request, alert: e.message
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
     redirect_to @request, alert: "Magnet link could not be queued. Please try again."
+  end
+
+  def manual_nzb
+    unless Current.user.admin?
+      redirect_to @request, alert: "You don't have permission to add NZB URLs"
+      return
+    end
+
+    @request.add_manual_nzb!(params[:nzb_url])
+    redirect_to @request, notice: "NZB URL queued for download."
+  rescue ArgumentError => e
+    redirect_to @request, alert: e.message
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+    redirect_to @request, alert: "NZB URL could not be queued. Please try again."
   end
 
   def download

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -15,6 +15,7 @@ class DownloadJob < ApplicationJob
   MAX_DIRECT_DOWNLOAD_BYTES = 512.megabytes
   MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES = 2.gigabytes
   MAX_DIRECT_DOWNLOAD_REDIRECTS = 5
+  DIRECT_DOWNLOAD_HEARTBEAT_INTERVAL = 30.seconds
   DIRECT_EBOOK_EXTENSIONS = %w[epub pdf mobi azw3].freeze
   DIRECT_AUDIOBOOK_ARCHIVE_EXTENSIONS = %w[zip].freeze
   DIRECT_AUDIOBOOK_FILE_EXTENSIONS = %w[m4b mp3 m4a aac flac ogg opus].freeze
@@ -51,6 +52,7 @@ class DownloadJob < ApplicationJob
       return
     end
     download.update!(search_result: search_result) unless download.search_result_id
+    return unless claim_dispatch!(download, search_result)
 
     begin
       # Handle Anna's Archive downloads differently
@@ -68,54 +70,83 @@ class DownloadJob < ApplicationJob
         handle_standard_download(download, search_result)
       end
     rescue DownloadClientSelector::NoClientAvailableError => e
-      Rails.logger.error "[DownloadJob] No download client available: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      download.request.mark_for_attention!(e.message)
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] No download client available: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        download.request.mark_for_attention!(e.message)
+      end
     rescue DownloadClients::Base::AuthenticationError => e
-      Rails.logger.error "[DownloadJob] Download client authentication failed: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      download.request.mark_for_attention!("Download client authentication failed. Please check credentials.")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] Download client authentication failed: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        download.request.mark_for_attention!("Download client authentication failed. Please check credentials.")
+      end
     rescue DownloadClients::Base::ConnectionError => e
-      Rails.logger.error "[DownloadJob] Download client connection error: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      download.request.mark_for_attention!("Failed to connect to download client: #{e.message}")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] Download client connection error: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        download.request.mark_for_attention!("Failed to connect to download client: #{e.message}")
+      end
     rescue DownloadClients::Base::Error => e
-      Rails.logger.error "[DownloadJob] Download client error for download ##{download.id}: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      download.request.handle_download_failure!(download, reason: "Download client error: #{e.message}")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] Download client error for download ##{download.id}: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        download.request.handle_download_failure!(download, reason: "Download client error: #{e.message}")
+      end
     rescue AnnaArchiveClient::Error => e
-      Rails.logger.error "[DownloadJob] Anna's Archive error for download ##{download.id}: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      handle_download_source_failure(download, e, "Anna's Archive error: #{e.message}")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] Anna's Archive error for download ##{download.id}: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        handle_download_source_failure(download, e, "Anna's Archive error: #{e.message}")
+      end
     rescue ZLibraryClient::Error => e
-      Rails.logger.error "[DownloadJob] Z-Library error for download ##{download.id}: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      handle_download_source_failure(download, e, "Z-Library error: #{e.message}")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] Z-Library error for download ##{download.id}: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        handle_download_source_failure(download, e, "Z-Library error: #{e.message}")
+      end
     rescue LibrivoxClient::Error => e
-      Rails.logger.error "[DownloadJob] LibriVox error for download ##{download.id}: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      handle_download_source_failure(download, e, "LibriVox error: #{e.message}")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] LibriVox error for download ##{download.id}: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        handle_download_source_failure(download, e, "LibriVox error: #{e.message}")
+      end
     rescue GutenbergClient::Error => e
-      Rails.logger.error "[DownloadJob] Project Gutenberg error for download ##{download.id}: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      handle_download_source_failure(download, e, "Project Gutenberg error: #{e.message}")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] Project Gutenberg error for download ##{download.id}: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        handle_download_source_failure(download, e, "Project Gutenberg error: #{e.message}")
+      end
     rescue CustomAcquisitionProviderClient::Error => e
-      Rails.logger.error "[DownloadJob] Custom provider error for download ##{download.id}: #{e.message}"
-      track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
-      download.update!(status: :failed)
-      handle_download_source_failure(download, e, "Custom provider error: #{e.message}")
+      with_current_dispatch(download) do
+        Rails.logger.error "[DownloadJob] Custom provider error for download ##{download.id}: #{e.message}"
+        track_request_event(download.request, "dispatch_failed", download: download, message: e.message, level: :error)
+        download.update!(status: :failed)
+        handle_download_source_failure(download, e, "Custom provider error: #{e.message}")
+      end
     end
   end
 
   private
+
+  def with_current_dispatch(download)
+    download.request.with_lock do
+      download.reload
+      next unless download.queued? || download.downloading?
+
+      yield
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
 
   def handle_download_source_failure(download, error, message)
     if transient_download_source_error?(error)
@@ -214,11 +245,7 @@ class DownloadJob < ApplicationJob
   rescue LibrivoxClient::Error
     raise
   rescue => e
-    Rails.logger.error "[DownloadJob] LibriVox download failed: #{e.message}"
-    Rails.logger.error e.backtrace.first(5).join("\n")
-    track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
-    download.update!(status: :failed)
-    handle_direct_download_failure(download, e, message: "LibriVox download failed: #{e.message}")
+    fail_direct_dispatch!(download, e, message: "LibriVox download failed: #{e.message}")
   end
 
   def handle_custom_provider_download(download, search_result)
@@ -244,14 +271,10 @@ class DownloadJob < ApplicationJob
     else
       raise CustomAcquisitionProviderClient::UnusableArtifactError, "Unsupported custom provider artifact type: #{acquisition.download_type}"
     end
-  rescue CustomAcquisitionProviderClient::Error
+  rescue CustomAcquisitionProviderClient::Error, DownloadClientSelector::NoClientAvailableError, DownloadClients::Base::Error
     raise
   rescue => e
-    Rails.logger.error "[DownloadJob] Custom provider download failed: #{e.message}"
-    Rails.logger.error e.backtrace.first(5).join("\n")
-    track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
-    download.update!(status: :failed)
-    handle_direct_download_failure(download, e, message: "Custom provider download failed: #{e.message}")
+    fail_direct_dispatch!(download, e, message: "Custom provider download failed: #{e.message}")
   end
 
   def handle_direct_audiobook_download(download, search_result, download_url, source_name:)
@@ -272,30 +295,33 @@ class DownloadJob < ApplicationJob
     destination_dir = PathTemplateService.build_destination(book, base_path: base_path)
 
     Rails.logger.info "[DownloadJob] Downloading #{source_name} audiobook to: #{destination_dir}"
-    FileUtils.mkdir_p(destination_dir)
+    mark_direct_download_active!(download)
+    FileUtils.mkdir_p(File.dirname(destination_dir))
 
-    Tempfile.create([ "shelfarr-audiobook-", ".zip" ]) do |archive|
-      archive.binmode
-      download_file_via_http(
-        search_result,
-        download_url,
-        archive.path,
-        max_bytes: MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES
-      )
-      verify_downloaded_zip!(archive.path)
-      extract_zip_to_directory(archive.path, destination_dir)
+    finalized = Dir.mktmpdir(".shelfarr-audiobook-", File.dirname(destination_dir)) do |staging_dir|
+      Tempfile.create([ "shelfarr-audiobook-", ".zip" ]) do |archive|
+        archive.binmode
+        download_file_via_http(
+          search_result,
+          download_url,
+          archive.path,
+          max_bytes: MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES,
+          download: download
+        )
+        verify_downloaded_zip!(archive.path)
+        refresh_direct_download_heartbeat!(download)
+        extract_zip_to_directory(archive.path, staging_dir)
+      end
+
+      refresh_direct_download_heartbeat!(download)
+      # Archives extract to many files, so flat output has no single file to
+      # track; the root is recorded and guarded against delete/zip by consumers.
+      finalize_direct_download!(download, download_path: destination_dir, book_path: destination_dir) do
+        install_staged_directory!(staging_dir, destination_dir)
+      end
     end
+    return unless finalized
 
-    download.update!(
-      status: :completed,
-      download_path: destination_dir,
-      download_type: "direct"
-    )
-
-    # Archives extract to many files, so flat output has no single file to
-    # track; the root is recorded and guarded against delete/zip by consumers
-    book.update!(file_path: destination_dir)
-    download.request.complete!
     trigger_library_scan(book) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
@@ -304,6 +330,7 @@ class DownloadJob < ApplicationJob
   end
 
   def handle_direct_audiobook_file_download(download, search_result, download_url, extension:, source_name:)
+    finalized = false
     book = download.request.book
     base_path = SettingsService.get(:audiobook_output_path, default: "/audiobooks")
     destination_dir = PathTemplateService.build_destination(book, base_path: base_path)
@@ -311,36 +338,43 @@ class DownloadJob < ApplicationJob
     destination_path = File.join(destination_dir, filename)
 
     Rails.logger.info "[DownloadJob] Downloading #{source_name} audiobook file to: #{destination_path}"
+    mark_direct_download_active!(download)
     FileUtils.mkdir_p(destination_dir)
 
     download_file_via_http(
       search_result,
       download_url,
       destination_path,
-      max_bytes: MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES
+      max_bytes: MAX_DIRECT_AUDIOBOOK_DOWNLOAD_BYTES,
+      download: download
     )
     verify_downloaded_audiobook_file!(destination_path)
 
-    download.update!(
-      status: :completed,
-      download_path: destination_path,
-      download_type: "direct"
-    )
-
+    refresh_direct_download_heartbeat!(download)
     # Flat output shares destination_dir across books; track the file itself
-    book.update!(file_path: PathTemplateService.flat_output?(book) ? destination_path : destination_dir)
-    download.request.complete!
+    book_path = PathTemplateService.flat_output?(book) ? destination_path : destination_dir
+    finalized = finalize_direct_download!(download, download_path: destination_path, book_path: book_path)
+    unless finalized
+      FileUtils.rm_f(destination_path)
+      return
+    end
+
     trigger_library_scan(book) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
     Rails.logger.info "[DownloadJob] #{source_name} download completed: #{destination_path}"
   rescue => e
-    FileUtils.rm_f(destination_path) if defined?(destination_path) && destination_path.present?
-    raise e
+    if finalized
+      Rails.logger.warn "[DownloadJob] Post-completion action failed for download ##{download.id}: #{e.class}"
+    else
+      FileUtils.rm_f(destination_path) if defined?(destination_path) && destination_path.present?
+      raise e
+    end
   end
 
   def handle_direct_http_download(download, search_result, download_url)
+    finalized = false
     book = download.request.book
 
     # Build destination path similar to how PostProcessingJob does it
@@ -352,28 +386,24 @@ class DownloadJob < ApplicationJob
     destination_path = File.join(destination_dir, filename)
 
     Rails.logger.info "[DownloadJob] Downloading directly to: #{destination_path}"
+    mark_direct_download_active!(download)
 
     # Ensure directory exists
     FileUtils.mkdir_p(destination_dir)
 
     # Download the file
     expected_extension = infer_extension(download_url, search_result)
-    download_file_via_http(search_result, download_url, destination_path)
+    download_file_via_http(search_result, download_url, destination_path, download: download)
     verify_downloaded_ebook!(destination_path, expected_extension: expected_extension)
 
-    # Update download record as completed
-    download.update!(
-      status: :completed,
-      download_path: destination_path,
-      download_type: "direct"
-    )
-
-    # Update book with file path
     # Flat output shares destination_dir across books; track the file itself
-    book.update!(file_path: PathTemplateService.flat_output?(book) ? destination_path : destination_dir)
-
-    # Complete the request
-    download.request.complete!
+    refresh_direct_download_heartbeat!(download)
+    book_path = PathTemplateService.flat_output?(book) ? destination_path : destination_dir
+    finalized = finalize_direct_download!(download, download_path: destination_path, book_path: book_path)
+    unless finalized
+      FileUtils.rm_f(destination_path)
+      return
+    end
 
     # Trigger library scan if configured
     trigger_library_scan(book) if LibraryPlatformClient.configured?
@@ -384,11 +414,12 @@ class DownloadJob < ApplicationJob
 
     Rails.logger.info "[DownloadJob] Direct download completed: #{destination_path}"
   rescue => e
-    Rails.logger.error "[DownloadJob] Direct download failed: #{e.message}"
-    Rails.logger.error e.backtrace.first(5).join("\n")
-    track_request_event(download.request, "failed", download: download, message: e.message, level: :error)
-    download.update!(status: :failed)
-    handle_direct_download_failure(download, e)
+    if finalized
+      Rails.logger.warn "[DownloadJob] Post-completion action failed for download ##{download.id}: #{e.class}"
+    else
+      FileUtils.rm_f(destination_path) if defined?(destination_path) && destination_path.present?
+      fail_direct_dispatch!(download, e, message: "Direct download failed: #{e.message}")
+    end
   end
 
   def infer_filename_from_url(url, search_result)
@@ -526,7 +557,7 @@ class DownloadJob < ApplicationJob
     result
   end
 
-  def download_file_via_http(search_result, url, destination, max_bytes: MAX_DIRECT_DOWNLOAD_BYTES)
+  def download_file_via_http(search_result, url, destination, max_bytes: MAX_DIRECT_DOWNLOAD_BYTES, download: nil)
     endpoint = validate_direct_download_url!(url, search_result)
 
     Rails.logger.info "[DownloadJob] Starting HTTP download..."
@@ -534,6 +565,7 @@ class DownloadJob < ApplicationJob
     bytes_written = 0
     redirects_followed = 0
     download_complete = false
+    last_heartbeat_at = refresh_direct_download_heartbeat!(download) if download
 
     loop do
       response_handled = false
@@ -573,6 +605,9 @@ class DownloadJob < ApplicationJob
 
           File.open(destination, "wb") do |dest|
             response.read_body do |chunk|
+              if download && last_heartbeat_at < DIRECT_DOWNLOAD_HEARTBEAT_INTERVAL.ago
+                last_heartbeat_at = refresh_direct_download_heartbeat!(download)
+              end
               bytes_written += chunk.bytesize
               raise "Direct download exceeds size limit of #{max_bytes / 1.megabyte} MB" if bytes_written > max_bytes
 
@@ -595,6 +630,28 @@ class DownloadJob < ApplicationJob
     Rails.logger.info "[DownloadJob] Downloaded #{(file_size / 1024.0 / 1024.0).round(2)} MB"
   rescue SocketError, IOError, EOFError, Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
     raise DirectDownloadError, "Direct download request failed: #{e.message}"
+  end
+
+  def mark_direct_download_active!(download)
+    now = Time.current
+    claimed = Download
+      .where(id: download.id, status: Download.statuses[:downloading], download_type: "dispatching")
+      .update_all(download_type: "direct", updated_at: now)
+    raise DirectDownloadError, "Direct download is no longer active" unless claimed == 1
+
+    download.download_type = "direct"
+    download.updated_at = now
+  end
+
+  def refresh_direct_download_heartbeat!(download)
+    now = Time.current
+    refreshed = Download
+      .where(id: download.id, status: Download.statuses[:downloading], download_type: "direct")
+      .update_all(updated_at: now)
+    raise DirectDownloadError, "Direct download is no longer active" unless refreshed == 1
+
+    download.updated_at = now
+    now
   end
 
   def validate_direct_download_url!(url, search_result = nil)
@@ -730,6 +787,14 @@ class DownloadJob < ApplicationJob
     raise "Failed to extract audiobook archive: #{e.message}"
   end
 
+  def install_staged_directory!(staging_dir, destination_dir)
+    if File.exist?(destination_dir)
+      FileUtils.cp_r(Dir.children(staging_dir).map { |entry| File.join(staging_dir, entry) }, destination_dir)
+    else
+      FileUtils.mv(staging_dir, destination_dir)
+    end
+  end
+
   def trigger_library_scan(book)
     lib_id = SettingsService.library_id_for_book(book)
 
@@ -751,40 +816,17 @@ class DownloadJob < ApplicationJob
     # add_torrent now returns the hash directly (or nil on failure)
     torrent_hash = client.add_torrent(download_url)
 
-    if torrent_hash
-      # Defensive check: warn if another download already has this external_id
-      check_for_duplicate_external_id(torrent_hash, download.id)
-
-      download.update!(
-        status: :downloading,
-        download_client: client_record,
-        external_id: torrent_hash,
+    if torrent_hash.present?
+      finalize_standard_dispatch!(
+        download,
+        search_result,
+        client,
+        client_record,
+        torrent_hash,
         download_type: "torrent"
       )
-      track_request_event(
-        download.request,
-        "dispatched",
-        download: download,
-        message: "Sent torrent download to #{client_record.name}",
-        details: {
-          client_name: client_record.name,
-          download_type: "torrent",
-          external_id: torrent_hash
-        }
-      )
-      Rails.logger.info "[DownloadJob] Successfully added torrent for download ##{download.id}, hash: #{torrent_hash}"
     else
-      track_request_event(
-        download.request,
-        "dispatch_failed",
-        download: download,
-        message: "Client did not return a torrent hash",
-        level: :error,
-        details: { client_name: client_record.name }
-      )
-      download.update!(status: :failed)
-      download.request.handle_download_failure!(download, reason: "Failed to add to #{client_record.name}")
-      Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
+      fail_standard_dispatch!(download, search_result, client_record, download_type: "torrent")
     end
   end
 
@@ -799,36 +841,16 @@ class DownloadJob < ApplicationJob
     external_id = result.is_a?(Hash) ? result["nzo_ids"]&.first : nil
 
     if external_id.present?
-      check_for_duplicate_external_id(external_id, download.id)
-
-      download.update!(
-        status: :downloading,
-        download_client: client_record,
-        external_id: external_id,
+      finalize_standard_dispatch!(
+        download,
+        search_result,
+        client,
+        client_record,
+        external_id,
         download_type: "usenet"
       )
-      track_request_event(
-        download.request,
-        "dispatched",
-        download: download,
-        message: "Sent usenet download to #{client_record.name}",
-        details: {
-          client_name: client_record.name,
-          download_type: "usenet",
-          external_id: external_id
-        }
-      )
     else
-      track_request_event(
-        download.request,
-        "dispatch_failed",
-        download: download,
-        message: "Client did not return an external ID",
-        level: :error,
-        details: { client_name: client_record.name, download_type: "usenet" }
-      )
-      download.update!(status: :failed)
-      download.request.handle_download_failure!(download, reason: "Failed to add to #{client_record.name}")
+      fail_standard_dispatch!(download, search_result, client_record, download_type: "usenet")
     end
   end
 
@@ -841,6 +863,9 @@ class DownloadJob < ApplicationJob
       return
     end
 
+    download_link = search_result.download_link
+    validate_manual_nzb_dispatch_url!(download_link) if search_result.from_manual_nzb?
+
     # Select best available client based on download type and priority
     client_record = DownloadClientSelector.for_download(search_result)
     client = client_record.adapter
@@ -848,7 +873,6 @@ class DownloadJob < ApplicationJob
 
     Rails.logger.info "[DownloadJob] Using client '#{client_record.name}' for download ##{download.id}"
 
-    download_link = search_result.download_link
     Rails.logger.info "[DownloadJob] Download link type: #{is_usenet ? 'usenet' : 'torrent'}, length: #{download_link.to_s.length} chars"
     if search_result.from_manual_nzb?
       Rails.logger.debug "[DownloadJob] Full download URL: [REDACTED MANUAL NZB URL]"
@@ -872,29 +896,83 @@ class DownloadJob < ApplicationJob
     end
 
     if success
-      # Defensive check: warn if another download already has this external_id
-      # This should not happen with the race condition fix, but log it if it does
-      check_for_duplicate_external_id(external_id, download.id)
-
-      download.update!(
-        status: :downloading,
-        download_client: client_record,
-        external_id: external_id,
+      finalize_standard_dispatch!(
+        download,
+        search_result,
+        client,
+        client_record,
+        external_id,
         download_type: is_usenet ? "usenet" : "torrent"
       )
-      track_request_event(
-        download.request,
-        "dispatched",
-        download: download,
-        message: "Sent #{download.download_type} download to #{client_record.name}",
-        details: {
-          client_name: client_record.name,
-          download_type: download.download_type,
-          external_id: external_id
-        }
-      )
-      Rails.logger.info "[DownloadJob] Successfully added #{download.download_type} for download ##{download.id}, external_id: #{external_id}"
     else
+      fail_standard_dispatch!(
+        download,
+        search_result,
+        client_record,
+        download_type: is_usenet ? "usenet" : "torrent"
+      )
+    end
+  end
+
+  def claim_dispatch!(download, search_result)
+    claimed = false
+
+    download.request.with_lock do
+      download.reload
+      search_result.reload
+      next unless download.queued?
+
+      download.update!(status: :downloading, download_type: "dispatching")
+      claimed = true
+    end
+
+    claimed
+  rescue ActiveRecord::RecordNotFound
+    false
+  end
+
+  def finalize_standard_dispatch!(download, search_result, client, client_record, external_id, download_type:)
+    finalized = false
+
+    begin
+      finalized = download.request.with_lock do
+        next false unless current_standard_dispatch?(download, search_result)
+
+        check_for_duplicate_external_id(external_id, download.id)
+        download.update!(
+          download_client: client_record,
+          external_id: external_id,
+          download_type: download_type
+        )
+        track_request_event(
+          download.request,
+          "dispatched",
+          download: download,
+          message: "Sent #{download_type} download to #{client_record.name}",
+          details: {
+            client_name: client_record.name,
+            download_type: download_type,
+            external_id: external_id
+          }
+        )
+        true
+      end
+    rescue ActiveRecord::RecordNotFound
+      finalized = false
+    ensure
+      remove_stale_client_dispatch(client, client_record, external_id, download.id) unless finalized
+    end
+
+    Rails.logger.info "[DownloadJob] Successfully added #{download_type} for download ##{download.id}, external_id: #{external_id}" if finalized
+    finalized
+  end
+
+  def fail_standard_dispatch!(download, search_result, client_record, download_type:)
+    failed = false
+
+    download.request.with_lock do
+      next unless current_standard_dispatch?(download, search_result)
+
       track_request_event(
         download.request,
         "dispatch_failed",
@@ -903,13 +981,79 @@ class DownloadJob < ApplicationJob
         level: :error,
         details: {
           client_name: client_record.name,
-          download_type: is_usenet ? "usenet" : "torrent"
+          download_type: download_type
         }
       )
       download.update!(status: :failed)
       download.request.handle_download_failure!(download, reason: "Failed to add to #{client_record.name}")
-      Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}"
+      failed = true
     end
+
+    Rails.logger.error "[DownloadJob] Failed to add download ##{download.id}" if failed
+    failed
+  rescue ActiveRecord::RecordNotFound
+    false
+  end
+
+  def current_standard_dispatch?(download, search_result)
+    download.reload
+    search_result.reload
+    download.downloading? && download.download_type == "dispatching" && download.external_id.blank?
+  end
+
+  def finalize_direct_download!(download, download_path:, book_path:)
+    finalized = download.request.with_lock do
+      download.reload
+      next false unless download.downloading? && download.download_type == "direct" && download.external_id.blank?
+
+      yield if block_given?
+      download.request.book.update!(file_path: book_path)
+      download.update!(status: :completed, download_path: download_path)
+      download.request.complete!
+      true
+    end
+
+    Rails.logger.info "[DownloadJob] Direct dispatch no longer owns download ##{download.id}; discarding completion" unless finalized
+    finalized
+  rescue ActiveRecord::RecordNotFound
+    false
+  end
+
+  def fail_direct_dispatch!(download, error, message:)
+    handled = download.request.with_lock do
+      download.reload
+      next false unless download.downloading? && download.download_type.in?([ "dispatching", "direct" ])
+
+      Rails.logger.error "[DownloadJob] #{message}"
+      Rails.logger.error error.backtrace.first(5).join("\n") if error.backtrace
+      track_request_event(download.request, "failed", download: download, message: error.message, level: :error)
+      download.update!(status: :failed)
+      handle_direct_download_failure(download, error, message: message)
+      true
+    end
+
+    handled
+  rescue ActiveRecord::RecordNotFound
+    false
+  end
+
+  def remove_stale_client_dispatch(client, client_record, external_id, download_id)
+    removed = client.remove_torrent(external_id, delete_files: true)
+    if removed
+      Rails.logger.info "[DownloadJob] Removed stale client dispatch for replaced download ##{download_id}"
+    else
+      Rails.logger.warn "[DownloadJob] Client did not remove stale dispatch for replaced download ##{download_id}; scheduling cleanup"
+      enqueue_stale_client_cleanup(client_record.id, external_id, download_id)
+    end
+  rescue StandardError => e
+    Rails.logger.warn "[DownloadJob] Failed to remove stale dispatch for replaced download ##{download_id}: #{e.class}; scheduling cleanup"
+    enqueue_stale_client_cleanup(client_record.id, external_id, download_id)
+  end
+
+  def enqueue_stale_client_cleanup(client_id, external_id, download_id)
+    StaleClientDispatchCleanupJob.perform_later(client_id, external_id)
+  rescue StandardError => e
+    Rails.logger.error "[DownloadJob] Failed to enqueue stale dispatch cleanup for download ##{download_id}: #{e.class}"
   end
 
   def check_for_duplicate_external_id(external_id, current_download_id)
@@ -934,6 +1078,15 @@ class DownloadJob < ApplicationJob
     return parts.join(" - ") if parts.any?
 
     search_result.title.to_s.strip.presence
+  end
+
+  def validate_manual_nzb_dispatch_url!(url)
+    # Manual URLs are admin-provided and may intentionally target a home-lab
+    # service, but metadata, link-local, multicast, and reserved destinations
+    # should never be delegated to a download client.
+    OutboundUrlGuard.validate!(url, allow_private: true)
+  rescue OutboundUrlGuard::BlockedUrlError
+    raise DownloadClients::Base::Error, "Manual NZB URL points to a blocked or invalid destination"
   end
 
   def track_request_event(request, event_type, download: nil, message: nil, level: :info, details: {})

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -850,11 +850,19 @@ class DownloadJob < ApplicationJob
 
     download_link = search_result.download_link
     Rails.logger.info "[DownloadJob] Download link type: #{is_usenet ? 'usenet' : 'torrent'}, length: #{download_link.to_s.length} chars"
-    Rails.logger.debug "[DownloadJob] Full download URL: #{UrlRedactor.redact(download_link)}"
+    if search_result.from_manual_nzb?
+      Rails.logger.debug "[DownloadJob] Full download URL: [REDACTED MANUAL NZB URL]"
+    else
+      Rails.logger.debug "[DownloadJob] Full download URL: #{UrlRedactor.redact(download_link)}"
+    end
 
     if is_usenet
       # SABnzbd returns a hash with nzo_ids
-      result = client.add_torrent(download_link, nzbname: build_usenet_job_name(search_result))
+      result = client.add_torrent(
+        download_link,
+        nzbname: build_usenet_job_name(search_result),
+        sensitive_url: search_result.from_manual_nzb?
+      )
       external_id = result.is_a?(Hash) ? result["nzo_ids"]&.first : nil
       success = external_id.present?
     else

--- a/app/jobs/download_monitor_job.rb
+++ b/app/jobs/download_monitor_job.rb
@@ -5,13 +5,14 @@ class DownloadMonitorJob < ApplicationJob
   CONCURRENCY_KEY = "download_monitor"
   NOT_FOUND_THRESHOLD = 3
   SCHEDULE_CACHE_KEY = "download_monitor/next_run_at"
+  DIRECT_DOWNLOAD_STALE_TIMEOUT = 30.minutes
 
   queue_as :default
   limits_concurrency key: CONCURRENCY_KEY, duration: 30.minutes
 
   class << self
     def ensure_running!
-      return unless DownloadClient.enabled.exists?
+      return unless monitoring_required?
       return if monitor_job_pending?
 
       interval = poll_interval_seconds
@@ -23,6 +24,16 @@ class DownloadMonitorJob < ApplicationJob
       reserve_schedule!(interval)
       Rails.logger.info "[DownloadMonitorJob] Scheduling monitor chain"
       perform_later
+    end
+
+    def monitoring_required?
+      return true if DownloadClient.enabled.exists?
+      return true if Download.active.where(download_type: [ "direct", "dispatching" ]).exists?
+
+      Download.active
+        .where(download_type: [ nil, "" ])
+        .includes(:search_result)
+        .any? { |download| download.search_result&.direct_download? }
     end
 
     def clear_schedule!
@@ -66,7 +77,7 @@ class DownloadMonitorJob < ApplicationJob
   end
 
   def perform
-    unless any_client_configured?
+    unless self.class.monitoring_required?
       self.class.clear_schedule!
       return
     end
@@ -87,7 +98,11 @@ class DownloadMonitorJob < ApplicationJob
 
   def check_download_status(download)
     unless download.external_id.present?
-      handle_stale_queued_download(download)
+      if download.download_type == "direct"
+        handle_stale_direct_download(download)
+      else
+        handle_stale_queued_download(download)
+      end
       return
     end
 
@@ -132,57 +147,119 @@ class DownloadMonitorJob < ApplicationJob
   end
 
   def handle_failed(download)
-    Rails.logger.error "[DownloadMonitorJob] Download #{download.id} failed in client"
+    download.request.with_lock do
+      download.reload
+      next unless current_monitored_download?(download)
 
-    track_request_event(download.request, "failed", download: download, message: "Download failed in client", level: :error)
-    download.update!(status: :failed)
-    download.request.handle_download_failure!(download, reason: "Download failed in client")
+      Rails.logger.error "[DownloadMonitorJob] Download #{download.id} failed in client"
+      track_request_event(download.request, "failed", download: download, message: "Download failed in client", level: :error)
+      download.update!(status: :failed)
+      download.request.handle_download_failure!(download, reason: "Download failed in client")
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def handle_missing(download)
-    client_name = download.download_client&.name || "unknown"
-    new_count = download.not_found_count + 1
+    download.request.with_lock do
+      download.reload
+      next unless current_monitored_download?(download)
 
-    if new_count >= NOT_FOUND_THRESHOLD
-      Rails.logger.error "[DownloadMonitorJob] Download #{download.id} (hash: #{download.external_id}) not found in client '#{client_name}' after #{new_count} consecutive checks"
+      client_name = download.download_client&.name || "unknown"
+      new_count = download.not_found_count + 1
 
-      track_request_event(
-        download.request,
-        "failed",
-        download: download,
-        message: "Download not found in client after #{new_count} checks",
-        level: :error,
-        details: { client_name: client_name }
-      )
-      download.update!(status: :failed, not_found_count: new_count)
-      download.request.handle_download_failure!(download, reason: "Download not found in client '#{client_name}' (hash: #{download.external_id})")
-    else
-      Rails.logger.warn "[DownloadMonitorJob] Download #{download.id} (hash: #{download.external_id}) not found in client '#{client_name}' (attempt #{new_count}/#{NOT_FOUND_THRESHOLD})"
+      if new_count >= NOT_FOUND_THRESHOLD
+        Rails.logger.error "[DownloadMonitorJob] Download #{download.id} (hash: #{download.external_id}) not found in client '#{client_name}' after #{new_count} consecutive checks"
 
-      download.update!(not_found_count: new_count)
+        track_request_event(
+          download.request,
+          "failed",
+          download: download,
+          message: "Download not found in client after #{new_count} checks",
+          level: :error,
+          details: { client_name: client_name }
+        )
+        download.update!(status: :failed, not_found_count: new_count)
+        download.request.handle_download_failure!(download, reason: "Download not found in client '#{client_name}' (hash: #{download.external_id})")
+      else
+        Rails.logger.warn "[DownloadMonitorJob] Download #{download.id} (hash: #{download.external_id}) not found in client '#{client_name}' (attempt #{new_count}/#{NOT_FOUND_THRESHOLD})"
+
+        download.update!(not_found_count: new_count)
+      end
     end
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def handle_stale_queued_download(download)
-    return unless download.queued?
+    return unless download.queued? || download.downloading?
 
     timeout_minutes = SettingsService.get(:download_enqueue_timeout_minutes, default: 5).to_i
     return if timeout_minutes <= 0
-    return if download.created_at > timeout_minutes.minutes.ago
+    cutoff = timeout_minutes.minutes.ago
+    download.request.with_lock do
+      stale_scope = Download.where(id: download.id, external_id: [ nil, "" ])
+      stale_scope = if download.queued?
+        stale_scope.where(status: Download.statuses[:queued]).where("created_at <= ?", cutoff)
+      else
+        stale_scope
+          .where(
+            status: Download.statuses[:downloading],
+            download_type: [ nil, "", "dispatching", "torrent", "usenet" ]
+          )
+          .where("updated_at <= ?", cutoff)
+      end
+      claimed = stale_scope.update_all(status: Download.statuses[:failed], updated_at: Time.current)
+      next unless claimed == 1
 
-    Rails.logger.error "[DownloadMonitorJob] Download #{download.id} stayed queued for more than #{timeout_minutes} minutes without reaching a download client"
+      download.reload
+      Rails.logger.error "[DownloadMonitorJob] Download #{download.id} stayed queued for more than #{timeout_minutes} minutes without reaching a download client"
+      track_request_event(
+        download.request,
+        "dispatch_stalled",
+        download: download,
+        message: "Download stayed queued for more than #{timeout_minutes} minutes without an external client ID",
+        level: :warn
+      )
+      download.request.mark_for_attention!(
+        "Download stayed queued in Shelfarr for more than #{timeout_minutes} minutes and was never sent to the download client. Retry the request and check the job queue/logs."
+      )
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
 
-    track_request_event(
-      download.request,
-      "dispatch_stalled",
-      download: download,
-      message: "Download stayed queued for more than #{timeout_minutes} minutes without an external client ID",
-      level: :warn
-    )
-    download.update!(status: :failed)
-    download.request.mark_for_attention!(
-      "Download stayed queued in Shelfarr for more than #{timeout_minutes} minutes and was never sent to the download client. Retry the request and check the job queue/logs."
-    )
+  def handle_stale_direct_download(download)
+    return unless download.downloading?
+    cutoff = DIRECT_DOWNLOAD_STALE_TIMEOUT.ago
+
+    download.request.with_lock do
+      claimed = Download
+        .where(
+          id: download.id,
+          status: Download.statuses[:downloading],
+          download_type: "direct",
+          external_id: [ nil, "" ]
+        )
+        .where("updated_at <= ?", cutoff)
+        .update_all(status: Download.statuses[:failed], updated_at: Time.current)
+      next unless claimed == 1
+
+      download.reload
+      Rails.logger.error "[DownloadMonitorJob] Direct download #{download.id} stopped reporting progress"
+      track_request_event(
+        download.request,
+        "dispatch_stalled",
+        download: download,
+        message: "Direct download stopped reporting progress",
+        level: :warn
+      )
+      download.request.mark_for_attention!(
+        "Direct download stopped reporting progress. Retry the request and check the job queue/logs."
+      )
+    end
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 
   def schedule_next_run
@@ -197,8 +274,11 @@ class DownloadMonitorJob < ApplicationJob
     DownloadMonitorJob.set(wait: interval.seconds).perform_later
   end
 
-  def any_client_configured?
-    DownloadClient.enabled.exists?
+  def current_monitored_download?(download)
+    return false unless download.downloading? && download.external_id.present?
+    return true if download.search_result_id.blank?
+
+    download.request.search_results.selected.where(id: download.search_result_id).exists?
   end
 
   def track_request_event(request, event_type, download: nil, message: nil, level: :info, details: {})

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -25,15 +25,11 @@ class PostProcessingJob < ApplicationJob
     return unless download&.completed?
 
     request = download.request
-    return if request.completed?
-    return unless request.downloading? || request.processing?
-    return unless download.claim_post_processing!(job_id, expected_owner_job_id: expected_owner_job_id)
+    return unless claim_request_for_post_processing(download, request, expected_owner_job_id)
 
     book = request.book
 
     Rails.logger.info "[PostProcessingJob] Starting post-processing for download #{download.id} (#{book.title})"
-
-    request.update!(status: :processing) unless request.processing?
 
     begin
       base_path = get_base_path(book)
@@ -71,6 +67,24 @@ class PostProcessingJob < ApplicationJob
   end
 
   private
+
+  def claim_request_for_post_processing(download, request, expected_owner_job_id)
+    request.with_lock do
+      download.reload
+      return false unless download.completed?
+      return false if request.completed?
+      return false unless request.downloading? || request.processing?
+
+      selected_result_id = request.search_results.selected.pick(:id)
+      return false if download.search_result_id.present? && download.search_result_id != selected_result_id
+      return false if request.downloads.active.where.not(id: download.id).exists?
+      return false unless download.claim_post_processing!(job_id, expected_owner_job_id: expected_owner_job_id)
+
+      request.update!(status: :processing) unless request.processing?
+    end
+
+    true
+  end
 
   def source_path_unavailable?(source_path)
     source_path.present? && !File.exist?(source_path)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -286,7 +286,7 @@ class SearchJob < ApplicationJob
 
   def save_results(request, tagged_results)
     blocklisted_by_guid = request.search_results
-      .where.not(source: SearchResult::SOURCE_MANUAL_MAGNET)
+      .where.not(source: SearchResult::MANUAL_SOURCES)
       .blocklisted
       .pluck(:guid, :blocklisted_at, :blocklist_reason)
       .to_h { |guid, blocklisted_at, blocklist_reason| [ guid, { blocklisted_at: blocklisted_at, blocklist_reason: blocklist_reason } ] }
@@ -298,7 +298,7 @@ class SearchJob < ApplicationJob
       .pluck(:search_result_id)
 
     request.search_results
-      .where.not(source: SearchResult::SOURCE_MANUAL_MAGNET)
+      .where.not(source: SearchResult::MANUAL_SOURCES)
       .where.not(id: active_download_result_ids)
       .not_blocklisted
       .destroy_all

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -44,12 +44,9 @@ class SearchJob < ApplicationJob
   def perform(request_id)
     request = Request.find_by(id: request_id)
     return unless request
-    return unless request.pending?
-    return unless request.book # Guard against orphaned requests
+    return unless claim_search!(request)
 
     Rails.logger.info "[SearchJob] Starting search for request ##{request.id} (book: #{request.book.title})"
-
-    request.update!(status: :searching)
 
     # Check if any search sources are configured
     indexer_available = IndexerClient.configured?
@@ -61,7 +58,11 @@ class SearchJob < ApplicationJob
 
     unless indexer_available || anna_available || zlibrary_available || gutenberg_available || librivox_available || custom_providers.any?
       Rails.logger.error "[SearchJob] No search sources configured"
-      request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, Z-Library, Project Gutenberg, LibriVox, or a custom acquisition provider.")
+      request.with_lock do
+        next unless request.searching?
+
+        request.mark_for_attention!("No search sources configured. Please configure an indexer, Anna's Archive, Z-Library, Project Gutenberg, LibriVox, or a custom acquisition provider.")
+      end
       return
     end
 
@@ -105,17 +106,35 @@ class SearchJob < ApplicationJob
       Rails.logger.info "[SearchJob] Found #{provider_results.count} custom provider results from #{provider.name}"
     end
 
-    if all_results.any?
-      save_results(request, all_results)
-      Rails.logger.info "[SearchJob] Total #{all_results.count} results for request ##{request.id}"
-      attempt_auto_select(request)
-    else
-      Rails.logger.info "[SearchJob] No results found for request ##{request.id}"
-      handle_no_results(request, indexer_error)
+    request.with_lock do
+      unless request.searching?
+        Rails.logger.info "[SearchJob] Request ##{request.id} left searching state; discarding stale search results"
+        return
+      end
+
+      if all_results.any?
+        save_results(request, all_results)
+        Rails.logger.info "[SearchJob] Total #{all_results.count} results for request ##{request.id}"
+        attempt_auto_select(request)
+      else
+        Rails.logger.info "[SearchJob] No results found for request ##{request.id}"
+        handle_no_results(request, indexer_error)
+      end
     end
   end
 
   private
+
+  def claim_search!(request)
+    request.with_lock do
+      next false unless request.pending? && request.book
+
+      request.update!(status: :searching)
+      true
+    end
+  rescue ActiveRecord::RecordNotFound
+    false
+  end
 
   def search_indexer_safely(request)
     results = search_indexer(request)

--- a/app/jobs/stale_client_dispatch_cleanup_job.rb
+++ b/app/jobs/stale_client_dispatch_cleanup_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class StaleClientDispatchCleanupJob < ApplicationJob
+  class CleanupError < StandardError; end
+
+  SAFE_EXTERNAL_ID = /\A[A-Za-z0-9][A-Za-z0-9._:-]{0,254}\z/
+
+  queue_as :default
+  retry_on CleanupError, wait: :polynomially_longer, attempts: 5
+
+  def perform(download_client_id, external_id)
+    return unless external_id.is_a?(String) && external_id.match?(SAFE_EXTERNAL_ID)
+
+    client_record = DownloadClient.find_by(id: download_client_id)
+    return unless client_record
+
+    client = client_record.adapter
+    return if client.remove_torrent(external_id, delete_files: true)
+    return unless client.torrent_info(external_id)
+
+    raise CleanupError, "Download client still contains stale dispatch"
+  rescue CleanupError
+    raise
+  rescue StandardError => e
+    raise CleanupError, "Stale dispatch cleanup failed: #{e.class}"
+  end
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,7 +1,11 @@
+require "digest"
+require "uri"
+
 class Request < ApplicationRecord
   CREATED_VIA_VALUES = %w[web api telegram].freeze
   REQUEST_SCOPE_VALUES = %w[single collection].freeze
   MANUAL_MAGNET_GUID_PREFIX = "manual-magnet"
+  MANUAL_NZB_GUID_PREFIX = "manual-nzb"
 
   belongs_to :book
   belongs_to :user
@@ -224,9 +228,12 @@ class Request < ApplicationRecord
     not_found? && next_retry_at.present? && next_retry_at <= Time.current
   end
 
-  def manual_magnet_allowed?
+  def manual_download_allowed?
     !completed? && !processing?
   end
+
+  alias_method :manual_magnet_allowed?, :manual_download_allowed?
+  alias_method :manual_nzb_allowed?, :manual_download_allowed?
 
   # Select a search result and initiate download
   # Returns the created Download record
@@ -304,6 +311,28 @@ class Request < ApplicationRecord
       seeders: nil,
       leechers: nil,
       download_url: nil,
+      status: :pending
+    )
+    search_result.save!
+
+    select_result!(search_result)
+  end
+
+  def add_manual_nzb!(nzb_url)
+    nzb_url = nzb_url.to_s.strip
+    raise ArgumentError, "Enter a valid HTTP(S) NZB URL" unless valid_manual_nzb_url?(nzb_url)
+    raise ArgumentError, "Cannot add an NZB URL to a completed request" if completed?
+    raise ArgumentError, "Cannot add an NZB URL while post-processing is active" if processing?
+
+    search_result = search_results.find_or_initialize_by(guid: manual_nzb_guid(nzb_url))
+    search_result.assign_attributes(
+      title: "Manual NZB for #{book.display_name}",
+      download_url: nzb_url,
+      magnet_url: nil,
+      source: SearchResult::SOURCE_MANUAL_NZB,
+      indexer: "Manual NZB",
+      seeders: nil,
+      leechers: nil,
       status: :pending
     )
     search_result.save!
@@ -418,6 +447,17 @@ class Request < ApplicationRecord
 
   def manual_magnet_guid(info_hash)
     "#{MANUAL_MAGNET_GUID_PREFIX}:#{info_hash}"
+  end
+
+  def manual_nzb_guid(nzb_url)
+    "#{MANUAL_NZB_GUID_PREFIX}:#{Digest::SHA256.hexdigest(nzb_url)}"
+  end
+
+  def valid_manual_nzb_url?(value)
+    uri = URI.parse(value)
+    uri.is_a?(URI::HTTP) && uri.host.present?
+  rescue URI::InvalidURIError
+    false
   end
 
   def set_default_language

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -195,10 +195,16 @@ class Request < ApplicationRecord
     if download.external_id.present? && download.download_client.present?
       begin
         client = download.download_client.client_instance
-        client.remove_torrent(download.external_id, delete_files: true)
-        Rails.logger.info "[Request] Removed download #{download.id} from #{download.download_client.name}"
+        removed = client.remove_torrent(download.external_id, delete_files: true)
+        if removed
+          Rails.logger.info "[Request] Removed download #{download.id} from #{download.download_client.name}"
+        else
+          Rails.logger.warn "[Request] Client did not confirm removal for download #{download.id}; scheduling cleanup"
+          enqueue_stale_client_cleanup(download)
+        end
       rescue => e
-        Rails.logger.warn "[Request] Failed to remove download from client: #{e.message}"
+        Rails.logger.warn "[Request] Failed to remove download from client: #{e.class}; scheduling cleanup"
+        enqueue_stale_client_cleanup(download)
       end
     end
 
@@ -229,7 +235,7 @@ class Request < ApplicationRecord
   end
 
   def manual_download_allowed?
-    !completed? && !processing?
+    !completed? && !processing? && !download_dispatch_in_progress?
   end
 
   alias_method :manual_magnet_allowed?, :manual_download_allowed?
@@ -241,103 +247,66 @@ class Request < ApplicationRecord
     raise ArgumentError, "Result not downloadable" unless search_result.downloadable?
     raise ArgumentError, "Result does not belong to this request" unless search_result.request_id == id
 
-    download = nil
-    ActiveRecord::Base.transaction do
-      downloads.where(status: [ :queued, :downloading, :paused ]).find_each do |download|
-        cancel_download(download)
-      end
+    with_lock do
+      raise ArgumentError, "Cannot replace a download while dispatch is in progress" if download_dispatch_in_progress?
 
-      if search_result.blocklisted?
-        search_result.clear_blocklist!
-        track_diagnostic(
-          "blocklist_overridden",
-          message: "Blocklist overridden for selected release",
-          level: :warn,
-          user_visible: true,
-          details: {
-            search_result_id: search_result.id,
-            title: search_result.title
-          }
-        )
-      end
-
-      search_results.where.not(id: search_result.id).update_all(status: :rejected)
-      search_result.update!(status: :selected)
-
-      download = downloads.create!(
-        name: search_result.title,
-        size_bytes: search_result.size_bytes,
-        search_result: search_result,
-        status: :queued
-      )
-
-      update!(
-        status: :downloading,
-        next_retry_at: nil,
-        attention_needed: false,
-        issue_description: nil
-      )
+      select_result_under_lock!(search_result)
     end
-
-    track_diagnostic(
-      "download_queued",
-      download: download,
-      message: "Download queued from manual result selection",
-      details: {
-        search_result_id: search_result.id,
-        title: search_result.title,
-        trigger: "manual_select"
-      }
-    )
-    DownloadJob.perform_later(download.id)
-    download
   end
 
   def add_manual_magnet!(magnet_link)
     magnet_link = magnet_link.to_s.strip
     raise ArgumentError, "Enter a valid magnet link" unless magnet_link.start_with?("magnet:?")
-    raise ArgumentError, "Cannot add a magnet link to a completed request" if completed?
-    raise ArgumentError, "Cannot add a magnet link while post-processing is active" if processing?
 
     info_hash = MagnetLink.info_hash(magnet_link)
     raise ArgumentError, "Enter a magnet link with a valid info hash" if info_hash.blank?
 
-    search_result = search_results.find_or_initialize_by(guid: manual_magnet_guid(info_hash))
-    search_result.assign_attributes(
-      title: "Manual magnet for #{book.display_name}",
-      magnet_url: magnet_link,
-      source: SearchResult::SOURCE_MANUAL_MAGNET,
-      indexer: "Manual Magnet",
-      seeders: nil,
-      leechers: nil,
-      download_url: nil,
-      status: :pending
-    )
-    search_result.save!
+    with_lock do
+      raise ArgumentError, "Cannot add a magnet link to a completed request" if completed?
+      raise ArgumentError, "Cannot add a magnet link while post-processing is active" if processing?
+      raise ArgumentError, "Cannot replace a download while dispatch is in progress" if download_dispatch_in_progress?
 
-    select_result!(search_result)
+      search_result = search_results.find_or_initialize_by(guid: manual_magnet_guid(info_hash))
+      search_result.assign_attributes(
+        title: "Manual magnet for #{book.display_name}",
+        magnet_url: magnet_link,
+        source: SearchResult::SOURCE_MANUAL_MAGNET,
+        indexer: "Manual Magnet",
+        seeders: nil,
+        leechers: nil,
+        download_url: nil,
+        status: :pending
+      )
+      search_result.save!
+
+      select_result_under_lock!(search_result)
+    end
   end
 
   def add_manual_nzb!(nzb_url)
     nzb_url = nzb_url.to_s.strip
     raise ArgumentError, "Enter a valid HTTP(S) NZB URL" unless valid_manual_nzb_url?(nzb_url)
-    raise ArgumentError, "Cannot add an NZB URL to a completed request" if completed?
-    raise ArgumentError, "Cannot add an NZB URL while post-processing is active" if processing?
 
-    search_result = search_results.find_or_initialize_by(guid: manual_nzb_guid(nzb_url))
-    search_result.assign_attributes(
-      title: "Manual NZB for #{book.display_name}",
-      download_url: nzb_url,
-      magnet_url: nil,
-      source: SearchResult::SOURCE_MANUAL_NZB,
-      indexer: "Manual NZB",
-      seeders: nil,
-      leechers: nil,
-      status: :pending
-    )
-    search_result.save!
+    with_lock do
+      raise ArgumentError, "Cannot add an NZB URL to a completed request" if completed?
+      raise ArgumentError, "Cannot add an NZB URL while post-processing is active" if processing?
+      raise ArgumentError, "Cannot replace a download while dispatch is in progress" if download_dispatch_in_progress?
 
-    select_result!(search_result)
+      search_result = search_results.find_or_initialize_by(guid: manual_nzb_guid(nzb_url))
+      search_result.assign_attributes(
+        title: "Manual NZB for #{book.display_name}",
+        download_url: nzb_url,
+        magnet_url: nil,
+        source: SearchResult::SOURCE_MANUAL_NZB,
+        indexer: "Manual NZB",
+        seeders: nil,
+        leechers: nil,
+        status: :pending
+      )
+      search_result.save!
+
+      select_result_under_lock!(search_result)
+    end
   end
 
   def next_retry_in_words
@@ -367,6 +336,66 @@ class Request < ApplicationRecord
   end
 
   private
+
+  def select_result_under_lock!(search_result)
+    downloads.where(status: [ :queued, :downloading, :paused ]).find_each do |download|
+      cancel_download(download)
+    end
+
+    if search_result.blocklisted?
+      search_result.clear_blocklist!
+      track_diagnostic(
+        "blocklist_overridden",
+        message: "Blocklist overridden for selected release",
+        level: :warn,
+        user_visible: true,
+        details: {
+          search_result_id: search_result.id,
+          title: search_result.title
+        }
+      )
+    end
+
+    search_results.where.not(id: search_result.id).update_all(status: :rejected)
+    search_result.update!(status: :selected)
+
+    download = downloads.create!(
+      name: search_result.title,
+      size_bytes: search_result.size_bytes,
+      search_result: search_result,
+      status: :queued
+    )
+
+    update!(
+      status: :downloading,
+      next_retry_at: nil,
+      attention_needed: false,
+      issue_description: nil
+    )
+
+    track_diagnostic(
+      "download_queued",
+      download: download,
+      message: "Download queued from manual result selection",
+      details: {
+        search_result_id: search_result.id,
+        title: search_result.title,
+        trigger: "manual_select"
+      }
+    )
+
+    download_id = download.id
+    monitor_direct_download = search_result.direct_download?
+    ActiveRecord.after_all_transactions_commit do
+      DownloadJob.perform_later(download_id)
+      begin
+        DownloadMonitorJob.ensure_running! if monitor_direct_download
+      rescue StandardError => e
+        Rails.logger.error "[Request] Failed to start direct download monitor: #{e.class}"
+      end
+    end
+    download
+  end
 
   def broadcast_show_refresh_later_if_needed
     broadcast_show_refresh_later if (previous_changes.keys & SHOW_PAGE_BROADCAST_ATTRIBUTES).any?
@@ -458,6 +487,16 @@ class Request < ApplicationRecord
     uri.is_a?(URI::HTTP) && uri.host.present?
   rescue URI::InvalidURIError
     false
+  end
+
+  def download_dispatch_in_progress?
+    downloads.downloading.where(external_id: [ nil, "" ]).exists?
+  end
+
+  def enqueue_stale_client_cleanup(download)
+    StaleClientDispatchCleanupJob.perform_later(download.download_client_id, download.external_id)
+  rescue StandardError => e
+    Rails.logger.error "[Request] Failed to enqueue stale client cleanup for download #{download.id}: #{e.class}"
   end
 
   def set_default_language

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -23,6 +23,8 @@ class SearchResult < ApplicationRecord
   SOURCE_LIBRIVOX = "librivox"
   SOURCE_CUSTOM = "custom"
   SOURCE_MANUAL_MAGNET = "manual_magnet"
+  SOURCE_MANUAL_NZB = "manual_nzb"
+  MANUAL_SOURCES = [ SOURCE_MANUAL_MAGNET, SOURCE_MANUAL_NZB ].freeze
 
   validates :guid, presence: true, uniqueness: { scope: :request_id }
   validates :title, presence: true
@@ -268,6 +270,10 @@ class SearchResult < ApplicationRecord
     source == SOURCE_CUSTOM
   end
 
+  def from_manual_nzb?
+    source == SOURCE_MANUAL_NZB
+  end
+
   def source_display_name
     case source
     when SOURCE_JACKETT
@@ -286,6 +292,8 @@ class SearchResult < ApplicationRecord
       acquisition_provider&.name || indexer.presence || "Custom Provider"
     when SOURCE_MANUAL_MAGNET
       "Manual Magnet"
+    when SOURCE_MANUAL_NZB
+      "Manual NZB"
     else
       indexer.presence || "Prowlarr"
     end

--- a/app/services/download_clients/nzbget.rb
+++ b/app/services/download_clients/nzbget.rb
@@ -8,10 +8,12 @@ module DownloadClients
     def add_torrent(url, options = {})
       Rails.logger.info "[Nzbget] Adding URL to queue (#{url.to_s.length} chars)"
 
-      # appendurl params: URL, NZBFilename, Category, Priority, AddToTop, AddPaused, DupeKey, DupeScore, DupeMode
-      result = rpc_call("appendurl", [
-        "",                               # Filename
-        url,                              # URL
+      # append params: Filename, Content, Category, Priority, AddToTop, AddPaused,
+      # DupeKey, DupeScore, DupeMode, AutoCategory, PPParameters.
+      # Content may be either an NZB payload or a URL for NZBGet to fetch.
+      result = rpc_call("append", [
+        nzb_filename(options[:nzbname]),  # Filename
+        url,                              # Content (URL)
         config.category.presence || "",   # Category
         0,                                # Priority
         false,                            # AddToTop
@@ -20,8 +22,8 @@ module DownloadClients
         0,                                # DupeScore
         "SCORE",                          # DupeMode
         false,                            # AutoCategory
-        [],                               # PPParameters
-      ])
+        []                                # PPParameters
+      ], sensitive_url: options[:sensitive_url])
 
       if result && result > 0
         Rails.logger.info "[Nzbget] Added NZB with ID: #{result}"
@@ -31,6 +33,11 @@ module DownloadClients
         false
       end
     rescue Faraday::Error => e
+      if options[:sensitive_url]
+        Rails.logger.error "[Nzbget] Connection error while submitting sensitive NZB URL"
+        raise Base::ConnectionError, "Failed to connect to NZBGet while submitting NZB URL"
+      end
+
       Rails.logger.error "[Nzbget] Connection error: #{e.message}"
       raise Base::ConnectionError, "Failed to connect to NZBGet: #{e.message}"
     end
@@ -100,7 +107,18 @@ module DownloadClients
 
     private
 
-    def rpc_call(method, params = [])
+    def nzb_filename(value)
+      name = value.to_s
+        .gsub(/[<>:"\/\\|?*]/, "")
+        .gsub(/[\x00-\x1f]/, "")
+        .squish
+        .sub(/\.nzb\z/i, "")
+        .truncate(196, omission: "")
+
+      name.present? ? "#{name}.nzb" : ""
+    end
+
+    def rpc_call(method, params = [], sensitive_url: false)
       response = connection.post do |req|
         req.url "jsonrpc"
         req.headers["Content-Type"] = "application/json"
@@ -110,7 +128,7 @@ module DownloadClients
         }.to_json
       end
 
-      handle_response(response)
+      handle_response(response, sensitive_url: sensitive_url)
     end
 
     def connection
@@ -123,12 +141,17 @@ module DownloadClients
       end
     end
 
-    def handle_response(response)
+    def handle_response(response, sensitive_url: false)
       case response.status
       when 200
         body = response.body
         if body.is_a?(Hash)
           if body["error"]
+            if sensitive_url
+              Rails.logger.error "[Nzbget] API rejected sensitive NZB URL"
+              raise Base::Error, "NZBGet rejected the NZB URL"
+            end
+
             Rails.logger.error "[Nzbget] API returned error: #{body['error']}"
             raise Base::Error, "NZBGet error: #{body['error']}"
           end
@@ -141,10 +164,19 @@ module DownloadClients
         Rails.logger.error "[Nzbget] Authentication failed (status #{response.status})"
         raise Base::AuthenticationError, "NZBGet authentication failed"
       else
-        Rails.logger.error "[Nzbget] API error (status #{response.status}): #{response.body.inspect.truncate(200)}"
+        if sensitive_url
+          Rails.logger.error "[Nzbget] API error while submitting sensitive NZB URL (status #{response.status})"
+        else
+          Rails.logger.error "[Nzbget] API error (status #{response.status}): #{response.body.inspect.truncate(200)}"
+        end
         raise Base::Error, "NZBGet API error: #{response.status}"
       end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      if sensitive_url
+        Rails.logger.error "[Nzbget] Connection error while submitting sensitive NZB URL"
+        raise Base::ConnectionError, "Failed to connect to NZBGet while submitting NZB URL"
+      end
+
       Rails.logger.error "[Nzbget] Connection error: #{e.message}"
       raise Base::ConnectionError, "Failed to connect to NZBGet: #{e.message}"
     end

--- a/app/services/download_clients/nzbget.rb
+++ b/app/services/download_clients/nzbget.rb
@@ -25,11 +25,15 @@ module DownloadClients
         []                                # PPParameters
       ], sensitive_url: options[:sensitive_url])
 
-      if result && result > 0
+      if result.is_a?(Integer) && result.positive?
         Rails.logger.info "[Nzbget] Added NZB with ID: #{result}"
         { "nzo_ids" => [ result.to_s ] }
       else
-        Rails.logger.error "[Nzbget] Failed to add NZB, result: #{result.inspect}"
+        if options[:sensitive_url]
+          Rails.logger.error "[Nzbget] Failed to add sensitive NZB URL"
+        else
+          Rails.logger.error "[Nzbget] Failed to add NZB, result: #{result.inspect}"
+        end
         false
       end
     rescue Faraday::Error => e
@@ -60,9 +64,12 @@ module DownloadClients
 
     # Test connection to NZBGet
     def test_connection
-      result = rpc_call("version")
-      if result.is_a?(String) && result.present?
-        Rails.logger.info "[Nzbget] Connection test passed - version: #{result}"
+      # Add-only NZBGet credentials can call version and append but cannot
+      # monitor queue/history. Probe status so accepted credentials cover the
+      # full lifecycle Shelfarr requires.
+      result = rpc_call("status")
+      if result.is_a?(Hash)
+        Rails.logger.info "[Nzbget] Connection test passed"
         true
       else
         Rails.logger.error "[Nzbget] Connection test failed - unexpected response: #{result.inspect}"
@@ -157,7 +164,11 @@ module DownloadClients
           end
           body["result"]
         else
-          Rails.logger.error "[Nzbget] Unexpected response format: #{body.inspect.truncate(200)}"
+          if sensitive_url
+            Rails.logger.error "[Nzbget] Unexpected response while submitting sensitive NZB URL"
+          else
+            Rails.logger.error "[Nzbget] Unexpected response format: #{body.inspect.truncate(200)}"
+          end
           raise Base::Error, "NZBGet returned unexpected response format"
         end
       when 401, 403
@@ -197,16 +208,11 @@ module DownloadClients
     end
 
     def find_in_queue(nzbget_id)
-      id = nzbget_id.to_i
       list_queue.find { |item| item.hash == nzbget_id.to_s }
-    rescue Base::Error
-      nil
     end
 
     def find_in_history(nzbget_id)
       list_history.find { |item| item.hash == nzbget_id.to_s }
-    rescue Base::Error
-      nil
     end
 
     def parse_queue_item(data)

--- a/app/services/download_clients/sabnzbd.rb
+++ b/app/services/download_clients/sabnzbd.rb
@@ -4,6 +4,8 @@ module DownloadClients
   # SABnzbd API client for usenet downloads
   # https://sabnzbd.org/wiki/advanced/api
   class Sabnzbd < Base
+    SAFE_NZO_ID = /\A[A-Za-z0-9][A-Za-z0-9._:-]{0,254}\z/
+
     # Add an NZB by URL
     def add_torrent(url, options = {})
       Rails.logger.info "[Sabnzbd] Adding URL to queue (#{url.to_s.length} chars)"
@@ -22,9 +24,20 @@ module DownloadClients
 
       response = connection.get("api", params)
       handle_response(response, sensitive_url: options[:sensitive_url]) do |data|
-        Rails.logger.info "[Sabnzbd] API response: status=#{data['status']}, nzo_ids=#{data['nzo_ids']&.inspect}"
-        # Return the response data so we can extract nzo_ids
-        data["status"] == true ? data : false
+        if options[:sensitive_url]
+          Rails.logger.info "[Sabnzbd] API response received for sensitive NZB URL"
+        else
+          Rails.logger.info "[Sabnzbd] API response: status=#{data['status']}, nzo_ids=#{data['nzo_ids']&.inspect}"
+        end
+
+        nzo_ids = data["nzo_ids"]
+        external_id = nzo_ids.first if nzo_ids.is_a?(Array)
+        if data["status"] == true && safe_nzo_id?(external_id)
+          data
+        else
+          Rails.logger.error "[Sabnzbd] API response did not include a valid external ID" if data["status"] == true
+          false
+        end
       end
     rescue Faraday::Error => e
       if options[:sensitive_url]
@@ -54,8 +67,11 @@ module DownloadClients
 
     # Test connection to SABnzbd
     def test_connection
-      response = connection.get("api", { mode: "version", apikey: api_key, output: "json" })
-      response.status == 200
+      # version/auth do not validate SABnzbd API keys. get_cats is a
+      # lightweight authenticated endpoint with the access level Shelfarr
+      # also needs for queue and history monitoring.
+      response = connection.get("api", { mode: "get_cats", apikey: api_key, output: "json" })
+      response.status == 200 && response.body.is_a?(Hash) && response.body["categories"].is_a?(Array)
     rescue Base::Error, Faraday::Error
       false
     end
@@ -105,6 +121,10 @@ module DownloadClients
       config.api_key
     end
 
+    def safe_nzo_id?(value)
+      value.is_a?(String) && value.match?(SAFE_NZO_ID)
+    end
+
     def connection
       @connection ||= Faraday.new(url: base_url) do |f|
         f.response :json, parser_options: { symbolize_names: false }
@@ -118,8 +138,17 @@ module DownloadClients
       case response.status
       when 200
         body = response.body
+        unless body.is_a?(Hash)
+          if sensitive_url
+            Rails.logger.error "[Sabnzbd] Unexpected response while submitting sensitive NZB URL"
+          else
+            Rails.logger.error "[Sabnzbd] Unexpected response format: #{body.inspect.truncate(200)}"
+          end
+          raise Base::Error, "SABnzbd returned unexpected response format"
+        end
+
         # SABnzbd returns error in JSON body sometimes
-        if body.is_a?(Hash) && body["error"]
+        if body["error"]
           if sensitive_url
             Rails.logger.error "[Sabnzbd] API rejected sensitive NZB URL"
             raise Base::Error, "SABnzbd rejected the NZB URL"
@@ -168,14 +197,10 @@ module DownloadClients
 
     def find_in_queue(nzo_id)
       list_queue.find { |item| item.hash == nzo_id }
-    rescue Base::Error
-      nil
     end
 
     def find_in_history(nzo_id)
       list_history.find { |item| item.hash == nzo_id }
-    rescue Base::Error
-      nil
     end
 
     def parse_queue_item(data)

--- a/app/services/download_clients/sabnzbd.rb
+++ b/app/services/download_clients/sabnzbd.rb
@@ -7,7 +7,9 @@ module DownloadClients
     # Add an NZB by URL
     def add_torrent(url, options = {})
       Rails.logger.info "[Sabnzbd] Adding URL to queue (#{url.to_s.length} chars)"
-      Rails.logger.debug "[Sabnzbd] Full URL being sent: #{UrlRedactor.redact(url)}"
+      unless options[:sensitive_url]
+        Rails.logger.debug "[Sabnzbd] Full URL being sent: #{UrlRedactor.redact(url)}"
+      end
 
       params = {
         mode: "addurl",
@@ -19,12 +21,17 @@ module DownloadClients
       params[:cat] = config.category if config.category.present?
 
       response = connection.get("api", params)
-      handle_response(response) do |data|
+      handle_response(response, sensitive_url: options[:sensitive_url]) do |data|
         Rails.logger.info "[Sabnzbd] API response: status=#{data['status']}, nzo_ids=#{data['nzo_ids']&.inspect}"
         # Return the response data so we can extract nzo_ids
         data["status"] == true ? data : false
       end
     rescue Faraday::Error => e
+      if options[:sensitive_url]
+        Rails.logger.error "[Sabnzbd] Connection error while submitting sensitive NZB URL"
+        raise Base::ConnectionError, "Failed to connect to SABnzbd while submitting NZB URL"
+      end
+
       Rails.logger.error "[Sabnzbd] Connection error: #{e.message}"
       raise Base::ConnectionError, "Failed to connect to SABnzbd: #{e.message}"
     end
@@ -107,12 +114,17 @@ module DownloadClients
       end
     end
 
-    def handle_response(response)
+    def handle_response(response, sensitive_url: false)
       case response.status
       when 200
         body = response.body
         # SABnzbd returns error in JSON body sometimes
         if body.is_a?(Hash) && body["error"]
+          if sensitive_url
+            Rails.logger.error "[Sabnzbd] API rejected sensitive NZB URL"
+            raise Base::Error, "SABnzbd rejected the NZB URL"
+          end
+
           Rails.logger.error "[Sabnzbd] API returned error: #{body['error']}"
           raise Base::Error, "SABnzbd error: #{body['error']}"
         end
@@ -121,10 +133,19 @@ module DownloadClients
         Rails.logger.error "[Sabnzbd] Authentication failed (status #{response.status})"
         raise Base::AuthenticationError, "SABnzbd authentication failed"
       else
-        Rails.logger.error "[Sabnzbd] API error (status #{response.status}): #{response.body.inspect.truncate(200)}"
+        if sensitive_url
+          Rails.logger.error "[Sabnzbd] API error while submitting sensitive NZB URL (status #{response.status})"
+        else
+          Rails.logger.error "[Sabnzbd] API error (status #{response.status}): #{response.body.inspect.truncate(200)}"
+        end
         raise Base::Error, "SABnzbd API error: #{response.status}"
       end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      if sensitive_url
+        Rails.logger.error "[Sabnzbd] Connection error while submitting sensitive NZB URL"
+        raise Base::ConnectionError, "Failed to connect to SABnzbd while submitting NZB URL"
+      end
+
       Rails.logger.error "[Sabnzbd] Connection error: #{e.message}"
       raise Base::ConnectionError, "Failed to connect to SABnzbd: #{e.message}"
     end

--- a/app/services/outbound_url_guard.rb
+++ b/app/services/outbound_url_guard.rb
@@ -22,11 +22,15 @@ class OutboundUrlGuard
   # (incl. cloud metadata at 169.254.169.254), multicast, and reserved space.
   ALWAYS_BLOCKED_RANGES = %w[
     0.0.0.0/8
+    100.100.100.200/32
     169.254.0.0/16
     224.0.0.0/4
     240.0.0.0/4
     ::/128
     64:ff9b::/96
+    fd00:a9fe:a9fe::1/128
+    fd00:ec2::254/128
+    fd20:ce::254/128
     fe80::/10
     ff00::/8
   ].map { |cidr| IPAddr.new(cidr) }.freeze

--- a/app/services/url_redactor.rb
+++ b/app/services/url_redactor.rb
@@ -16,6 +16,16 @@ class UrlRedactor
     sig
     auth
     key
+    x-amz-signature
+    x-amz-credential
+    x-amz-security-token
+    x-goog-signature
+    x-goog-credential
+    x-goog-security-token
+    policy
+    key-pair-id
+    awsaccesskeyid
+    googleaccessid
   ].freeze
 
   def self.redact(value)
@@ -24,7 +34,8 @@ class UrlRedactor
 
     base, fragment = url.split("#", 2)
     path, query = base.split("?", 2)
-    return url if query.blank?
+    path = redact_userinfo(path)
+    return append_redacted_fragment(path, fragment) if query.blank?
 
     redacted_query = query.split("&").map do |pair|
       key, = pair.split("=", 2)
@@ -33,13 +44,20 @@ class UrlRedactor
       sensitive_query_key?(key) ? "#{key}=[REDACTED]" : pair
     end.join("&")
 
-    result = "#{path}?#{redacted_query}"
-    fragment.present? ? "#{result}##{fragment}" : result
+    append_redacted_fragment("#{path}?#{redacted_query}", fragment)
   end
 
   def self.sensitive_query_key?(key)
     SENSITIVE_QUERY_KEYS.include?(CGI.unescape(key.to_s).downcase)
   end
 
-  private_class_method :sensitive_query_key?
+  def self.redact_userinfo(path)
+    path.sub(%r{\A([a-z][a-z0-9+.-]*://)[^/@]*@}i, '\1[REDACTED]@')
+  end
+
+  def self.append_redacted_fragment(value, fragment)
+    fragment.nil? ? value : "#{value}#[REDACTED]"
+  end
+
+  private_class_method :sensitive_query_key?, :redact_userinfo, :append_redacted_fragment
 end

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -239,7 +239,7 @@
         </div>
       <% end %>
 
-      <% if Current.user.admin? && @request.manual_magnet_allowed? %>
+      <% if Current.user.admin? && @request.manual_download_allowed? %>
         <div class="mt-6 pt-6 border-t border-gray-800">
           <h3 class="text-sm font-medium text-gray-500 mb-2">Manual Magnet Link</h3>
           <p class="text-sm text-gray-400 mb-3">Paste a magnet link to send it to the configured torrent client for this request. If a download is already active, it will be replaced.</p>
@@ -249,6 +249,21 @@
                 placeholder: "magnet:?xt=urn:btih:...",
                 class: "flex-1 rounded-lg bg-gray-800 border border-gray-700 text-white placeholder-gray-500 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500" %>
             <%= f.submit "Add Magnet",
+                class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition text-sm" %>
+          <% end %>
+        </div>
+
+        <div class="mt-6 pt-6 border-t border-gray-800">
+          <h3 class="text-sm font-medium text-gray-500 mb-2">Manual NZB URL</h3>
+          <p class="text-sm text-gray-400 mb-3">Paste an HTTP(S) NZB URL to send it to the highest-priority available Usenet client. The URL does not need to end in .nzb. If a download is already active, it will be replaced.</p>
+          <%= form_with url: manual_nzb_request_path(@request), method: :post, local: true, class: "flex flex-col sm:flex-row gap-3" do |f| %>
+            <%= f.url_field :nzb_url,
+                name: :nzb_url,
+                placeholder: "https://example.com/download",
+                autocomplete: "off",
+                spellcheck: false,
+                class: "flex-1 rounded-lg bg-gray-800 border border-gray-700 text-white placeholder-gray-500 px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500" %>
+            <%= f.submit "Add NZB URL",
                 class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition text-sm" %>
           <% end %>
         </div>

--- a/config/initializers/download_monitor.rb
+++ b/config/initializers/download_monitor.rb
@@ -4,12 +4,11 @@
 Rails.application.config.after_initialize do
   # Only start in server mode, not in console or rake tasks
   if defined?(Rails::Server)
-    # Check if any download client is configured
-    if DownloadClient.enabled.exists?
+    if DownloadMonitorJob.monitoring_required?
       Rails.logger.info "[Shelfarr] Starting DownloadMonitorJob chain"
       DownloadMonitorJob.ensure_running!
     else
-      Rails.logger.info "[Shelfarr] No download client configured, DownloadMonitorJob not started"
+      Rails.logger.info "[Shelfarr] No downloads require monitoring, DownloadMonitorJob not started"
     end
   end
 rescue => e

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,6 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
+  :nzb_url, :download_url
 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
     member do
       get :download
       post :manual_magnet
+      post :manual_nzb
       post :retry
     end
   end

--- a/test/controllers/admin/search_results_controller_test.rb
+++ b/test/controllers/admin/search_results_controller_test.rb
@@ -177,8 +177,8 @@ module Admin
       assert_match /refreshed/, flash[:notice]
     end
 
-    test "refresh preserves manual magnet results" do
-      manual_result = @request_record.search_results.create!(
+    test "refresh preserves manual download results" do
+      manual_magnet = @request_record.search_results.create!(
         guid: "manual-magnet:#{'a' * 40}",
         title: "Manual magnet result",
         magnet_url: "magnet:?xt=urn:btih:#{'a' * 40}",
@@ -186,11 +186,20 @@ module Admin
         indexer: "Manual Magnet",
         status: :selected
       )
+      manual_nzb = @request_record.search_results.create!(
+        guid: "manual-nzb:#{'b' * 64}",
+        title: "Manual NZB result",
+        download_url: "https://downloads.example/book.nzb",
+        seeders: nil,
+        source: SearchResult::SOURCE_MANUAL_NZB,
+        indexer: "Manual NZB",
+        status: :selected
+      )
 
       post refresh_admin_request_search_results_path(@request_record)
 
       @request_record.reload
-      assert_equal [ manual_result ], @request_record.search_results.to_a
+      assert_equal [ manual_magnet, manual_nzb ], @request_record.search_results.order(:id).to_a
     end
   end
 end

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -700,7 +700,7 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "show displays manual magnet form for open request" do
+  test "show displays manual download forms for open request" do
     sign_out
     sign_in_as(@admin)
 
@@ -709,16 +709,19 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']"
     assert_select "input[name='magnet_url']"
+    assert_select "form[action='#{manual_nzb_request_path(@pending_request)}']"
+    assert_select "input[name='nzb_url'][type='url'][autocomplete='off']"
   end
 
-  test "show hides manual magnet form from regular users" do
+  test "show hides manual download forms from regular users" do
     get request_path(@pending_request)
 
     assert_response :success
     assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']", count: 0
+    assert_select "form[action='#{manual_nzb_request_path(@pending_request)}']", count: 0
   end
 
-  test "show hides manual magnet form for completed request" do
+  test "show hides manual download forms for completed request" do
     @pending_request.complete!
     sign_out
     sign_in_as(@admin)
@@ -727,9 +730,10 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']", count: 0
+    assert_select "form[action='#{manual_nzb_request_path(@pending_request)}']", count: 0
   end
 
-  test "show hides manual magnet form for processing request" do
+  test "show hides manual download forms for processing request" do
     @pending_request.update!(status: :processing)
     sign_out
     sign_in_as(@admin)
@@ -738,6 +742,7 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "form[action='#{manual_magnet_request_path(@pending_request)}']", count: 0
+    assert_select "form[action='#{manual_nzb_request_path(@pending_request)}']", count: 0
   end
 
   test "manual magnet creates selected result and queues download" do
@@ -821,6 +826,80 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
 
     assert_no_difference [ "SearchResult.count", "Download.count" ] do
       post manual_magnet_request_path(other_request), params: { magnet_url: "magnet:?xt=urn:btih:#{'c' * 40}" }
+    end
+
+    assert_response :not_found
+  end
+
+  test "manual NZB creates selected result and queues download" do
+    sign_out
+    sign_in_as(@admin)
+    url = "https://downloads.example/release/123?X-Amz-Signature=very-secret"
+
+    assert_enqueued_with(job: DownloadJob) do
+      assert_difference [ "SearchResult.count", "Download.count" ], 1 do
+        post manual_nzb_request_path(@pending_request), params: { nzb_url: "  #{url}  " }
+      end
+    end
+
+    @pending_request.reload
+    result = @pending_request.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_NZB)
+    download = @pending_request.downloads.order(:created_at).last
+
+    assert @pending_request.downloading?
+    assert result.selected?
+    assert result.usenet?
+    assert_equal url, result.download_url
+    assert_equal result, download.search_result
+    assert_equal "NZB URL queued for download.", flash[:notice]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual NZB rejects invalid URL" do
+    sign_out
+    sign_in_as(@admin)
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      post manual_nzb_request_path(@pending_request), params: { nzb_url: "file:///tmp/book.nzb" }
+    end
+
+    assert_equal "Enter a valid HTTP(S) NZB URL", flash[:alert]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual NZB redirects when duplicate result save races" do
+    sign_out
+    sign_in_as(@admin)
+
+    request = @pending_request
+    request.define_singleton_method(:add_manual_nzb!) do |_nzb_url|
+      raise ActiveRecord::RecordNotUnique, "duplicate"
+    end
+    finder = Object.new
+    finder.define_singleton_method(:find) { |_id| request }
+
+    Request.stub(:includes, finder) do
+      post manual_nzb_request_path(@pending_request), params: { nzb_url: "https://downloads.example/book.nzb" }
+    end
+
+    assert_equal "NZB URL could not be queued. Please try again.", flash[:alert]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual NZB cannot be added by regular users" do
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      post manual_nzb_request_path(@pending_request), params: { nzb_url: "https://downloads.example/book.nzb" }
+    end
+
+    assert_equal "You don't have permission to add NZB URLs", flash[:alert]
+    assert_redirected_to request_path(@pending_request)
+  end
+
+  test "manual NZB cannot be added to another user's request" do
+    other_request = Request.create!(book: books(:ebook_pending), user: @admin, status: :pending)
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      post manual_nzb_request_path(other_request), params: { nzb_url: "https://downloads.example/book.nzb" }
     end
 
     assert_response :not_found

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -538,6 +538,94 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_not_includes log_output, "apikey=secret"
   end
 
+  test "dispatches a manual NZB URL unchanged to the highest-priority healthy usenet client without logging secrets" do
+    @client.destroy!
+    high_priority = DownloadClient.create!(
+      name: "High Priority SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://sab-high.test:8080",
+      api_key: "high-api-key",
+      priority: 0,
+      enabled: true
+    )
+    DownloadClient.create!(
+      name: "Low Priority SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://sab-low.test:8080",
+      api_key: "low-api-key",
+      priority: 10,
+      enabled: true
+    )
+    signed_url = "https://alice:password@downloads.example/release/123?custom_secret=opaque&X-Amz-Signature=very-secret"
+    manual_result = @request.search_results.create!(
+      guid: "manual-nzb:#{Digest::SHA256.hexdigest(signed_url)}",
+      title: "Manual NZB for #{@request.book.display_name}",
+      indexer: "Manual NZB",
+      source: SearchResult::SOURCE_MANUAL_NZB,
+      download_url: signed_url,
+      magnet_url: nil,
+      seeders: nil,
+      status: :selected
+    )
+    @download.update!(search_result: manual_result)
+    logger = build_test_logger
+
+    VCR.turned_off do
+      high_connection = stub_request(:get, "http://sab-high.test:8080/api")
+        .with(query: hash_including(
+          "mode" => "version",
+          "apikey" => "high-api-key",
+          "output" => "json"
+        ))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "version" => "4.0.0" }.to_json
+        )
+      low_connection = stub_request(:get, "http://sab-low.test:8080/api")
+        .with(query: hash_including("mode" => "version"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "version" => "4.0.0" }.to_json
+        )
+      submission = stub_request(:get, "http://sab-high.test:8080/api")
+        .with(query: hash_including(
+          "mode" => "addurl",
+          "name" => signed_url,
+          "nzbname" => "Another Author - The Pending Ebook",
+          "apikey" => "high-api-key",
+          "output" => "json"
+        ))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => true, "nzo_ids" => [ "SABnzbd_manual_123" ] }.to_json
+        )
+
+      Rails.stub(:logger, logger) do
+        DownloadJob.perform_now(@download.id)
+      end
+
+      assert_requested high_connection, times: 1
+      assert_not_requested low_connection
+      assert_requested submission, times: 1
+    end
+
+    @download.reload
+    assert @download.downloading?
+    assert_equal high_priority.id.to_s, @download.download_client_id
+    assert_equal "SABnzbd_manual_123", @download.external_id
+    assert_equal "usenet", @download.download_type
+
+    log_output = logger.messages.join("\n")
+    assert_includes log_output, "[REDACTED MANUAL NZB URL]"
+    assert_not_includes log_output, "alice"
+    assert_not_includes log_output, "password"
+    assert_not_includes log_output, "opaque"
+    assert_not_includes log_output, "very-secret"
+  end
+
   test "sends selected newznab result directly to a usenet client" do
     @client.destroy!
     sabnzbd = DownloadClient.create!(

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -496,14 +496,14 @@ class DownloadJobTest < ActiveJob::TestCase
       VCR.turned_off do
         stub_request(:get, "http://localhost:8080/api")
           .with(query: hash_including(
-            "mode" => "version",
+            "mode" => "get_cats",
             "apikey" => "test-api-key-12345",
             "output" => "json"
           ))
           .to_return(
             status: 200,
             headers: { "Content-Type" => "application/json" },
-            body: { "version" => "4.0.0" }.to_json
+            body: { "categories" => [ "*" ] }.to_json
           )
 
         request_stub = stub_request(:get, "http://localhost:8080/api")
@@ -573,21 +573,21 @@ class DownloadJobTest < ActiveJob::TestCase
     VCR.turned_off do
       high_connection = stub_request(:get, "http://sab-high.test:8080/api")
         .with(query: hash_including(
-          "mode" => "version",
+          "mode" => "get_cats",
           "apikey" => "high-api-key",
           "output" => "json"
         ))
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "version" => "4.0.0" }.to_json
+          body: { "categories" => [ "*" ] }.to_json
         )
       low_connection = stub_request(:get, "http://sab-low.test:8080/api")
-        .with(query: hash_including("mode" => "version"))
+        .with(query: hash_including("mode" => "get_cats"))
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "version" => "4.0.0" }.to_json
+          body: { "categories" => [ "*" ] }.to_json
         )
       submission = stub_request(:get, "http://sab-high.test:8080/api")
         .with(query: hash_including(
@@ -626,6 +626,135 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_not_includes log_output, "very-secret"
   end
 
+  test "rejects manual NZB URLs targeting link-local services before client selection" do
+    blocked_url = "http://169.254.169.254/latest/meta-data?token=very-secret"
+    manual_result = @request.search_results.create!(
+      guid: "manual-nzb:#{Digest::SHA256.hexdigest(blocked_url)}",
+      title: "Manual NZB for #{@request.book.display_name}",
+      indexer: "Manual NZB",
+      source: SearchResult::SOURCE_MANUAL_NZB,
+      download_url: blocked_url,
+      magnet_url: nil,
+      seeders: nil,
+      status: :selected
+    )
+    @download.update!(search_result: manual_result)
+    SettingsService.set(:auto_select_enabled, false)
+    logger = build_test_logger
+
+    Rails.stub(:logger, logger) do
+      DownloadJob.perform_now(@download.id)
+    end
+
+    assert @download.reload.failed?
+    assert manual_result.reload.blocklisted?
+    assert_includes @request.reload.issue_description, "blocked or invalid destination"
+
+    log_output = logger.messages.join("\n")
+    assert_not_includes log_output, blocked_url
+    assert_not_includes log_output, "very-secret"
+  end
+
+  test "rejects a manual replacement while a client dispatch is in flight" do
+    @client.destroy!
+    DownloadClient.create!(
+      name: "Test SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://localhost:8080",
+      api_key: "test-api-key-12345",
+      priority: 0,
+      enabled: true
+    )
+    @selected_result.update!(
+      magnet_url: nil,
+      download_url: "https://indexer.example/old.nzb",
+      seeders: nil,
+      status: :selected
+    )
+    replacement_url = "https://downloads.example/replacement.nzb"
+    replacement_error = nil
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "get_cats"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "categories" => [ "*" ] }.to_json
+        )
+      submission = stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "addurl", "name" => "https://indexer.example/old.nzb"))
+        .to_return do
+          replacement_error = assert_raises(ArgumentError) do
+            @request.reload.add_manual_nzb!(replacement_url)
+          end
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "status" => true, "nzo_ids" => [ "SABnzbd_nzo_current" ] }.to_json
+          }
+        end
+
+      DownloadJob.perform_now(@download.id)
+
+      assert_requested submission
+    end
+
+    assert_match(/dispatch is in progress/, replacement_error.message)
+    assert_nil @request.reload.search_results.find_by(download_url: replacement_url)
+    assert @selected_result.reload.selected?
+    assert @download.reload.downloading?
+    assert_equal "SABnzbd_nzo_current", @download.external_id
+  end
+
+  test "cleans up a custom client dispatch that loses ownership before finalization" do
+    @download.update!(status: :downloading, download_type: "dispatching")
+    removed_ids = []
+    claimed_download = @download
+    client = Object.new
+    client.define_singleton_method(:add_torrent) do |_url|
+      claimed_download.update!(status: :failed)
+      "stale-torrent-hash"
+    end
+    client.define_singleton_method(:remove_torrent) do |external_id, delete_files:|
+      removed_ids << [ external_id, delete_files ]
+      true
+    end
+
+    DownloadClientSelector.stub(:for_torrent, @client) do
+      @client.stub(:adapter, client) do
+        DownloadJob.new.send(
+          :send_to_torrent_client,
+          @download,
+          @selected_result,
+          "magnet:?xt=urn:btih:#{'c' * 40}"
+        )
+      end
+    end
+
+    assert @download.reload.failed?
+    assert_nil @download.external_id
+    assert_equal [ [ "stale-torrent-hash", true ] ], removed_ids
+  end
+
+  test "does not finalize a direct download after ownership is lost" do
+    @download.update!(status: :downloading, download_type: "direct")
+    @download.update!(status: :failed)
+    job = DownloadJob.new
+
+    finalized = job.send(
+      :finalize_direct_download!,
+      @download,
+      download_path: "/tmp/stale-book.epub",
+      book_path: "/tmp/stale-book.epub"
+    )
+
+    assert_not finalized
+    assert @download.reload.failed?
+    assert_not @request.reload.completed?
+    assert_nil @request.book.reload.file_path
+  end
+
   test "sends selected newznab result directly to a usenet client" do
     @client.destroy!
     sabnzbd = DownloadClient.create!(
@@ -651,14 +780,14 @@ class DownloadJobTest < ActiveJob::TestCase
     VCR.turned_off do
       stub_request(:get, "http://localhost:8080/api")
         .with(query: hash_including(
-          "mode" => "version",
+          "mode" => "get_cats",
           "apikey" => "test-api-key-12345",
           "output" => "json"
         ))
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "version" => "4.0.0" }.to_json
+          body: { "categories" => [ "*" ] }.to_json
         )
 
       request_stub = stub_request(:get, "http://localhost:8080/api")
@@ -929,11 +1058,11 @@ class DownloadJobTest < ActiveJob::TestCase
             body: { download_type: "usenet", nzb_url: "https://files.test/custom-book.nzb" }.to_json
           )
         stub_request(:get, "http://localhost:8080/api")
-          .with(query: hash_including("mode" => "version"))
+          .with(query: hash_including("mode" => "get_cats"))
           .to_return(
             status: 200,
             headers: { "Content-Type" => "application/json" },
-            body: { "version" => "4.0.0" }.to_json
+            body: { "categories" => [ "*" ] }.to_json
           )
         stub_request(:get, "http://localhost:8080/api")
           .with(query: hash_including(
@@ -1116,6 +1245,26 @@ class DownloadJobTest < ActiveJob::TestCase
     end
   end
 
+  test "librivox discards staged extraction after dispatch ownership is lost" do
+    Dir.mktmpdir do |dir|
+      setup_librivox_download(output_path: dir)
+      zip_body = build_zip_archive("chapter_01.mp3" => "audio-data")
+      job = DownloadJob.new
+
+      VCR.turned_off do
+        stub_request(:get, "https://archive.org/compress/test_librivox/formats=64KBPS%20MP3")
+          .to_return(status: 200, body: zip_body, headers: { "Content-Type" => "application/zip" })
+
+        job.stub(:finalize_direct_download!, ->(*) { false }) do
+          job.perform(@librivox_download.id)
+        end
+      end
+
+      assert_equal "downloading", @librivox_download.reload.status
+      assert_empty Dir.glob(File.join(dir, "**", "chapter_01.mp3"))
+    end
+  end
+
   test "librivox download rejects unsafe zip paths" do
     Dir.mktmpdir do |dir|
       setup_librivox_download(output_path: dir)
@@ -1235,6 +1384,7 @@ class DownloadJobTest < ActiveJob::TestCase
   end
 
   test "send_to_torrent_client marks attention when client returns no hash" do
+    @download.update!(status: :downloading, download_type: "dispatching")
     client = Object.new
     def client.add_torrent(_url)
       nil

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -464,6 +464,23 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     end
   end
 
+  test "ensure_running! starts a watchdog for a queued direct download without clients" do
+    DownloadClient.destroy_all
+    direct_result = search_results(:selected_result)
+    direct_result.update!(source: SearchResult::SOURCE_GUTENBERG)
+    @download.update!(
+      status: :queued,
+      external_id: nil,
+      download_client: nil,
+      download_type: nil,
+      search_result: direct_result
+    )
+
+    assert_enqueued_with(job: DownloadMonitorJob) do
+      DownloadMonitorJob.ensure_running!
+    end
+  end
+
   test "limits monitor execution to one protected job" do
     assert_equal DownloadMonitorJob::CONCURRENCY_KEY, DownloadMonitorJob.concurrency_key
     assert_equal 1, DownloadMonitorJob.concurrency_limit
@@ -572,6 +589,119 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     end
 
     assert_equal [ @request ], attention_requests
+  end
+
+  test "fails an abandoned claimed dispatch without an external ID" do
+    @download.update_columns(
+      status: Download.statuses[:downloading],
+      external_id: nil,
+      download_client_id: nil,
+      created_at: 10.minutes.ago,
+      updated_at: 10.minutes.ago
+    )
+    SettingsService.set(:download_enqueue_timeout_minutes, 5)
+
+    DownloadMonitorJob.perform_now
+
+    assert @download.reload.failed?
+    assert @request.reload.attention_needed?
+    assert_includes @request.issue_description, "never sent to the download client"
+  end
+
+  test "does not fail an active direct download based on its old creation time" do
+    @download.update_columns(
+      status: Download.statuses[:downloading],
+      external_id: nil,
+      download_client_id: nil,
+      download_type: "direct",
+      created_at: 1.hour.ago,
+      updated_at: Time.current
+    )
+
+    DownloadMonitorJob.perform_now
+
+    assert @download.reload.downloading?
+    assert_not @request.reload.attention_needed?
+  end
+
+  test "fails a direct download whose heartbeat went stale" do
+    DownloadClient.destroy_all
+    stale_at = DownloadMonitorJob::DIRECT_DOWNLOAD_STALE_TIMEOUT.ago - 1.minute
+    @download.update_columns(
+      status: Download.statuses[:downloading],
+      external_id: nil,
+      download_client_id: nil,
+      download_type: "direct",
+      created_at: 1.hour.ago,
+      updated_at: stale_at
+    )
+
+    DownloadMonitorJob.perform_now
+
+    assert @download.reload.failed?
+    assert @request.reload.attention_needed?
+    assert_includes @request.issue_description, "stopped reporting progress"
+  end
+
+  test "does not overwrite a direct download completed after the monitor loaded it" do
+    stale_at = DownloadMonitorJob::DIRECT_DOWNLOAD_STALE_TIMEOUT.ago - 1.minute
+    @download.update_columns(
+      status: Download.statuses[:downloading],
+      external_id: nil,
+      download_type: "direct",
+      updated_at: stale_at
+    )
+    stale_download = Download.find(@download.id)
+    @download.update!(status: :completed, progress: 100)
+
+    DownloadMonitorJob.new.send(:handle_stale_direct_download, stale_download)
+
+    assert @download.reload.completed?
+    assert_not @request.reload.attention_needed?
+  end
+
+  test "does not overwrite a dispatch finalized after the monitor loaded it" do
+    @download.update_columns(
+      status: Download.statuses[:queued],
+      external_id: nil,
+      download_type: nil,
+      created_at: 10.minutes.ago,
+      updated_at: 10.minutes.ago
+    )
+    stale_download = Download.find(@download.id)
+    @download.update!(
+      status: :downloading,
+      external_id: "finalized-hash",
+      download_type: "torrent",
+      download_client: @qbittorrent
+    )
+
+    DownloadMonitorJob.new.send(:handle_stale_queued_download, stale_download)
+
+    assert @download.reload.downloading?
+    assert_equal "finalized-hash", @download.external_id
+    assert_not @request.reload.attention_needed?
+  end
+
+  test "ignores a stale client failure after the download was replaced" do
+    stale_download = Download.find(@download.id)
+    @download.update!(status: :failed)
+
+    DownloadMonitorJob.new.send(:handle_failed, stale_download)
+
+    assert @download.reload.failed?
+    assert_not @request.reload.attention_needed?
+  end
+
+  test "ignores a stale missing result after the download was replaced" do
+    @download.update!(not_found_count: DownloadMonitorJob::NOT_FOUND_THRESHOLD - 1)
+    stale_download = Download.find(@download.id)
+    @download.update!(status: :failed)
+
+    DownloadMonitorJob.new.send(:handle_missing, stale_download)
+
+    assert @download.reload.failed?
+    assert_not @request.reload.attention_needed?
   end
 
   private

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -69,6 +69,41 @@ class PostProcessingJobTest < ActiveJob::TestCase
     end
   end
 
+  test "skips a completed download replaced by a manual selection" do
+    old_result = @request.search_results.create!(
+      guid: "old-result",
+      title: "Old result",
+      magnet_url: "magnet:?xt=urn:btih:#{'a' * 40}",
+      status: :selected
+    )
+    @download.update!(search_result: old_result)
+
+    replacement = @request.add_manual_nzb!("https://downloads.example/replacement.nzb")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    assert @request.reload.downloading?
+    assert replacement.search_result.reload.selected?
+    assert_nil @download.reload.post_processing_job_id
+    assert_nil @book.reload.file_path
+  end
+
+  test "skips a superseded completed download when no result remains selected" do
+    old_result = @request.search_results.create!(
+      guid: "superseded-result",
+      title: "Superseded result",
+      magnet_url: "magnet:?xt=urn:btih:#{'b' * 40}",
+      status: :rejected
+    )
+    @download.update!(search_result: old_result)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    assert @request.reload.downloading?
+    assert_nil @download.reload.post_processing_job_id
+    assert_nil @book.reload.file_path
+  end
+
   test "library_id_for routes comic books to comic library" do
     SettingsService.set(:audiobookshelf_ebook_library_id, "ebook-lib")
     SettingsService.set(:audiobookshelf_comicbook_library_id, "comic-lib")

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -65,7 +65,7 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
-  test "preserves manual magnet results when saving new results" do
+  test "preserves manual download results when saving new results" do
     VCR.turned_off do
       stub_prowlarr_search_with_results
 
@@ -77,12 +77,23 @@ class SearchJobTest < ActiveJob::TestCase
         indexer: "Manual Magnet",
         status: :selected
       )
+      manual_nzb = @request.search_results.create!(
+        guid: "manual-nzb:#{'c' * 64}",
+        title: "Manual NZB result",
+        download_url: "https://downloads.example/book.nzb",
+        seeders: nil,
+        source: SearchResult::SOURCE_MANUAL_NZB,
+        indexer: "Manual NZB",
+        status: :selected
+      )
 
       SearchJob.perform_now(@request.id)
       @request.reload
 
       assert_includes @request.search_results, manual_result
       assert manual_result.reload.selected?
+      assert_includes @request.search_results, manual_nzb
+      assert manual_nzb.reload.selected?
     end
   end
 

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -65,6 +65,80 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "does not overwrite a manual NZB submitted while search results are in flight" do
+    manual_url = "https://downloads.example/manual-book.nzb?token=secret"
+    manual_submitted = false
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_return do
+          unless manual_submitted
+            manual_submitted = true
+            @request.reload.add_manual_nzb!(manual_url)
+          end
+
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: [ prowlarr_result_payload ].to_json
+          }
+        end
+
+      assert_enqueued_with(job: DownloadJob) do
+        SearchJob.perform_now(@request.id)
+      end
+    end
+
+    manual_result = @request.reload.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_NZB)
+    assert @request.downloading?
+    assert manual_result.selected?
+    assert_equal manual_url, manual_result.download_url
+    assert_equal [ manual_result.id ], @request.downloads.pluck(:search_result_id)
+    assert_not @request.search_results.exists?(guid: "test-guid-123")
+  end
+
+  test "does not reclaim a request after a manual NZB selection" do
+    stale_request = Request.find(@request.id)
+    @request.add_manual_nzb!("https://downloads.example/manual-before-search.nzb")
+
+    claimed = SearchJob.new.send(:claim_search!, stale_request)
+
+    assert_not claimed
+    assert @request.reload.downloading?
+    assert @request.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_NZB).selected?
+  end
+
+  test "does not schedule a retry when a manual NZB is submitted during an empty search" do
+    manual_submitted = false
+    original_retry_count = @request.retry_count
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_return do
+          unless manual_submitted
+            manual_submitted = true
+            @request.reload.add_manual_nzb!("https://downloads.example/manual-book.nzb")
+          end
+
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: [].to_json
+          }
+        end
+
+      assert_enqueued_with(job: DownloadJob) do
+        SearchJob.perform_now(@request.id)
+      end
+    end
+
+    @request.reload
+    assert @request.downloading?
+    assert_equal original_retry_count, @request.retry_count
+    assert_nil @request.next_retry_at
+    assert @request.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_NZB).selected?
+  end
+
   test "preserves manual download results when saving new results" do
     VCR.turned_off do
       stub_prowlarr_search_with_results

--- a/test/jobs/stale_client_dispatch_cleanup_job_test.rb
+++ b/test/jobs/stale_client_dispatch_cleanup_job_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StaleClientDispatchCleanupJobTest < ActiveJob::TestCase
+  setup do
+    DownloadClient.destroy_all
+    @client = DownloadClient.create!(
+      name: "Cleanup SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://localhost:8080",
+      api_key: "cleanup-api-key",
+      priority: 0,
+      enabled: true
+    )
+  end
+
+  test "removes a stale client dispatch" do
+    VCR.turned_off do
+      removal = stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including(
+          "mode" => "queue",
+          "name" => "delete",
+          "value" => "SABnzbd_nzo_stale",
+          "del_files" => "1"
+        ))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => true }.to_json
+        )
+
+      StaleClientDispatchCleanupJob.perform_now(@client.id, "SABnzbd_nzo_stale")
+
+      assert_requested removal
+    end
+  end
+
+  test "treats an already absent stale dispatch as cleaned up" do
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "queue", "name" => "delete"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => false }.to_json
+        )
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "history", "name" => "delete"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => false }.to_json
+        )
+      queue = stub_request(:get, "http://localhost:8080/api")
+        .with(query: {
+          "mode" => "queue",
+          "apikey" => "cleanup-api-key",
+          "output" => "json"
+        })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "queue" => { "slots" => [] } }.to_json
+        )
+      history = stub_request(:get, "http://localhost:8080/api")
+        .with(query: {
+          "mode" => "history",
+          "limit" => "50",
+          "apikey" => "cleanup-api-key",
+          "output" => "json"
+        })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "history" => { "slots" => [] } }.to_json
+        )
+
+      assert_nothing_raised do
+        StaleClientDispatchCleanupJob.perform_now(@client.id, "SABnzbd_nzo_absent")
+      end
+      assert_requested queue
+      assert_requested history
+    end
+  end
+
+  test "ignores invalid external IDs" do
+    StaleClientDispatchCleanupJob.perform_now(@client.id, "https://example.com/?token=secret")
+
+    assert_not_requested :get, %r{localhost:8080}
+  end
+end

--- a/test/models/request_manual_magnet_test.rb
+++ b/test/models/request_manual_magnet_test.rb
@@ -85,6 +85,19 @@ class RequestManualMagnetTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_manual_magnet reloads request state before overriding a download" do
+    stale_request = Request.find(@request.id)
+    @request.update!(status: :processing)
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      assert_raises(ArgumentError, match: /post-processing/) do
+        stale_request.add_manual_magnet!("magnet:?xt=urn:btih:#{'f' * 40}")
+      end
+    end
+
+    assert @request.reload.processing?
+  end
+
   test "manual_magnet_allowed allows downloading override but not processing" do
     @request.update!(status: :downloading)
     assert @request.manual_magnet_allowed?

--- a/test/models/request_manual_nzb_test.rb
+++ b/test/models/request_manual_nzb_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RequestManualNzbTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @request = requests(:pending_request)
+  end
+
+  test "add_manual_nzb creates a selected usenet result and queued download" do
+    @request.update!(
+      status: :not_found,
+      next_retry_at: 1.hour.from_now,
+      attention_needed: true,
+      issue_description: "Previous search failed"
+    )
+    url = "https://user:password@nzb.example/download?id=42&X-Amz-Signature=very-secret"
+
+    assert_enqueued_with(job: DownloadJob) do
+      assert_difference [ "SearchResult.count", "Download.count" ], 1 do
+        @request.add_manual_nzb!("  #{url}  ")
+      end
+    end
+
+    result = @request.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_NZB)
+    download = @request.downloads.order(:created_at).last
+
+    assert_equal url, result.download_url
+    assert_equal "manual-nzb:#{Digest::SHA256.hexdigest(url)}", result.guid
+    assert_not_includes result.guid, "very-secret"
+    assert_equal "Manual NZB", result.indexer
+    assert_nil result.magnet_url
+    assert_nil result.seeders
+    assert_nil result.leechers
+    assert result.usenet?
+    assert result.selected?
+    assert_equal result, download.search_result
+    assert download.queued?
+
+    @request.reload
+    assert @request.downloading?
+    assert_nil @request.next_retry_at
+    assert_not @request.attention_needed?
+    assert_nil @request.issue_description
+  end
+
+  test "add_manual_nzb accepts opaque signed URLs without an NZB suffix" do
+    url = "https://downloads.example/api/release/123?token=opaque-value"
+
+    assert_enqueued_with(job: DownloadJob) do
+      @request.add_manual_nzb!(url)
+    end
+
+    assert_equal url, @request.search_results.find_by!(source: SearchResult::SOURCE_MANUAL_NZB).download_url
+  end
+
+  test "add_manual_nzb rejects blank relative hostless and non HTTP URLs" do
+    invalid_urls = [
+      "",
+      "/downloads/book.nzb",
+      "https:///downloads/book.nzb",
+      "ftp://example.com/book.nzb",
+      "file:///tmp/book.nzb",
+      "magnet:?xt=urn:btih:#{'a' * 40}",
+      "javascript:alert(1)"
+    ]
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      invalid_urls.each do |url|
+        assert_raises(ArgumentError, match: /valid HTTP\(S\) NZB URL/) do
+          @request.add_manual_nzb!(url)
+        end
+      end
+    end
+  end
+
+  test "add_manual_nzb reuses the result for the exact same URL" do
+    url = "https://downloads.example/release?id=123&token=same-token"
+    @request.add_manual_nzb!(url)
+
+    assert_no_difference "SearchResult.count" do
+      assert_difference "Download.count", 1 do
+        @request.add_manual_nzb!(url)
+      end
+    end
+
+    results = @request.search_results.where(source: SearchResult::SOURCE_MANUAL_NZB)
+    assert_equal 1, results.count
+    assert_equal "manual-nzb:#{Digest::SHA256.hexdigest(url)}", results.first.guid
+    assert results.first.selected?
+  end
+
+  test "add_manual_nzb rejects completed requests" do
+    @request.complete!
+
+    assert_raises(ArgumentError, match: /completed request/) do
+      @request.add_manual_nzb!("https://downloads.example/book.nzb")
+    end
+  end
+
+  test "add_manual_nzb rejects processing requests" do
+    @request.update!(status: :processing)
+
+    assert_raises(ArgumentError, match: /post-processing/) do
+      @request.add_manual_nzb!("https://downloads.example/book.nzb")
+    end
+  end
+
+  test "manual download allows a downloading override but not processing" do
+    @request.update!(status: :downloading)
+    assert @request.manual_download_allowed?
+    assert @request.manual_nzb_allowed?
+    assert @request.manual_magnet_allowed?
+
+    @request.update!(status: :processing)
+    assert_not @request.manual_download_allowed?
+    assert_not @request.manual_nzb_allowed?
+    assert_not @request.manual_magnet_allowed?
+  end
+end

--- a/test/models/request_manual_nzb_test.rb
+++ b/test/models/request_manual_nzb_test.rb
@@ -108,6 +108,35 @@ class RequestManualNzbTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_manual_nzb reloads request state before overriding a download" do
+    stale_request = Request.find(@request.id)
+    @request.update!(status: :processing)
+
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      assert_raises(ArgumentError, match: /post-processing/) do
+        stale_request.add_manual_nzb!("https://downloads.example/book.nzb")
+      end
+    end
+
+    assert @request.reload.processing?
+  end
+
+  test "add_manual_nzb enqueues dispatch after its transaction commits" do
+    baseline_transactions = Request.connection.open_transactions
+    transactions_at_enqueue = nil
+    enqueued_download_id = nil
+
+    DownloadJob.stub(:perform_later, ->(download_id) {
+      transactions_at_enqueue = Request.connection.open_transactions
+      enqueued_download_id = download_id
+    }) do
+      download = @request.add_manual_nzb!("https://downloads.example/book.nzb")
+      assert_equal download.id, enqueued_download_id
+    end
+
+    assert_equal baseline_transactions, transactions_at_enqueue
+  end
+
   test "manual download allows a downloading override but not processing" do
     @request.update!(status: :downloading)
     assert @request.manual_download_allowed?
@@ -118,5 +147,21 @@ class RequestManualNzbTest < ActiveSupport::TestCase
     assert_not @request.manual_download_allowed?
     assert_not @request.manual_nzb_allowed?
     assert_not @request.manual_magnet_allowed?
+  end
+
+  test "manual download is blocked while a client dispatch is in progress" do
+    @request.update!(status: :downloading)
+    @request.downloads.create!(
+      name: "Dispatch in progress",
+      status: :downloading,
+      external_id: nil
+    )
+
+    assert_not @request.manual_download_allowed?
+    assert_no_difference [ "SearchResult.count", "Download.count" ] do
+      assert_raises(ArgumentError, match: /dispatch is in progress/) do
+        @request.add_manual_nzb!("https://downloads.example/book.nzb")
+      end
+    end
   end
 end

--- a/test/models/request_retry_test.rb
+++ b/test/models/request_retry_test.rb
@@ -624,6 +624,23 @@ class RequestRetryTest < ActiveSupport::TestCase
     assert_equal replacement_result, request.downloads.order(:created_at).last.search_result
   end
 
+  test "select_result! rejects an override while dispatch is in progress" do
+    request = requests(:pending_request)
+    replacement_result = search_results(:pending_result)
+    request.downloads.create!(
+      name: "Dispatch in progress",
+      status: :downloading,
+      external_id: nil,
+      download_type: "dispatching"
+    )
+
+    assert_no_difference -> { request.downloads.count } do
+      assert_raises(ArgumentError, match: /dispatch is in progress/) do
+        request.select_result!(replacement_result)
+      end
+    end
+  end
+
   test "cancel! removes active downloads from download client" do
     book = Book.create!(title: "Cancel Test Book", book_type: :ebook, open_library_work_id: "OL_CANCEL_TEST")
     request = Request.create!(
@@ -646,6 +663,42 @@ class RequestRetryTest < ActiveSupport::TestCase
 
     assert request.failed?
     assert download.failed?
+  end
+
+  test "cancel_download schedules cleanup when the client does not confirm removal" do
+    client = DownloadClient.create!(
+      name: "Cancellation SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://localhost:8089",
+      api_key: "cancel-api-key",
+      priority: 0,
+      enabled: true
+    )
+    request = requests(:pending_request)
+    download = request.downloads.create!(
+      name: "Client dispatch",
+      status: :downloading,
+      external_id: "SABnzbd_nzo_cancel",
+      download_client: client
+    )
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8089/api")
+        .with(query: hash_including("mode" => "queue", "name" => "delete"))
+        .to_return(status: 200, body: { "status" => false }.to_json)
+      stub_request(:get, "http://localhost:8089/api")
+        .with(query: hash_including("mode" => "history", "name" => "delete"))
+        .to_return(status: 200, body: { "status" => false }.to_json)
+
+      assert_enqueued_with(
+        job: StaleClientDispatchCleanupJob,
+        args: [ client.id.to_s, "SABnzbd_nzo_cancel" ]
+      ) do
+        request.cancel_download(download)
+      end
+    end
+
+    assert download.reload.failed?
   end
 
   test "cancel! also cancels paused downloads" do

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -439,12 +439,22 @@ class SearchResultTest < ActiveSupport::TestCase
     assert SearchResult.new(source: SearchResult::SOURCE_ANNA_ARCHIVE).from_anna_archive?
     assert SearchResult.new(source: SearchResult::SOURCE_ZLIBRARY).from_zlibrary?
     assert SearchResult.new(source: SearchResult::SOURCE_GUTENBERG).from_gutenberg?
+    manual_nzb = SearchResult.new(
+      source: SearchResult::SOURCE_MANUAL_NZB,
+      download_url: "https://downloads.example/book.nzb",
+      seeders: nil
+    )
+    assert manual_nzb.from_manual_nzb?
+    assert manual_nzb.usenet?
+    assert_not manual_nzb.from_indexer?
+    assert_equal [ SearchResult::SOURCE_MANUAL_MAGNET, SearchResult::SOURCE_MANUAL_NZB ], SearchResult::MANUAL_SOURCES
 
     assert_equal "Custom Jackett", SearchResult.new(source: SearchResult::SOURCE_JACKETT, indexer: "Custom Jackett").source_display_name
     assert_equal "NZBHydra Books", SearchResult.new(source: SearchResult::SOURCE_NEWZNAB, indexer: "NZBHydra Books").source_display_name
     assert_equal "Anna's Archive", SearchResult.new(source: SearchResult::SOURCE_ANNA_ARCHIVE).source_display_name
     assert_equal "Z-Library", SearchResult.new(source: SearchResult::SOURCE_ZLIBRARY).source_display_name
     assert_equal "Project Gutenberg", SearchResult.new(source: SearchResult::SOURCE_GUTENBERG).source_display_name
+    assert_equal "Manual NZB", manual_nzb.source_display_name
     assert_equal "Prowlarr", SearchResult.new.source_display_name
   end
 end

--- a/test/services/download_client_selector_test.rb
+++ b/test/services/download_client_selector_test.rb
@@ -61,13 +61,50 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
     )
 
     VCR.turned_off do
-      stub_sabnzbd_version
+      stub_sabnzbd_connection
 
       search_result = Minitest::Mock.new
       search_result.expect :usenet?, true
 
       selected = DownloadClientSelector.for_download(search_result)
       assert_equal sab, selected
+    end
+  end
+
+  test "skips a higher-priority SABnzbd client with an invalid API key" do
+    DownloadClient.create!(
+      name: "Invalid SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://localhost:8080",
+      api_key: "invalid-key",
+      priority: 0
+    )
+    fallback = DownloadClient.create!(
+      name: "Authenticated SABnzbd",
+      client_type: "sabnzbd",
+      url: "http://localhost:8081",
+      api_key: "valid-key",
+      priority: 10
+    )
+
+    VCR.turned_off do
+      rejected = stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "get_cats", "apikey" => "invalid-key"))
+        .to_return(status: 403)
+      accepted = stub_request(:get, "http://localhost:8081/api")
+        .with(query: hash_including("mode" => "get_cats", "apikey" => "valid-key"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "categories" => [ "*" ] }.to_json
+        )
+
+      search_result = Minitest::Mock.new
+      search_result.expect :usenet?, true
+
+      assert_equal fallback, DownloadClientSelector.for_download(search_result)
+      assert_requested rejected
+      assert_requested accepted
     end
   end
 
@@ -172,7 +209,7 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "result" => ["new-id"], "error" => nil, "id" => 1 }.to_json
+          body: { "result" => [ "new-id" ], "error" => nil, "id" => 1 }.to_json
         )
 
       search_result = Minitest::Mock.new
@@ -388,12 +425,12 @@ class DownloadClientSelectorTest < ActiveSupport::TestCase
 
   private
 
-  def stub_sabnzbd_version
-    stub_request(:get, %r{localhost:8080/api.*mode=version})
+  def stub_sabnzbd_connection
+    stub_request(:get, %r{localhost:8080/api.*mode=get_cats})
       .to_return(
         status: 200,
         headers: { "Content-Type" => "application/json" },
-        body: { "version" => "4.0.0" }.to_json
+        body: { "categories" => [ "*" ] }.to_json
       )
   end
 end

--- a/test/services/download_clients/nzbget_test.rb
+++ b/test/services/download_clients/nzbget_test.rb
@@ -20,7 +20,7 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
     VCR.turned_off do
       stub_request(:post, "http://localhost:6789/jsonrpc")
         .with(
-          body: hash_including("method" => "appendurl"),
+          body: hash_including("method" => "append"),
           basic_auth: [ "nzbget", "tegbzn6789" ]
         )
         .to_return(
@@ -32,6 +32,44 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
       result = @client.add_torrent("http://example.com/test.nzb")
       assert result
       assert_equal [ "12345" ], result["nzo_ids"]
+    end
+  end
+
+  test "add_torrent submits an opaque URL with a sanitized NZB filename" do
+    url = "https://downloads.example/api/release/123?token=opaque"
+
+    VCR.turned_off do
+      request_stub = stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: ->(body) {
+            payload = JSON.parse(body)
+            payload["method"] == "append" &&
+              payload["params"] == [
+                "Author Book.nzb",
+                url,
+                "",
+                0,
+                false,
+                false,
+                "",
+                0,
+                "SCORE",
+                false,
+                []
+              ]
+          },
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => 54321 }.to_json
+        )
+
+      result = @client.add_torrent(url, nzbname: "Author / Book")
+
+      assert_equal [ "54321" ], result["nzo_ids"]
+      assert_requested request_stub
     end
   end
 
@@ -48,6 +86,41 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
       result = @client.add_torrent("http://example.com/test.nzb")
       assert_not result
     end
+  end
+
+  test "add_torrent does not expose a sensitive URL echoed by an API error" do
+    url = "https://alice:password@downloads.example/book?X-Amz-Signature=very-secret"
+    logger = Struct.new(:messages) do
+      %i[debug info warn error].each do |level|
+        define_method(level) { |message| messages << message }
+      end
+    end.new([])
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(
+          body: hash_including("method" => "append"),
+          basic_auth: [ "nzbget", "tegbzn6789" ]
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "error" => "Could not fetch #{url}" }.to_json
+        )
+
+      error = Rails.stub(:logger, logger) do
+        assert_raises(DownloadClients::Base::Error) do
+          @client.add_torrent(url, sensitive_url: true)
+        end
+      end
+
+      assert_equal "NZBGet rejected the NZB URL", error.message
+    end
+
+    output = logger.messages.join("\n")
+    assert_not_includes output, "alice"
+    assert_not_includes output, "password"
+    assert_not_includes output, "very-secret"
   end
 
   test "list_torrents returns queue and history items" do

--- a/test/services/download_clients/nzbget_test.rb
+++ b/test/services/download_clients/nzbget_test.rb
@@ -88,6 +88,20 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
     end
   end
 
+  test "add_torrent rejects a non-integer job ID" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(basic_auth: [ "nzbget", "tegbzn6789" ])
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => 1.5 }.to_json
+        )
+
+      assert_not @client.add_torrent("http://example.com/test.nzb")
+    end
+  end
+
   test "add_torrent does not expose a sensitive URL echoed by an API error" do
     url = "https://alice:password@downloads.example/book?X-Amz-Signature=very-secret"
     logger = Struct.new(:messages) do
@@ -115,6 +129,66 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
       end
 
       assert_equal "NZBGet rejected the NZB URL", error.message
+    end
+
+    output = logger.messages.join("\n")
+    assert_not_includes output, "alice"
+    assert_not_includes output, "password"
+    assert_not_includes output, "very-secret"
+  end
+
+  test "add_torrent does not expose a sensitive URL in an unexpected response" do
+    url = "https://alice:password@downloads.example/book?X-Amz-Signature=very-secret"
+    logger = Struct.new(:messages) do
+      %i[debug info warn error].each do |level|
+        define_method(level) { |message| messages << message }
+      end
+    end.new([])
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(body: hash_including("method" => "append"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: "Could not fetch #{url}".to_json
+        )
+
+      Rails.stub(:logger, logger) do
+        assert_raises(DownloadClients::Base::Error) do
+          @client.add_torrent(url, sensitive_url: true)
+        end
+      end
+    end
+
+    output = logger.messages.join("\n")
+    assert_not_includes output, "alice"
+    assert_not_includes output, "password"
+    assert_not_includes output, "very-secret"
+  end
+
+  test "add_torrent does not expose a sensitive URL returned as a failed result" do
+    url = "https://alice:password@downloads.example/book?X-Amz-Signature=very-secret"
+    logger = Struct.new(:messages) do
+      %i[debug info warn error].each do |level|
+        define_method(level) { |message| messages << message }
+      end
+    end.new([])
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(body: hash_including("method" => "append"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "result" => "Could not fetch #{url}" }.to_json
+        )
+
+      result = Rails.stub(:logger, logger) do
+        @client.add_torrent(url, sensitive_url: true)
+      end
+
+      assert_not result
     end
 
     output = logger.messages.join("\n")
@@ -191,13 +265,13 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
     VCR.turned_off do
       stub_request(:post, "http://localhost:6789/jsonrpc")
         .with(
-          body: hash_including("method" => "version"),
+          body: hash_including("method" => "status"),
           basic_auth: [ "nzbget", "tegbzn6789" ]
         )
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "result" => "21.1" }.to_json
+          body: { "result" => { "RemainingSizeMB" => 0 } }.to_json
         )
 
       assert @client.test_connection
@@ -215,13 +289,13 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
 
         request_stub = stub_request(:post, jsonrpc_url)
           .with(
-            body: hash_including("method" => "version"),
+            body: hash_including("method" => "status"),
             basic_auth: [ "nzbget", "tegbzn6789" ]
           )
           .to_return(
             status: 200,
             headers: { "Content-Type" => "application/json" },
-            body: { "result" => "21.1" }.to_json
+            body: { "result" => { "RemainingSizeMB" => 0 } }.to_json
           )
 
         assert client.test_connection, "#{base_url} should connect through #{jsonrpc_url}"
@@ -326,6 +400,18 @@ class DownloadClients::NzbgetTest < ActiveSupport::TestCase
       assert_equal "888", info.hash
       assert_equal "Completed Item", info.name
       assert_equal :completed, info.state
+    end
+  end
+
+  test "torrent_info propagates queue API failures" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:6789/jsonrpc")
+        .with(body: hash_including("method" => "listgroups"))
+        .to_return(status: 503, body: "temporarily unavailable")
+
+      assert_raises(DownloadClients::Base::Error) do
+        @client.torrent_info("999")
+      end
     end
   end
 

--- a/test/services/download_clients/sabnzbd_test.rb
+++ b/test/services/download_clients/sabnzbd_test.rb
@@ -84,6 +84,80 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
     assert_not_includes output, "very-secret"
   end
 
+  test "add_torrent does not log response fields for a sensitive URL" do
+    url = "https://alice:password@downloads.example/book?X-Amz-Signature=very-secret"
+    logger = Struct.new(:messages) do
+      %i[debug info warn error].each do |level|
+        define_method(level) { |message| messages << message }
+      end
+    end.new([])
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "addurl", "name" => url))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => "Could not fetch #{url}", "nzo_ids" => nil }.to_json
+        )
+
+      result = Rails.stub(:logger, logger) do
+        @client.add_torrent(url, sensitive_url: true)
+      end
+
+      assert_not result
+    end
+
+    output = logger.messages.join("\n")
+    assert_not_includes output, "alice"
+    assert_not_includes output, "password"
+    assert_not_includes output, "very-secret"
+  end
+
+  test "add_torrent rejects a sensitive URL echoed as an external ID" do
+    url = "https://alice:password@downloads.example/book?X-Amz-Signature=very-secret"
+    logger = Struct.new(:messages) do
+      %i[debug info warn error].each do |level|
+        define_method(level) { |message| messages << message }
+      end
+    end.new([])
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "addurl", "name" => url))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => true, "nzo_ids" => [ url ] }.to_json
+        )
+
+      result = Rails.stub(:logger, logger) do
+        @client.add_torrent(url, sensitive_url: true)
+      end
+
+      assert_not result
+    end
+
+    output = logger.messages.join("\n")
+    assert_not_includes output, "alice"
+    assert_not_includes output, "password"
+    assert_not_includes output, "very-secret"
+  end
+
+  test "add_torrent rejects a scalar external ID response" do
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "addurl"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => true, "nzo_ids" => "SABnzbd_nzo_12345" }.to_json
+        )
+
+      assert_not @client.add_torrent("https://downloads.example/book.nzb")
+    end
+  end
+
   test "list_torrents returns queue and history items" do
     VCR.turned_off do
       stub_request(:get, %r{localhost:8080/api.*mode=queue})
@@ -144,11 +218,11 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
 
   test "test_connection returns true on success" do
     VCR.turned_off do
-      stub_request(:get, %r{localhost:8080/api.*mode=version})
+      stub_request(:get, %r{localhost:8080/api.*mode=get_cats})
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "version" => "4.0.0" }.to_json
+          body: { "categories" => [ "*", "books" ] }.to_json
         )
 
       assert @client.test_connection
@@ -166,14 +240,14 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
 
         request_stub = stub_request(:get, api_url)
           .with(query: hash_including(
-            "mode" => "version",
+            "mode" => "get_cats",
             "apikey" => "test-api-key-12345",
             "output" => "json"
           ))
           .to_return(
             status: 200,
             headers: { "Content-Type" => "application/json" },
-            body: { "version" => "4.0.0" }.to_json
+            body: { "categories" => [ "*" ] }.to_json
           )
 
         assert client.test_connection, "#{base_url} should connect through #{api_url}"
@@ -184,8 +258,8 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
 
   test "test_connection returns false on failure" do
     VCR.turned_off do
-      stub_request(:get, %r{localhost:8080/api.*mode=version})
-        .to_return(status: 401)
+      stub_request(:get, %r{localhost:8080/api.*mode=get_cats})
+        .to_return(status: 403)
 
       assert_not @client.test_connection
     end
@@ -219,6 +293,17 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
       assert_equal "test_nzo_id", info.hash
       assert_equal "Test Item", info.name
       assert_equal 75, info.progress
+    end
+  end
+
+  test "torrent_info propagates queue API failures" do
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:8080/api.*mode=queue})
+        .to_return(status: 503, body: "temporarily unavailable")
+
+      assert_raises(DownloadClients::Base::Error) do
+        @client.torrent_info("test_nzo_id")
+      end
     end
   end
 end

--- a/test/services/download_clients/sabnzbd_test.rb
+++ b/test/services/download_clients/sabnzbd_test.rb
@@ -21,7 +21,7 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "status" => true, "nzo_ids" => ["SABnzbd_nzo_12345"] }.to_json
+          body: { "status" => true, "nzo_ids" => [ "SABnzbd_nzo_12345" ] }.to_json
         )
 
       result = @client.add_torrent("http://example.com/test.nzb")
@@ -42,7 +42,7 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "status" => true, "nzo_ids" => ["SABnzbd_nzo_12345"] }.to_json
+          body: { "status" => true, "nzo_ids" => [ "SABnzbd_nzo_12345" ] }.to_json
         )
 
       result = @client.add_torrent("http://example.com/test.nzb", nzbname: "Another Author - The Pending Ebook")
@@ -50,6 +50,38 @@ class DownloadClients::SabnzbdTest < ActiveSupport::TestCase
       assert result
       assert_requested request_stub
     end
+  end
+
+  test "add_torrent does not expose a sensitive URL echoed by an API error" do
+    url = "https://alice:password@downloads.example/book?X-Amz-Signature=very-secret"
+    logger = Struct.new(:messages) do
+      %i[debug info warn error].each do |level|
+        define_method(level) { |message| messages << message }
+      end
+    end.new([])
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "addurl", "name" => url))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "status" => false, "error" => "Could not fetch #{url}" }.to_json
+        )
+
+      error = Rails.stub(:logger, logger) do
+        assert_raises(DownloadClients::Base::Error) do
+          @client.add_torrent(url, sensitive_url: true)
+        end
+      end
+
+      assert_equal "SABnzbd rejected the NZB URL", error.message
+    end
+
+    output = logger.messages.join("\n")
+    assert_not_includes output, "alice"
+    assert_not_includes output, "password"
+    assert_not_includes output, "very-secret"
   end
 
   test "list_torrents returns queue and history items" do

--- a/test/services/outbound_url_guard_test.rb
+++ b/test/services/outbound_url_guard_test.rb
@@ -43,9 +43,13 @@ class OutboundUrlGuardTest < ActiveSupport::TestCase
   test "always rejects link-local and metadata addresses" do
     %w[
       http://169.254.169.254/latest/meta-data
+      http://100.100.100.200/latest/meta-data
       http://0.0.0.0/file
       http://[fe80::1]/file
       http://[64:ff9b::a9fe:a9fe]/file
+      http://[fd00:a9fe:a9fe::1]/v1/instance
+      http://[fd00:ec2::254]/latest/meta-data
+      http://[fd20:ce::254]/computeMetadata/v1
     ].each do |url|
       assert_raises(OutboundUrlGuard::BlockedUrlError, "expected #{url} to be blocked") do
         OutboundUrlGuard.validate!(url, allow_private: true)

--- a/test/services/url_redactor_test.rb
+++ b/test/services/url_redactor_test.rb
@@ -16,4 +16,30 @@ class UrlRedactorTest < ActiveSupport::TestCase
 
     assert_equal url, UrlRedactor.redact(url)
   end
+
+  test "redacts URL userinfo and fragments" do
+    url = "https://alice:password@example.com/download/book.nzb#secret-fragment"
+
+    assert_equal "https://[REDACTED]@example.com/download/book.nzb#[REDACTED]", UrlRedactor.redact(url)
+  end
+
+  test "redacts common signed URL parameters case insensitively" do
+    url = "https://example.com/download?X-Amz-Credential=credential&X-Amz-Signature=signature&X-Amz-Security-Token=session&file=book"
+
+    assert_equal(
+      "https://example.com/download?X-Amz-Credential=[REDACTED]&X-Amz-Signature=[REDACTED]&X-Amz-Security-Token=[REDACTED]&file=book",
+      UrlRedactor.redact(url)
+    )
+  end
+
+  test "Rails parameter filtering hides NZB and persisted download URLs" do
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    filtered = filter.filter(
+      nzb_url: "https://example.com/nzb?token=secret",
+      download_url: "https://example.com/download?token=secret"
+    )
+
+    assert_equal "[FILTERED]", filtered[:nzb_url]
+    assert_equal "[FILTERED]", filtered[:download_url]
+  end
 end


### PR DESCRIPTION
## Summary
- add an admin-only Manual NZB URL form beside the existing manual magnet flow
- accept opaque HTTP(S) URLs without requiring a `.nzb` suffix, preserve the exact signed URL for dispatch, and identify results with a SHA-256-based GUID
- classify and preserve manual NZB results through search refreshes, then route them to the highest-priority healthy SABnzbd or NZBGet client
- update NZBGet URL submission to its current `append(Filename, Content, ...)` RPC signature with a sanitized metadata-based `.nzb` filename
- protect credential-bearing URLs from request, SQL-bind, dispatch, client, and echoed-error logs

This PR intentionally covers URL submission only. Local NZB file upload requires separate multipart/content APIs for each Usenet client and remains follow-up work.

Closes #339

## Validation
- 1,746 Rails tests / 5,484 assertions
- focused model, controller, search-refresh, client-adapter, URL-redaction, and end-to-end dispatch tests
- RuboCop on all touched Ruby files
- `bin/quality commit --staged`
- `bin/quality push`
- independent correctness/security review
- verified NZBGet payload against the current official API reference