### PR TITLE
fix: include path prefix in search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,6 +45,7 @@ class SearchController < ApplicationController
   end
 
   def stream_results
+    @relative_url_root = request.script_name
     @query = params[:q].to_s.strip
     @content_kind = normalized_content_kind(params[:content_kind])
 
@@ -169,11 +170,32 @@ class SearchController < ApplicationController
     @audiobookshelf_matches = enrichment[:audiobookshelf_matches]
     @existing_books_lookup = enrichment[:existing_books_lookup]
 
-    render_to_string(
-      template: "search/results",
-      formats: [ :turbo_stream ],
-      layout: false
-    )
+    with_relative_url_root do
+      render_to_string(
+        template: "search/results",
+        formats: [ :turbo_stream ],
+        layout: false
+      )
+    end
+  end
+
+  # ActionController::Live runs the action body in a background thread and
+  # returns the response back up the Rack stack as soon as the first chunk
+  # commits, so path-prefixing middleware (e.g. Rack::URLMap, used when the
+  # app is mounted under RAILS_RELATIVE_URL_ROOT) can unwind its SCRIPT_NAME
+  # mutation on the shared env hash before later chunks are rendered. Without
+  # reapplying the prefix captured at the top of #stream_results, url_for and
+  # friends would drop it from links in every chunk after the first. We
+  # restore the previous value afterwards so the mutation doesn't leak beyond
+  # this render.
+  def with_relative_url_root
+    return yield if @relative_url_root.blank?
+
+    original_script_name = request.script_name
+    request.script_name = @relative_url_root
+    yield
+  ensure
+    request.script_name = original_script_name if @relative_url_root.present?
   end
 
   def audiobookshelf_matches_for(results)

--- a/test/controllers/search_controller_rendering_test.rb
+++ b/test/controllers/search_controller_rendering_test.rb
@@ -58,6 +58,52 @@ class SearchControllerRenderingTest < ActionController::TestCase
     assert_includes html, "Search failed. Please try again."
   end
 
+  test "render_search_results_stream keeps the mounted prefix in chunks rendered after SCRIPT_NAME reverts mid-stream" do
+    @controller.instance_variable_set(:@query, "dune")
+
+    @request.set_header("SCRIPT_NAME", "")
+    @request.set_header("PATH_INFO", "/books/search/results/stream")
+
+    mounted = Rack::URLMap.new(
+      "/books" => lambda do |env|
+        # #stream_results captures @relative_url_root once, up front, from
+        # whatever prefix mounted the app for this request (e.g. Rack::URLMap
+        # under RAILS_RELATIVE_URL_ROOT).
+        @controller.instance_variable_set(:@relative_url_root, env[Rack::SCRIPT_NAME])
+
+        @controller.send(
+          :render_search_results_stream,
+          results: [],
+          loading: true,
+          pending_providers: %w[openlibrary],
+          completed_providers: [],
+          error: nil
+        )
+
+        [ 200, {}, [] ]
+      end
+    )
+    mounted.call(@request.env)
+
+    # ActionController::Live returns control up the Rack stack as soon as the
+    # first chunk commits, well before later chunks render on the background
+    # thread. Whatever mounted the app at /books is done touching SCRIPT_NAME
+    # on this (shared) env by then, so it can revert -- reproduce that here.
+    @request.set_header("SCRIPT_NAME", "")
+
+    second_chunk = @controller.send(
+      :render_search_results_stream,
+      results: [ candidate ],
+      loading: false,
+      pending_providers: [],
+      completed_providers: %w[openlibrary],
+      error: nil
+    )
+
+    assert_match %r{href="/books/search/details\?}, second_chunk
+    assert_no_match %r{href="/search/details\?}, second_chunk
+  end
+
   test "audiobookshelf_matches_for returns placeholders without library items" do
     LibraryItem.destroy_all
 

--- a/test/controllers/search_controller_rendering_test.rb
+++ b/test/controllers/search_controller_rendering_test.rb
@@ -58,50 +58,19 @@ class SearchControllerRenderingTest < ActionController::TestCase
     assert_includes html, "Search failed. Please try again."
   end
 
-  test "render_search_results_stream keeps the mounted prefix in chunks rendered after SCRIPT_NAME reverts mid-stream" do
-    @controller.instance_variable_set(:@query, "dune")
+  test "with_relative_url_root reapplies the captured prefix and restores the prior SCRIPT_NAME afterward" do
+    @controller.instance_variable_set(:@relative_url_root, "/books")
 
-    @request.set_header("SCRIPT_NAME", "")
-    @request.set_header("PATH_INFO", "/books/search/results/stream")
-
-    mounted = Rack::URLMap.new(
-      "/books" => lambda do |env|
-        # #stream_results captures @relative_url_root once, up front, from
-        # whatever prefix mounted the app for this request (e.g. Rack::URLMap
-        # under RAILS_RELATIVE_URL_ROOT).
-        @controller.instance_variable_set(:@relative_url_root, env[Rack::SCRIPT_NAME])
-
-        @controller.send(
-          :render_search_results_stream,
-          results: [],
-          loading: true,
-          pending_providers: %w[openlibrary],
-          completed_providers: [],
-          error: nil
-        )
-
-        [ 200, {}, [] ]
-      end
-    )
-    mounted.call(@request.env)
-
-    # ActionController::Live returns control up the Rack stack as soon as the
-    # first chunk commits, well before later chunks render on the background
-    # thread. Whatever mounted the app at /books is done touching SCRIPT_NAME
-    # on this (shared) env by then, so it can revert -- reproduce that here.
+    # Simulates SCRIPT_NAME having reverted on the shared env since the
+    # prefix was captured at the top of #stream_results (e.g. once whatever
+    # mounted the app under /books is done touching this request).
     @request.set_header("SCRIPT_NAME", "")
 
-    second_chunk = @controller.send(
-      :render_search_results_stream,
-      results: [ candidate ],
-      loading: false,
-      pending_providers: [],
-      completed_providers: %w[openlibrary],
-      error: nil
-    )
+    observed_script_name = nil
+    @controller.send(:with_relative_url_root) { observed_script_name = @request.script_name }
 
-    assert_match %r{href="/books/search/details\?}, second_chunk
-    assert_no_match %r{href="/search/details\?}, second_chunk
+    assert_equal "/books", observed_script_name
+    assert_equal "", @request.script_name
   end
 
   test "audiobookshelf_matches_for returns placeholders without library items" do

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -263,6 +263,52 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "graphic" ], aggregated_content_kinds
   end
 
+  test "stream_results renders provider-result links under the mounted path prefix" do
+    candidate = MetadataSearch::Candidate.new(
+      canonical_key: "openlibrary:OL_PREFIXW",
+      title: "Prefixed Stream Book",
+      author: "Prefix Author",
+      year: 2020,
+      description: nil,
+      cover_url: nil,
+      series_name: nil,
+      series_position: nil,
+      has_ebook: true,
+      has_audiobook: false,
+      sources: [
+        {
+          source: "openlibrary",
+          source_id: "OL_PREFIXW",
+          source_name: "Open Library",
+          source_url: nil,
+          work_id: "openlibrary:OL_PREFIXW"
+        }
+      ],
+      editions: [],
+      confidence: 100,
+      content_kind: "book"
+    )
+
+    stream_search = lambda do |_query, **_kwargs, &block|
+      block.call("openlibrary", [ candidate ])
+    end
+    aggregate = lambda do |_results, **_kwargs|
+      [ candidate ]
+    end
+
+    MetadataService.stub(:enabled_metadata_providers, [ "openlibrary" ]) do
+      MetadataService.stub(:each_provider_search, stream_search) do
+        MetadataService.stub(:aggregate_provider_results, aggregate) do
+          get search_results_stream_path, params: { q: "prefixed" }, env: { "SCRIPT_NAME" => "/books" }
+        end
+      end
+    end
+
+    assert_response :success
+    assert_match %r{href="/books/search/details\?}, response.body
+    assert_no_match %r{href="/search/details\?}, response.body
+  end
+
   test "stream_results handles blank query" do
     get search_results_stream_path, params: { q: "" }
 


### PR DESCRIPTION
Capture request.script_name once at the very start of the action (before any commit can trigger the reset), then re-apply it via request.set_header before each subsequent render.

Fixes #349 