### PR TITLE
fix: validate Anna's Archive search mirrors

### DIFF
--- a/app/services/anna_archive_client.rb
+++ b/app/services/anna_archive_client.rb
@@ -12,6 +12,7 @@ class AnnaArchiveClient
   class NotConfiguredError < Error; end
   class ConfigurationError < Error; end
   class ScrapingError < Error; end
+  class IncompatibleSiteError < Error; end
   class BotProtectionError < Error; end
   class RetryableError < Error; end
 
@@ -29,7 +30,7 @@ class AnnaArchiveClient
     end
   end
 
-  DEFAULT_BASE_URL = "https://annas-archive.se"
+  DEFAULT_BASE_URL = SettingsService::DEFAULT_ANNA_ARCHIVE_URL
   ALLOWED_BASE_URL_SCHEMES = %w[http https].freeze
 
   class << self
@@ -53,7 +54,7 @@ class AnnaArchiveClient
       url = build_search_url(query, file_types, language: language)
       Rails.logger.info "[AnnaArchiveClient] Searching: #{url}"
 
-      html = fetch_with_rotation(url, context: "search")
+      html = fetch_with_rotation(url, context: "search", validator: method(:validate_search_page!))
       parse_search_results(html, limit)
     end
 
@@ -97,23 +98,25 @@ class AnnaArchiveClient
       @working_base_url = nil
     end
 
-    # Test connection by fetching search page
+    # Test the search interface rather than accepting any homepage returning 200.
     def test_connection
-      configured_base_urls.any? do |base_url|
-        response = connection_for(base_url).get("/")
-        response.status == 200
-      rescue Faraday::Error
-        false
-      end
-    rescue Error
+      fetch_with_rotation(
+        "/search?q=shelfarr",
+        context: "connection test",
+        validator: method(:validate_search_page!)
+      )
+      true
+    rescue Error, Faraday::Error
       false
     end
 
     private
 
-    def fetch_with_rotation(path, context:)
+    def fetch_with_rotation(path, context:, validator: nil)
       with_base_url_rotation(context: context) do |base_url|
-        fetch_with_protection_bypass(path, base_url: base_url)
+        html = fetch_with_protection_bypass(path, base_url: base_url)
+        validator&.call(html)
+        html
       end
     end
 
@@ -124,7 +127,7 @@ class AnnaArchiveClient
       ordered_base_urls.each do |base_url|
         return yield(base_url).tap { remember_working_base_url(base_url) }
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError,
-             ConnectionError, BotProtectionError, RetryableError => e
+             ConnectionError, IncompatibleSiteError, BotProtectionError, RetryableError => e
         last_error = e
         bot_protection_error ||= e if e.is_a?(BotProtectionError)
         Rails.logger.debug "[AnnaArchiveClient] #{context} failed on #{base_url}: #{e.message}"
@@ -163,6 +166,17 @@ class AnnaArchiveClient
         html.include?("Checking your browser") ||
         html.include?("Just a moment") ||
         html.include?("Enable JavaScript and cookies")
+    end
+
+    def validate_search_page!(html)
+      require "nokogiri"
+
+      doc = Nokogiri::HTML(html)
+      return if doc.at_css("a[href*='/md5/']")
+      return if doc.at_css('form[action="/search"], form[action$="/search"]')
+
+      raise IncompatibleSiteError,
+        "Configured URL does not expose a compatible Anna's Archive /search interface"
     end
 
     def ensure_configured!

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -1,4 +1,5 @@
 class SettingsService
+  DEFAULT_ANNA_ARCHIVE_URL = "https://annas-archive.gl"
   DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
   ENV_OVERRIDE_PREFIX = "SHELFARR_SETTING_"
 
@@ -159,7 +160,7 @@ class SettingsService
 
     # Anna's Archive
     anna_archive_enabled: { type: "boolean", default: false, category: "anna_archive", description: "Enable Anna's Archive as an additional search source for ebooks" },
-    anna_archive_url: { type: "string", default: "https://annas-archive.se", category: "anna_archive", description: "Anna's Archive base URLs to try. Shelfarr uses the first reachable URL." },
+    anna_archive_url: { type: "string", default: DEFAULT_ANNA_ARCHIVE_URL, category: "anna_archive", description: "Anna's Archive base URLs to try. Shelfarr uses the first compatible URL." },
     anna_archive_api_key: { type: "string", default: "", category: "anna_archive", description: "Member API key from Anna's Archive (requires donation)" },
     flaresolverr_url: { type: "string", default: "", category: "anna_archive", description: "FlareSolverr URL for bypassing DDoS protection (e.g., http://flaresolverr:8191)" },
 

--- a/db/migrate/20260712120000_update_default_anna_archive_url.rb
+++ b/db/migrate/20260712120000_update_default_anna_archive_url.rb
@@ -1,0 +1,16 @@
+class UpdateDefaultAnnaArchiveUrl < ActiveRecord::Migration[8.1]
+  class MigrationSetting < ApplicationRecord
+    self.table_name = "settings"
+  end
+
+  OLD_DEFAULT = "https://annas-archive.se"
+  NEW_DEFAULT = "https://annas-archive.gl"
+
+  def up
+    MigrationSetting.where(key: "anna_archive_url", value: OLD_DEFAULT).update_all(value: NEW_DEFAULT)
+  end
+
+  def down
+    MigrationSetting.where(key: "anna_archive_url", value: NEW_DEFAULT).update_all(value: OLD_DEFAULT)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_10_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"

--- a/test/services/anna_archive_client_test.rb
+++ b/test/services/anna_archive_client_test.rb
@@ -78,6 +78,44 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "search tries next configured URL when first URL has an incompatible search page" do
+    VCR.turned_off do
+      SettingsService.set(:anna_archive_url, "https://incompatible.example\nhttps://annas-archive.org")
+
+      stub_request(:get, /incompatible\.example\/search/)
+        .to_return(status: 200, body: '<html><form action="/s/"></form></html>')
+      stub_anna_search_with_results
+
+      results = AnnaArchiveClient.search("test book")
+
+      assert_equal "abc123def456", results.first.md5
+      assert_requested :get, /incompatible\.example\/search/
+      assert_requested :get, /annas-archive\.org\/search/
+    end
+  end
+
+  test "search raises IncompatibleSiteError for a successful non-Anna response" do
+    VCR.turned_off do
+      stub_request(:get, /annas-archive\.org\/search/)
+        .to_return(status: 200, body: '<html><form action="/s/"></form><p>404 Page not found</p></html>')
+
+      error = assert_raises AnnaArchiveClient::IncompatibleSiteError do
+        AnnaArchiveClient.search("test query")
+      end
+
+      assert_includes error.message, "compatible Anna's Archive /search interface"
+    end
+  end
+
+  test "search accepts a compatible page with no results" do
+    VCR.turned_off do
+      stub_request(:get, /annas-archive\.org\/search/)
+        .to_return(status: 200, body: anna_search_page_without_results)
+
+      assert_empty AnnaArchiveClient.search("missing book")
+    end
+  end
+
   test "search returns empty array on connection error" do
     VCR.turned_off do
       stub_request(:get, /annas-archive\.org\/search/)
@@ -129,10 +167,10 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "test_connection returns true when site is reachable" do
+  test "test_connection returns true when search interface is compatible" do
     VCR.turned_off do
-      stub_request(:get, "https://annas-archive.org/")
-        .to_return(status: 200, body: "<html></html>")
+      stub_request(:get, "https://annas-archive.org/search?q=shelfarr")
+        .to_return(status: 200, body: anna_search_page_without_results)
 
       assert AnnaArchiveClient.test_connection
     end
@@ -142,21 +180,30 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
     VCR.turned_off do
       SettingsService.set(:anna_archive_url, "https://offline.example\nhttps://annas-archive.org")
 
-      stub_request(:get, "https://offline.example/")
+      stub_request(:get, "https://offline.example/search?q=shelfarr")
         .to_raise(Faraday::ConnectionFailed.new("Connection failed"))
-      stub_request(:get, "https://annas-archive.org/")
-        .to_return(status: 200, body: "<html></html>")
+      stub_request(:get, "https://annas-archive.org/search?q=shelfarr")
+        .to_return(status: 200, body: anna_search_page_without_results)
 
       assert AnnaArchiveClient.test_connection
-      assert_requested :get, "https://offline.example/"
-      assert_requested :get, "https://annas-archive.org/"
+      assert_requested :get, "https://offline.example/search?q=shelfarr"
+      assert_requested :get, "https://annas-archive.org/search?q=shelfarr"
     end
   end
 
   test "test_connection returns false when site is unreachable" do
     VCR.turned_off do
-      stub_request(:get, "https://annas-archive.org/")
+      stub_request(:get, "https://annas-archive.org/search?q=shelfarr")
         .to_raise(Faraday::ConnectionFailed.new("Connection failed"))
+
+      assert_not AnnaArchiveClient.test_connection
+    end
+  end
+
+  test "test_connection returns false when homepage-like HTML is incompatible" do
+    VCR.turned_off do
+      stub_request(:get, "https://annas-archive.org/search?q=shelfarr")
+        .to_return(status: 200, body: "<html><body>Not Anna's Archive</body></html>")
 
       assert_not AnnaArchiveClient.test_connection
     end
@@ -237,6 +284,19 @@ class AnnaArchiveClientTest < ActiveSupport::TestCase
   end
 
   private
+
+  def anna_search_page_without_results
+    <<~HTML
+      <html>
+        <body>
+          <form action="/search">
+            <input name="q">
+          </form>
+          <p>No files found.</p>
+        </body>
+      </html>
+    HTML
+  end
 
   def stub_flaresolverr_with_search_results
     html = <<~HTML


### PR DESCRIPTION
## Summary

- update the default Anna's Archive domain from the unavailable `.se` domain to the current `.gl` domain
- validate the actual `/search` interface before accepting a configured mirror
- rotate past incompatible mirrors instead of silently returning no results
- migrate only installations still using the exact old default, preserving custom URL lists
- test compatible empty results, incompatible HTML, mirror rotation, and connection checks

## Context

Issue #352 correctly identified that searches against `annas-archive.cc` return no Shelfarr results, but changing Shelfarr to `/s/` would not fix the integration. That site currently returns Z-Library-style `/book/<id>` records, while the official Anna's Archive interface uses `/search` and `/md5/<hash>` records required by the member download API. This change makes that mismatch explicit and refreshes Shelfarr's stale default domain.

Closes #352

## Verification

- `bin/quality commit --staged`
- `bin/quality push`
- full Rails suite: 1,630 tests and 4,870 assertions passed before rebasing the work onto current `main`; the repository gates passed again on the final branch