### PR TITLE
fix: isolate Deluge downloads by label

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -38,6 +38,7 @@ class PostProcessingJob < ApplicationJob
       if source_path_unavailable?(source_path)
         return retry_source_path_later(download, request, source_path, source_path_retry_count)
       end
+      validate_download_specific_source_path!(source_path, download)
 
       source_cleanup = import_files(source_path, destination, book: book, base_path: base_path)
       cleanup_usenet_download(download)
@@ -88,6 +89,48 @@ class PostProcessingJob < ApplicationJob
 
   def source_path_unavailable?(source_path)
     source_path.present? && !File.exist?(source_path)
+  end
+
+  def validate_download_specific_source_path!(source_path, download)
+    return unless source_path.present? && File.directory?(source_path)
+
+    source = canonical_path(source_path)
+    shared_roots = shared_download_roots(download).filter_map do |path|
+      canonical_path(path) if path.present?
+    end
+    return unless shared_roots.include?(source)
+
+    raise "Refusing to import shared download root: #{source_path}. " \
+      "The download client must report a download-specific file or directory."
+  end
+
+  def shared_download_roots(download)
+    roots = [
+      SettingsService.get(:download_local_path, default: "/downloads"),
+      SettingsService.get(:download_remote_path),
+      download.download_client&.download_path
+    ].compact_blank
+
+    categories = category_path_variants(download.download_client&.category)
+    return roots if categories.empty?
+
+    roots + roots.flat_map { |root| categories.map { |category| File.join(root, category) } }
+  end
+
+  # Deluge normalizes labels to lowercase while other clients preserve the
+  # configured category casing. Include both forms so path checks match disk.
+  def category_path_variants(category)
+    return [] if category.blank?
+
+    value = category.to_s
+    [ value, value.downcase, value.strip, value.strip.downcase ].map(&:presence).compact.uniq
+  end
+
+  def canonical_path(path)
+    expanded = File.expand_path(normalize_path_separators(path))
+    File.realpath(expanded)
+  rescue SystemCallError
+    expanded
   end
 
   def retry_source_path_later(download, request, source_path, retry_count)
@@ -731,7 +774,7 @@ class PostProcessingJob < ApplicationJob
     normalized_path = normalize_path_separators(path)
     remote_path = normalize_path_separators(SettingsService.get(:download_remote_path))
     local_path = normalize_path_separators(SettingsService.get(:download_local_path, default: "/downloads"))
-    category = download.download_client&.category
+    categories = category_path_variants(download.download_client&.category)
     client_download_path = normalize_path_separators(download.download_client&.download_path)
     basename = File.basename(normalized_path)
 
@@ -741,19 +784,24 @@ class PostProcessingJob < ApplicationJob
     end
 
     # 2. local_path/category/basename — most common torrent client layout
-    if category.present?
+    categories.each do |category|
       candidates << { strategy: "local_path_with_category", path: File.join(local_path, category, basename) }
     end
 
     # 3. Category-aware sibling remap — when remote_path points to a sibling folder
     #    e.g., remote=/mnt/Torrents/Completed, path=/mnt/Torrents/shelfarr/File
-    if category.present? && remote_path.present? && normalized_path.include?("/#{category}/")
-      category_idx = normalized_path.index("/#{category}/")
-      remote_base = normalized_path[0...category_idx]
-      relative_after_base = normalized_path[(category_idx)..]
+    if remote_path.present?
+      categories.each do |category|
+        marker = "/#{category}/"
+        next unless normalized_path.include?(marker)
 
-      if remote_base == File.dirname(remote_path)
-        candidates << { strategy: "category_sibling_remap", path: File.join(File.dirname(local_path), relative_after_base) }
+        category_idx = normalized_path.index(marker)
+        remote_base = normalized_path[0...category_idx]
+        relative_after_base = normalized_path[(category_idx)..]
+
+        if remote_base == File.dirname(remote_path)
+          candidates << { strategy: "category_sibling_remap", path: File.join(File.dirname(local_path), relative_after_base) }
+        end
       end
     end
 

--- a/app/services/download_clients/deluge.rb
+++ b/app/services/download_clients/deluge.rb
@@ -23,19 +23,35 @@ module DownloadClients
       "save_path"
     ].freeze
 
+    LABEL_ASSIGN_MAX_ATTEMPTS = 3
+    LABEL_ASSIGN_RETRY_WAIT = 0.25
+    LABEL_PLUGIN_READY_MAX_ATTEMPTS = 5
+    LABEL_PLUGIN_READY_RETRY_WAIT = 0.2
+    TRANSIENT_LABEL_ERROR_PATTERNS = [
+      /unknown torrent/i,
+      /timeout/i,
+      /timed out/i
+    ].freeze
+
     def add_torrent(url, options = {})
       ensure_authenticated!
+      ensure_configured_label!
 
       params = build_add_params(options)
       prepared = prepare_torrent_submission(url)
-      existing_ids = torrent_ids
-
       result = submit_torrent(prepared, params)
+      torrent_id = result if result.is_a?(String) && result.present?
 
-      return result if result.is_a?(String) && result.present?
+      if torrent_id.blank?
+        if configured_label.present?
+          raise Base::Error, "Deluge did not return a torrent id after add; cannot assign label"
+        end
 
-      new_ids = torrent_ids - existing_ids
-      new_ids.first
+        return nil
+      end
+
+      assign_configured_label!(torrent_id)
+      torrent_id
     rescue Faraday::Error => e
       raise Base::ConnectionError, "Failed to connect to Deluge: #{e.message}"
     end
@@ -60,6 +76,7 @@ module DownloadClients
       ensure_authenticated!
 
       torrent_ids
+      ensure_configured_label!
       true
     rescue Base::Error, Base::AuthenticationError, Faraday::Error => e
       Rails.logger.warn "[Deluge] Connection test failed: #{e.message}"
@@ -71,7 +88,7 @@ module DownloadClients
 
       # Deluge accepts arrays of torrent IDs
       result = rpc_call("core.remove_torrents", [Array(hash), delete_files])
-      !result.nil?
+      result == true || (result.is_a?(Array) && result.empty?)
 
     rescue Faraday::Error => e
       raise Base::ConnectionError, "Failed to connect to Deluge: #{e.message}"
@@ -181,8 +198,16 @@ module DownloadClients
         progress: progress,
         state: normalize_state(data["state"].to_s),
         size_bytes: data["total_size"].to_f,
-        download_path: data["download_location"].presence || data["save_path"].to_s
+        download_path: torrent_download_path(data)
       )
+    end
+
+    def torrent_download_path(data)
+      location = data["download_location"].presence || data["save_path"].presence
+      name = data["name"].presence
+      return location.to_s if location.blank? || name.blank?
+
+      File.join(location, name)
     end
 
     def normalize_progress(progress)
@@ -213,9 +238,129 @@ module DownloadClients
     def build_add_params(options)
       params = {}
       params["download_location"] = options[:save_path] if options[:save_path].present?
-      params["label"] = config.category if config.category.present?
       params["add_paused"] = options[:paused] if options.key?(:paused)
       params
+    end
+
+    def ensure_configured_label!
+      label = configured_label
+      return unless label
+
+      ensure_label_plugin_enabled!
+      labels = fetch_labels_with_retry!
+      add_label!(label) unless labels.include?(label)
+    end
+
+    def ensure_label_plugin_enabled!
+      enabled_plugins = Array(rpc_call("core.get_enabled_plugins"))
+      return if enabled_plugins.include?("Label")
+
+      available_plugins = Array(rpc_call("core.get_available_plugins"))
+      unless available_plugins.include?("Label")
+        raise Base::NotConfiguredError, "Deluge Label plugin is not available"
+      end
+
+      enabled = rpc_call("core.enable_plugin", [ "Label" ])
+      raise Base::NotConfiguredError, "Deluge Label plugin could not be enabled" unless enabled
+    end
+
+    def fetch_labels_with_retry!
+      last_error = nil
+
+      LABEL_PLUGIN_READY_MAX_ATTEMPTS.times do |attempt|
+        sleep LABEL_PLUGIN_READY_RETRY_WAIT if attempt > 0
+
+        begin
+          return Array(rpc_call("label.get_labels"))
+        rescue Base::Error => e
+          last_error = e
+          next if plugin_method_not_ready?(e)
+
+          raise
+        end
+      end
+
+      raise last_error if last_error
+
+      raise Base::NotConfiguredError, "Deluge Label plugin methods are not available yet"
+    end
+
+    def plugin_method_not_ready?(error)
+      error.message.match?(/unknown method|method not found|not available|has no attribute/i)
+    end
+
+    def add_label!(label)
+      rpc_call("label.add", [ label ])
+    rescue Base::Error
+      raise unless fetch_labels_with_retry!.include?(label)
+    end
+
+    def assign_configured_label!(torrent_id)
+      label = configured_label
+      return if label.blank? || torrent_id.blank?
+
+      set_torrent_label_with_retry!(torrent_id, label)
+    rescue Base::Error, Faraday::Error => label_error
+      if stale_label_configuration_error?(label_error)
+        begin
+          ensure_configured_label!
+          return set_torrent_label_with_retry!(torrent_id, label)
+        rescue Base::Error, Faraday::Error => retry_error
+          label_error = retry_error
+        end
+      end
+
+      remove_unlabelled_torrent(torrent_id)
+      raise label_error
+    end
+
+    def stale_label_configuration_error?(error)
+      error.message.match?(/unknown label|unknown method|method not found|not available|has no attribute/i)
+    end
+
+    def set_torrent_label_with_retry!(torrent_id, label)
+      last_error = nil
+
+      LABEL_ASSIGN_MAX_ATTEMPTS.times do |attempt|
+        sleep LABEL_ASSIGN_RETRY_WAIT if attempt > 0
+
+        begin
+          return rpc_call("label.set_torrent", [ torrent_id, label ])
+        rescue Base::Error, Faraday::Error => e
+          last_error = e
+          next if transient_label_error?(e)
+
+          raise
+        end
+      end
+
+      raise last_error
+    end
+
+    def transient_label_error?(error)
+      return true if error.is_a?(Faraday::Error)
+
+      TRANSIENT_LABEL_ERROR_PATTERNS.any? { |pattern| pattern.match?(error.message) }
+    end
+
+    def remove_unlabelled_torrent(torrent_id)
+      # The ID came directly from this add request, so removing its partial data
+      # cannot affect a torrent submitted by another application.
+      removed = remove_torrent(torrent_id, delete_files: true)
+      enqueue_stale_cleanup(torrent_id) unless removed
+    rescue Base::Error => cleanup_error
+      Rails.logger.error "[Deluge] Failed to remove unlabelled torrent #{torrent_id}: #{cleanup_error.message}"
+      enqueue_stale_cleanup(torrent_id)
+    end
+
+    def enqueue_stale_cleanup(torrent_id)
+      StaleClientDispatchCleanupJob.perform_later(config.id, torrent_id)
+    rescue StandardError => e
+      Rails.logger.error "[Deluge] Failed to enqueue cleanup for unlabelled torrent #{torrent_id}: #{e.class}"
+    end
+
+    def configured_label
+      config.category.to_s.strip.downcase.presence
     end
 
     def connection

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -69,6 +69,51 @@ class PostProcessingJobTest < ActiveJob::TestCase
     end
   end
 
+  test "refuses to import a shared download client root" do
+    client = DownloadClient.create!(
+      name: "Shared Deluge Root",
+      client_type: "deluge",
+      url: "http://localhost:8112",
+      password: "deluge",
+      category: "shelfarr",
+      download_path: @temp_source
+    )
+    @download.update!(download_client: client)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    refute File.exist?(File.join(expected_dest, "audiobook.mp3"))
+    assert @request.reload.attention_needed?
+    assert_includes @request.issue_description, "Refusing to import shared download root"
+  end
+
+  test "refuses to import a Deluge label category root when category casing differs" do
+    # Deluge stores labels lowercase on disk; config may retain mixed case.
+    category_root = File.join(@temp_source, "shelfarr")
+    FileUtils.mkdir_p(category_root)
+    File.write(File.join(category_root, "audiobook.mp3"), "test audio content")
+
+    client = DownloadClient.create!(
+      name: "Deluge Mixed Case Label",
+      client_type: "deluge",
+      url: "http://localhost:8112",
+      password: "deluge",
+      category: " Shelfarr ",
+      download_path: @temp_source
+    )
+    @download.update!(download_client: client, download_path: category_root)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
+    refute File.exist?(File.join(expected_dest, "audiobook.mp3"))
+    assert @request.reload.attention_needed?
+    assert_includes @request.issue_description, "Refusing to import shared download root"
+  end
+
   test "skips a completed download replaced by a manual selection" do
     old_result = @request.search_results.create!(
       guid: "old-result",

--- a/test/services/download_clients/deluge_test.rb
+++ b/test/services/download_clients/deluge_test.rb
@@ -3,7 +3,10 @@
 require "test_helper"
 
 class DownloadClients::DelugeTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   setup do
+    clear_enqueued_jobs
     @client_record = DownloadClient.create!(
       name: "Test Deluge",
       client_type: "deluge",
@@ -48,6 +51,276 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
 
       result = @client.add_torrent("magnet:?xt=urn:btih:abcdef")
       assert_equal "new_torrent_id", result
+    end
+  end
+
+  test "add_torrent assigns configured category through the Label plugin" do
+    VCR.turned_off do
+      @client_record.update!(category: "Shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      stub_deluge_rpc("label.get_labels", [ "shelfarr" ])
+      stub_deluge_rpc("core.get_session_state", [ "known_torrent_id" ])
+
+      add_stub = stub_request(:post, "http://localhost:8112/json")
+        .with do |request|
+          body = JSON.parse(request.body)
+          options = body.dig("params", 1)
+          body["method"] == "core.add_torrent_magnet" && !options.key?("label")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { result: "new_torrent_id", error: nil, id: 1 }.to_json
+        )
+
+      label_stub = stub_request(:post, "http://localhost:8112/json")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "label.set_torrent" && body["params"] == [ "new_torrent_id", "shelfarr" ]
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { result: nil, error: nil, id: 1 }.to_json
+        )
+
+      assert_equal "new_torrent_id", client.add_torrent("magnet:?xt=urn:btih:abcdef")
+      assert_requested(add_stub)
+      assert_requested(label_stub)
+    end
+  end
+
+  test "add_torrent retries transient label failures before removing its partial files" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      stub_deluge_rpc("label.get_labels", [ "shelfarr" ])
+      stub_deluge_rpc("core.get_session_state", [ "known_torrent_id" ])
+      stub_deluge_rpc("core.add_torrent_magnet", "new_torrent_id")
+      set_stub = stub_deluge_rpc("label.set_torrent", nil, error: { "message" => "Unknown Torrent" })
+      remove_stub = stub_deluge_rpc("core.remove_torrents", [], params: [ [ "new_torrent_id" ], true ])
+
+      client.stub(:sleep, nil) do
+        assert_raises DownloadClients::Base::Error do
+          client.add_torrent("magnet:?xt=urn:btih:abcdef")
+        end
+      end
+
+      assert_requested(set_stub, times: DownloadClients::Deluge::LABEL_ASSIGN_MAX_ATTEMPTS)
+      assert_requested(remove_stub)
+    end
+  end
+
+  test "add_torrent schedules cleanup when Deluge reports a removal error" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      stub_deluge_rpc("label.get_labels", [ "shelfarr" ])
+      stub_deluge_rpc("core.add_torrent_magnet", "new_torrent_id")
+      stub_deluge_rpc("label.set_torrent", nil, error: { "message" => "Permission denied" })
+      stub_deluge_rpc(
+        "core.remove_torrents",
+        [ [ "new_torrent_id", "Permission denied" ] ],
+        params: [ [ "new_torrent_id" ], true ]
+      )
+
+      assert_enqueued_with(job: StaleClientDispatchCleanupJob, args: [ @client_record.id, "new_torrent_id" ]) do
+        assert_raises DownloadClients::Base::Error do
+          client.add_torrent("magnet:?xt=urn:btih:abcdef")
+        end
+      end
+    end
+  end
+
+  test "add_torrent cleans up after repeated label connection failures" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      stub_deluge_rpc("label.get_labels", [ "shelfarr" ])
+      stub_deluge_rpc("core.add_torrent_magnet", "new_torrent_id")
+      set_stub = stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"label.set_torrent"/)
+        .to_raise(Faraday::ConnectionFailed.new("connection lost"))
+      remove_stub = stub_deluge_rpc("core.remove_torrents", [], params: [ [ "new_torrent_id" ], true ])
+
+      client.stub(:sleep, nil) do
+        assert_raises DownloadClients::Base::ConnectionError do
+          client.add_torrent("magnet:?xt=urn:btih:abcdef")
+        end
+      end
+
+      assert_requested(set_stub, times: DownloadClients::Deluge::LABEL_ASSIGN_MAX_ATTEMPTS)
+      assert_requested(remove_stub)
+    end
+  end
+
+  test "add_torrent recovers when label assignment fails transiently then succeeds" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      stub_deluge_rpc("label.get_labels", [ "shelfarr" ])
+      stub_deluge_rpc("core.get_session_state", [ "known_torrent_id" ])
+      stub_deluge_rpc("core.add_torrent_magnet", "new_torrent_id")
+
+      set_stub = stub_request(:post, "http://localhost:8112/json")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "label.set_torrent" && body["params"] == [ "new_torrent_id", "shelfarr" ]
+        end
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: nil, error: { "message" => "Unknown Torrent" }, id: 1 }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: nil, error: nil, id: 1 }.to_json
+          }
+        )
+
+      client.stub(:sleep, nil) do
+        assert_equal "new_torrent_id", client.add_torrent("magnet:?xt=urn:btih:abcdef")
+      end
+
+      assert_requested(set_stub, times: 2)
+      assert_not_requested :post, "http://localhost:8112/json", body: /"core.remove_torrents"/
+    end
+  end
+
+  test "add_torrent recreates a label deleted during dispatch" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      plugins_stub = stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      labels_stub = stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"label.get_labels"/)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: [ "shelfarr" ], error: nil, id: 1 }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: [], error: nil, id: 1 }.to_json
+          }
+        )
+      add_label_stub = stub_deluge_rpc("label.add", nil, params: [ "shelfarr" ])
+      stub_deluge_rpc("core.add_torrent_magnet", "new_torrent_id")
+
+      set_stub = stub_request(:post, "http://localhost:8112/json")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body["method"] == "label.set_torrent" && body["params"] == [ "new_torrent_id", "shelfarr" ]
+        end
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: nil, error: { "message" => "Unknown Label" }, id: 1 }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: nil, error: nil, id: 1 }.to_json
+          }
+        )
+
+      assert_equal "new_torrent_id", client.add_torrent("magnet:?xt=urn:btih:abcdef")
+      assert_requested(plugins_stub, times: 2)
+      assert_requested(labels_stub, times: 2)
+      assert_requested(add_label_stub)
+      assert_requested(set_stub, times: 2)
+      assert_not_requested :post, "http://localhost:8112/json", body: /"core.remove_torrents"/
+    end
+  end
+
+  test "add_torrent raises when a label is configured but no torrent id is returned" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      stub_deluge_rpc("label.get_labels", [ "shelfarr" ])
+      stub_deluge_rpc("core.get_session_state", [ "known_torrent_id", "foreign_torrent_id" ])
+      stub_deluge_rpc("core.add_torrent_magnet", nil)
+
+      error = assert_raises DownloadClients::Base::Error do
+        client.add_torrent("magnet:?xt=urn:btih:abcdef")
+      end
+      assert_match(/did not return a torrent id/i, error.message)
+      assert_not_requested :post, "http://localhost:8112/json", body: /"label.set_torrent"/
+      assert_not_requested :post, "http://localhost:8112/json", body: /"core.get_session_state"/
     end
   end
 
@@ -223,6 +496,172 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
     end
   end
 
+  test "test_connection enables Label plugin and creates configured label" do
+    VCR.turned_off do
+      @client_record.update!(category: "Shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_session_state", [])
+      stub_deluge_rpc("core.get_enabled_plugins", [])
+      stub_deluge_rpc("core.get_available_plugins", [ "Label" ])
+      enable_stub = stub_deluge_rpc("core.enable_plugin", true, params: [ "Label" ])
+      stub_deluge_rpc("label.get_labels", [])
+      add_label_stub = stub_deluge_rpc("label.add", nil, params: [ "shelfarr" ])
+
+      assert client.test_connection
+      assert_requested(enable_stub)
+      assert_requested(add_label_stub)
+    end
+  end
+
+  test "test_connection retries Label RPC until the plugin is ready after enable" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_session_state", [])
+      stub_deluge_rpc("core.get_enabled_plugins", [])
+      stub_deluge_rpc("core.get_available_plugins", [ "Label" ])
+      stub_deluge_rpc("core.enable_plugin", true, params: [ "Label" ])
+
+      labels_stub = stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"label.get_labels"/)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: nil, error: { "message" => "Unknown method" }, id: 1 }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: [], error: nil, id: 1 }.to_json
+          }
+        )
+      add_label_stub = stub_deluge_rpc("label.add", nil, params: [ "shelfarr" ])
+
+      client.stub(:sleep, nil) do
+        assert client.test_connection
+      end
+
+      assert_requested(labels_stub, times: 2)
+      assert_requested(add_label_stub)
+    end
+  end
+
+  test "test_connection revalidates label readiness for every call" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_session_state", [])
+      plugins_stub = stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"core.get_enabled_plugins"/)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: [ "Label" ], error: nil, id: 1 }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: [], error: nil, id: 1 }.to_json
+          }
+        )
+      stub_deluge_rpc("core.get_available_plugins", [ "Label" ])
+      enable_stub = stub_deluge_rpc("core.enable_plugin", true, params: [ "Label" ])
+      labels_stub = stub_deluge_rpc("label.get_labels", [ "shelfarr" ])
+
+      assert client.test_connection
+      assert client.test_connection
+      assert_requested(plugins_stub, times: 2)
+      assert_requested(labels_stub, times: 2)
+      assert_requested(enable_stub)
+    end
+  end
+
+  test "test_connection tolerates a label created concurrently" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_session_state", [])
+      stub_deluge_rpc("core.get_enabled_plugins", [ "Label" ])
+      labels_stub = stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"label.get_labels"/)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: [], error: nil, id: 1 }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: [ "shelfarr" ], error: nil, id: 1 }.to_json
+          }
+        )
+      stub_deluge_rpc("label.add", nil, error: { "message" => "Label already exists" })
+
+      assert client.test_connection
+      assert_requested(labels_stub, times: 2)
+    end
+  end
+
+  test "test_connection fails when configured label plugin is unavailable" do
+    VCR.turned_off do
+      @client_record.update!(category: "shelfarr")
+      client = @client_record.adapter
+
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc("core.get_session_state", [])
+      stub_deluge_rpc("core.get_enabled_plugins", [])
+      stub_deluge_rpc("core.get_available_plugins", [])
+
+      assert_not client.test_connection
+    end
+  end
+
   test "test_connection preserves path-based reverse proxy URL" do
     VCR.turned_off do
       [
@@ -277,7 +716,8 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
                 "progress" => 1.0,
                 "state" => "Seeding",
                 "total_size" => 2048,
-                "save_path" => "/downloads/Info Torrent"
+                "download_location" => "/downloads",
+                "save_path" => "/legacy-downloads"
               }
             },
             error: nil,
@@ -290,7 +730,14 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
       assert_equal "known_torrent", info.hash
       assert_equal "Info Torrent", info.name
       assert_equal :completed, info.state
+      assert_equal "/downloads/Info Torrent", info.download_path
     end
+  end
+
+  test "torrent download path appends a name matching the download root basename" do
+    data = { "download_location" => "/downloads/shelfarr", "name" => "shelfarr" }
+
+    assert_equal "/downloads/shelfarr/shelfarr", @client.send(:torrent_download_path, data)
   end
 
   test "remove_torrent returns true on success" do
@@ -308,10 +755,45 @@ class DownloadClients::DelugeTest < ActiveSupport::TestCase
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { result: { "removed" => true }, error: nil, id: 1 }.to_json
+          body: { result: [], error: nil, id: 1 }.to_json
         )
 
       assert @client.remove_torrent("known_torrent")
     end
+  end
+
+  test "remove_torrent returns false when Deluge reports removal errors" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8112/json")
+        .with(body: /"auth.login"/)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json", "Set-Cookie" => "sessionid=test_session_id; Path=/" },
+          body: { result: true, error: nil, id: 1 }.to_json
+        )
+
+      stub_deluge_rpc(
+        "core.remove_torrents",
+        [ [ "known_torrent", "Unknown Torrent" ] ],
+        params: [ [ "known_torrent" ], false ]
+      )
+
+      assert_not @client.remove_torrent("known_torrent")
+    end
+  end
+
+  private
+
+  def stub_deluge_rpc(method, result, params: nil, error: nil)
+    stub_request(:post, "http://localhost:8112/json")
+      .with do |request|
+        body = JSON.parse(request.body)
+        body["method"] == method && (params.nil? || body["params"] == params)
+      end
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { result: result, error: error, id: 1 }.to_json
+      )
   end
 end


### PR DESCRIPTION
## Summary

- enable Deluge's Label plugin and create/assign the configured Shelfarr label through the plugin RPC
- resolve completed Deluge downloads to the torrent-specific file or directory
- refuse to import shared client/category roots
- retry transient plugin/label races and durably clean up failed dispatches
- interpret Deluge bulk-removal results correctly

## Root cause

Shelfarr passed `label` as a core torrent option, but Deluge only supports labels through its Label plugin, so the option was silently ignored. Shelfarr also treated Deluge's shared `download_location` as the completed item path, which could import unrelated Sonarr or Radarr downloads from the same directory.

The previous session-diff fallback could also claim a torrent concurrently added by another application when Deluge returned no ID. This PR removes that unsafe fallback and only trusts the ID returned directly by the add RPC.

## Impact

Deluge downloads now receive the configured label, remain isolated from other applications sharing the client, and cannot post-process an entire configured download root. External label/plugin changes are revalidated, and failed post-add labeling is cleaned up safely.

## Validation

- `bin/quality commit --staged`
- `bin/quality push`
- full Rails suite: 1,869 tests, 5,854 assertions, 0 failures
- pre-commit and pre-push hooks passed

Closes #351