### PR TITLE
fix: silence expected Docker writability probe error

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -42,9 +42,11 @@ ensure_storage_path_permissions() {
   mkdir -p "$path"
 
   if [ "$(id -u)" = "0" ] && [ "$policy" != "never" ]; then
-    if verify_path_writable "$path"; then
+    if verify_path_writable "$path" 2>/dev/null; then
       return 0
     fi
+
+    echo "Storage path ${path} is not yet writable by the rails user; adjusting ownership..."
 
     if ! chown -R rails:rails "$path" 2>/tmp/shelfarr-chown-error.$$; then
       if [ "$policy" = "always" ]; then


### PR DESCRIPTION
## Summary

- silence stderr only for the expected pre-ownership-adjustment writability probe
- log an intentional message before correcting path ownership
- preserve native stderr for the final, genuinely fatal writability check

## Root cause

The initial `verify_path_writable` call is expected to fail when a container remaps the `rails` user through `PUID`/`PGID`. That failure triggers the ownership correction, but the probe's raw `touch` error was leaking to container logs and looking like a fatal startup failure.

## Impact

Fresh containers that need ownership adjustment now report the remediation clearly without emitting a misleading bare `Permission denied`. Genuine permission failures remain fully diagnosable.

## Validation

- `bash -n bin/docker-entrypoint`
- `git diff --check`
- ShellCheck comparison against `main` (no new warnings)
- `bin/quality commit --staged`
- pre-commit and pre-push quality hooks

Closes #353