### PR TITLE
fix: validate indexer URLs before saving

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -17,10 +17,10 @@ module Admin
         return
       end
 
-      value = params[:setting][:value]
+      value = normalize_setting_value(key, params[:setting][:value])
 
       unless preserve_blank_secret?(key, value)
-        validate_path_template!(key, value)
+        validate_setting_value!(key, value)
         SettingsService.set(key, value)
         handle_settings_side_effects([ key.to_s ])
       end
@@ -41,9 +41,10 @@ module Admin
         next if SettingsService.env_managed?(key)
         next if preserve_blank_secret?(key, value)
 
-        error = validate_path_template(key, value)
+        value = normalize_setting_value(key, value)
+        error = validate_setting_value(key, value)
         if error
-          errors << "#{key.to_s.titleize}: #{error}"
+          errors << "#{SettingsService.label_for(key)}: #{error}"
         else
           SettingsService.set(key, value)
           changed_keys << key.to_s
@@ -483,10 +484,19 @@ module Admin
 
     PATH_TEMPLATE_SETTINGS = %w[audiobook_path_template ebook_path_template].freeze
     FILENAME_TEMPLATE_SETTINGS = %w[audiobook_filename_template ebook_filename_template].freeze
+    INDEXER_URL_PROVIDERS = {
+      "prowlarr_url" => IndexerClients::Prowlarr,
+      "jackett_url" => IndexerClients::Jackett,
+      "newznab_url" => IndexerClients::Newznab
+    }.freeze
 
-    def validate_path_template!(key, value)
-      error = validate_path_template(key, value)
-      raise ArgumentError, error if error
+    def validate_setting_value!(key, value)
+      error = validate_setting_value(key, value)
+      raise ArgumentError, "#{SettingsService.label_for(key)}: #{error}" if error
+    end
+
+    def validate_setting_value(key, value)
+      validate_path_template(key, value) || validate_indexer_url(key, value)
     end
 
     def validate_path_template(key, value)
@@ -501,6 +511,21 @@ module Admin
 
       valid, error = PathTemplateService.validate_template(value, mode: mode)
       valid ? nil : error
+    end
+
+    def validate_indexer_url(key, value)
+      provider = INDEXER_URL_PROVIDERS[key.to_s]
+      return nil unless provider
+      return nil if value.blank?
+
+      provider.validate_url!(value)
+      nil
+    rescue IndexerClients::Base::InvalidUrlError
+      "must be a valid HTTP or HTTPS URL"
+    end
+
+    def normalize_setting_value(key, value)
+      INDEXER_URL_PROVIDERS.key?(key.to_s) ? value.to_s.strip : value
     end
 
     def fetch_audiobookshelf_libraries

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -520,8 +520,17 @@ module Admin
 
       provider.validate_url!(value)
       nil
-    rescue IndexerClients::Base::InvalidUrlError
-      "must be a valid HTTP or HTTPS URL"
+    rescue IndexerClients::Base::InvalidUrlError => e
+      indexer_url_validation_message(e)
+    end
+
+    def indexer_url_validation_message(error)
+      detail = error.message.to_s
+      if (match = detail.match(/\AInvalid .+ URL: (.+)\z/))
+        "must be a valid HTTP or HTTPS URL (#{match[1]})"
+      else
+        "must be a valid HTTP or HTTPS URL (include http:// or https://)"
+      end
     end
 
     def normalize_setting_value(key, value)

--- a/app/javascript/controllers/settings_form_controller.js
+++ b/app/javascript/controllers/settings_form_controller.js
@@ -108,14 +108,13 @@ export default class extends Controller {
   }
 
   submitForm() {
-    if (this.hasFormTarget) {
-      if (!this.formTarget.reportValidity()) {
-        this.hideStatus();
-        return;
-      }
+    if (!this.hasFormTarget) return;
 
-      this.formTarget.requestSubmit();
-    }
+    // Server-side validation is authoritative for bulk auto-save. Full-form
+    // HTML5 constraint validation would block unrelated settings when an
+    // indexer URL is mid-edit or on a hidden tab (where the browser bubble is
+    // easy to miss). The form uses novalidate; type="url" remains a soft hint.
+    this.formTarget.requestSubmit();
   }
 
   handleSubmitEnd(event) {

--- a/app/javascript/controllers/settings_form_controller.js
+++ b/app/javascript/controllers/settings_form_controller.js
@@ -109,6 +109,11 @@ export default class extends Controller {
 
   submitForm() {
     if (this.hasFormTarget) {
+      if (!this.formTarget.reportValidity()) {
+        this.hideStatus();
+        return;
+      }
+
       this.formTarget.requestSubmit();
     }
   }
@@ -137,16 +142,23 @@ export default class extends Controller {
     const provider = this.indexerProviderTarget.value;
 
     if (this.hasProwlarrFieldsTarget) {
-      this.prowlarrFieldsTarget.classList.toggle("hidden", provider !== "prowlarr");
+      this.toggleProviderFields(this.prowlarrFieldsTarget, provider === "prowlarr");
     }
 
     if (this.hasJackettFieldsTarget) {
-      this.jackettFieldsTarget.classList.toggle("hidden", provider !== "jackett");
+      this.toggleProviderFields(this.jackettFieldsTarget, provider === "jackett");
     }
 
     if (this.hasNewznabFieldsTarget) {
-      this.newznabFieldsTarget.classList.toggle("hidden", provider !== "newznab");
+      this.toggleProviderFields(this.newznabFieldsTarget, provider === "newznab");
     }
+  }
+
+  toggleProviderFields(container, active) {
+    container.classList.toggle("hidden", !active);
+    container.querySelectorAll('input[type="url"]').forEach((input) => {
+      input.disabled = !active;
+    });
   }
 
   urlListContainer(event) {

--- a/app/services/indexer_clients/base.rb
+++ b/app/services/indexer_clients/base.rb
@@ -8,6 +8,7 @@ module IndexerClients
     class ConnectionError < Error; end
     class AuthenticationError < Error; end
     class NotConfiguredError < Error; end
+    class InvalidUrlError < Error; end
 
     class << self
       def search(...)
@@ -30,6 +31,11 @@ module IndexerClients
         name.demodulize
       end
 
+      def validate_url!(url)
+        normalize_base_url(url)
+        true
+      end
+
       private
 
       def categories_for_type(book_type)
@@ -50,17 +56,17 @@ module IndexerClients
 
       def normalize_base_url(url)
         value = url.to_s.strip
-        raise ArgumentError, "#{display_name} URL is blank" if value.blank?
+        raise InvalidUrlError, "#{display_name} URL is blank" if value.blank?
 
         uri = URI.parse(value)
         unless %w[http https].include?(uri.scheme) && uri.host.present?
-          raise ArgumentError, "#{display_name} URL must be a valid http or https URL"
+          raise InvalidUrlError, "#{display_name} URL must be a valid http or https URL"
         end
 
         normalized = uri.to_s
         normalized.end_with?("/") ? normalized : "#{normalized}/"
       rescue URI::InvalidURIError => e
-        raise ArgumentError, "Invalid #{display_name} URL: #{e.message}"
+        raise InvalidUrlError, "Invalid #{display_name} URL: #{e.message}"
       end
     end
   end

--- a/app/services/indexer_clients/base.rb
+++ b/app/services/indexer_clients/base.rb
@@ -50,6 +50,10 @@ module IndexerClients
         yield
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
         raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
+      rescue InvalidUrlError => e
+        # Preserve connection-error classification for malformed stored URLs so
+        # search/dispatch paths keep treating them like other connect failures.
+        raise ConnectionError, e.message
       rescue URI::Error, ArgumentError => e
         raise ConnectionError, "Invalid #{display_name} URL: #{e.message}"
       end

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -249,6 +249,9 @@ class SettingsService
   }.freeze
 
   LABELS = {
+    prowlarr_url: "Prowlarr URL",
+    jackett_url: "Jackett URL",
+    newznab_url: "Newznab URL",
     library_platform: "Active Library Platform",
     audiobookshelf_url: "Audiobookshelf URL",
     audiobookshelf_api_key: "Audiobookshelf API Key",

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -25,7 +25,7 @@
 %>
 
 <div data-controller="settings-tabs" data-settings-tabs-active-value="search">
-  <%= form_with url: bulk_update_admin_settings_path, method: :patch, data: { settings_form_target: "form" } do |form| %>
+  <%= form_with url: bulk_update_admin_settings_path, method: :patch, html: { novalidate: true }, data: { settings_form_target: "form" } do |form| %>
     <div class="flex justify-between items-center mb-6">
       <h1 class="font-bold text-4xl text-white">Settings</h1>
       <div class="flex items-center gap-4">

--- a/app/views/admin/settings/_indexer_section.html.erb
+++ b/app/views/admin/settings/_indexer_section.html.erb
@@ -65,7 +65,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:prowlarr_url, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.text_field "settings[prowlarr_url]", value: settings.dig(:prowlarr_url, :value), id: "settings_prowlarr_url", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.url_field "settings[prowlarr_url]", value: settings.dig(:prowlarr_url, :value), id: "settings_prowlarr_url", disabled: selected_provider != "prowlarr", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
         </div>
       </div>
 
@@ -97,7 +97,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:jackett_url, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.text_field "settings[jackett_url]", value: settings.dig(:jackett_url, :value), id: "settings_jackett_url", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.url_field "settings[jackett_url]", value: settings.dig(:jackett_url, :value), id: "settings_jackett_url", disabled: selected_provider != "jackett", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
         </div>
       </div>
 
@@ -129,7 +129,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:newznab_url, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.text_field "settings[newznab_url]", value: settings.dig(:newznab_url, :value), id: "settings_newznab_url", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.url_field "settings[newznab_url]", value: settings.dig(:newznab_url, :value), id: "settings_newznab_url", disabled: selected_provider != "newznab", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
         </div>
       </div>
 

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -52,6 +52,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index shows indexer provider dropdown" do
+    SettingsService.set(:indexer_provider, "prowlarr")
     SettingsService.set(:prowlarr_api_key, "stored-prowlarr-secret")
 
     get admin_settings_url
@@ -61,7 +62,9 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "option[value='prowlarr']", text: "Prowlarr"
     assert_select "option[value='jackett']", text: "Jackett"
     assert_select "option[value='newznab']", text: "NZBHydra2 / Newznab"
-    assert_select "input[name='settings[newznab_url]']"
+    assert_select "input[type='url'][name='settings[prowlarr_url]']:not([disabled])"
+    assert_select "input[type='url'][name='settings[jackett_url]'][disabled]"
+    assert_select "input[type='url'][name='settings[newznab_url]'][disabled]"
     assert_select "input[name='settings[newznab_api_key]']"
     assert_select "input[type='password'][name='settings[prowlarr_api_key]'][value='']"
     assert_no_match /stored-prowlarr-secret/, @response.body
@@ -457,6 +460,18 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert flash[:alert].present?
   end
 
+  test "update rejects malformed indexer URL without replacing saved value" do
+    SettingsService.set(:prowlarr_url, "https://prowlarr.example.com")
+
+    patch admin_setting_url("prowlarr_url"), params: {
+      setting: { value: "prowlarr.example.com:9696" }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_match(/Prowlarr URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
+    assert_equal "https://prowlarr.example.com", SettingsService.get(:prowlarr_url)
+  end
+
   test "index shows webhook settings" do
     get admin_settings_url
 
@@ -537,6 +552,54 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_settings_path
     assert flash[:alert].present?
+  end
+
+  test "bulk_update rejects malformed URLs for every indexer provider" do
+    original_urls = {
+      prowlarr_url: "https://prowlarr.example.com",
+      jackett_url: "https://jackett.example.com",
+      newznab_url: "https://newznab.example.com"
+    }
+    original_urls.each { |key, value| SettingsService.set(key, value) }
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        prowlarr_url: "prowlarr.example.com:9696",
+        jackett_url: "ftp://jackett.example.com",
+        newznab_url: "not a url"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_match(/Prowlarr URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
+    assert_match(/Jackett URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
+    assert_match(/Newznab URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
+    original_urls.each do |key, value|
+      assert_equal value, SettingsService.get(key), "expected #{key} to keep its saved value"
+    end
+  end
+
+  test "bulk_update reports malformed indexer URL in turbo response" do
+    SettingsService.set(:jackett_url, "https://jackett.example.com")
+
+    patch bulk_update_admin_settings_url,
+      params: { settings: { jackett_url: "jackett.example.com:9117" } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_match "turbo-stream", response.body
+    assert_match "Jackett URL: must be a valid HTTP or HTTPS URL", response.body
+    assert_equal "https://jackett.example.com", SettingsService.get(:jackett_url)
+  end
+
+  test "bulk_update trims valid indexer URLs before saving" do
+    patch bulk_update_admin_settings_url, params: {
+      settings: { newznab_url: "  https://newznab.example.com/api  " }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert flash[:alert].blank?
+    assert_equal "https://newznab.example.com/api", SettingsService.get(:newznab_url)
   end
 
   test "bulk_update accepts blank path templates" do
@@ -660,6 +723,24 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
       assert_redirected_to admin_settings_path
       assert flash[:alert].present?
+    end
+  end
+
+  test "test_indexer handles previously stored malformed provider URLs" do
+    {
+      "prowlarr" => [ :prowlarr_url, :prowlarr_api_key ],
+      "jackett" => [ :jackett_url, :jackett_api_key ],
+      "newznab" => [ :newznab_url, :newznab_api_key ]
+    }.each do |provider, (url_key, api_key)|
+      SettingsService.set(:indexer_provider, provider)
+      SettingsService.set(url_key, "#{provider}.example.com:1234")
+      SettingsService.set(api_key, "test-api-key")
+      IndexerClient.reset_all_connections!
+
+      post test_indexer_admin_settings_url
+
+      assert_redirected_to admin_settings_path
+      assert_match(/connection failed/i, flash[:alert], "expected #{provider} to fail without a server error")
     end
   end
 

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -468,7 +468,10 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to admin_settings_path
-    assert_match(/Prowlarr URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
+    assert_match(
+      %r{Prowlarr URL: must be a valid HTTP or HTTPS URL \(include http:// or https://\)},
+      flash[:alert]
+    )
     assert_equal "https://prowlarr.example.com", SettingsService.get(:prowlarr_url)
   end
 
@@ -571,9 +574,17 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to admin_settings_path
-    assert_match(/Prowlarr URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
-    assert_match(/Jackett URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
-    assert_match(/Newznab URL: must be a valid HTTP or HTTPS URL/, flash[:alert])
+    assert_match(
+      %r{Prowlarr URL: must be a valid HTTP or HTTPS URL \(include http:// or https://\)},
+      flash[:alert]
+    )
+    assert_match(
+      %r{Jackett URL: must be a valid HTTP or HTTPS URL \(include http:// or https://\)},
+      flash[:alert]
+    )
+    # Space-containing values fail URI.parse and include the parser detail.
+    assert_match(%r{Newznab URL: must be a valid HTTP or HTTPS URL \(}, flash[:alert])
+    assert_match(/not a url/i, flash[:alert])
     original_urls.each do |key, value|
       assert_equal value, SettingsService.get(key), "expected #{key} to keep its saved value"
     end
@@ -588,8 +599,21 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match "turbo-stream", response.body
-    assert_match "Jackett URL: must be a valid HTTP or HTTPS URL", response.body
+    assert_match "Jackett URL: must be a valid HTTP or HTTPS URL (include http:// or https://)", response.body
     assert_equal "https://jackett.example.com", SettingsService.get(:jackett_url)
+  end
+
+  test "bulk_update surfaces URI parse details for invalid indexer URLs" do
+    SettingsService.set(:prowlarr_url, "https://prowlarr.example.com")
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: { prowlarr_url: "http://[not-a-valid-host" }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_match(%r{Prowlarr URL: must be a valid HTTP or HTTPS URL \(}, flash[:alert])
+    assert_no_match(/include http:\/\/ or https:\/\//, flash[:alert])
+    assert_equal "https://prowlarr.example.com", SettingsService.get(:prowlarr_url)
   end
 
   test "bulk_update trims valid indexer URLs before saving" do

--- a/test/services/indexer_clients/jackett_test.rb
+++ b/test/services/indexer_clients/jackett_test.rb
@@ -59,6 +59,19 @@ class IndexerClients::JackettTest < ActiveSupport::TestCase
     end
   end
 
+  test "search maps InvalidUrlError to ConnectionError for malformed stored URLs" do
+    SettingsService.set(:jackett_url, "jackett.example.com:9117")
+    IndexerClients::Jackett.reset_connection!
+
+    error = assert_raises IndexerClients::Base::ConnectionError do
+      IndexerClients::Jackett.search("test query", book_type: :ebook)
+    end
+
+    assert_match(/must be a valid http or https URL/i, error.message)
+    assert_kind_of IndexerClients::Base::ConnectionError, error
+    refute_kind_of IndexerClients::Base::InvalidUrlError, error
+  end
+
   test "search does not treat info link as a download url when enclosure is missing" do
     body = <<~XML
       <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- validate Prowlarr, Jackett, and Newznab URLs before persisting settings
- preserve the previously saved value when validation fails
- treat malformed legacy URLs as safe connection-test failures instead of server errors
- use URL inputs with inactive-provider fields disabled to avoid hidden validation blockers
- return clear validation feedback for both HTML and Turbo submissions

## Root cause

Indexer URL settings considered any non-empty string configured. A URL without an HTTP or HTTPS scheme was therefore saved successfully, but the indexer client later raised `ArgumentError` while constructing its connection. That exception escaped the connection-test request and produced a 500 response.

## Impact

Admins now receive an actionable validation error before an invalid URL is saved. Existing malformed values no longer crash connection testing, and valid URLs are trimmed before storage.

## Validation

- focused suite: 234 tests, 867 assertions
- `bin/quality fast` for the changed Ruby files and controller tests
- full `bin/quality push` gate, including RuboCop, Brakeman, tests, and coverage
- pre-commit and pre-push quality hooks
- `git diff --check`

Closes #356