### PR TITLE
fix: refresh BookOrbit connection when settings change

### DIFF
--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -91,6 +91,7 @@ class BookOrbitClient
     def reset_connection!
       @connection = nil
       @access_token = nil
+      @connection_configuration = nil
     end
 
     private
@@ -106,6 +107,8 @@ class BookOrbitClient
     end
 
     def connection
+      refresh_connection_cache!
+
       @connection ||= Faraday.new(url: base_url) do |f|
         f.request :json
         f.response :json, parser_options: { symbolize_names: false }
@@ -141,6 +144,23 @@ class BookOrbitClient
           token
         end
       end
+    end
+
+    def refresh_connection_cache!
+      configuration = current_connection_configuration
+      return if @connection_configuration == configuration
+
+      @connection = nil
+      @access_token = nil
+      @connection_configuration = configuration
+    end
+
+    def current_connection_configuration
+      [
+        SettingsService.get(:bookorbit_url).to_s.strip,
+        SettingsService.get(:bookorbit_username).to_s,
+        SettingsService.get(:bookorbit_password).to_s
+      ]
     end
 
     def base_url

--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -3,6 +3,8 @@
 # Client for BookOrbit's current internal API. BookOrbit does not publish stable
 # API docs yet, so this intentionally covers only library inventory and scans.
 class BookOrbitClient
+  CONNECTION_MUTEX = Mutex.new
+
   class Error < StandardError; end
   class ConnectionError < Error; end
   class AuthenticationError < Error; end
@@ -89,9 +91,7 @@ class BookOrbitClient
     end
 
     def reset_connection!
-      @connection = nil
-      @access_token = nil
-      @connection_configuration = nil
+      CONNECTION_MUTEX.synchronize { clear_connection_cache! }
     end
 
     private
@@ -107,20 +107,27 @@ class BookOrbitClient
     end
 
     def connection
-      refresh_connection_cache!
+      configuration = current_connection_configuration
 
-      @connection ||= Faraday.new(url: base_url) do |f|
+      CONNECTION_MUTEX.synchronize do
+        rebuild_connection!(configuration) if @connection.nil? || @connection_configuration != configuration
+        @connection
+      end
+    end
+
+    def build_connection(configuration)
+      Faraday.new(url: validated_base_url(configuration)) do |f|
         f.request :json
         f.response :json, parser_options: { symbolize_names: false }
         f.adapter Faraday.default_adapter
-        f.headers["Authorization"] = "Bearer #{access_token}"
+        f.headers["Authorization"] = "Bearer #{access_token(configuration)}"
         f.options.timeout = 15
         f.options.open_timeout = 5
       end
     end
 
-    def auth_connection
-      Faraday.new(url: base_url) do |f|
+    def auth_connection(configuration)
+      Faraday.new(url: validated_base_url(configuration)) do |f|
         f.request :json
         f.response :json, parser_options: { symbolize_names: false }
         f.adapter Faraday.default_adapter
@@ -129,12 +136,12 @@ class BookOrbitClient
       end
     end
 
-    def access_token
+    def access_token(configuration)
       @access_token ||= begin
         response = request do
-          auth_connection.post("/api/v1/auth/login", {
-            username: SettingsService.get(:bookorbit_username),
-            password: SettingsService.get(:bookorbit_password)
+          auth_connection(configuration).post("/api/v1/auth/login", {
+            username: configuration.fetch(1),
+            password: configuration.fetch(2)
           })
         end
         handle_response(response) do |data|
@@ -146,25 +153,31 @@ class BookOrbitClient
       end
     end
 
-    def refresh_connection_cache!
-      configuration = current_connection_configuration
-      return if @connection_configuration == configuration
-
+    def clear_connection_cache!
       @connection = nil
       @access_token = nil
+      @connection_configuration = nil
+    end
+
+    def rebuild_connection!(configuration)
+      clear_connection_cache!
+      connection = build_connection(configuration)
+      @connection = connection
       @connection_configuration = configuration
     end
 
     def current_connection_configuration
-      [
+      configuration = [
         SettingsService.get(:bookorbit_url).to_s.strip,
         SettingsService.get(:bookorbit_username).to_s,
         SettingsService.get(:bookorbit_password).to_s
       ]
+      configuration.each(&:freeze)
+      configuration.freeze
     end
 
-    def base_url
-      url = SettingsService.get(:bookorbit_url).to_s.strip
+    def validated_base_url(configuration)
+      url = configuration.fetch(0)
       parsed_url = URI.parse(url)
 
       unless parsed_url.is_a?(URI::HTTP) && parsed_url.host.present?

--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -107,9 +107,8 @@ class BookOrbitClient
     end
 
     def connection
-      configuration = current_connection_configuration
-
       CONNECTION_MUTEX.synchronize do
+        configuration = current_connection_configuration
         rebuild_connection!(configuration) if @connection.nil? || @connection_configuration != configuration
         @connection
       end

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -93,6 +93,77 @@ class BookOrbitClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "concurrent connection rebuilds cannot publish stale BookOrbit settings" do
+    VCR.turned_off do
+      old_login_started = Queue.new
+      release_old_login = Queue.new
+
+      stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .to_return do
+          old_login_started << true
+          release_old_login.pop
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "old-token" }.to_json
+          }
+        end
+      stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer old-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { id: 1, name: "Old Library", folders: [] } ].to_json
+        )
+      stub_request(:post, "http://localhost:4000/api/v1/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { accessToken: "new-token" }.to_json
+        )
+      stub_request(:get, "http://localhost:4000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer new-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { id: 2, name: "New Library", folders: [] } ].to_json
+        )
+
+      original_configuration = BookOrbitClient.method(:current_connection_configuration)
+      new_configuration_read = Queue.new
+      configuration_reader = lambda do
+        configuration = original_configuration.call
+        new_configuration_read << true if Thread.current[:bookorbit_new_connection]
+        configuration
+      end
+
+      BookOrbitClient.stub(:current_connection_configuration, configuration_reader) do
+        old_request = Thread.new { BookOrbitClient.libraries }
+        old_login_started.pop
+
+        SettingsService.set(:bookorbit_url, "http://localhost:4000")
+        new_request = Thread.new do
+          Thread.current[:bookorbit_new_connection] = true
+          BookOrbitClient.libraries
+        end
+        new_configuration_read.pop
+
+        begin
+          assert_nil new_request.join(0.2), "new connection build should wait for the in-flight rebuild"
+        ensure
+          release_old_login << true
+          old_request.join
+          new_request.join
+        end
+
+        assert_equal "Old Library", old_request.value.first.name
+        assert_equal "New Library", new_request.value.first.name
+      end
+
+      assert_equal "New Library", BookOrbitClient.libraries.first.name
+    end
+  end
+
   test "library_items maps BookOrbit book cards into Shelfarr library item attributes" do
     VCR.turned_off do
       stub_login

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "timeout"
 
 class BookOrbitClientTest < ActiveSupport::TestCase
   setup do
@@ -95,19 +96,15 @@ class BookOrbitClientTest < ActiveSupport::TestCase
 
   test "concurrent connection rebuilds cannot publish stale BookOrbit settings" do
     VCR.turned_off do
-      old_login_started = Queue.new
-      release_old_login = Queue.new
+      old_configuration_read = Queue.new
+      release_old_configuration = Queue.new
 
       stub_request(:post, "http://localhost:3000/api/v1/auth/login")
-        .to_return do
-          old_login_started << true
-          release_old_login.pop
-          {
-            status: 200,
-            headers: { "Content-Type" => "application/json" },
-            body: { accessToken: "old-token" }.to_json
-          }
-        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { accessToken: "old-token" }.to_json
+        )
       stub_request(:get, "http://localhost:3000/api/v1/libraries")
         .with(headers: { "Authorization" => "Bearer old-token" })
         .to_return(
@@ -130,34 +127,42 @@ class BookOrbitClientTest < ActiveSupport::TestCase
         )
 
       original_configuration = BookOrbitClient.method(:current_connection_configuration)
-      new_configuration_read = Queue.new
       configuration_reader = lambda do
         configuration = original_configuration.call
-        new_configuration_read << true if Thread.current[:bookorbit_new_connection]
+        if Thread.current[:bookorbit_old_connection]
+          old_configuration_read << true
+          release_old_configuration.pop
+        end
         configuration
       end
 
+      old_request = nil
+      new_request = nil
       BookOrbitClient.stub(:current_connection_configuration, configuration_reader) do
-        old_request = Thread.new { BookOrbitClient.libraries }
-        old_login_started.pop
-
-        SettingsService.set(:bookorbit_url, "http://localhost:4000")
-        new_request = Thread.new do
-          Thread.current[:bookorbit_new_connection] = true
-          BookOrbitClient.libraries
-        end
-        new_configuration_read.pop
-
         begin
-          assert_nil new_request.join(0.2), "new connection build should wait for the in-flight rebuild"
-        ensure
-          release_old_login << true
-          old_request.join
-          new_request.join
-        end
+          old_request = Thread.new do
+            Thread.current[:bookorbit_old_connection] = true
+            BookOrbitClient.libraries
+          end
+          Timeout.timeout(2) { old_configuration_read.pop }
 
-        assert_equal "Old Library", old_request.value.first.name
-        assert_equal "New Library", new_request.value.first.name
+          SettingsService.set(:bookorbit_url, "http://localhost:4000")
+          new_request = Thread.new { BookOrbitClient.libraries }
+
+          assert_nil new_request.join(0.2), "new connection build should wait for the in-flight rebuild"
+          release_old_configuration << true
+
+          assert_equal "Old Library", Timeout.timeout(2) { old_request.value.first.name }
+          assert_equal "New Library", Timeout.timeout(2) { new_request.value.first.name }
+        ensure
+          release_old_configuration << true
+          [ old_request, new_request ].compact.each do |thread|
+            next if thread.join(2)
+
+            thread.kill
+            thread.join
+          end
+        end
       end
 
       assert_equal "New Library", BookOrbitClient.libraries.first.name

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -49,6 +49,50 @@ class BookOrbitClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "libraries rebuilds cached connection when BookOrbit settings change" do
+    VCR.turned_off do
+      old_login = stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { accessToken: "old-token" }.to_json
+        )
+      old_libraries = stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer old-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { id: 1, name: "Old Library", folders: [] } ].to_json
+        )
+
+      assert_equal "Old Library", BookOrbitClient.libraries.first.name
+
+      SettingsService.set(:bookorbit_url, "http://localhost:4000")
+
+      new_login = stub_request(:post, "http://localhost:4000/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { accessToken: "new-token" }.to_json
+        )
+      new_libraries = stub_request(:get, "http://localhost:4000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer new-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { id: 2, name: "New Library", folders: [] } ].to_json
+        )
+
+      assert_equal "New Library", BookOrbitClient.libraries.first.name
+      assert_requested old_login, times: 1
+      assert_requested old_libraries, times: 1
+      assert_requested new_login, times: 1
+      assert_requested new_libraries, times: 1
+    end
+  end
+
   test "library_items maps BookOrbit book cards into Shelfarr library item attributes" do
     VCR.turned_off do
       stub_login


### PR DESCRIPTION
## Summary

- track the BookOrbit URL and credentials used to build the cached connection
- clear the cached Faraday connection and access token when persisted configuration changes
- add a regression test that changes the URL without explicitly resetting the client and verifies the next request uses the new endpoint and token

## Root cause

`BookOrbitClient` memoized its Faraday connection and access token at class level. Saving integration settings reset that cache only in the web process handling the request. A long-running Solid Queue worker could retain its own connection to the old URL, so foreground connection tests used the new endpoint while background library syncs continued using the old one.

## Impact

Every process now compares its cached BookOrbit configuration with the current persisted settings before making a request. URL or credential changes invalidate the connection and token inside the process actually performing the work, without requiring a Shelfarr restart.

## Validation

- regression reproduced before the fix: expected `New Library`, received `Old Library`
- `test/services/bookorbit_client_test.rb`: 6 tests, 28 assertions
- related sync/controller suite: 146 tests, 645 assertions
- `bin/quality fast` for the changed service and test
- full `bin/quality push`, including RuboCop, Brakeman, tests, and coverage
- pre-commit and pre-push quality hooks
- `git diff --check`

Closes #358