### PR TITLE
fix: preserve path prefix in live search stream

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,7 +45,9 @@ class SearchController < ApplicationController
   end
 
   def stream_results
-    @relative_url_root = request.script_name
+    # Live returns up the Rack stack after the first write commits, so URLMap can
+    # restore SCRIPT_NAME while later chunks are still rendering. Preserve it for URLs.
+    @live_script_name = request.script_name.presence
     @query = params[:q].to_s.strip
     @content_kind = normalized_content_kind(params[:content_kind])
 
@@ -146,6 +148,13 @@ class SearchController < ApplicationController
     render :close_modal, layout: false
   end
 
+  def url_options
+    options = super
+    return options if @live_script_name.blank?
+
+    options.merge(script_name: @live_script_name)
+  end
+
   private
 
   def write_search_results_stream(results:, loading:, pending_providers: [], completed_providers: [], error: nil)
@@ -170,32 +179,11 @@ class SearchController < ApplicationController
     @audiobookshelf_matches = enrichment[:audiobookshelf_matches]
     @existing_books_lookup = enrichment[:existing_books_lookup]
 
-    with_relative_url_root do
-      render_to_string(
-        template: "search/results",
-        formats: [ :turbo_stream ],
-        layout: false
-      )
-    end
-  end
-
-  # ActionController::Live runs the action body in a background thread and
-  # returns the response back up the Rack stack as soon as the first chunk
-  # commits, so path-prefixing middleware (e.g. Rack::URLMap, used when the
-  # app is mounted under RAILS_RELATIVE_URL_ROOT) can unwind its SCRIPT_NAME
-  # mutation on the shared env hash before later chunks are rendered. Without
-  # reapplying the prefix captured at the top of #stream_results, url_for and
-  # friends would drop it from links in every chunk after the first. We
-  # restore the previous value afterwards so the mutation doesn't leak beyond
-  # this render.
-  def with_relative_url_root
-    return yield if @relative_url_root.blank?
-
-    original_script_name = request.script_name
-    request.script_name = @relative_url_root
-    yield
-  ensure
-    request.script_name = original_script_name if @relative_url_root.present?
+    render_to_string(
+      template: "search/results",
+      formats: [ :turbo_stream ],
+      layout: false
+    )
   end
 
   def audiobookshelf_matches_for(results)

--- a/test/controllers/search_controller_rendering_test.rb
+++ b/test/controllers/search_controller_rendering_test.rb
@@ -58,19 +58,34 @@ class SearchControllerRenderingTest < ActionController::TestCase
     assert_includes html, "Search failed. Please try again."
   end
 
-  test "with_relative_url_root reapplies the captured prefix and restores the prior SCRIPT_NAME afterward" do
-    @controller.instance_variable_set(:@relative_url_root, "/books")
+  test "stream_results keeps mounted paths after the first live chunk commits" do
+    @controller.define_singleton_method(:require_authentication) { true }
+    @request.set_header("SCRIPT_NAME", "/books")
+    writes = 0
+    @controller.define_singleton_method(:write_search_results_stream) do |**arguments|
+      super(**arguments).tap do
+        writes += 1
+        request.script_name = "" if writes == 1
+      end
+    end
+    stream_search = lambda do |_query, **_kwargs, &block|
+      block.call("openlibrary", [ candidate ])
+    end
 
-    # Simulates SCRIPT_NAME having reverted on the shared env since the
-    # prefix was captured at the top of #stream_results (e.g. once whatever
-    # mounted the app under /books is done touching this request).
-    @request.set_header("SCRIPT_NAME", "")
+    MetadataService.stub(:enabled_metadata_providers, [ "openlibrary" ]) do
+      MetadataService.stub(:each_provider_search, stream_search) do
+        MetadataService.stub(:aggregate_provider_results, [ candidate ]) do
+          get :stream_results, params: { q: "dune" }
+        end
+      end
+    end
 
-    observed_script_name = nil
-    @controller.send(:with_relative_url_root) { observed_script_name = @request.script_name }
-
-    assert_equal "/books", observed_script_name
-    assert_equal "", @request.script_name
+    assert_response :success
+    assert_match %r{href="/books/search/details\?}, response.body
+    assert_match %r{href="/books/requests/new\?}, response.body
+    assert_no_match %r{href="/search/details\?}, response.body
+    assert_no_match %r{href="/requests/new\?}, response.body
+    assert_no_match %r{href="/books/books/}, response.body
   end
 
   test "audiobookshelf_matches_for returns placeholders without library items" do

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -238,6 +238,8 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_match %r{href="/search/details\?}, response.body
+    assert_no_match %r{href="//search/details\?}, response.body
   end
 
   test "stream_results applies the normalized content filter to partial results" do
@@ -261,52 +263,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal [ "graphic" ], aggregated_content_kinds
-  end
-
-  test "stream_results renders provider-result links under the mounted path prefix" do
-    candidate = MetadataSearch::Candidate.new(
-      canonical_key: "openlibrary:OL_PREFIXW",
-      title: "Prefixed Stream Book",
-      author: "Prefix Author",
-      year: 2020,
-      description: nil,
-      cover_url: nil,
-      series_name: nil,
-      series_position: nil,
-      has_ebook: true,
-      has_audiobook: false,
-      sources: [
-        {
-          source: "openlibrary",
-          source_id: "OL_PREFIXW",
-          source_name: "Open Library",
-          source_url: nil,
-          work_id: "openlibrary:OL_PREFIXW"
-        }
-      ],
-      editions: [],
-      confidence: 100,
-      content_kind: "book"
-    )
-
-    stream_search = lambda do |_query, **_kwargs, &block|
-      block.call("openlibrary", [ candidate ])
-    end
-    aggregate = lambda do |_results, **_kwargs|
-      [ candidate ]
-    end
-
-    MetadataService.stub(:enabled_metadata_providers, [ "openlibrary" ]) do
-      MetadataService.stub(:each_provider_search, stream_search) do
-        MetadataService.stub(:aggregate_provider_results, aggregate) do
-          get search_results_stream_path, params: { q: "prefixed" }, env: { "SCRIPT_NAME" => "/books" }
-        end
-      end
-    end
-
-    assert_response :success
-    assert_match %r{href="/books/search/details\?}, response.body
-    assert_no_match %r{href="/search/details\?}, response.body
   end
 
   test "stream_results handles blank query" do


### PR DESCRIPTION
## Summary

- capture the mounted `SCRIPT_NAME` before the first live stream write
- preserve that prefix through controller `url_options` for later route helpers without mutating the shared Rack env around each render
- replace the mounted-request assertion with a deterministic regression that clears `SCRIPT_NAME` after the first chunk and checks later details and request links
- verify unmounted live search links keep a single leading slash

Follow-up to #350.

Fixes #349

## Test plan

- `bin/rails test test/controllers/search_controller_test.rb test/controllers/search_controller_rendering_test.rb`
- `bin/quality push`