### PR TITLE
fix: preserve Unicode filenames during post-processing

### DIFF
--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -1304,12 +1304,22 @@ class FileCopyService
           raise UnsafePathError, "source tree contains too many entries"
         end
 
-        children << entry
+        children << utf8_directory_entry(entry)
       end
       children.sort
     ensure
       listing&.close
       duplicate&.close unless duplicate&.closed?
+    end
+
+    def utf8_directory_entry(entry)
+      # Dir.for_fd has no path or encoding argument, so Ruby returns raw
+      # filename bytes as ASCII-8BIT. Shelfarr paths and metadata are UTF-8;
+      # retag valid bytes without transcoding or changing syscall identity.
+      name = entry.dup.force_encoding(Encoding::UTF_8)
+      return name if name.valid_encoding?
+
+      raise UnsafePathError, "source tree contains a filename that is not valid UTF-8"
     end
 
     def directory_manifest_entry(stat)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -239,6 +239,39 @@ class PostProcessingJobTest < ActiveJob::TestCase
     end
   end
 
+  test "copies audiobook files with UTF-8 names into UTF-8 destination paths" do
+    SettingsService.set(:audiobookshelf_url, "")
+    title = "The Reverse Centaur’s Guide to Life After AI"
+    filename = "Cory Doctorow - #{title}.mp3"
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    File.write(File.join(@temp_source, filename), "unicode audio")
+    @book.update!(title: title, author: "Cory Doctorow")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, title)
+    assert @request.reload.completed?
+    assert_equal "unicode audio", File.read(File.join(expected_dest, filename))
+  end
+
+  test "copies UTF-8 nested audiobook directories into UTF-8 destination paths" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:move_completed_downloads, true)
+    title = "The Reverse Centaur’s Guide to Life After AI"
+    nested_directory = "Doctorow’s Extras"
+    nested_source = File.join(@temp_source, nested_directory)
+    FileUtils.mkdir_p(nested_source)
+    FileUtils.mv(File.join(@temp_source, "audiobook.mp3"), File.join(nested_source, "afterword.mp3"))
+    @book.update!(title: title, author: "Cory Doctorow")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_file = File.join(@temp_dest_base, @book.author, title, nested_directory, "afterword.mp3")
+    assert @request.reload.completed?
+    assert_equal "test audio content", File.read(expected_file)
+    assert_not File.exist?(@temp_source)
+  end
+
   test "keeps multi-file audiobook directory imports flat when bundle splitting is disabled" do
     SettingsService.set(:audiobookshelf_url, "")
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
@@ -1336,6 +1369,26 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert File.exist?(File.join(expected_dest, "Michael Crichton - Jurassic Park (1990).epub"))
     assert File.exist?(File.join(expected_dest, "cover.jpg"))
     assert_not File.exist?(File.join(expected_dest, "Calibre Export"))
+  end
+
+  test "copies UTF-8 ebook sidecar names into UTF-8 destination paths" do
+    FileUtils.rm_rf(@temp_source)
+    FileUtils.mkdir_p(@temp_source)
+    title = "The Reverse Centaur’s Guide to Life After AI"
+    sidecar = "Doctorow’s Notes.nfo"
+    write_valid_ebook_file(File.join(@temp_source, "book.epub"))
+    File.write(File.join(@temp_source, sidecar), "release notes")
+
+    @book.update!(title: title, author: "Cory Doctorow", book_type: :ebook)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    expected_dest = File.join(@temp_dest_base, @book.author, title)
+    assert @request.reload.completed?
+    assert_equal "release notes", File.read(File.join(expected_dest, sidecar))
+    assert File.exist?(File.join(expected_dest, "Cory Doctorow - #{title}.epub"))
   end
 
   test "imports bundled DjVu ebooks" do

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -249,6 +249,33 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "source snapshots retain UTF-8 encoding for UTF-8 entry names" do
+    source_root_path = File.join(@tmp_dir, "unicode-download")
+    filename = "The Reverse Centaur’s Guide.mp3"
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(File.join(source_root_path, filename), "chapter")
+
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+    snapshotted_name = snapshot.entries.keys.fetch(0)
+
+    assert_equal filename, snapshotted_name
+    assert_equal Encoding::UTF_8, snapshotted_name.encoding
+  end
+
+  test "source snapshots reject invalid UTF-8 names in nested directories" do
+    source_root_path = File.join(@tmp_dir, "invalid-name-download")
+    nested = File.join(source_root_path, "nested")
+    invalid_filename = "chapter-\xFF.mp3".b
+    FileUtils.mkdir_p(nested)
+    File.binwrite(File.join(nested, invalid_filename), "chapter")
+
+    error = assert_raises(FileCopyService::UnsafePathError) do
+      FileCopyService.snapshot_source_root(source_root_path)
+    end
+
+    assert_match(/not valid UTF-8/, error.message)
+  end
+
   test "snapshotted source root rejects a same-path file replacement" do
     source_root_path = File.join(@tmp_dir, "download")
     FileUtils.mkdir_p(source_root_path)


### PR DESCRIPTION
## Summary

- restore UTF-8 encoding for raw names returned by descriptor-based directory enumeration
- reject malformed filename bytes with a controlled unsafe-path error while preserving syscall bytes
- cover Unicode audiobook filenames, nested move cleanup, ebook sidecars, and source snapshot manifests

## Verification

- 136 focused tests, 447 assertions
- reported Unicode case under LANG=C
- bin/quality push
- three parallel adversarial reviews covering encoding portability, filesystem safety, and regression coverage

Closes #367