### PR TITLE
fix: keep request metadata out of URLs

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -44,28 +44,32 @@ class RequestsController < ApplicationController
   end
 
   def new
-    @work_id = params[:work_id]
-    @title = params[:title]
-    @author = params[:author]
-    @cover_url = params[:cover_url]
-    @first_publish_year = params[:first_publish_year]
-    @source_work_ids = Array(params[:source_work_ids]).compact_blank
+    return if redirect_legacy_description_handoff?
+
+    cached_metadata = request_handoff_metadata
+    @work_id = params[:work_id].presence || cached_metadata[:work_id]
+    @source_work_ids = [ *Array(params[:source_work_ids]), *Array(cached_metadata[:source_work_ids]) ].compact_blank.uniq
+    metadata = resolved_new_request_metadata(cached_metadata)
+    @title = metadata[:title]
+    @author = metadata[:author]
+    @cover_url = metadata[:cover_url]
+    @first_publish_year = metadata[:first_publish_year]
     @content_kind = ContentKinds.resolve(
-      params[:content_kind],
+      metadata[:content_kind],
       source_work_ids: [ @work_id, *@source_work_ids ],
-      collection_source: params[:collection_source],
+      collection_source: metadata[:collection_source],
       default: ContentKinds::BOOK
     )
-    @description = params[:description]
-    @publisher = params[:publisher]
-    @issue_number = params[:issue_number]
-    @release_date = params[:release_date]
-    @series = params[:series]
-    @series_position = params[:series_position]
-    @request_scope = params[:request_scope].presence || "single"
-    @collection_source = params[:collection_source]
-    @collection_id = params[:collection_id]
-    @collection_title = params[:collection_title]
+    @description = metadata[:description]
+    @publisher = metadata[:publisher]
+    @issue_number = metadata[:issue_number]
+    @release_date = metadata[:release_date]
+    @series = metadata[:series]
+    @series_position = metadata[:series_position]
+    @request_scope = metadata[:request_scope].presence || "single"
+    @collection_source = metadata[:collection_source]
+    @collection_id = metadata[:collection_id]
+    @collection_title = metadata[:collection_title]
     @available_book_types = RequestOptionPolicy.book_types_for(@content_kind)
 
     if @work_id.blank? || @title.blank?
@@ -429,6 +433,39 @@ class RequestsController < ApplicationController
 
       [ info[:name], code ]
     end.sort_by(&:first)
+  end
+
+  def request_handoff_metadata
+    metadata = RequestMetadataHandoff.fetch(user: Current.user, token: params[:metadata_token])
+    return metadata if params[:work_id].blank? || metadata[:work_id] == params[:work_id]
+
+    {}
+  end
+
+  def redirect_legacy_description_handoff?
+    return false if params[:metadata_token].present? || params[:description].blank?
+
+    metadata = request_metadata_attrs.merge(
+      work_id: params[:work_id],
+      source_work_ids: params[:source_work_ids]
+    )
+    redirect_to new_request_path(RequestMetadataHandoff.params_for(user: Current.user, metadata: metadata))
+    true
+  end
+
+  def resolved_new_request_metadata(cached_metadata)
+    lookup_metadata = if cached_metadata.empty?
+      BookMetadataLookupService.call(
+        [ @work_id, *@source_work_ids ],
+        fallback: request_metadata_attrs
+      ).tap do |metadata|
+        metadata[:first_publish_year] ||= metadata.delete(:year)
+      end
+    else
+      {}
+    end
+
+    lookup_metadata.merge(request_metadata_attrs.compact).merge(cached_metadata)
   end
 
   def remove_associated_torrents(request)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -107,25 +107,28 @@ class SearchController < ApplicationController
   end
 
   def details
-    @work_id = params[:work_id]
-    @source_work_ids = Array(params[:source_work_ids]).compact_blank
-    @title = params[:title]
-    @author = params[:author]
-    @cover_url = params[:cover_url]
-    @first_publish_year = params[:first_publish_year]
-    @description = params[:description]
-    @content_kind = normalized_content_kind(params[:content_kind])
-    @publisher = params[:publisher]
+    return if redirect_legacy_details_handoff?
+
+    cached_metadata = details_handoff_metadata
+    @work_id = params[:work_id].presence || cached_metadata[:work_id]
+    @source_work_ids = [ *Array(params[:source_work_ids]), *Array(cached_metadata[:source_work_ids]) ].compact_blank.uniq
+    @title = cached_metadata[:title].presence || params[:title]
+    @author = cached_metadata[:author].presence || params[:author]
+    @cover_url = cached_metadata[:cover_url].presence || params[:cover_url]
+    @first_publish_year = cached_metadata[:first_publish_year].presence || params[:first_publish_year]
+    @description = cached_metadata[:description].presence || params[:description]
+    @content_kind = normalized_content_kind(cached_metadata[:content_kind].presence || params[:content_kind])
+    @publisher = cached_metadata[:publisher].presence || params[:publisher]
     @page_count = params[:page_count]
     @language = params[:language]
     @genres = params[:genres]
-    @issue_number = params[:issue_number]
-    @release_date = params[:release_date]
-    @series = params[:series]
-    @series_position = params[:series_position]
-    @collection_source = params[:collection_source]
-    @collection_id = params[:collection_id]
-    @collection_title = params[:collection_title]
+    @issue_number = cached_metadata[:issue_number].presence || params[:issue_number]
+    @release_date = cached_metadata[:release_date].presence || params[:release_date]
+    @series = cached_metadata[:series].presence || params[:series]
+    @series_position = cached_metadata[:series_position].presence || params[:series_position]
+    @collection_source = cached_metadata[:collection_source].presence || params[:collection_source]
+    @collection_id = cached_metadata[:collection_id].presence || params[:collection_id]
+    @collection_title = cached_metadata[:collection_title].presence || params[:collection_title]
     @modal = params[:modal] == "1"
     @metadata_source_name, @metadata_source_url = metadata_source_for(@work_id)
     @details_enrichment_attempted = false
@@ -156,6 +159,29 @@ class SearchController < ApplicationController
   end
 
   private
+
+  def details_handoff_metadata
+    metadata = RequestMetadataHandoff.fetch(user: Current.user, token: params[:metadata_token])
+    return metadata if params[:work_id].blank? || metadata[:work_id] == params[:work_id]
+
+    {}
+  end
+
+  def redirect_legacy_details_handoff?
+    return false if params[:metadata_token].present? || params[:description].blank?
+
+    metadata = params.permit(
+      :work_id, :title, :author, :cover_url, :first_publish_year,
+      :description, :publisher, :content_kind, :issue_number,
+      :release_date, :series, :series_position, :request_scope,
+      :collection_source, :collection_id, :collection_title,
+      source_work_ids: []
+    ).to_h.symbolize_keys
+    navigation_params = RequestMetadataHandoff.params_for(user: Current.user, metadata: metadata)
+    navigation_params[:modal] = params[:modal] if params[:modal].present?
+    redirect_to search_details_path(navigation_params)
+    true
+  end
 
   def write_search_results_stream(results:, loading:, pending_providers: [], completed_providers: [], error: nil)
     response.stream.write(
@@ -241,19 +267,74 @@ class SearchController < ApplicationController
   def enrich_details_from_source
     return if @work_id.blank?
 
-    source, source_id = Book.parse_work_id(@work_id)
+    @details_enrichment_loaded = enrich_details_for_source(@work_id) || @details_enrichment_loaded
+    return if essential_details_present?
+
+    alternate_work_ids = @source_work_ids.reject do |work_id|
+      Book.parse_work_id(work_id).first == Book.parse_work_id(@work_id).first
+    end
+    metadata = BookMetadataLookupService.call(alternate_work_ids, fallback: details_lookup_fallback)
+    apply_lookup_metadata(metadata)
+    @details_enrichment_loaded ||= metadata.present?
+  end
+
+  def essential_details_present?
+    @title.present? && @author.present? && @description.present?
+  end
+
+  def details_lookup_fallback
+    {
+      title: @title,
+      author: @author,
+      cover_url: @cover_url,
+      year: @first_publish_year,
+      description: @description,
+      publisher: @publisher,
+      content_kind: @content_kind,
+      issue_number: @issue_number,
+      release_date: @release_date,
+      series: @series,
+      series_position: @series_position,
+      collection_source: @collection_source,
+      collection_id: @collection_id,
+      collection_title: @collection_title
+    }
+  end
+
+  def apply_lookup_metadata(metadata)
+    @title = @title.presence || metadata[:title]
+    @author = @author.presence || metadata[:author]
+    @cover_url = @cover_url.presence || metadata[:cover_url]
+    @first_publish_year = @first_publish_year.presence || metadata[:year]
+    @description = @description.presence || metadata[:description]
+    @publisher = @publisher.presence || metadata[:publisher]
+    @content_kind = @content_kind.presence || metadata[:content_kind]
+    @issue_number = @issue_number.presence || metadata[:issue_number]
+    @release_date = @release_date.presence || metadata[:release_date]
+    @series = @series.presence || metadata[:series]
+    @series_position = @series_position.presence || metadata[:series_position]
+    @collection_source = @collection_source.presence || metadata[:collection_source]
+    @collection_id = @collection_id.presence || metadata[:collection_id]
+    @collection_title = @collection_title.presence || metadata[:collection_title]
+  end
+
+  def enrich_details_for_source(work_id)
+    source, source_id = Book.parse_work_id(work_id)
     case source
     when "hardcover"
-      @details_enrichment_loaded = enrich_hardcover_details(source_id)
+      enrich_hardcover_details(source_id)
     when "comic_vine"
-      @details_enrichment_loaded = enrich_comic_vine_details(source_id)
+      enrich_comic_vine_details(source_id)
     when "google_books"
-      @details_enrichment_loaded = enrich_google_books_details(source_id)
+      enrich_google_books_details(source_id)
     when "openlibrary"
-      @details_enrichment_loaded = enrich_openlibrary_details(source_id)
+      enrich_openlibrary_details(source_id)
+    else
+      false
     end
   rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, ComicVineClient::Error, MetadataService::Error => e
-    Rails.logger.warn("[SearchController] Details enrichment failed for #{@work_id}: #{e.message}")
+    Rails.logger.warn("[SearchController] Details enrichment failed for #{work_id}: #{e.message}")
+    false
   end
 
   def enrich_hardcover_details(source_id)

--- a/app/services/book_metadata_backfill_service.rb
+++ b/app/services/book_metadata_backfill_service.rb
@@ -4,9 +4,16 @@
 # without overwriting values that are already present.
 class BookMetadataBackfillService
   class << self
-    def apply!(book, work_id:, fallback_attrs: {}, lookup_details: true)
-      details = lookup_details ? fetch_details(work_id) : nil
-      attrs = attributes_for(book, work_id, details, fallback_attrs)
+    def apply!(book, work_id:, source_work_ids: [], fallback_attrs: {}, lookup_details: true)
+      metadata = if lookup_details
+        BookMetadataLookupService.call(
+          [ work_id, *Array(source_work_ids) ],
+          fallback: fallback_attrs
+        )
+      else
+        {}
+      end
+      attrs = attributes_for(book, work_id, metadata, fallback_attrs)
       book.assign_attributes(attrs) unless attrs.empty?
       return false unless book.changed?
 
@@ -16,21 +23,21 @@ class BookMetadataBackfillService
 
     private
 
-    def attributes_for(book, work_id, details, fallback_attrs)
+    def attributes_for(book, work_id, metadata, fallback_attrs)
       source, _source_id = Book.parse_work_id(work_id)
 
       attrs = {
-        title: value_for(book.title, details&.title, fallback_attrs[:title]),
-        author: value_for(book.author, details&.author, fallback_attrs[:author]),
-        cover_url: value_for(book.cover_url, details&.cover_url, fallback_attrs[:cover_url]),
-        year: numeric_value_for(book.year, details&.year, fallback_attrs[:year]),
-        description: value_for(book.description, details&.description, fallback_attrs[:description]),
-        series: value_for(book.series, details&.series_name, fallback_attrs[:series]),
-        series_position: value_for(book.series_position, details&.series_position, fallback_attrs[:series_position]),
-        publisher: value_for(book.publisher, detail_value(details, :publisher), fallback_attrs[:publisher]),
-        content_kind: content_kind_value_for(book, detail_value(details, :content_kind), fallback_attrs[:content_kind]),
-        issue_number: value_for(book.issue_number, detail_value(details, :issue_number), fallback_attrs[:issue_number]),
-        release_date: value_for(book.release_date, detail_value(details, :release_date), fallback_attrs[:release_date])
+        title: value_for(book.title, metadata[:title], fallback_attrs[:title]),
+        author: value_for(book.author, metadata[:author], fallback_attrs[:author]),
+        cover_url: value_for(book.cover_url, metadata[:cover_url], fallback_attrs[:cover_url]),
+        year: numeric_value_for(book.year, metadata[:year], fallback_attrs[:year]),
+        description: value_for(book.description, metadata[:description], fallback_attrs[:description]),
+        series: value_for(book.series, metadata[:series], fallback_attrs[:series]),
+        series_position: value_for(book.series_position, metadata[:series_position], fallback_attrs[:series_position]),
+        publisher: value_for(book.publisher, metadata[:publisher], fallback_attrs[:publisher]),
+        content_kind: content_kind_value_for(book, metadata[:content_kind], fallback_attrs[:content_kind]),
+        issue_number: value_for(book.issue_number, metadata[:issue_number], fallback_attrs[:issue_number]),
+        release_date: value_for(book.release_date, metadata[:release_date], fallback_attrs[:release_date])
       }.compact
 
       attrs[:metadata_source] = source if book.metadata_source.blank? || book.new_record?
@@ -41,10 +48,6 @@ class BookMetadataBackfillService
       return nil if current_value.present?
 
       detail_value.presence || fallback_value.presence
-    end
-
-    def detail_value(details, field)
-      details.public_send(field) if details.respond_to?(field)
     end
 
     def numeric_value_for(current_value, detail_value, fallback_value = nil)
@@ -61,20 +64,6 @@ class BookMetadataBackfillService
       return nil if !book.new_record? && book.content_kind.present? && !book.content_book?
 
       value
-    end
-
-    def fetch_details(work_id)
-      MetadataService.book_details(work_id)
-    rescue *metadata_lookup_errors => e
-      Rails.logger.warn("[BookMetadataBackfillService] Metadata lookup failed for #{work_id}: #{e.message}")
-      nil
-    end
-
-    def metadata_lookup_errors
-      errors = [ HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, ComicVineClient::Error, MetadataService::Error, ArgumentError ]
-      errors << VCR::Errors::UnhandledHTTPRequestError if defined?(VCR::Errors::UnhandledHTTPRequestError)
-      errors << WebMock::NetConnectNotAllowedError if defined?(WebMock::NetConnectNotAllowedError)
-      errors
     end
   end
 end

--- a/app/services/book_metadata_lookup_service.rb
+++ b/app/services/book_metadata_lookup_service.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "set"
+
+class BookMetadataLookupService
+  MAX_WORK_ID_BYTES = 255
+  ESSENTIAL_FIELDS = %i[title author description].freeze
+  FIELD_READERS = {
+    title: :title,
+    author: :author,
+    cover_url: :cover_url,
+    year: :year,
+    description: :description,
+    publisher: :publisher,
+    content_kind: :content_kind,
+    issue_number: :issue_number,
+    release_date: :release_date,
+    series: :series_name,
+    series_position: :series_position,
+    collection_id: :collection_id,
+    collection_title: :collection_title
+  }.freeze
+
+  class << self
+    def call(work_ids, fallback: {})
+      work_ids = normalize_work_ids(work_ids)
+      return {} if work_ids.empty?
+
+      metadata = {}
+      merge_details!(metadata, fetch_details(work_ids.first), work_ids.first)
+      return metadata if work_ids.one? || essential_metadata_complete?(metadata, fallback)
+
+      work_ids.drop(1).zip(fetch_concurrently(work_ids.drop(1))).each do |work_id, details|
+        merge_details!(metadata, details, work_id)
+      end
+      metadata
+    end
+
+    def normalize_work_ids(work_ids)
+      seen_sources = Set.new
+
+      Array(work_ids).compact_blank.filter_map do |work_id|
+        work_id = work_id.to_s
+        next if work_id.bytesize > MAX_WORK_ID_BYTES
+
+        source, source_id = Book.parse_work_id(work_id)
+        next unless MetadataSources::NAMES.key?(source) && source_id.present?
+        next if seen_sources.include?(source)
+
+        seen_sources << source
+        "#{source}:#{source_id}"
+      end
+    end
+
+    private
+
+    def fetch_concurrently(work_ids)
+      work_ids.map do |work_id|
+        Thread.new do
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection { fetch_details(work_id) }
+          end
+        end
+      end.map(&:value)
+    end
+
+    def fetch_details(work_id)
+      MetadataService.book_details(work_id)
+    rescue *metadata_lookup_errors => e
+      Rails.logger.warn("[BookMetadataLookupService] Metadata lookup failed for #{work_id}: #{e.message}")
+      nil
+    end
+
+    def merge_details!(metadata, details, work_id)
+      return unless details
+
+      FIELD_READERS.each do |field, reader|
+        next unless details.respond_to?(reader)
+
+        metadata[field] ||= details.public_send(reader).presence
+      end
+
+      merge_provider_collection!(metadata, details, work_id)
+    end
+
+    def essential_metadata_complete?(metadata, fallback)
+      fallback = fallback.to_h.symbolize_keys
+      ESSENTIAL_FIELDS.all? { |field| metadata[field].present? || fallback[field].present? }
+    end
+
+    def merge_provider_collection!(metadata, details, work_id)
+      source, = Book.parse_work_id(work_id)
+      collection_id = if details.respond_to?(:collection_id)
+        details.collection_id
+      elsif details.respond_to?(:series_id)
+        details.series_id
+      end
+      collection_title = if details.respond_to?(:collection_title)
+        details.collection_title
+      elsif details.respond_to?(:series_name)
+        details.series_name
+      end
+      return if collection_id.blank? || collection_title.blank?
+
+      metadata[:collection_source] ||= source
+      metadata[:collection_id] ||= collection_id
+      metadata[:collection_title] ||= collection_title
+    end
+
+    def metadata_lookup_errors
+      errors = [ HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, ComicVineClient::Error, MetadataService::Error, ArgumentError ]
+      errors << VCR::Errors::UnhandledHTTPRequestError if defined?(VCR::Errors::UnhandledHTTPRequestError)
+      errors << WebMock::NetConnectNotAllowedError if defined?(WebMock::NetConnectNotAllowedError)
+      errors
+    end
+  end
+end

--- a/app/services/request_creation_service.rb
+++ b/app/services/request_creation_service.rb
@@ -26,7 +26,8 @@ class RequestCreationService
   def initialize(user:, work_id:, book_types:, metadata_attrs: {}, notes: nil, language: nil, origin: {}, source_work_ids: nil, collection_item_ids: nil, expand_collection: false)
     @user = user
     @work_id = work_id.to_s.strip
-    @source_work_ids = [ @work_id, *Array(source_work_ids) ].compact_blank.map(&:to_s).uniq
+    @source_work_ids = BookMetadataLookupService.normalize_work_ids([ @work_id, *Array(source_work_ids) ])
+    @source_work_ids = [ @work_id ] if @source_work_ids.empty? && @work_id.present?
     @book_types = normalize_book_types(book_types)
     @metadata_attrs = normalize_metadata_attrs(metadata_attrs)
     @notes = notes
@@ -190,6 +191,7 @@ class RequestCreationService
     BookMetadataBackfillService.apply!(
       book,
       work_id: input.work_id,
+      source_work_ids: input.source_work_ids,
       fallback_attrs: fallback_attrs(input.metadata_attrs),
       lookup_details: !collection_request?
     )

--- a/app/services/request_metadata_handoff.rb
+++ b/app/services/request_metadata_handoff.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class RequestMetadataHandoff
+  TTL = 1.hour
+  MAX_IDENTITY_BYTES = 255
+  MAX_SOURCE_WORK_IDS = 8
+  TOKEN_PATTERN = /\A[A-Za-z0-9_-]{32}\z/
+  IDENTITY_KEYS = %i[
+    work_id
+    source_work_ids
+    content_kind
+    request_scope
+    collection_source
+    collection_id
+  ].freeze
+  METADATA_KEYS = %i[
+    work_id
+    source_work_ids
+    title
+    author
+    cover_url
+    first_publish_year
+    description
+    publisher
+    content_kind
+    issue_number
+    release_date
+    series
+    series_position
+    request_scope
+    collection_source
+    collection_id
+    collection_title
+  ].freeze
+
+  class << self
+    def params_for(user:, metadata:)
+      metadata = normalize(metadata)
+      token = store(user: user, metadata: metadata)
+
+      compact_identity(metadata).merge(metadata_token: token).compact
+    end
+
+    def fetch(user:, token:)
+      return {} unless TOKEN_PATTERN.match?(token.to_s)
+
+      normalize(Rails.cache.read(cache_key(user, token)))
+    rescue StandardError => e
+      Rails.logger.warn("[RequestMetadataHandoff] Cache read failed: #{e.class}")
+      {}
+    end
+
+    private
+
+    def store(user:, metadata:)
+      token = SecureRandom.urlsafe_base64(24)
+      written = Rails.cache.write(cache_key(user, token), metadata, expires_in: TTL)
+      token if written
+    rescue StandardError => e
+      Rails.logger.warn("[RequestMetadataHandoff] Cache write failed: #{e.class}")
+      nil
+    end
+
+    def normalize(metadata)
+      metadata.to_h.symbolize_keys.slice(*METADATA_KEYS).compact.tap do |normalized|
+        normalized[:source_work_ids] = Array(normalized[:source_work_ids]).compact_blank.uniq if normalized.key?(:source_work_ids)
+      end
+    end
+
+    def compact_identity(metadata)
+      metadata.slice(*IDENTITY_KEYS).transform_values do |value|
+        if value.is_a?(Array)
+          value.filter_map { |item| bounded_identity(item) }.first(MAX_SOURCE_WORK_IDS)
+        else
+          bounded_identity(value)
+        end
+      end.compact
+    end
+
+    def bounded_identity(value)
+      return value unless value.is_a?(String)
+      return value if value.bytesize <= MAX_IDENTITY_BYTES
+
+      nil
+    end
+
+    def cache_key(user, token)
+      "request_metadata_handoff:v1:#{user&.id || 'anonymous'}:#{token}"
+    end
+  end
+end

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -36,6 +36,7 @@
     collection_title: (result.collection_title if result.respond_to?(:collection_title)),
     source_work_ids: source_work_ids
   }.compact
+  navigation_params = RequestMetadataHandoff.params_for(user: Current.user, metadata: metadata_params)
   format_statuses = available_book_types.to_h do |book_type|
     existing_book = Book.find_in_lookup(existing_books_lookup, source_work_ids, book_type: book_type)
     status = if existing_book&.acquired?
@@ -58,7 +59,7 @@
 
 <div class="group relative overflow-hidden rounded-xl bg-gray-900 shadow-lg ring-1 ring-gray-800 transition-all duration-300 hover:scale-[1.03] hover:shadow-2xl">
   <div class="relative aspect-[2/3]">
-    <%= link_to search_details_path(metadata_params.merge(modal: 1)), class: "block h-full w-full", title: "View details for #{result.title}", data: { turbo_frame: "modal" } do %>
+    <%= link_to search_details_path(navigation_params.merge(modal: 1)), class: "block h-full w-full", title: "View details for #{result.title}", data: { turbo_frame: "modal" } do %>
       <% if result.cover_url.present? %>
         <img src="<%= result.cover_url %>" alt="Cover of <%= result.title %>" class="h-full w-full object-cover" loading="lazy">
       <% else %>
@@ -79,7 +80,7 @@
 
     <div class="absolute inset-x-0 bottom-0 flex flex-col gap-2 bg-gradient-to-t from-black via-black/80 to-transparent p-3 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
       <% if requestable_book_types.any? %>
-        <%= link_to request_label, new_request_path(metadata_params), class: "w-full rounded-md bg-blue-600 px-3 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-blue-500" %>
+        <%= link_to request_label, new_request_path(navigation_params), class: "w-full rounded-md bg-blue-600 px-3 py-2 text-center text-sm font-medium text-white transition-colors hover:bg-blue-500" %>
       <% elsif blocked_status.present? %>
         <span class="w-full rounded-md bg-gray-800/90 px-3 py-2 text-center text-sm font-medium text-gray-300">
           <%= blocked_status == :acquired ? "In library" : "Requested" %>
@@ -102,7 +103,7 @@
         <% end %>
       <% end %>
     </div>
-    <%= link_to search_details_path(metadata_params.merge(modal: 1)), class: "block", data: { turbo_frame: "modal" } do %>
+    <%= link_to search_details_path(navigation_params.merge(modal: 1)), class: "block", data: { turbo_frame: "modal" } do %>
       <h3 class="line-clamp-2 text-sm font-semibold leading-tight text-white hover:text-blue-300"><%= result.title %></h3>
     <% end %>
     <% if result.author.present? %>

--- a/app/views/search/details.html.erb
+++ b/app/views/search/details.html.erb
@@ -65,6 +65,7 @@
     collection_title: @collection_title,
     source_work_ids: @source_work_ids
   }.compact
+  request_navigation_params = RequestMetadataHandoff.params_for(user: Current.user, metadata: metadata_params)
 %>
 
 <% details_content = capture do %>
@@ -97,7 +98,7 @@
 
       <div class="flex flex-wrap gap-3">
         <% if @available_book_types.any? %>
-          <%= link_to request_label, new_request_path(metadata_params), class: "rounded-lg bg-blue-600 px-4 py-2 font-medium text-white transition hover:bg-blue-500", data: { turbo_frame: "_top" } %>
+          <%= link_to request_label, new_request_path(request_navigation_params), class: "rounded-lg bg-blue-600 px-4 py-2 font-medium text-white transition hover:bg-blue-500", data: { turbo_frame: "_top" } %>
         <% else %>
           <span class="rounded-lg bg-gray-800 px-4 py-2 font-medium text-gray-400">No requestable formats</span>
         <% end %>

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -378,6 +378,59 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", "Test Book"
   end
 
+  test "compact metadata handoff preserves long descriptions through creation" do
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    description = "Long description " * 1_000
+    metadata = {
+      work_id: "openlibrary:OL_HANDOFF_W",
+      source_work_ids: [ "openlibrary:OL_HANDOFF_W", "google_books:gb-handoff" ],
+      title: "Handoff Book",
+      author: "Handoff Author",
+      description: description,
+      content_kind: "book"
+    }
+    navigation_params = RequestMetadataHandoff.params_for(user: @user, metadata: metadata)
+
+    get new_request_path(navigation_params)
+
+    assert_response :success
+    assert_select "input[name='description']" do |inputs|
+      assert_equal description, inputs.first["value"]
+    end
+
+    MetadataService.stub(:book_details, ->(*) { raise OpenLibraryClient::ConnectionError, "timeout" }) do
+      post requests_path, params: {
+        work_id: metadata[:work_id],
+        source_work_ids: metadata[:source_work_ids],
+        title: metadata[:title],
+        author: metadata[:author],
+        description: description,
+        book_type: "ebook"
+      }
+    end
+
+    assert_redirected_to request_path(Request.last)
+    assert_equal description, Request.last.book.description
+  ensure
+    Rails.cache = original_cache
+  end
+
+  test "legacy request URLs with descriptions redirect to a compact handoff" do
+    get new_request_path, params: {
+      work_id: "openlibrary:OL_LEGACY_HANDOFF_W",
+      title: "Legacy Handoff Book",
+      description: "Long legacy description " * 1_000
+    }
+
+    assert_response :redirect
+    location = CGI.unescapeHTML(response.location)
+    query = Rack::Utils.parse_nested_query(URI.parse(location).query)
+    assert_empty query.keys & %w[title description]
+    assert_equal "openlibrary:OL_LEGACY_HANDOFF_W", query["work_id"]
+    assert_operator location.bytesize, :<, 1.kilobyte
+  end
+
   test "new uses server-authoritative book formats" do
     get new_request_path, params: {
       work_id: "google_books:gb-ebook-only",

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -74,6 +74,48 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "result navigation only encodes bounded identity metadata in URLs" do
+    long_value = "Long provider metadata " * 1_000
+    result = MetadataSearch::Candidate.new(
+      canonical_key: "google_books:gb-long-metadata",
+      title: long_value,
+      author: long_value,
+      year: 2026,
+      description: long_value,
+      cover_url: "https://example.com/#{long_value}",
+      series_name: long_value,
+      series_position: long_value,
+      has_audiobook: nil,
+      has_ebook: true,
+      sources: [
+        {
+          source: "google_books",
+          source_id: "gb-long-metadata",
+          source_name: "Google Books",
+          source_url: nil,
+          work_id: "google_books:gb-long-metadata"
+        }
+      ],
+      editions: [],
+      confidence: 100,
+      collection_source: "hardcover",
+      collection_id: "series-123",
+      collection_title: long_value
+    )
+
+    MetadataService.stub(:search, [ result ]) do
+      get search_results_path, params: { q: "long description" }
+    end
+
+    assert_response :success
+    assert_select "a[href^='#{new_request_path}']", text: "Request" do |links|
+      assert_compact_metadata_url links.first["href"]
+    end
+    assert_select "a[data-turbo-frame='modal']" do |links|
+      links.each { |link| assert_compact_metadata_url(link["href"]) }
+    end
+  end
+
   test "results keep an awaiting purchase work marked as requested" do
     source_id = "OL_SEARCH_AWAITING_PURCHASE"
     ebook = Book.create!(
@@ -571,6 +613,34 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_match "Bella must choose between friendship and love.", response.body
   end
 
+  test "details does not forward descriptions to the request URL" do
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+
+    GoogleBooksClient.stub(:configured?, false) do
+      get search_details_path, params: {
+        modal: "1",
+        work_id: "google_books:gb-long-description",
+        title: "Long title " * 1_000,
+        author: "Long author " * 1_000,
+        cover_url: "https://example.com/#{'long-cover-' * 1_000}",
+        description: "Long description " * 1_000,
+        series: "Long series " * 1_000,
+        collection_title: "Long collection " * 1_000
+      }
+
+      assert_response :redirect
+      assert_compact_metadata_url response.location
+      follow_redirect!
+      assert_response :success
+      assert_select "a[href^='#{new_request_path}']", text: "Request" do |links|
+        assert_compact_metadata_url links.first["href"]
+      end
+    end
+  ensure
+    Rails.cache = original_cache
+  end
+
   test "close_modal returns an empty modal frame" do
     get search_modal_close_path
 
@@ -580,6 +650,18 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def assert_compact_metadata_url(href)
+    decoded_href = CGI.unescapeHTML(href)
+    query = Rack::Utils.parse_nested_query(URI.parse(decoded_href).query)
+    allowed_keys = %w[
+      metadata_token work_id source_work_ids content_kind request_scope
+      collection_source collection_id modal
+    ]
+
+    assert_empty query.keys - allowed_keys
+    assert_operator decoded_href.bytesize, :<, 1.kilobyte
+  end
 
   def metadata_result(source_id:, title:, author:, year:)
     MetadataService::SearchResult.new(

--- a/test/services/book_metadata_lookup_service_test.rb
+++ b/test/services/book_metadata_lookup_service_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BookMetadataLookupServiceTest < ActiveSupport::TestCase
+  test "fills missing primary metadata from alternate source identifiers" do
+    primary = metadata_details(
+      source: "openlibrary",
+      source_id: "OL123W",
+      title: "Primary title",
+      description: nil
+    )
+    alternate = metadata_details(
+      source: "google_books",
+      source_id: "gb-123",
+      title: "Alternate title",
+      description: "Description from the alternate provider"
+    )
+
+    lookup = lambda do |work_id|
+      work_id == "openlibrary:OL123W" ? primary : alternate
+    end
+
+    metadata = MetadataService.stub(:book_details, lookup) do
+      BookMetadataLookupService.call([ "openlibrary:OL123W", "google_books:gb-123" ])
+    end
+
+    assert_equal "Primary title", metadata[:title]
+    assert_equal "Description from the alternate provider", metadata[:description]
+  end
+
+  test "continues with alternate identifiers when the primary lookup fails" do
+    alternate = metadata_details(
+      source: "google_books",
+      source_id: "gb-123",
+      title: "Recovered title",
+      description: "Recovered description"
+    )
+    lookup = lambda do |work_id|
+      raise OpenLibraryClient::ConnectionError, "timeout" if work_id == "openlibrary:OL123W"
+
+      alternate
+    end
+
+    metadata = MetadataService.stub(:book_details, lookup) do
+      BookMetadataLookupService.call([ "openlibrary:OL123W", "google_books:gb-123" ])
+    end
+
+    assert_equal "Recovered title", metadata[:title]
+    assert_equal "Recovered description", metadata[:description]
+  end
+
+  test "skips alternate lookups when primary and fallback metadata are complete" do
+    calls = []
+    primary = metadata_details(
+      source: "openlibrary",
+      source_id: "OL123W",
+      title: "Primary title",
+      description: nil
+    )
+    lookup = lambda do |work_id|
+      calls << work_id
+      primary
+    end
+
+    MetadataService.stub(:book_details, lookup) do
+      BookMetadataLookupService.call(
+        [ "openlibrary:OL123W", "google_books:gb-123" ],
+        fallback: { description: "Cached description" }
+      )
+    end
+
+    assert_equal [ "openlibrary:OL123W" ], calls
+  end
+
+  test "normalizes to one bounded identifier per supported provider" do
+    oversized = "openlibrary:#{'x' * BookMetadataLookupService::MAX_WORK_ID_BYTES}"
+    work_ids = [
+      "OL123W",
+      "openlibrary:OL456W",
+      "google_books:gb-1",
+      "google_books:gb-2",
+      "hardcover:123",
+      "comic_vine:4000-123",
+      "unsupported:123",
+      oversized
+    ]
+
+    assert_equal(
+      [
+        "openlibrary:OL123W",
+        "google_books:gb-1",
+        "hardcover:123",
+        "comic_vine:4000-123"
+      ],
+      BookMetadataLookupService.normalize_work_ids(work_ids)
+    )
+  end
+
+  private
+
+  def metadata_details(source:, source_id:, title:, description:)
+    MetadataService::SearchResult.new(
+      source: source,
+      source_id: source_id,
+      title: title,
+      author: "Example Author",
+      description: description,
+      year: 2026,
+      cover_url: nil,
+      has_audiobook: nil,
+      has_ebook: true,
+      series_name: nil,
+      series_position: nil
+    )
+  end
+end

--- a/test/services/request_creation_service_test.rb
+++ b/test/services/request_creation_service_test.rb
@@ -208,6 +208,73 @@ class RequestCreationServiceTest < ActiveSupport::TestCase
     assert_equal "gb-multi-source", book.google_books_id
   end
 
+  test "backfills description from an alternate candidate source" do
+    primary = MetadataService::SearchResult.new(
+      source: "openlibrary",
+      source_id: "OL_AGGREGATED_W",
+      title: "Aggregated Book",
+      author: nil,
+      description: nil,
+      year: 2026,
+      cover_url: nil,
+      has_audiobook: nil,
+      has_ebook: nil,
+      series_name: nil,
+      series_position: nil
+    )
+    alternate = primary.with(
+      source: "google_books",
+      source_id: "gb-aggregated",
+      description: "Description supplied by the alternate provider"
+    )
+    lookup = lambda do |work_id|
+      work_id == "openlibrary:OL_AGGREGATED_W" ? primary : alternate
+    end
+
+    result = MetadataService.stub(:book_details, lookup) do
+      RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_AGGREGATED_W",
+        source_work_ids: [ "google_books:gb-aggregated" ],
+        book_types: [ "ebook" ],
+        metadata_attrs: { title: "Aggregated Book" }
+      )
+    end
+
+    assert result.success?
+    assert_equal "Description supplied by the alternate provider", result.created_requests.first.book.description
+  end
+
+  test "keeps at most one identifier per supported metadata provider" do
+    result = MetadataService.stub(:book_details, nil) do
+      RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_BOUNDED_W",
+        source_work_ids: [
+          "openlibrary:OL_IGNORED_W",
+          "google_books:gb-first",
+          "google_books:gb-ignored",
+          "hardcover:123",
+          "comic_vine:4000-123",
+          "unsupported:ignored"
+        ],
+        book_types: [ "comicbook" ],
+        metadata_attrs: {
+          title: "Bounded Sources",
+          author: "Bounded Author",
+          description: "Bounded description"
+        }
+      )
+    end
+
+    assert result.success?
+    book = result.created_requests.first.book
+    assert_equal "OL_BOUNDED_W", book.open_library_work_id
+    assert_equal "gb-first", book.google_books_id
+    assert_equal "123", book.hardcover_id
+    assert_equal "4000-123", book.comic_vine_id
+  end
+
   test "persists newly assigned source ids on reused book with complete metadata" do
     book = Book.create!(
       title: "Existing Google Book",

--- a/test/services/request_metadata_handoff_test.rb
+++ b/test/services/request_metadata_handoff_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RequestMetadataHandoffTest < ActiveSupport::TestCase
+  setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+  end
+
+  test "stores full metadata behind compact identity params" do
+    description = "Long description " * 1_000
+    metadata = {
+      work_id: "openlibrary:OL123W",
+      source_work_ids: [ "openlibrary:OL123W", "google_books:gb-123" ],
+      title: "Example Book",
+      author: "Example Author",
+      cover_url: "https://example.com/cover.jpg",
+      description: description,
+      content_kind: "book"
+    }
+
+    params = RequestMetadataHandoff.params_for(user: users(:one), metadata: metadata)
+
+    assert_equal "openlibrary:OL123W", params[:work_id]
+    assert_equal metadata[:source_work_ids], params[:source_work_ids]
+    assert_equal "book", params[:content_kind]
+    assert_match RequestMetadataHandoff::TOKEN_PATTERN, params[:metadata_token]
+    assert_empty params.keys & %i[title author cover_url description]
+    assert_equal metadata, RequestMetadataHandoff.fetch(user: users(:one), token: params[:metadata_token])
+  end
+
+  test "scopes cached metadata to the current user" do
+    params = RequestMetadataHandoff.params_for(
+      user: users(:one),
+      metadata: { work_id: "openlibrary:OL123W", title: "Private handoff" }
+    )
+
+    assert_empty RequestMetadataHandoff.fetch(user: users(:two), token: params[:metadata_token])
+  end
+
+  test "omits oversized identity values from generated params" do
+    oversized_id = "x" * (RequestMetadataHandoff::MAX_IDENTITY_BYTES + 1)
+
+    params = RequestMetadataHandoff.params_for(
+      user: users(:one),
+      metadata: {
+        work_id: "openlibrary:OL123W",
+        source_work_ids: [ oversized_id, "google_books:gb-123" ],
+        collection_id: oversized_id
+      }
+    )
+
+    assert_equal [ "google_books:gb-123" ], params[:source_work_ids]
+    assert_not params.key?(:collection_id)
+  end
+
+  test "rejects malformed tokens without reading arbitrary cache keys" do
+    Rails.cache.write("request_metadata_handoff:v1:#{users(:one).id}:../settings", { title: "Wrong" })
+
+    assert_empty RequestMetadataHandoff.fetch(user: users(:one), token: "../settings")
+  end
+end


### PR DESCRIPTION
## Summary

- keep full aggregated request metadata in a user-scoped server-side handoff while generated URLs carry only bounded identifiers and an opaque token
- canonicalize legacy long request and details URLs, with bounded provider refetch when a handoff expires or is unavailable
- normalize alternate source IDs and use primary-first, selective parallel metadata fallback to avoid unbounded external lookups
- add regression coverage for oversized provider fields, metadata preservation, legacy URLs, cache isolation, and source-ID bounds

## Verification

- `bin/quality push`
- `bin/quality commit --staged`
- targeted suite: 176 tests, 815 assertions
- adversarial subagent review: approved with no remaining findings

Fixes #369