### PR TITLE
feat: add hardlink import mode

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -509,9 +509,17 @@ module Admin
     end
 
     def validate_setting_value(key, value)
-      validate_path_template(key, value) ||
+      validate_completed_download_import_mode(key, value) ||
+        validate_path_template(key, value) ||
         validate_indexer_url(key, value) ||
         validate_ebooks_com_setting(key, value)
+    end
+
+    def validate_completed_download_import_mode(key, value)
+      return nil unless key.to_s == "completed_download_import_mode"
+      return nil if SettingsService::COMPLETED_DOWNLOAD_IMPORT_MODES.include?(value.to_s)
+
+      "must be one of: #{SettingsService::COMPLETED_DOWNLOAD_IMPORT_MODES.join(', ')}"
     end
 
     def validate_path_template(key, value)

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -31,6 +31,9 @@ class PostProcessingJob < ApplicationJob
   private
 
   def perform_privately(download_id, source_path_retry_count, expected_owner_job_id)
+    @hardlinked_file_count = 0
+    @hardlink_fallback_copied_count = 0
+    @reused_file_count = 0
     download = Download.find_by(id: download_id)
     return unless download&.completed?
 
@@ -415,7 +418,11 @@ class PostProcessingJob < ApplicationJob
     @imported_book_path_override = nil
     @import_base_path = Pathname(base_path || get_base_path(book)).expand_path
     @defer_source_removal = directory_source && move_completed_downloads?
-    action = move_completed_downloads? ? "Moving" : "Copying"
+    action = {
+      "copy" => "Copying",
+      "move" => "Moving",
+      "hardlink" => "Hardlinking"
+    }.fetch(completed_download_import_mode, "Copying")
     Rails.logger.info "[PostProcessingJob] #{action} library content"
     validate_ebook_source!(source) if readable_file_import?(book)
     source_cleanup = nil
@@ -433,7 +440,16 @@ class PostProcessingJob < ApplicationJob
       import_renamed_file(source, destination, book)
     end
 
-    Rails.logger.info "[PostProcessingJob] #{action} completed successfully"
+    if hardlink_completed_downloads?
+      Rails.logger.info(
+        "[PostProcessingJob] Hardlink import completed successfully: " \
+          "#{@hardlinked_file_count} hardlinked, " \
+          "#{@hardlink_fallback_copied_count} copied after unsupported fallback, " \
+          "#{@reused_file_count} reused"
+      )
+    else
+      Rails.logger.info "[PostProcessingJob] #{action} completed successfully"
+    end
     source_cleanup
   ensure
     remove_instance_variable(:@defer_source_removal) if instance_variable_defined?(:@defer_source_removal)
@@ -639,6 +655,28 @@ class PostProcessingJob < ApplicationJob
         root: @import_base_path,
         source_root: @import_source_root
       )
+    elsif hardlink_completed_downloads?
+      begin
+        FileCopyService.hardlink_noreplace(
+          source,
+          destination,
+          root: @import_base_path,
+          source_root: @import_source_root
+        )
+        @hardlinked_file_count += 1
+      rescue FileCopyService::HardlinkUnsupportedError
+        Rails.logger.warn(
+          "[PostProcessingJob] Hardlink unavailable for one file; falling back to a retained-source copy"
+        )
+        FileCopyService.cp_noreplace(
+          source,
+          destination,
+          root: @import_base_path,
+          source_root: @import_source_root,
+          hardlink_mode: true
+        )
+        @hardlink_fallback_copied_count += 1
+      end
     else
       FileCopyService.cp_noreplace(
         source,
@@ -660,7 +698,11 @@ class PostProcessingJob < ApplicationJob
     loop do
       destination, already_imported = retry_safe_destination(source, original_destination)
       if already_imported
-        FileCopyService.secure_library_file!(destination, root: @import_base_path)
+        if hardlink_completed_downloads?
+          @reused_file_count += 1
+        else
+          FileCopyService.secure_library_file!(destination, root: @import_base_path)
+        end
         record_imported_source!(source)
         Rails.logger.info "[PostProcessingJob] Reusing one identical previously imported file"
         return destination
@@ -684,7 +726,24 @@ class PostProcessingJob < ApplicationJob
       break unless path_occupied?(candidate)
 
       if !File.symlink?(candidate) && same_file_content?(source, candidate)
-        return [ candidate, true ]
+        unless hardlink_completed_downloads?
+          return [ candidate, true ]
+        end
+
+        same_source_inode = FileCopyService.same_file_identity?(
+          source,
+          candidate,
+          root: @import_base_path,
+          source_root: @import_source_root,
+          hardlink_mode: true
+        )
+        prior_fallback_copy = FileCopyService.secure_library_file_mode?(
+          candidate,
+          root: @import_base_path
+        )
+        if same_source_inode || prior_fallback_copy
+          return [ candidate, true ]
+        end
       end
 
       counter += 1
@@ -699,7 +758,8 @@ class PostProcessingJob < ApplicationJob
       source,
       destination,
       root: @import_base_path,
-      source_root: @import_source_root
+      source_root: @import_source_root,
+      hardlink_mode: hardlink_completed_downloads?
     )
   end
 
@@ -729,9 +789,20 @@ class PostProcessingJob < ApplicationJob
   end
 
   def move_completed_downloads?
-    return @move_completed_downloads if defined?(@move_completed_downloads)
+    completed_download_import_mode == "move"
+  end
 
-    @move_completed_downloads = SettingsService.get(:move_completed_downloads, default: false)
+  def hardlink_completed_downloads?
+    completed_download_import_mode == "hardlink"
+  end
+
+  def completed_download_import_mode
+    return @completed_download_import_mode if defined?(@completed_download_import_mode)
+
+    @completed_download_import_mode = SettingsService.get(
+      :completed_download_import_mode,
+      default: "copy"
+    ).to_s
   end
 
   def remove_import_source(source_cleanup)

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -17,14 +17,22 @@ class FileCopyService
   BUFFER_SIZE = 1024 * 1024 # 1 MB
   LIBRARY_FILE_MODE = 0o640
   DIRECTORY_MODE = 0o750
-  COPY_LOCK_MAGIC = "shelfarr-copy-v1"
+  COPY_LOCK_LEGACY_MAGIC = "shelfarr-copy-v1"
+  COPY_LOCK_MAGIC = "shelfarr-copy-v2"
   COPY_LOCK_PATTERN = /\A\.shelfarr-copy-([0-9a-f]{32})\.lock\z/
+  COPY_LOCK_LEGACY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_LEGACY_MAGIC)}:([0-9a-f]{32})\z/
+  COPY_LOCK_PENDING_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):pending\z/
+  COPY_LOCK_RECORD_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):full:([0-9]+):([0-9]+)\z/
+  COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
+  COPY_QUARANTINE_ENTRY = "entry"
+  COPY_QUARANTINE_STALE_AGE = 24 * 60 * 60
   LINUX_RENAME_NOREPLACE = 0x1
   DARWIN_RENAME_EXCL = 0x4
   AT_REMOVEDIR = RUBY_PLATFORM.include?("darwin") ? 0x80 : 0x200
 
   class UnsafePathError < StandardError; end
   class AtomicPublicationUnsupportedError < StandardError; end
+  class HardlinkUnsupportedError < StandardError; end
   SourceRoot = Struct.new(
     :path,
     :canonical_path,
@@ -67,9 +75,29 @@ class FileCopyService
     # destination directory, then published with an atomic no-replace link (or
     # platform no-replace rename). Every destination component is opened from
     # a pinned root descriptor with O_NOFOLLOW.
-    def cp_noreplace(src, dest, root: nil, source_root: nil, heartbeat: nil)
-      with_pinned_source(src, source_root: source_root) do |source, _source_parent, _source_basename, _source_parent_path|
+    def cp_noreplace(src, dest, root: nil, source_root: nil, heartbeat: nil, hardlink_mode: false)
+      source_opener = hardlink_mode ? :with_pinned_hardlink_source : :with_pinned_source
+      send(source_opener, src, source_root: source_root) do |source, *_source_path|
         publish_source_io_noreplace(source, dest, root: root, heartbeat: heartbeat)
+      end
+      dest
+    end
+
+    # Hardlink a regular source without exposing a pathname selected by a
+    # source race. The source name is first linked to a private destination
+    # entry, which must match the already-open source descriptor before the
+    # existing no-replace publication protocol can make it final.
+    def hardlink_noreplace(src, dest, root:, source_root:)
+      with_pinned_hardlink_source(src, source_root: source_root) do |source, source_parent, source_basename, source_parent_path, source_manifest|
+        publish_hardlink_noreplace(
+          source,
+          source_parent,
+          source_basename,
+          source_parent_path,
+          source_manifest,
+          dest,
+          root: root
+        )
       end
       dest
     end
@@ -681,10 +709,67 @@ class FileCopyService
     # Compare regular files through pinned descriptors. This is used by retry
     # reconciliation so a path swap cannot trick an import into reusing an
     # unrelated library file.
-    def same_file_content?(source_path, destination_path, root: nil, source_root: nil)
-      with_pinned_source(source_path, source_root: source_root) do |source, _source_parent, _source_basename, _source_parent_path|
-        return same_io_content?(source, destination_path, root: root)
+    def same_file_content?(source_path, destination_path, root: nil, source_root: nil, hardlink_mode: false)
+      source_opener = hardlink_mode ? :with_pinned_hardlink_source : :with_pinned_source
+      result = nil
+      send(source_opener, source_path, source_root: source_root) do |source, *_source_path|
+        result = same_io_content?(source, destination_path, root: root)
       end
+      result
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+      false
+    end
+
+    # Compare regular-file identities through pinned source and destination
+    # descriptors. This distinguishes a reused hardlink from an independent
+    # file with identical content without trusting either pathname alone.
+    def same_file_identity?(source_path, destination_path, root:, source_root:, hardlink_mode: false)
+      source_opener = hardlink_mode ? :with_pinned_hardlink_source : :with_pinned_source
+      result = nil
+      send(source_opener, source_path, source_root: source_root) do |source, *_source_path|
+        source_identity = file_identity(source.stat)
+        with_pinned_destination_parent(destination_path, root: root) do |parent, basename, parent_path|
+          destination_identity = nil
+          with_pinned_regular_child(parent, basename) do |destination|
+            destination_identity = file_identity(destination.stat)
+          end
+          with_pinned_regular_child(parent, basename) do |current|
+            unless file_identity(current.stat) == destination_identity
+              raise Errno::ESTALE, "destination changed during identity validation"
+            end
+          end
+          validate_current_directory_identity!(parent_path, parent)
+          result = source_identity == destination_identity
+        end
+      end
+      result
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+      false
+    end
+
+    # Check retry eligibility without chmodding a path that may be a hardlink
+    # to retained download data. The pathname is reopened before returning so
+    # a replacement cannot inherit the first descriptor's result.
+    def secure_library_file_mode?(path, root:)
+      result = false
+      with_pinned_destination_parent(path, root: root) do |parent, basename, parent_path|
+        expected_identity = nil
+        expected_mode = nil
+        with_pinned_regular_child(parent, basename) do |file|
+          stat = file.stat
+          expected_identity = file_identity(stat)
+          expected_mode = stat.mode & 0o7777
+          result = expected_mode == LIBRARY_FILE_MODE
+        end
+        with_pinned_regular_child(parent, basename) do |current|
+          stat = current.stat
+          unless file_identity(stat) == expected_identity && (stat.mode & 0o7777) == expected_mode
+            raise Errno::ESTALE, "library file changed during mode validation"
+          end
+        end
+        validate_current_directory_identity!(parent_path, parent)
+      end
+      result
     rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
       false
     end
@@ -837,10 +922,15 @@ class FileCopyService
       with_pinned_destination_parent(destination, root: root) do |parent, _basename, parent_path|
         validate_current_directory_identity!(parent_path, parent)
         Dir.children(parent_path).each do |entry|
-          match = COPY_LOCK_PATTERN.match(entry)
-          next unless match
-
-          cleanup_interrupted_copy(parent, match[1])
+          if (match = COPY_LOCK_PATTERN.match(entry))
+            cleanup_interrupted_copy(parent, match[1])
+          elsif (match = COPY_QUARANTINE_PATTERN.match(entry))
+            cleanup_interrupted_quarantine(
+              parent,
+              entry,
+              [ match[1].to_i(16), match[2].to_i(16) ]
+            )
+          end
         end
         validate_current_directory_identity!(parent_path, parent)
       end
@@ -918,12 +1008,13 @@ class FileCopyService
             lock_identity = file_identity(lock.stat)
             raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
 
-            lock.write("#{COPY_LOCK_MAGIC}:#{token}")
-            flush_and_sync(lock)
             sync_io(parent)
+            persist_copy_lock_pending!(lock, token)
 
             with_created_regular_child(parent, temporary_basename, 0o600) do |temporary|
               temporary_identity = file_identity(temporary.stat)
+              persist_copy_lock_identity!(lock, token, temporary_identity)
+              sync_io(parent)
               if heartbeat
                 copy_source_io(source, temporary, heartbeat: heartbeat)
               else
@@ -950,9 +1041,142 @@ class FileCopyService
           # otherwise delete a replacement installed by another worker.
           raise
         ensure
-          remove_pinned_child_if_identity(parent, temporary_basename, temporary_identity)
-          remove_pinned_child_if_identity(parent, lock_basename, lock_identity)
+          temporary_cleanup = remove_pinned_child_if_identity(
+            parent,
+            temporary_basename,
+            temporary_identity
+          )
+          if temporary_cleanup.in?([ :removed, :missing ])
+            remove_pinned_child_if_identity(parent, lock_basename, lock_identity)
+          end
           sync_io(parent)
+        end
+      end
+    end
+
+    def publish_hardlink_noreplace(
+      source,
+      source_parent,
+      source_basename,
+      source_parent_path,
+      source_manifest,
+      destination,
+      root:
+    )
+      source_identity = source_manifest.first(2)
+      expected_stable_manifest = stable_hardlink_snapshot_entry(source_manifest)
+      source_mode = expected_stable_manifest.last
+
+      cleanup_interrupted_copies(File.dirname(destination), root: root)
+      with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
+        token = SecureRandom.hex(16)
+        temporary_basename = ".shelfarr-copy-#{token}.tmp"
+        lock_basename = ".shelfarr-copy-#{token}.lock"
+        temporary_identity = nil
+        lock_identity = nil
+
+        begin
+          with_created_regular_child(parent, lock_basename, 0o600) do |lock|
+            lock_identity = file_identity(lock.stat)
+            raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
+
+            sync_io(parent)
+
+            validate_hardlink_source!(
+              source,
+              source_parent,
+              source_basename,
+              source_parent_path,
+              source_manifest
+            )
+            persist_copy_lock_identity!(lock, token, source_identity)
+            begin
+              native_linkat(
+                source_parent.fileno,
+                source_basename,
+                parent.fileno,
+                temporary_basename
+              )
+              temporary_identity = source_identity
+            rescue Errno::EXDEV, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP,
+                Errno::ENOSYS, Errno::EMLINK, Fiddle::DLError, NotImplementedError => error
+              raise HardlinkUnsupportedError,
+                "The source and destination filesystems cannot create the requested hardlink",
+                cause: error
+            end
+
+            with_pinned_regular_child(parent, temporary_basename) do |temporary|
+              temporary_stat = temporary.stat
+              unless file_identity(temporary_stat) == temporary_identity &&
+                  stable_hardlink_manifest_entry(temporary_stat) == expected_stable_manifest
+                raise Errno::ESTALE, "private hardlink does not match the pinned source"
+              end
+            end
+            sync_io(parent)
+
+            validate_hardlink_source!(
+              source,
+              source_parent,
+              source_basename,
+              source_parent_path,
+              source_manifest
+            )
+            validate_current_directory_identity!(parent_path, parent)
+
+            publish_private_child_noreplace!(
+              parent,
+              temporary_basename,
+              basename,
+              temporary_identity,
+              mode: source_mode
+            )
+            validate_published_child!(
+              parent,
+              basename,
+              source_identity,
+              expected_mode: source_mode,
+              expected_manifest: source_manifest
+            )
+            validate_hardlink_source!(
+              source,
+              source_parent,
+              source_basename,
+              source_parent_path,
+              source_manifest
+            )
+            validate_current_directory_identity!(parent_path, parent)
+            sync_io(parent)
+          end
+        ensure
+          temporary_cleanup = remove_pinned_child_if_identity(
+            parent,
+            temporary_basename,
+            temporary_identity
+          )
+          if temporary_cleanup.in?([ :removed, :missing ])
+            remove_pinned_child_if_identity(parent, lock_basename, lock_identity)
+          end
+          sync_io(parent)
+        end
+      end
+    end
+
+    def validate_hardlink_source!(
+      source,
+      parent,
+      basename,
+      parent_path,
+      expected_manifest
+    )
+      expected = stable_hardlink_snapshot_entry(expected_manifest)
+      unless stable_hardlink_manifest_entry(source.stat) == expected
+        raise Errno::ESTALE, "source file changed during hardlink publication"
+      end
+
+      validate_current_directory_identity!(parent_path, parent)
+      with_pinned_regular_child(parent, basename) do |current|
+        unless stable_hardlink_manifest_entry(current.stat) == expected
+          raise Errno::ESTALE, "source path changed during hardlink publication"
         end
       end
     end
@@ -988,7 +1212,8 @@ class FileCopyService
         parent.fileno,
         destination_basename
       )
-    rescue Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS
+    rescue Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS, Errno::EMLINK,
+        Fiddle::DLError, NotImplementedError
       result = native_rename_noreplace(
         parent.fileno,
         temporary_basename,
@@ -1003,13 +1228,24 @@ class FileCopyService
       validate_published_child!(parent, destination_basename, identity, expected_mode: mode)
     end
 
-    def validate_published_child!(parent, basename, expected_identity, expected_mode: LIBRARY_FILE_MODE)
+    def validate_published_child!(
+      parent,
+      basename,
+      expected_identity,
+      expected_mode: LIBRARY_FILE_MODE,
+      expected_manifest: nil
+    )
       with_pinned_regular_child(parent, basename) do |published|
-        unless file_identity(published.stat) == expected_identity
+        stat = published.stat
+        unless file_identity(stat) == expected_identity
           raise Errno::ESTALE, "destination changed during no-clobber publication"
         end
-        unless (published.stat.mode & 0o777) == expected_mode
+        unless (stat.mode & 0o7777) == expected_mode
           raise UnsafePathError, "published library file permissions changed"
+        end
+        if expected_manifest &&
+            stable_hardlink_manifest_entry(stat) != stable_hardlink_snapshot_entry(expected_manifest)
+          raise Errno::ESTALE, "published hardlink changed during no-clobber publication"
         end
       end
     end
@@ -1042,14 +1278,113 @@ class FileCopyService
 
         lock_identity = file_identity(lock.stat)
         lock.rewind
-        return unless lock.read == "#{COPY_LOCK_MAGIC}:#{token}"
+        state, expected_temporary_identity = copy_lock_cleanup_state(lock.read, token)
+        cleanup_result = case state
+        when :full
+          remove_pinned_child_if_identity(
+            parent,
+            temporary_basename,
+            expected_temporary_identity
+          )
+        when :pending, :legacy
+          remove_pinned_regular_child(parent, temporary_basename)
+        else
+          pinned_child_missing?(parent, temporary_basename) ? :missing : :retained
+        end
+        return unless cleanup_result.in?([ :removed, :missing ])
 
-        remove_pinned_regular_child(parent, temporary_basename)
         remove_pinned_child_if_identity(parent, lock_basename, lock_identity)
         sync_io(parent)
       end
     rescue Errno::ENOENT, Errno::EACCES, Errno::EWOULDBLOCK, IOError
       nil
+    end
+
+    def cleanup_interrupted_quarantine(parent, basename, expected_identity)
+      quarantine = open_pinned_directory_child(parent, basename)
+      begin
+        stat = quarantine.stat
+        return unless stat.uid == Process.euid && (stat.mode & 0o777) == 0o700
+
+        quarantine_identity = file_identity(stat)
+        children = pinned_directory_children(quarantine)
+        if children.empty?
+          return if stat.mtime > Time.now - COPY_QUARANTINE_STALE_AGE
+
+          remove_empty_cleanup_quarantine!(
+            parent,
+            basename,
+            quarantine,
+            quarantine_identity
+          )
+          return
+        end
+        return unless children == [ COPY_QUARANTINE_ENTRY ]
+
+        with_pinned_regular_child(quarantine, COPY_QUARANTINE_ENTRY) do |entry|
+          return unless file_identity(entry.stat) == expected_identity
+
+          native_unlinkat(quarantine.fileno, COPY_QUARANTINE_ENTRY)
+        end
+        sync_io(quarantine)
+
+        remove_empty_cleanup_quarantine!(
+          parent,
+          basename,
+          quarantine,
+          quarantine_identity
+        )
+      ensure
+        quarantine.close unless quarantine.closed?
+      end
+    rescue Errno::ENOENT, Errno::ELOOP, UnsafePathError
+      nil
+    end
+
+    def persist_copy_lock_pending!(lock, token)
+      persist_copy_lock_record!(lock, "#{COPY_LOCK_MAGIC}:#{token}:pending")
+    end
+
+    def persist_copy_lock_identity!(lock, token, identity)
+      persist_copy_lock_record!(
+        lock,
+        "#{COPY_LOCK_MAGIC}:#{token}:full:#{identity.first}:#{identity.last}"
+      )
+    end
+
+    def persist_copy_lock_record!(lock, record)
+      lock.rewind
+      lock.truncate(0)
+      lock.write(record)
+      flush_and_sync(lock)
+    end
+
+    def copy_lock_cleanup_state(contents, token)
+      if (record = COPY_LOCK_RECORD_PATTERN.match(contents)) && record[1] == token
+        [ :full, [ record[2].to_i, record[3].to_i ] ]
+      elsif (record = COPY_LOCK_PENDING_PATTERN.match(contents)) && record[1] == token
+        [ :pending, nil ]
+      elsif (record = COPY_LOCK_LEGACY_PATTERN.match(contents)) && record[1] == token
+        [ :legacy, nil ]
+      else
+        [ :malformed, nil ]
+      end
+    end
+
+    def pinned_child_missing?(parent, basename)
+      descriptor = native_openat(
+        parent.fileno,
+        basename,
+        File::RDONLY | File::NOFOLLOW | File::NONBLOCK,
+        0
+      )
+      child = IO.new(descriptor, "rb", autoclose: true)
+      child.close
+      false
+    rescue Errno::ENOENT
+      true
+    rescue Errno::EACCES, Errno::ELOOP, Errno::ENOTDIR
+      false
     end
 
     def compare_io(left, right)
@@ -1075,6 +1410,71 @@ class FileCopyService
         end
       end
     rescue Errno::ELOOP, Errno::ENOTDIR => error
+      raise UnsafePathError, "source path contains a symbolic link or non-directory: #{error.message}"
+    end
+
+    def with_pinned_hardlink_source(path, source_root:)
+      expanded = Pathname(path).expand_path
+      if source_root
+        return with_pinned_hardlink_source_root(expanded, source_root) { |*values| yield(*values) }
+      end
+
+      canonical_parent = expanded.parent.realpath
+      with_pinned_absolute_directory(canonical_parent) do |parent|
+        validate_current_directory_identity!(expanded.parent, parent)
+        with_pinned_regular_child(parent, expanded.basename.to_s) do |source|
+          manifest = file_manifest_entry(source.stat)
+          result = yield source, parent, expanded.basename.to_s, expanded.parent, manifest
+          unless stable_hardlink_manifest_entry(source.stat) == stable_hardlink_snapshot_entry(manifest)
+            raise Errno::ESTALE, "source file changed while it was being hardlinked"
+          end
+          result
+        end
+      end
+    rescue Errno::ELOOP, Errno::ENOTDIR => error
+      raise UnsafePathError, "source path contains a symbolic link or non-directory: #{error.message}"
+    end
+
+    def with_pinned_hardlink_source_root(expanded, source_root)
+      relative = expanded.relative_path_from(source_root.path)
+      if relative.to_s == ".." || relative.to_s.start_with?("..#{File::SEPARATOR}") || relative.to_s == "."
+        raise UnsafePathError, "source file is outside the snapshotted download tree"
+      end
+
+      with_pinned_absolute_directory(source_root.canonical_path) do |root|
+        unless file_identity(root.stat) == [ source_root.device, source_root.inode ]
+          raise Errno::ESTALE, "source root identity changed during import"
+        end
+        validate_current_directory_identity!(source_root.path, root)
+
+        with_pinned_relative_directory(root, relative.dirname, create: false) do |parent|
+          parent_path = source_root.path.join(relative.dirname)
+          validate_current_directory_identity!(parent_path, parent)
+          expected_parent = if relative.dirname.to_s == "."
+            [ source_root.device, source_root.inode, :directory ]
+          else
+            source_root.entries[relative.dirname.to_s]
+          end
+          unless expected_parent && expected_parent.first(2) == file_identity(parent.stat) &&
+              expected_parent[2] == :directory
+            raise Errno::ESTALE, "source directory changed after it was snapshotted"
+          end
+
+          with_pinned_regular_child(parent, relative.basename.to_s) do |source|
+            expected_source = source_root.entries[relative.to_s]
+            unless expected_source &&
+                stable_hardlink_snapshot_entry(expected_source) == stable_hardlink_manifest_entry(source.stat)
+              raise Errno::ESTALE, "source file changed after it was snapshotted"
+            end
+            result = yield source, parent, relative.basename.to_s, parent_path, expected_source
+            unless stable_hardlink_manifest_entry(source.stat) == stable_hardlink_snapshot_entry(expected_source)
+              raise Errno::ESTALE, "source file changed while it was being hardlinked"
+            end
+            result
+          end
+        end
+      end
+    rescue ArgumentError, Errno::ELOOP, Errno::ENOTDIR => error
       raise UnsafePathError, "source path contains a symbolic link or non-directory: #{error.message}"
     end
 
@@ -1327,7 +1727,15 @@ class FileCopyService
     end
 
     def file_manifest_entry(stat)
-      [ stat.dev, stat.ino, :file, stat.size, stat.mtime.to_r, stat.ctime.to_r ]
+      [ stat.dev, stat.ino, :file, stat.size, stat.mtime.to_r, stat.ctime.to_r, stat.mode & 0o7777 ]
+    end
+
+    def stable_hardlink_manifest_entry(stat)
+      [ stat.dev, stat.ino, :file, stat.size, stat.mtime.to_r, stat.mode & 0o7777 ]
+    end
+
+    def stable_hardlink_snapshot_entry(manifest)
+      [ *manifest.first(5), manifest.fetch(6) ]
     end
 
     def pinned_child_identity(parent, basename, directory: false)
@@ -1502,7 +1910,7 @@ class FileCopyService
 
     def validate_current_directory_identity!(path, pinned_directory)
       current = File.lstat(Pathname(path).realpath)
-      unless current.directory? && same_file_identity?(current, pinned_directory.stat)
+      unless current.directory? && same_stat_identity?(current, pinned_directory.stat)
         raise Errno::ESTALE, "destination directory changed during publication"
       end
       true
@@ -1511,21 +1919,139 @@ class FileCopyService
     end
 
     def remove_pinned_child_if_identity(parent, basename, expected_identity)
-      return unless expected_identity
+      return :mismatch unless expected_identity
 
-      with_pinned_regular_child(parent, basename) do |child|
-        return unless file_identity(child.stat) == expected_identity
+      begin
+        with_pinned_regular_child(parent, basename) do |child|
+          return :mismatch unless file_identity(child.stat) == expected_identity
+        end
+      rescue Errno::ENOENT
+        return :missing
+      rescue Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+        return :retained
       end
-      native_unlinkat(parent.fileno, basename)
-    rescue Errno::ENOENT, UnsafePathError
-      nil
+
+      quarantine, quarantine_basename, quarantine_identity = create_cleanup_quarantine(
+        parent,
+        expected_identity
+      )
+      moved = false
+      begin
+        native_renameat(
+          parent.fileno,
+          basename,
+          quarantine.fileno,
+          COPY_QUARANTINE_ENTRY
+        )
+        moved = true
+        sync_io(quarantine)
+        sync_io(parent)
+
+        quarantined_identity = nil
+        result = begin
+          removal_result = with_pinned_regular_child(quarantine, COPY_QUARANTINE_ENTRY) do |child|
+            quarantined_identity = file_identity(child.stat)
+            if quarantined_identity == expected_identity
+              native_unlinkat(quarantine.fileno, COPY_QUARANTINE_ENTRY)
+              :removed
+            end
+          end
+          removal_result || :retained
+        rescue Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+          :retained
+        end
+        if quarantined_identity && quarantined_identity != expected_identity
+          restore_quarantined_child!(quarantine, parent, basename)
+          result = :mismatch
+        end
+        sync_io(quarantine)
+        remove_empty_cleanup_quarantine!(
+          parent,
+          quarantine_basename,
+          quarantine,
+          quarantine_identity
+        )
+        result
+      rescue Errno::ENOENT
+        moved ? :retained : :missing
+      ensure
+        unless moved
+          remove_empty_cleanup_quarantine!(
+            parent,
+            quarantine_basename,
+            quarantine,
+            quarantine_identity
+          )
+        end
+        quarantine.close unless quarantine.closed?
+      end
+    rescue Errno::ENOENT
+      :missing
     end
 
     def remove_pinned_regular_child(parent, basename)
-      with_pinned_regular_child(parent, basename) { |_child| nil }
-      native_unlinkat(parent.fileno, basename)
+      identity = nil
+      with_pinned_regular_child(parent, basename) do |child|
+        identity = file_identity(child.stat)
+      end
+      remove_pinned_child_if_identity(parent, basename, identity)
+    rescue Errno::ENOENT
+      :missing
+    rescue Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+      :retained
+    end
+
+    def create_cleanup_quarantine(parent, expected_identity)
+      loop do
+        basename = ".shelfarr-copy-quarantine-#{expected_identity.first.to_s(16)}-" \
+          "#{expected_identity.last.to_s(16)}-#{SecureRandom.hex(16)}"
+        begin
+          native_mkdirat(parent.fileno, basename, 0o700)
+        rescue Errno::EEXIST
+          next
+        end
+
+        quarantine = open_pinned_directory_child(parent, basename)
+        begin
+          stat = quarantine.stat
+          unless stat.uid == Process.euid
+            raise UnsafePathError, "cleanup quarantine is owned by another user"
+          end
+
+          native_fchmod(quarantine.fileno, 0o700)
+          sync_io(quarantine)
+          sync_io(parent)
+          return [ quarantine, basename, file_identity(stat) ]
+        rescue
+          quarantine.close unless quarantine.closed?
+          raise
+        end
+      end
+    end
+
+    def restore_quarantined_child!(quarantine, parent, basename)
+      restored = native_rename_noreplace(
+        quarantine.fileno,
+        COPY_QUARANTINE_ENTRY,
+        parent.fileno,
+        basename
+      )
+      return if restored
+
+      raise UnsafePathError, "mismatched cleanup entry was retained in quarantine"
+    rescue Errno::EEXIST
+      raise UnsafePathError, "mismatched cleanup entry was retained because its original path is occupied"
+    end
+
+    def remove_empty_cleanup_quarantine!(parent, basename, quarantine, expected_identity)
+      return false unless pinned_directory_children(quarantine).empty?
+      return false unless pinned_child_identity(parent, basename, directory: true) == expected_identity
+
+      native_unlinkat(parent.fileno, basename, AT_REMOVEDIR)
+      sync_io(parent)
+      true
     rescue Errno::ENOENT, UnsafePathError
-      nil
+      false
     end
 
     def native_openat(directory_fd, basename, flags, mode)
@@ -1599,6 +2125,19 @@ class FileCopyService
       )
     end
 
+    def native_renameat(source_fd, source_basename, destination_fd, destination_basename)
+      call_native_function(
+        native_function(
+          :renameat,
+          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ]
+        ),
+        source_fd,
+        source_basename,
+        destination_fd,
+        destination_basename
+      )
+    end
+
     def native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
       function, arguments = if RUBY_PLATFORM.include?("darwin")
         [
@@ -1655,7 +2194,7 @@ class FileCopyService
       nil
     end
 
-    def same_file_identity?(left, right)
+    def same_stat_identity?(left, right)
       left.dev == right.dev && left.ino == right.ino
     end
 

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -4,6 +4,7 @@ class SettingsService
   ENV_OVERRIDE_PREFIX = "SHELFARR_SETTING_"
 
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
+  COMPLETED_DOWNLOAD_IMPORT_MODES = %w[copy move hardlink].freeze
   LIBRARY_PLATFORMS = %w[audiobookshelf bookorbit grimmory].freeze
   INDEXER_SEARCH_SCOPES = %w[broad strict unrestricted custom].freeze
   INDEXER_SEARCH_SCOPE_OPTIONS = {
@@ -67,7 +68,7 @@ class SettingsService
     download_check_interval: { type: "integer", default: 60, category: "download", description: "Seconds between download status checks" },
     download_enqueue_timeout_minutes: { type: "integer", default: 5, category: "download", description: "Minutes a download may stay queued in Shelfarr before being flagged as never dispatched to the download client" },
     post_processing_source_path_retries: { type: "integer", default: 10, category: "download", description: "Number of post-processing retries while waiting for completed download files to appear" },
-    move_completed_downloads: { type: "boolean", default: false, category: "download", description: "Move completed download files into the library instead of copying them. Disable to preserve torrent seeding." },
+    completed_download_import_mode: { type: "string", default: "copy", category: "download", description: "Choose Copy, Move, or Hardlink. Hardlink requires one container-visible filesystem; unsupported or cross-filesystem links fall back to copy." },
     split_audiobook_bundle_imports: { type: "boolean", default: false, category: "download", description: "Split releases containing multiple self-contained M4B/AAX books into per-book folders. MP3, FLAC, and other chapter-based releases stay together." },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
@@ -318,6 +319,9 @@ class SettingsService
       return preferred_download_types if key == :preferred_download_types
 
       value = raw_setting_value(key)
+      if key == :completed_download_import_mode
+        return COMPLETED_DOWNLOAD_IMPORT_MODES.include?(value) ? value : "copy"
+      end
       return value unless value.nil?
 
       definition = DEFINITIONS[key]
@@ -330,6 +334,13 @@ class SettingsService
       definition = DEFINITIONS[key]
 
       raise ArgumentError, "Unknown setting: #{key}" unless definition
+
+      if key == :completed_download_import_mode
+        value = value.to_s
+        unless COMPLETED_DOWNLOAD_IMPORT_MODES.include?(value)
+          raise ArgumentError, "#{label_for(key)} must be one of: #{COMPLETED_DOWNLOAD_IMPORT_MODES.join(', ')}"
+        end
+      end
 
       Setting.transaction do
         setting = Setting.find_or_initialize_by(key: key.to_s)

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -110,7 +110,16 @@
                         <%= form.text_field "settings[#{key}]", value: data[:value].is_a?(Array) ? data[:value].join(', ') : data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <p class="mt-1 text-xs text-gray-500">For multiple values, use comma-separated format (e.g., en, fr, de)</p>
                       <% else %>
-                        <% if key.to_s == "library_platform" %>
+                        <% if key.to_s == "completed_download_import_mode" %>
+                          <% import_mode_options = SettingsService::COMPLETED_DOWNLOAD_IMPORT_MODES.map { |mode| [mode.titleize, mode] } %>
+                          <%= form.select "settings[#{key}]", options_for_select(import_mode_options, data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <div class="mt-2 space-y-1 text-xs text-gray-500">
+                            <p><strong class="text-gray-400">Copy:</strong> Retains the source and uses extra disk space.</p>
+                            <p><strong class="text-gray-400">Move:</strong> Removes the source and can stop torrent seeding.</p>
+                            <p><strong class="text-gray-400">Hardlink:</strong> Retains the source without duplicate data; unsupported or cross-filesystem links fall back to copy.</p>
+                            <p>Hardlinked names share content, ownership, and permissions; edits through either name affect both.</p>
+                          </div>
+                        <% elsif key.to_s == "library_platform" %>
                           <%= form.select "settings[#{key}]", options_for_select([["Audiobookshelf", "audiobookshelf"], ["BookOrbit", "bookorbit"], ["Grimmory", "grimmory"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s.end_with?("_library_id") && @audiobookshelf_libraries.any? %>
                           <% library_options = @audiobookshelf_libraries.map { |lib| ["#{lib.name} (#{lib.media_type})", lib.id] } %>

--- a/db/migrate/20260721120000_migrate_completed_download_import_mode.rb
+++ b/db/migrate/20260721120000_migrate_completed_download_import_mode.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class MigrateCompletedDownloadImportMode < ActiveRecord::Migration[8.1]
+  class MigrationSetting < ActiveRecord::Base
+    self.table_name = "settings"
+  end
+
+  OLD_KEY = "move_completed_downloads"
+  NEW_KEY = "completed_download_import_mode"
+  VALID_MODES = %w[copy move hardlink].freeze
+  LEGACY_BOOLEAN_TYPE = ActiveModel::Type::Boolean.new
+  DESCRIPTION = "Choose Copy, Move, or Hardlink. Hardlink requires one container-visible filesystem; unsupported or cross-filesystem links fall back to copy."
+
+  def up
+    return unless table_exists?(:settings)
+
+    legacy_setting = MigrationSetting.find_by(key: OLD_KEY)
+    import_mode_setting = MigrationSetting.find_or_initialize_by(key: NEW_KEY)
+    import_mode = if import_mode_setting.persisted? && VALID_MODES.include?(import_mode_setting.value)
+      import_mode_setting.value
+    elsif legacy_true?(legacy_setting&.value)
+      "move"
+    else
+      "copy"
+    end
+
+    import_mode_setting.assign_attributes(setting_attributes(NEW_KEY, import_mode, "string", DESCRIPTION))
+    import_mode_setting.save!
+    legacy_setting&.delete
+  end
+
+  def down
+    return unless table_exists?(:settings)
+
+    import_mode_setting = MigrationSetting.find_by(key: NEW_KEY)
+    legacy_value = import_mode_setting&.value == "move" ? "true" : "false"
+    legacy_setting = MigrationSetting.find_or_initialize_by(key: OLD_KEY)
+    legacy_setting.assign_attributes(
+      setting_attributes(
+        OLD_KEY,
+        legacy_value,
+        "boolean",
+        "Move completed download files into the library instead of copying them. Disable to preserve torrent seeding."
+      )
+    )
+    legacy_setting.save!
+    import_mode_setting&.delete
+  end
+
+  private
+
+  def legacy_true?(value)
+    LEGACY_BOOLEAN_TYPE.cast(value) == true
+  end
+
+  def setting_attributes(key, value, value_type, description)
+    {
+      key: key,
+      value: value,
+      value_type: value_type,
+      category: "download",
+      description: description
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_18_122500) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -730,11 +730,17 @@
               <tr><td class="key"><code>download_check_interval</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>60</code></td><td class="desc">Seconds between download status checks.</td></tr>
               <tr><td class="key"><code>download_enqueue_timeout_minutes</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>5</code></td><td class="desc">Minutes a download may stay queued before being flagged as never dispatched.</td></tr>
               <tr><td class="key"><code>post_processing_source_path_retries</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>10</code></td><td class="desc">Retries while waiting for completed download files to appear.</td></tr>
-              <tr><td class="key"><code>move_completed_downloads</code></td><td><span class="badge t-boolean">boolean</span></td><td class="default"><code>false</code></td><td class="desc">Move completed download files into the library instead of copying them. Keep disabled to preserve torrent seeding.</td></tr>
+              <tr><td class="key"><code>completed_download_import_mode</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>copy</code></td><td class="desc"><code>copy</code> retains the source but uses extra disk space; <code>move</code> removes the source and can stop torrent seeding; <code>hardlink</code> retains the source without duplicating data. Unsupported or cross-filesystem hardlinks fall back to copying.</td></tr>
               <tr><td class="key"><code>split_audiobook_bundle_imports</code></td><td><span class="badge t-boolean">boolean</span></td><td class="default"><code>false</code></td><td class="desc">Split releases containing multiple self-contained M4B/AAX books into per-book folders. MP3, FLAC, and other chapter-based releases stay together.</td></tr>
               <tr><td class="key"><code>remove_completed_usenet_downloads</code></td><td><span class="badge t-boolean">boolean</span></td><td class="default"><code>true</code></td><td class="desc">Remove completed usenet jobs from the client after import.</td></tr>
             </tbody>
           </table>
+        </div>
+        <div class="callout">
+          <span class="ico">i</span>
+          <div>
+            <strong>Hardlink storage layout.</strong> The download source and library destination must be on one container-visible filesystem. With Docker, mount a shared parent such as <code>/srv/media:/data</code> into Shelfarr and the download client, then use paths such as <code>/data/downloads</code>, <code>/data/audiobooks</code>, and <code>/data/ebooks</code>. Separate mounts such as <code>/downloads</code> and <code>/audiobooks</code> can cross filesystem boundaries and prevent hardlinking. Unsupported or cross-filesystem hardlink attempts fall back to copying. Hardlinked source and library names reference the same content and share ownership and permissions, so content, ownership, or permission changes through either name affect both. The example Compose mounts remain suitable for the default <code>copy</code> mode; change the layout only when enabling <code>hardlink</code>.
+          </div>
         </div>
 
         <h2 id="queue">Queue &amp; Retry <a class="anchor" href="#queue" aria-label="Link to Queue and Retry">#</a></h2>

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -203,6 +203,24 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: /MP3, FLAC, and other chapter-based releases stay together/
   end
 
+  test "index shows completed download import mode options and hardlink guidance" do
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label[for='settings_completed_download_import_mode']", text: "Completed Download Import Mode"
+    assert_select "select[name='settings[completed_download_import_mode]']" do
+      assert_select "option[value='copy']", text: "Copy"
+      assert_select "option[value='move']", text: "Move"
+      assert_select "option[value='hardlink'][selected='selected']", text: "Hardlink"
+    end
+    assert_select "p", text: /Copy: Retains the source and uses extra disk space/
+    assert_select "p", text: /Move: Removes the source and can stop torrent seeding/
+    assert_select "p", text: /Hardlink: Retains the source without duplicate data; unsupported or cross-filesystem links fall back to copy/
+    assert_select "p", text: /Hardlinked names share content, ownership, and permissions; edits through either name affect both/
+  end
+
   test "index shows OIDC auto redirect setting" do
     get admin_settings_url
 
@@ -263,6 +281,53 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_settings_path
     assert_equal true, SettingsService.get(:split_audiobook_bundle_imports)
+  end
+
+  test "bulk_update stores a valid completed download import mode" do
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        completed_download_import_mode: "hardlink"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal "hardlink", SettingsService.get(:completed_download_import_mode)
+  end
+
+  test "bulk_update rejects an invalid completed download import mode" do
+    SettingsService.set(:completed_download_import_mode, "move")
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        completed_download_import_mode: "rename"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_match /must be one of: copy, move, hardlink/, flash[:alert]
+    assert_equal "move", SettingsService.get(:completed_download_import_mode)
+  end
+
+  test "bulk_update collects an invalid import mode while saving valid settings and running side effects" do
+    reset_called = false
+
+    FlaresolverrClient.stub(:reset_connection!, -> { reset_called = true }) do
+      patch bulk_update_admin_settings_url,
+        params: {
+          settings: {
+            completed_download_import_mode: "rename",
+            flaresolverr_url: "http://localhost:8191"
+          }
+        },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_match "turbo-stream", response.body
+    assert_match "Completed Download Import Mode: must be one of: copy, move, hardlink", response.body
+    assert_equal "copy", SettingsService.get(:completed_download_import_mode)
+    assert_equal "http://localhost:8191", SettingsService.get(:flaresolverr_url)
+    assert reset_called
   end
 
   test "index shows library picker dropdown when audiobookshelf configured" do

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -44,7 +44,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     # Set output path to temp destination (Shelfarr always uses its own settings)
     SettingsService.set(:audiobook_output_path, @temp_dest_base)
     SettingsService.set(:download_local_path, @temp_download_base)
-    SettingsService.set(:move_completed_downloads, false)
+    SettingsService.set(:completed_download_import_mode, "copy")
 
     # Update download path to temp source
     @download.update!(download_path: @temp_source)
@@ -256,7 +256,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "copies UTF-8 nested audiobook directories into UTF-8 destination paths" do
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     title = "The Reverse Centaur’s Guide to Life After AI"
     nested_directory = "Doctorow’s Extras"
     nested_source = File.join(@temp_source, nested_directory)
@@ -398,13 +398,370 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
       # Destination file should also exist
       expected_dest = File.join(@temp_dest_base, @book.author, @book.title)
-      assert File.exist?(File.join(expected_dest, "audiobook.mp3")), "Destination file should exist"
+      destination_file = File.join(expected_dest, "audiobook.mp3")
+      assert File.exist?(destination_file), "Destination file should exist"
+      refute_equal [ File.stat(original_file).dev, File.stat(original_file).ino ],
+        [ File.stat(destination_file).dev, File.stat(destination_file).ino ]
     end
+  end
+
+  test "hardlinks directory imports and retains the source without scheduling cleanup" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    second_source = File.join(@temp_source, "second.mp3")
+    File.write(second_source, "second audio content")
+
+    output = FileCopyService.stub(:remove_source_tree, ->(*) { flunk "Hardlink imports must not schedule source cleanup" }) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    first_source = File.join(@temp_source, "audiobook.mp3")
+    first_destination = File.join(destination, "audiobook.mp3")
+    second_destination = File.join(destination, "second.mp3")
+
+    assert @request.reload.completed?
+    assert File.exist?(first_source)
+    assert File.exist?(second_source)
+    assert_equal [ File.stat(first_source).dev, File.stat(first_source).ino ],
+      [ File.stat(first_destination).dev, File.stat(first_destination).ino ]
+    assert_equal [ File.stat(second_source).dev, File.stat(second_source).ino ],
+      [ File.stat(second_destination).dev, File.stat(second_destination).ino ]
+    assert_includes output, "2 hardlinked, 0 copied after unsupported fallback, 0 reused"
+  end
+
+  test "hardlinks source aliases that share one inode" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    source_file = File.join(@temp_source, "audiobook.mp3")
+    alias_source = File.join(@temp_source, "alternate-name.mp3")
+    File.link(source_file, alias_source)
+
+    output = capture_private_post_processing_logs do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    destination_file = File.join(destination, "audiobook.mp3")
+    alias_destination = File.join(destination, "alternate-name.mp3")
+    identity = [ File.stat(source_file).dev, File.stat(source_file).ino ]
+
+    assert @request.reload.completed?
+    assert File.exist?(source_file)
+    assert File.exist?(alias_source)
+    assert_equal identity, [ File.stat(destination_file).dev, File.stat(destination_file).ino ]
+    assert_equal identity, [ File.stat(alias_destination).dev, File.stat(alias_destination).ino ]
+    assert_includes output, "2 hardlinked, 0 copied after unsupported fallback, 0 reused"
+  end
+
+  test "hardlinks and renames a single file while retaining its source" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.write(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    destination_file = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      "Test Author - Test Audiobook.m4b"
+    )
+    assert @request.reload.completed?
+    assert File.exist?(source_file)
+    assert_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(destination_file).dev, File.stat(destination_file).ino ]
+  end
+
+  test "falls back only for unsupported hardlinks and logs private aggregate counts" do
+    secret_title = "PRIVATE HARDLINK TITLE #{SecureRandom.hex(8)}"
+    secret_filename = "private-hardlink-file-#{SecureRandom.hex(8)}.mp3"
+    source_file = File.join(@temp_source, secret_filename)
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    File.write(source_file, "fallback audio content")
+    @book.update!(title: secret_title)
+
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+
+    output = FileCopyService.stub(:hardlink_noreplace, ->(*) {
+      raise FileCopyService::HardlinkUnsupportedError, "unsupported at #{source_file}"
+    }) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    destination_file = File.join(@temp_dest_base, @book.author, secret_title, secret_filename)
+    assert @request.reload.completed?
+    assert_equal "fallback audio content", File.binread(destination_file)
+    assert File.exist?(source_file)
+    refute_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(destination_file).dev, File.stat(destination_file).ino ]
+    assert_includes output, "Hardlink unavailable for one file; falling back to a retained-source copy"
+    assert_includes output, "0 hardlinked, 1 copied after unsupported fallback, 0 reused"
+    refute_includes output, secret_title
+    refute_includes output, secret_filename
+    refute_includes output, @temp_source
+    refute_includes output, @temp_dest_base
+  end
+
+  test "does not copy when hardlinking fails for a reason other than unsupported" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+
+    FileCopyService.stub(:hardlink_noreplace, ->(*) { raise Errno::EACCES, "permission denied" }) do
+      FileCopyService.stub(:cp_noreplace, ->(*) { flunk "Only unsupported hardlinks may fall back to copying" }) do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert @request.reload.attention_needed?
+    assert File.exist?(File.join(@temp_source, "audiobook.mp3"))
+  end
+
+  test "hardlink collisions use a suffix without replacing library content" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    FileUtils.mkdir_p(destination)
+    existing = File.join(destination, "audiobook.mp3")
+    File.write(existing, "existing library content")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    source_file = File.join(@temp_source, "audiobook.mp3")
+    imported_file = File.join(destination, "audiobook (2).mp3")
+    assert @request.reload.completed?
+    assert_equal "existing library content", File.binread(existing)
+    assert_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(imported_file).dev, File.stat(imported_file).ino ]
+    assert File.exist?(source_file)
+  end
+
+  test "suffixes an identical independent destination won after private hardlink creation" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    source_file = File.join(@temp_source, "audiobook.mp3")
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    destination_file = File.join(destination, "audiobook.mp3")
+    real_publish = FileCopyService.method(:publish_private_child_noreplace!)
+    raced = false
+
+    output = FileCopyService.stub(
+      :publish_private_child_noreplace!,
+      ->(parent, temporary, basename, identity, mode: FileCopyService::LIBRARY_FILE_MODE) {
+        unless raced
+          raced = true
+          File.binwrite(File.join(destination, basename), "test audio content")
+          raise Errno::EEXIST, basename
+        end
+
+        real_publish.call(parent, temporary, basename, identity, mode: mode)
+      }
+    ) do
+      FileCopyService.stub(:secure_library_file!, ->(*) { flunk "Hardlink-mode reuse must never chmod the destination" }) do
+        capture_private_post_processing_logs do
+          PostProcessingJob.perform_now(@download.id)
+        end
+      end
+    end
+
+    assert raced
+    assert @request.reload.completed?
+    assert_equal "test audio content", File.binread(destination_file)
+    assert File.exist?(source_file)
+    refute_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(destination_file).dev, File.stat(destination_file).ino ]
+    suffixed_file = File.join(destination, "audiobook (2).mp3")
+    assert_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(suffixed_file).dev, File.stat(suffixed_file).ino ]
+    assert_empty Dir.children(destination).grep(/\A\.shelfarr-copy-/)
+    assert_includes output, "1 hardlinked, 0 copied after unsupported fallback, 0 reused"
+  end
+
+  test "hardlink retries reuse the existing source inode" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    source_file = File.join(@temp_source, "audiobook.mp3")
+    File.chmod(0o744, source_file)
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    FileUtils.mkdir_p(destination)
+    destination_file = File.join(destination, "audiobook.mp3")
+    File.link(source_file, destination_file)
+
+    output = FileCopyService.stub(:secure_library_file!, ->(*) { flunk "Hardlink-mode reuse must never chmod" }) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert @request.reload.completed?
+    assert_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(destination_file).dev, File.stat(destination_file).ino ]
+    assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
+    assert_equal 0o744, File.stat(source_file).mode & 0o777
+    assert_includes output, "0 hardlinked, 0 copied after unsupported fallback, 1 reused"
+  end
+
+  test "hardlink retries suffix an independent identical destination without chmod" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    source_file = File.join(@temp_source, "audiobook.mp3")
+    File.chmod(0o744, source_file)
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    FileUtils.mkdir_p(destination)
+    destination_file = File.join(destination, "audiobook.mp3")
+    File.binwrite(destination_file, "test audio content")
+    File.chmod(0o777, destination_file)
+
+    output = FileCopyService.stub(:secure_library_file!, ->(*) { flunk "Hardlink-mode reuse must never chmod the destination" }) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert @request.reload.completed?
+    refute_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(destination_file).dev, File.stat(destination_file).ino ]
+    suffixed_file = File.join(destination, "audiobook (2).mp3")
+    assert_equal [ File.stat(source_file).dev, File.stat(source_file).ino ],
+      [ File.stat(suffixed_file).dev, File.stat(suffixed_file).ino ]
+    assert_equal 0o744, File.stat(source_file).mode & 0o777
+    assert_equal 0o777, File.stat(destination_file).mode & 0o777
+    assert_includes output, "1 hardlinked, 0 copied after unsupported fallback, 0 reused"
+  end
+
+  test "hardlink retry reuses a secure fallback copy after interruption" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    source_file = File.join(@temp_source, "audiobook.mp3")
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    destination_file = File.join(destination, "audiobook.mp3")
+    hardlink_attempts = 0
+    first_job = PostProcessingJob.new(@download.id)
+
+    output = FileCopyService.stub(:hardlink_noreplace, ->(*) {
+      hardlink_attempts += 1
+      raise FileCopyService::HardlinkUnsupportedError, "simulated unsupported hardlink"
+    }) do
+      first_job.stub(:finalize_acquisition!, ->(*) { raise Interrupt, "simulated interruption" }) do
+        assert_raises(Interrupt) { first_job.perform_now }
+      end
+
+      assert @request.reload.processing?
+      assert_equal first_job.job_id, @download.reload.post_processing_job_id
+      assert_equal 0o640, File.stat(destination_file).mode & 0o777
+
+      retry_job = PostProcessingJob.new(@download.id, 0, first_job.job_id)
+      FileCopyService.stub(:secure_library_file!, ->(*) { flunk "Hardlink-mode retry must never chmod" }) do
+        capture_private_post_processing_logs do
+          retry_job.perform_now
+        end
+      end
+    end
+
+    assert_equal 1, hardlink_attempts
+    assert @request.reload.completed?
+    assert File.exist?(source_file)
+    assert_equal "test audio content", File.binread(destination_file)
+    assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
+    assert_includes output, "0 hardlinked, 0 copied after unsupported fallback, 1 reused"
+  end
+
+  test "hardlinks a shared sidecar into each split bundle destination" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:split_audiobook_bundle_imports, true)
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    @book.update!(title: "Book Two")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    book_one_source = File.join(@temp_source, "Book One.m4b")
+    book_two_source = File.join(@temp_source, "Book Two.m4b")
+    cover_source = File.join(@temp_source, "cover.png")
+    File.write(book_one_source, "book one audio")
+    File.write(book_two_source, "book two audio")
+    File.write(cover_source, "shared cover")
+
+    output = capture_private_post_processing_logs do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    book_one_destination = File.join(@temp_dest_base, @book.author, "Book One")
+    book_two_destination = File.join(@temp_dest_base, @book.author, "Book Two")
+    book_one_file = File.join(book_one_destination, "Book One.m4b")
+    book_two_file = File.join(book_two_destination, "Book Two.m4b")
+    book_one_cover = File.join(book_one_destination, "cover.png")
+    book_two_cover = File.join(book_two_destination, "cover.png")
+
+    assert @request.reload.completed?
+    assert_equal [ File.stat(book_one_source).dev, File.stat(book_one_source).ino ],
+      [ File.stat(book_one_file).dev, File.stat(book_one_file).ino ]
+    assert_equal [ File.stat(book_two_source).dev, File.stat(book_two_source).ino ],
+      [ File.stat(book_two_file).dev, File.stat(book_two_file).ino ]
+    cover_identity = [ File.stat(cover_source).dev, File.stat(cover_source).ino ]
+    assert_equal cover_identity, [ File.stat(book_one_cover).dev, File.stat(book_one_cover).ino ]
+    assert_equal cover_identity, [ File.stat(book_two_cover).dev, File.stat(book_two_cover).ino ]
+    assert File.exist?(book_one_source)
+    assert File.exist?(book_two_source)
+    assert File.exist?(cover_source)
+    assert_includes output, "4 hardlinked, 0 copied after unsupported fallback, 0 reused"
+  end
+
+  test "copies a repeated shared sidecar after its second hardlink is unsupported" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:split_audiobook_bundle_imports, true)
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    @book.update!(title: "Book Two")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    book_one_source = File.join(@temp_source, "Book One.m4b")
+    book_two_source = File.join(@temp_source, "Book Two.m4b")
+    cover_source = File.join(@temp_source, "cover.png")
+    File.write(book_one_source, "book one audio")
+    File.write(book_two_source, "book two audio")
+    File.write(cover_source, "shared cover")
+    real_hardlink = FileCopyService.method(:hardlink_noreplace)
+    cover_attempts = 0
+
+    output = FileCopyService.stub(:hardlink_noreplace, ->(source, destination, **options) {
+      if source == cover_source
+        cover_attempts += 1
+        if cover_attempts == 2
+          raise FileCopyService::HardlinkUnsupportedError, "simulated unsupported second link"
+        end
+      end
+
+      real_hardlink.call(source, destination, **options)
+    }) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    book_one_destination = File.join(@temp_dest_base, @book.author, "Book One")
+    book_two_destination = File.join(@temp_dest_base, @book.author, "Book Two")
+    book_one_cover = File.join(book_one_destination, "cover.png")
+    book_two_cover = File.join(book_two_destination, "cover.png")
+    cover_identity = [ File.stat(cover_source).dev, File.stat(cover_source).ino ]
+
+    assert @request.reload.completed?
+    assert_equal 2, cover_attempts
+    assert_equal cover_identity, [ File.stat(book_one_cover).dev, File.stat(book_one_cover).ino ]
+    refute_equal cover_identity, [ File.stat(book_two_cover).dev, File.stat(book_two_cover).ino ]
+    assert_equal "shared cover", File.binread(book_two_cover)
+    assert File.exist?(cover_source)
+    assert_includes output, "3 hardlinked, 1 copied after unsupported fallback, 0 reused"
   end
 
   test "moves directory imports when enabled" do
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
 
     original_file = File.join(@temp_source, "audiobook.mp3")
     assert File.exist?(original_file), "Source file should exist before processing"
@@ -422,7 +779,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
   test "removes source directory after split audiobook bundle move import" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     @book.update!(title: "Book Two")
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
     File.write(File.join(@temp_source, "Book One.m4b"), "book one audio")
@@ -441,7 +798,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
   test "preserves hidden directories when bundle splitting falls back" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     @book.update!(title: "Book Two")
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
     File.write(File.join(@temp_source, "Book One.m4b"), "book one audio")
@@ -464,7 +821,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     SettingsService.set(:audiobook_output_path, @temp_source)
     SettingsService.set(:audiobook_path_template, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     @book.update!(title: "Book Two")
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
     book_one_source = File.join(@temp_source, "Book One.m4b")
@@ -556,7 +913,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
   test "does not follow a destination symlink during split move imports" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     @book.update!(title: "Book Two")
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
     book_one_source = File.join(@temp_source, "Book One.m4b")
@@ -683,7 +1040,11 @@ class PostProcessingJobTest < ActiveJob::TestCase
     temporary_path = File.join(book_one_directory, ".shelfarr-copy-#{token}.tmp")
     lock_path = File.join(book_one_directory, ".shelfarr-copy-#{token}.lock")
     File.write(temporary_path, "partial")
-    File.write(lock_path, "#{FileCopyService::COPY_LOCK_MAGIC}:#{token}")
+    temporary_stat = File.stat(temporary_path)
+    File.write(
+      lock_path,
+      "#{FileCopyService::COPY_LOCK_MAGIC}:#{token}:full:#{temporary_stat.dev}:#{temporary_stat.ino}"
+    )
 
     PostProcessingJob.perform_now(@download.id)
 
@@ -702,7 +1063,10 @@ class PostProcessingJobTest < ActiveJob::TestCase
     File.write(temporary_path, "active copy")
 
     File.open(lock_path, "w+") do |lock|
-      lock.write("#{FileCopyService::COPY_LOCK_MAGIC}:#{token}")
+      temporary_stat = File.stat(temporary_path)
+      lock.write(
+        "#{FileCopyService::COPY_LOCK_MAGIC}:#{token}:full:#{temporary_stat.dev}:#{temporary_stat.ino}"
+      )
       lock.flush
       lock.flock(File::LOCK_EX)
 
@@ -716,7 +1080,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
   test "keeps exact-stem companions with each split book during move import" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     @book.update!(title: "Book Two")
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
     File.write(File.join(@temp_source, "Book One.aax"), "book one audio")
@@ -744,7 +1108,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:audiobook_filename_template, "{author} - {title}")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
 
     FileCopyService.stub(:cp, ->(*) { flunk "Single-file move imports should not copy files" }) do
       PostProcessingJob.perform_now(@download.id)
@@ -763,7 +1127,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:audiobook_filename_template, "{author} - {title}")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
 
     FileUtils.stub(:mv, ->(*) { raise Errno::EACCES, "copy_file_range" }) do
       PostProcessingJob.perform_now(@download.id)
@@ -781,7 +1145,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     @download.update!(download_path: failing_file)
 
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
 
     FileCopyService.stub(:mv_noreplace, ->(*) { raise Errno::EACCES, "permission denied" }) do
       PostProcessingJob.perform_now(@download.id)
@@ -809,7 +1173,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     SettingsService.set(:ebook_path_template, "{author}/{title}")
     SettingsService.set(:ebook_filename_template, "{author} - {title} ({year})")
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
 
     FileCopyService.stub(:mv, ->(*) { flunk "Ebook directory imports should copy files, not move them individually" }) do
       PostProcessingJob.perform_now(@download.id)
@@ -825,7 +1189,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "imports every snapshotted file even when a later live directory listing omits one" do
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     File.binwrite(File.join(@temp_source, "second.mp3"), "second expected chapter")
     real_children = Dir.method(:children)
 
@@ -850,7 +1214,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "keeps source directory intact when directory import fails with move enabled" do
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
 
     File.write(File.join(@temp_source, "second.mp3"), "second file")
     original_file = File.join(@temp_source, "audiobook.mp3")
@@ -951,7 +1315,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "preserves both files and asks for review when another acquisition wins the book claim" do
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
     existing_path = File.join(@temp_dest_base, "already-owned", "existing.m4b")
     FileUtils.mkdir_p(File.dirname(existing_path))
     File.binwrite(existing_path, "existing acquisition")
@@ -976,7 +1340,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "completes request when import source removal fails non-fatally" do
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:move_completed_downloads, true)
+    SettingsService.set(:completed_download_import_mode, "move")
 
     FileCopyService.stub(:remove_source_tree, ->(*) { raise Errno::EACCES, "permission denied" }) do
       PostProcessingJob.perform_now(@download.id)

--- a/test/migrations/migrate_completed_download_import_mode_test.rb
+++ b/test/migrations/migrate_completed_download_import_mode_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require Rails.root.join("db/migrate/20260721120000_migrate_completed_download_import_mode")
+
+class MigrateCompletedDownloadImportModeTest < ActiveSupport::TestCase
+  setup do
+    Setting.where(key: %w[move_completed_downloads completed_download_import_mode]).delete_all
+  end
+
+  teardown do
+    Setting.where(key: %w[move_completed_downloads completed_download_import_mode]).delete_all
+  end
+
+  test "matches ActiveModel boolean casting for legacy values" do
+    boolean_type = ActiveModel::Type::Boolean.new
+    legacy_values = [
+      nil, "",
+      "0", "f", "F", "false", "FALSE", "off", "OFF",
+      "true", "1", "t", "TRUE", "on", "yes", "enabled", "False",
+      " false ", " off ", " ", "\t"
+    ]
+
+    legacy_values.each do |legacy_value|
+      clear_import_settings
+      create_setting("move_completed_downloads", legacy_value, "boolean")
+
+      migration.up
+
+      expected_mode = boolean_type.cast(legacy_value) ? "move" : "copy"
+      assert_import_mode expected_mode, "legacy value #{legacy_value.inspect}"
+      assert_not Setting.exists?(key: "move_completed_downloads")
+    end
+  end
+
+  test "reverses move to legacy true" do
+    create_setting("completed_download_import_mode", "move", "string")
+
+    migration.down
+
+    assert_legacy_move_value "true"
+    assert_not Setting.exists?(key: "completed_download_import_mode")
+  end
+
+  test "migrates a missing legacy row to copy" do
+    migration.up
+
+    assert_import_mode "copy"
+  end
+
+  test "preserves every valid explicit new mode and removes the legacy row" do
+    %w[copy move hardlink].each do |mode|
+      clear_import_settings
+      create_setting("move_completed_downloads", "true", "boolean")
+      create_setting("completed_download_import_mode", mode, "boolean")
+
+      migration.up
+
+      assert_import_mode mode
+      assert_not Setting.exists?(key: "move_completed_downloads")
+    end
+  end
+
+  test "replaces an invalid new mode using the legacy value" do
+    create_setting("move_completed_downloads", "true", "boolean")
+    create_setting("completed_download_import_mode", "rename", "string")
+
+    migration.up
+
+    assert_import_mode "move"
+  end
+
+  test "maps copy and hardlink to false when reversed" do
+    %w[copy hardlink].each do |mode|
+      Setting.where(key: %w[move_completed_downloads completed_download_import_mode]).delete_all
+      create_setting("completed_download_import_mode", mode, "string")
+
+      migration.down
+
+      assert_legacy_move_value "false"
+      assert_not Setting.exists?(key: "completed_download_import_mode")
+    end
+  end
+
+  private
+
+  def migration
+    MigrateCompletedDownloadImportMode.new
+  end
+
+  def clear_import_settings
+    Setting.where(key: %w[move_completed_downloads completed_download_import_mode]).delete_all
+  end
+
+  def create_setting(key, value, value_type)
+    Setting.create!(
+      key: key,
+      value: value,
+      value_type: value_type,
+      category: "download",
+      description: "Test setting"
+    )
+  end
+
+  def assert_import_mode(expected, message = nil)
+    setting = Setting.find_by!(key: "completed_download_import_mode")
+    assert_equal expected, setting.value, message
+    assert_equal "string", setting.value_type
+    assert_equal "download", setting.category
+  end
+
+  def assert_legacy_move_value(expected)
+    setting = Setting.find_by!(key: "move_completed_downloads")
+    assert_equal expected, setting.value
+    assert_equal "boolean", setting.value_type
+    assert_equal "download", setting.category
+  end
+end

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "fiddle"
 
 class FileCopyServiceTest < ActiveSupport::TestCase
   setup do
@@ -76,6 +77,1022 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal 0o777, File.stat(@src_file).mode & 0o777
   end
 
+  test "hardlink_noreplace publishes the source inode without removing or chmodding it" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    File.chmod(0o754, @src_file)
+
+    FileCopyService.hardlink_noreplace(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      source_root: nil
+    )
+
+    source_stat = File.stat(@src_file)
+    destination_stat = File.stat(destination)
+    assert_equal [ source_stat.dev, source_stat.ino ], [ destination_stat.dev, destination_stat.ino ]
+    assert_equal 2, source_stat.nlink
+    assert_equal 0o754, source_stat.mode & 0o7777
+    assert_equal 0o754, destination_stat.mode & 0o7777
+    assert_equal "test content", File.binread(@src_file)
+    assert_empty Dir.children(@dest_dir) - [ "hardlinked.txt" ]
+  end
+
+  test "hardlink_noreplace never overwrites an occupied destination" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    File.binwrite(destination, "existing library bytes")
+
+    error = assert_raises(Errno::EEXIST) do
+      FileCopyService.hardlink_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert_instance_of Errno::EEXIST, error
+    assert_equal "existing library bytes", File.binread(destination)
+    assert_equal "test content", File.binread(@src_file)
+    assert_equal 1, File.stat(@src_file).nlink
+    assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "hardlink_noreplace classifies only initial unsupported link errors" do
+    unsupported_errors = [
+      Errno::EXDEV,
+      Errno::EPERM,
+      Errno::EOPNOTSUPP,
+      Errno::ENOTSUP,
+      Errno::ENOSYS,
+      Errno::EMLINK,
+      Fiddle::DLError,
+      NotImplementedError
+    ]
+
+    unsupported_errors.each_with_index do |error_class, index|
+      destination = File.join(@dest_dir, "unsupported-#{index}.txt")
+      error = FileCopyService.stub(:native_linkat, ->(*) { raise error_class }) do
+        assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+      end
+
+      assert_instance_of error_class, error.cause
+      assert_not File.exist?(destination)
+      FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+      assert_empty Dir.children(@dest_dir)
+    end
+  end
+
+  test "hardlink_noreplace does not classify a post-publication error as unsupported" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    real_validate = FileCopyService.method(:validate_published_child!)
+
+    error = FileCopyService.stub(:validate_published_child!, lambda { |*args, **kwargs|
+      real_validate.call(*args, **kwargs)
+      raise Errno::EXDEV
+    }) do
+      assert_raises(Errno::EXDEV) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert_instance_of Errno::EXDEV, error
+    assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
+      [ File.stat(destination).dev, File.stat(destination).ino ]
+    assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "hardlink_noreplace cleans its verified temp and lock after publication failure" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+
+    FileCopyService.stub(:publish_private_child_noreplace!, ->(*) { raise IOError, "publication failed" }) do
+      assert_raises(IOError) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert_not File.exist?(destination)
+    assert_equal 1, File.stat(@src_file).nlink
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "hardlink_noreplace cleanup preserves a replacement at its temp path" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    displaced = File.join(@dest_dir, "displaced-private-link")
+    replacement = nil
+
+    publish = lambda do |_parent, temporary_basename, _destination_basename, _identity, mode:|
+      temporary = File.join(@dest_dir, temporary_basename)
+      File.rename(temporary, displaced)
+      File.binwrite(temporary, "replacement temp")
+      replacement = temporary
+      raise IOError, "publication failed"
+    end
+
+    FileCopyService.stub(:publish_private_child_noreplace!, publish) do
+      assert_raises(IOError) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert_equal "replacement temp", File.binread(replacement)
+    assert_equal "test content", File.binread(displaced)
+    assert_equal 2, File.stat(@src_file).nlink
+    assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
+  end
+
+  test "hardlink_noreplace cleanup restores a temp replacement swapped after initial verification" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    displaced = File.join(@dest_dir, "displaced-verified-link")
+    replacement = nil
+    real_rename = FileCopyService.method(:native_renameat)
+    swapped = false
+
+    racing_rename = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if !swapped && source_name.match?(/\A\.shelfarr-copy-.*\.tmp\z/) &&
+          destination_name == FileCopyService::COPY_QUARANTINE_ENTRY
+        swapped = true
+        temporary = File.join(@dest_dir, source_name)
+        File.rename(temporary, displaced)
+        File.binwrite(temporary, "replacement after verification")
+        replacement = temporary
+      end
+      real_rename.call(source_fd, source_name, destination_fd, destination_name)
+    end
+
+    FileCopyService.stub(:native_renameat, racing_rename) do
+      FileCopyService.hardlink_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert swapped
+    assert_equal "replacement after verification", File.binread(replacement)
+    assert_equal "test content", File.binread(displaced)
+    assert_equal 3, File.stat(@src_file).nlink
+    assert_empty Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*"))
+    assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
+  end
+
+  test "hardlink_noreplace cleanup does not require no-replace rename support" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+
+    FileCopyService.stub(:native_rename_noreplace, false) do
+      FileCopyService.hardlink_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
+      [ File.stat(destination).dev, File.stat(destination).ino ]
+    assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "destination-local EMLINK falls back to no-replace rename publication" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    real_link = FileCopyService.method(:native_linkat)
+    link_calls = 0
+
+    linking = lambda do |source_fd, source_name, destination_fd, destination_name|
+      link_calls += 1
+      raise Errno::EMLINK if link_calls == 2
+
+      real_link.call(source_fd, source_name, destination_fd, destination_name)
+    end
+
+    FileCopyService.stub(:native_linkat, linking) do
+      FileCopyService.hardlink_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert_equal 2, link_calls
+    assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
+      [ File.stat(destination).dev, File.stat(destination).ino ]
+    assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "destination-local low-level link failures fall back to rename publication" do
+    [ Fiddle::DLError, NotImplementedError ].each_with_index do |error_class, index|
+      destination = File.join(@dest_dir, "hardlinked-#{index}.txt")
+      real_link = FileCopyService.method(:native_linkat)
+      link_calls = 0
+
+      linking = lambda do |source_fd, source_name, destination_fd, destination_name|
+        link_calls += 1
+        raise error_class if link_calls == 2
+
+        real_link.call(source_fd, source_name, destination_fd, destination_name)
+      end
+
+      FileCopyService.stub(:native_linkat, linking) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+
+      assert_equal 2, link_calls
+      assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
+        [ File.stat(destination).dev, File.stat(destination).ino ]
+    end
+  end
+
+  test "copy and hardlink locks persist their verified temp identity" do
+    copy_destination = File.join(@dest_dir, "copied.txt")
+    hardlink_destination = File.join(@dest_dir, "hardlinked.txt")
+    real_copy = FileCopyService.method(:copy_source_io)
+    real_publish = FileCopyService.method(:publish_private_child_noreplace!)
+    verified_copy_lock = false
+    verified_hardlink_lock = false
+
+    inspecting_copy = lambda do |source, temporary, heartbeat: nil|
+      lock_path = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).sole
+      record = FileCopyService::COPY_LOCK_RECORD_PATTERN.match(File.binread(lock_path))
+      assert record
+      assert_equal [ temporary.stat.dev, temporary.stat.ino ], [ record[2].to_i, record[3].to_i ]
+      verified_copy_lock = true
+      real_copy.call(source, temporary, heartbeat: heartbeat)
+    end
+    FileCopyService.stub(:copy_source_io, inspecting_copy) do
+      FileCopyService.cp_noreplace(@src_file, copy_destination, root: @dest_dir)
+    end
+
+    inspecting_publish = lambda do |parent, temporary_basename, destination_basename, identity, mode:|
+      lock_path = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).sole
+      record = FileCopyService::COPY_LOCK_RECORD_PATTERN.match(File.binread(lock_path))
+      assert record
+      assert_equal identity, [ record[2].to_i, record[3].to_i ]
+      verified_hardlink_lock = true
+      real_publish.call(parent, temporary_basename, destination_basename, identity, mode: mode)
+    end
+    FileCopyService.stub(:publish_private_child_noreplace!, inspecting_publish) do
+      FileCopyService.hardlink_noreplace(
+        @src_file,
+        hardlink_destination,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert verified_copy_lock
+    assert verified_hardlink_lock
+  end
+
+  test "copy fsyncs a v2 pending lock before temp creation" do
+    destination = File.join(@dest_dir, "copied.txt")
+    real_create = FileCopyService.method(:with_created_regular_child)
+    verified_pending = false
+
+    inspecting_create = lambda do |parent, basename, mode, &operation|
+      if basename.end_with?(".tmp")
+        lock_path = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).sole
+        record = FileCopyService::COPY_LOCK_PENDING_PATTERN.match(File.binread(lock_path))
+        assert record
+        verified_pending = true
+      end
+      real_create.call(parent, basename, mode, &operation)
+    end
+
+    FileCopyService.stub(:with_created_regular_child, inspecting_create) do
+      FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    end
+
+    assert verified_pending
+    assert_equal "test content", File.binread(destination)
+  end
+
+  test "hardlink lock persists expected source identity before the initial link" do
+    destination = File.join(@dest_dir, "unsupported.txt")
+    source_identity = [ File.stat(@src_file).dev, File.stat(@src_file).ino ]
+    verified_lock = false
+
+    unsupported_link = lambda do |*|
+      lock_path = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).sole
+      record = FileCopyService::COPY_LOCK_RECORD_PATTERN.match(File.binread(lock_path))
+      assert record
+      assert_equal source_identity, [ record[2].to_i, record[3].to_i ]
+      verified_lock = true
+      raise Errno::EXDEV
+    end
+
+    FileCopyService.stub(:native_linkat, unsupported_link) do
+      assert_raises(FileCopyService::HardlinkUnsupportedError) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert verified_lock
+    assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "cleanup_interrupted_copies recovers a crash-left private quarantine" do
+    token = "a" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    File.binwrite(temporary, "interrupted bytes")
+    temporary_stat = File.stat(temporary)
+    lock = write_copy_lock(token, temporary_stat)
+    quarantine = copy_quarantine_path(temporary_stat, "b" * 32)
+    Dir.mkdir(quarantine, 0o700)
+    File.rename(temporary, File.join(quarantine, FileCopyService::COPY_QUARANTINE_ENTRY))
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(temporary)
+    assert_not File.exist?(lock)
+    assert_not File.exist?(quarantine)
+  end
+
+  test "cleanup_interrupted_copies retains a fresh empty quarantine" do
+    expected_stat = File.stat(@src_file)
+    quarantine = copy_quarantine_path(expected_stat, "5" * 32)
+    Dir.mkdir(quarantine, 0o700)
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert File.directory?(quarantine)
+    assert_empty Dir.children(quarantine)
+  end
+
+  test "cleanup_interrupted_copies removes a stale empty private quarantine" do
+    expected_stat = File.stat(@src_file)
+    quarantine = copy_quarantine_path(expected_stat, "6" * 32)
+    Dir.mkdir(quarantine, 0o700)
+    stale_time = Time.now - FileCopyService::COPY_QUARANTINE_STALE_AGE - 60
+    File.utime(stale_time, stale_time, quarantine)
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(quarantine)
+  end
+
+  test "cleanup_interrupted_copies retains stale empty quarantines with wrong owner or mode" do
+    expected_stat = File.stat(@src_file)
+    owner_quarantine = copy_quarantine_path(expected_stat, "7" * 32)
+    mode_quarantine = copy_quarantine_path(expected_stat, "8" * 32)
+    Dir.mkdir(owner_quarantine, 0o700)
+    Dir.mkdir(mode_quarantine, 0o700)
+    File.chmod(0o750, mode_quarantine)
+    stale_time = Time.now - FileCopyService::COPY_QUARANTINE_STALE_AGE - 60
+    File.utime(stale_time, stale_time, owner_quarantine)
+    File.utime(stale_time, stale_time, mode_quarantine)
+
+    Process.stub(:euid, Process.euid + 1) do
+      FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+    end
+    assert File.directory?(owner_quarantine)
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(owner_quarantine)
+    assert File.directory?(mode_quarantine)
+  end
+
+  test "concurrent interrupted cleanup leaves an active empty quarantine in place" do
+    target = File.join(@dest_dir, "cleanup-target")
+    File.binwrite(target, "cleanup bytes")
+    identity = [ File.stat(target).dev, File.stat(target).ino ]
+    entered = Queue.new
+    release = Queue.new
+    real_rename = FileCopyService.method(:native_renameat)
+    paused = false
+    worker = nil
+
+    pausing_rename = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if !paused && source_name == File.basename(target) &&
+          destination_name == FileCopyService::COPY_QUARANTINE_ENTRY
+        paused = true
+        entered << true
+        release.pop
+      end
+      real_rename.call(source_fd, source_name, destination_fd, destination_name)
+    end
+
+    FileCopyService.stub(:native_renameat, pausing_rename) do
+      FileCopyService.send(
+        :with_pinned_destination_parent,
+        target,
+        root: @dest_dir
+      ) do |parent, basename, _parent_path|
+        worker = Thread.new do
+          FileCopyService.send(:remove_pinned_child_if_identity, parent, basename, identity)
+        end
+        entered.pop
+        quarantine = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*")).sole
+
+        FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+        assert File.directory?(quarantine)
+        assert_empty Dir.children(quarantine)
+        release << true
+        assert_equal :removed, worker.value
+      end
+    end
+
+    assert_not File.exist?(target)
+    assert_empty Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*"))
+  ensure
+    release << true if release && worker&.alive?
+    worker&.join
+  end
+
+  test "interrupted cleanup removes an identity-bearing lock when no temp was created" do
+    token = "f" * 32
+    lock = write_copy_lock(token, File.stat(@src_file))
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(lock)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "interrupted cleanup retains a replacement temp not matching the lock identity" do
+    token = "c" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    displaced = File.join(@dest_dir, "expected-temp")
+    File.binwrite(temporary, "expected temp")
+    temporary_stat = File.stat(temporary)
+    lock = write_copy_lock(token, temporary_stat)
+    File.rename(temporary, displaced)
+    File.binwrite(temporary, "replacement temp")
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_equal "replacement temp", File.binread(temporary)
+    assert_equal "expected temp", File.binread(displaced)
+    assert File.exist?(lock)
+    assert_empty Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*"))
+  end
+
+  test "hardlink ensure removes a verified temp after transient post-link open failure" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    real_open = FileCopyService.method(:with_pinned_regular_child)
+    failed = false
+
+    transient_open = lambda do |parent, basename, &operation|
+      if !failed && basename.match?(/\A\.shelfarr-copy-.*\.tmp\z/)
+        failed = true
+        raise Errno::EIO
+      end
+      real_open.call(parent, basename, &operation)
+    end
+
+    FileCopyService.stub(:with_pinned_regular_child, transient_open) do
+      assert_raises(Errno::EIO) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert failed
+    assert_not File.exist?(destination)
+    assert_equal 1, File.stat(@src_file).nlink
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "completed hardlink cleanup retains symlink and directory temp replacements" do
+    [ :symlink, :directory ].each do |replacement_type|
+      case_directory = File.join(@dest_dir, replacement_type.to_s)
+      destination = File.join(case_directory, "hardlinked.txt")
+      FileUtils.mkdir_p(case_directory)
+      real_validate = FileCopyService.method(:validate_published_child!)
+      replacement = nil
+
+      replacing_validate = lambda do |*args, **kwargs|
+        result = real_validate.call(*args, **kwargs)
+        replacement = Dir.glob(File.join(case_directory, ".shelfarr-copy-*.tmp")).sole
+        File.unlink(replacement)
+        if replacement_type == :symlink
+          File.symlink(@src_file, replacement)
+        else
+          FileUtils.mkdir_p(replacement)
+        end
+        result
+      end
+
+      FileCopyService.stub(:validate_published_child!, replacing_validate) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+
+      assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
+        [ File.stat(destination).dev, File.stat(destination).ino ]
+      if replacement_type == :symlink
+        assert File.symlink?(replacement)
+      else
+        assert File.directory?(replacement)
+      end
+      assert_equal 1, Dir.glob(File.join(case_directory, ".shelfarr-copy-*.lock")).size
+    end
+  end
+
+  test "interrupted cleanup recovers v2 pending and legacy v1 regular temps" do
+    pending_token = "d" * 32
+    legacy_token = "e" * 32
+    pending_temporary = File.join(@dest_dir, ".shelfarr-copy-#{pending_token}.tmp")
+    pending_lock = File.join(@dest_dir, ".shelfarr-copy-#{pending_token}.lock")
+    legacy_temporary = File.join(@dest_dir, ".shelfarr-copy-#{legacy_token}.tmp")
+    legacy_lock = File.join(@dest_dir, ".shelfarr-copy-#{legacy_token}.lock")
+    File.binwrite(pending_temporary, "pending temp")
+    File.binwrite(pending_lock, "#{FileCopyService::COPY_LOCK_MAGIC}:#{pending_token}:pending")
+    File.binwrite(legacy_temporary, "legacy temp")
+    File.binwrite(legacy_lock, "#{FileCopyService::COPY_LOCK_LEGACY_MAGIC}:#{legacy_token}")
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(pending_temporary)
+    assert_not File.exist?(pending_lock)
+    assert_not File.exist?(legacy_temporary)
+    assert_not File.exist?(legacy_lock)
+  end
+
+  test "pending and legacy cleanup retain non-regular token replacements" do
+    pending_token = "3" * 32
+    legacy_token = "4" * 32
+    pending_temporary = File.join(@dest_dir, ".shelfarr-copy-#{pending_token}.tmp")
+    pending_lock = File.join(@dest_dir, ".shelfarr-copy-#{pending_token}.lock")
+    legacy_temporary = File.join(@dest_dir, ".shelfarr-copy-#{legacy_token}.tmp")
+    legacy_lock = File.join(@dest_dir, ".shelfarr-copy-#{legacy_token}.lock")
+    File.symlink(@src_file, pending_temporary)
+    File.binwrite(pending_lock, "#{FileCopyService::COPY_LOCK_MAGIC}:#{pending_token}:pending")
+    FileUtils.mkdir_p(legacy_temporary)
+    File.binwrite(legacy_lock, "#{FileCopyService::COPY_LOCK_LEGACY_MAGIC}:#{legacy_token}")
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert File.symlink?(pending_temporary)
+    assert File.exist?(pending_lock)
+    assert File.directory?(legacy_temporary)
+    assert File.exist?(legacy_lock)
+  end
+
+  test "interrupted cleanup retains malformed locks with temps and removes empty malformed locks" do
+    malformed_token = "1" * 32
+    empty_token = "2" * 32
+    malformed_temporary = File.join(@dest_dir, ".shelfarr-copy-#{malformed_token}.tmp")
+    malformed_lock = File.join(@dest_dir, ".shelfarr-copy-#{malformed_token}.lock")
+    empty_lock = File.join(@dest_dir, ".shelfarr-copy-#{empty_token}.lock")
+    File.binwrite(malformed_temporary, "malformed temp")
+    File.binwrite(malformed_lock, "not a copy lock record")
+    File.binwrite(empty_lock, "")
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_equal "malformed temp", File.binread(malformed_temporary)
+    assert File.exist?(malformed_lock)
+    assert_not File.exist?(empty_lock)
+  end
+
+  test "interrupted cleanup retains a mismatched quarantined entry" do
+    expected = File.join(@dest_dir, "expected-temp")
+    File.binwrite(expected, "expected")
+    expected_stat = File.stat(expected)
+    quarantine = copy_quarantine_path(expected_stat, "e" * 32)
+    Dir.mkdir(quarantine, 0o700)
+    entry = File.join(quarantine, FileCopyService::COPY_QUARANTINE_ENTRY)
+    File.binwrite(entry, "replacement")
+    stale_time = Time.now - FileCopyService::COPY_QUARANTINE_STALE_AGE - 60
+    File.utime(stale_time, stale_time, quarantine)
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert File.directory?(quarantine)
+    assert_equal "replacement", File.binread(entry)
+    assert_equal "expected", File.binread(expected)
+  end
+
+  test "cleanup raises and retains a mismatch when no-replace restoration is unsupported" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    displaced = File.join(@dest_dir, "displaced-verified-link")
+    real_rename = FileCopyService.method(:native_renameat)
+    swapped = false
+
+    racing_rename = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if !swapped && source_name.match?(/\A\.shelfarr-copy-.*\.tmp\z/) &&
+          destination_name == FileCopyService::COPY_QUARANTINE_ENTRY
+        swapped = true
+        temporary = File.join(@dest_dir, source_name)
+        File.rename(temporary, displaced)
+        File.binwrite(temporary, "retained replacement")
+      end
+      real_rename.call(source_fd, source_name, destination_fd, destination_name)
+    end
+
+    error = FileCopyService.stub(:native_renameat, racing_rename) do
+      FileCopyService.stub(:native_rename_noreplace, false) do
+        assert_raises(FileCopyService::UnsafePathError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+      end
+    end
+
+    quarantine = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*"))
+    assert_match(/retained in quarantine/, error.message)
+    assert_equal 1, quarantine.size
+    assert_equal "retained replacement",
+      File.binread(File.join(quarantine.sole, FileCopyService::COPY_QUARANTINE_ENTRY))
+    assert_equal "test content", File.binread(displaced)
+  end
+
+  test "cleanup raises and retains a mismatch when the original path becomes occupied" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    displaced = File.join(@dest_dir, "displaced-verified-link")
+    occupied = nil
+    real_rename = FileCopyService.method(:native_renameat)
+    swapped = false
+
+    racing_rename = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if !swapped && source_name.match?(/\A\.shelfarr-copy-.*\.tmp\z/) &&
+          destination_name == FileCopyService::COPY_QUARANTINE_ENTRY
+        swapped = true
+        temporary = File.join(@dest_dir, source_name)
+        File.rename(temporary, displaced)
+        File.binwrite(temporary, "quarantined replacement")
+        result = real_rename.call(source_fd, source_name, destination_fd, destination_name)
+        File.binwrite(temporary, "original-path winner")
+        occupied = temporary
+        result
+      else
+        real_rename.call(source_fd, source_name, destination_fd, destination_name)
+      end
+    end
+
+    error = FileCopyService.stub(:native_renameat, racing_rename) do
+      assert_raises(FileCopyService::UnsafePathError) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    quarantine = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*"))
+    assert_match(/original path is occupied/, error.message)
+    assert_equal "original-path winner", File.binread(occupied)
+    assert_equal 1, quarantine.size
+    assert_equal "quarantined replacement",
+      File.binread(File.join(quarantine.sole, FileCopyService::COPY_QUARANTINE_ENTRY))
+    assert_equal "test content", File.binread(displaced)
+  end
+
+  test "hardlink_noreplace rejects a source pathname swap before final publication" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    displaced_source = File.join(@tmp_dir, "pinned-source.txt")
+    real_linkat = FileCopyService.method(:native_linkat)
+    first_link = true
+
+    racing_link = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if first_link
+        first_link = false
+        File.rename(@src_file, displaced_source)
+        File.binwrite(@src_file, "replacement source")
+      end
+      real_linkat.call(source_fd, source_name, destination_fd, destination_name)
+    end
+
+    FileCopyService.stub(:native_linkat, racing_link) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert_not File.exist?(destination)
+    assert_equal "replacement source", File.binread(@src_file)
+    assert_equal "test content", File.binread(displaced_source)
+    retained_temp = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.tmp")).sole
+    assert_equal "replacement source", File.binread(retained_temp)
+    assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
+  end
+
+  test "hardlink_noreplace detects a destination ancestor swap before final publication" do
+    nested = File.join(@dest_dir, "nested")
+    moved = File.join(@dest_dir, "pinned-nested")
+    outside = File.join(@tmp_dir, "outside")
+    destination = File.join(nested, "hardlinked.txt")
+    FileUtils.mkdir_p(nested)
+    FileUtils.mkdir_p(outside)
+    real_linkat = FileCopyService.method(:native_linkat)
+    first_link = true
+
+    racing_link = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if first_link
+        first_link = false
+        File.rename(nested, moved)
+        File.symlink(outside, nested)
+      end
+      real_linkat.call(source_fd, source_name, destination_fd, destination_name)
+    end
+
+    FileCopyService.stub(:native_linkat, racing_link) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert_empty Dir.children(moved)
+    assert_empty Dir.children(outside)
+    assert_equal 1, File.stat(@src_file).nlink
+  end
+
+  test "hardlink_noreplace preserves the stable manifest of a snapshotted source" do
+    source_root_path = File.join(@tmp_dir, "download")
+    source = File.join(source_root_path, "chapter.mp3")
+    destination = File.join(@dest_dir, "chapter.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "chapter")
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+    expected_manifest = snapshot.entries.fetch("chapter.mp3")
+
+    FileCopyService.hardlink_noreplace(
+      source,
+      destination,
+      root: @dest_dir,
+      source_root: snapshot
+    )
+
+    current_stat = File.stat(source)
+    current_stable_manifest = [
+      current_stat.dev,
+      current_stat.ino,
+      :file,
+      current_stat.size,
+      current_stat.mtime.to_r,
+      current_stat.mode & 0o7777
+    ]
+    expected_stable_manifest = [ *expected_manifest.first(5), expected_manifest.fetch(6) ]
+    assert_equal expected_stable_manifest, current_stable_manifest
+    assert_equal [ current_stat.dev, current_stat.ino ],
+      [ File.stat(destination).dev, File.stat(destination).ino ]
+    assert_equal 2, current_stat.nlink
+  end
+
+  test "hardlink_noreplace imports two snapshotted source names for one inode" do
+    source_root_path = File.join(@tmp_dir, "download")
+    first_source = File.join(source_root_path, "chapter-one.mp3")
+    second_source = File.join(source_root_path, "chapter-two.mp3")
+    first_destination = File.join(@dest_dir, "chapter-one.mp3")
+    second_destination = File.join(@dest_dir, "chapter-two.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(first_source, "shared chapter")
+    File.link(first_source, second_source)
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+
+    FileCopyService.hardlink_noreplace(
+      first_source,
+      first_destination,
+      root: @dest_dir,
+      source_root: snapshot
+    )
+    FileCopyService.hardlink_noreplace(
+      second_source,
+      second_destination,
+      root: @dest_dir,
+      source_root: snapshot
+    )
+
+    identities = [ first_source, second_source, first_destination, second_destination ].map do |path|
+      stat = File.stat(path)
+      [ stat.dev, stat.ino ]
+    end
+    assert_equal 1, identities.uniq.size
+    assert_equal 4, File.stat(first_source).nlink
+  end
+
+  test "hardlink_noreplace imports one snapshotted source path more than once" do
+    source_root_path = File.join(@tmp_dir, "download")
+    source = File.join(source_root_path, "chapter.mp3")
+    first_destination = File.join(@dest_dir, "chapter-one.mp3")
+    second_destination = File.join(@dest_dir, "chapter-two.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "chapter")
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+
+    [ first_destination, second_destination ].each do |destination|
+      FileCopyService.hardlink_noreplace(
+        source,
+        destination,
+        root: @dest_dir,
+        source_root: snapshot
+      )
+    end
+
+    source_identity = [ File.stat(source).dev, File.stat(source).ino ]
+    assert_equal source_identity, [ File.stat(first_destination).dev, File.stat(first_destination).ino ]
+    assert_equal source_identity, [ File.stat(second_destination).dev, File.stat(second_destination).ino ]
+    assert_equal 3, File.stat(source).nlink
+  end
+
+  test "hardlink reconciliation remains valid after EEXIST temp cleanup" do
+    source_root_path = File.join(@tmp_dir, "download")
+    source = File.join(source_root_path, "chapter.mp3")
+    occupied = File.join(@dest_dir, "occupied.mp3")
+    fallback_destination = File.join(@dest_dir, "fallback-copy.mp3")
+    retry_destination = File.join(@dest_dir, "retry.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "chapter")
+    File.binwrite(occupied, "chapter")
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+
+    assert_raises(Errno::EEXIST) do
+      FileCopyService.hardlink_noreplace(
+        source,
+        occupied,
+        root: @dest_dir,
+        source_root: snapshot
+      )
+    end
+    assert FileCopyService.same_file_content?(
+      source,
+      occupied,
+      root: @dest_dir,
+      source_root: snapshot,
+      hardlink_mode: true
+    )
+    FileCopyService.cp_noreplace(
+      source,
+      fallback_destination,
+      root: @dest_dir,
+      source_root: snapshot,
+      hardlink_mode: true
+    )
+
+    FileCopyService.hardlink_noreplace(
+      source,
+      retry_destination,
+      root: @dest_dir,
+      source_root: snapshot
+    )
+
+    assert_equal "chapter", File.binread(occupied)
+    assert_equal "chapter", File.binread(fallback_destination)
+    assert_not_equal [ File.stat(source).dev, File.stat(source).ino ],
+      [ File.stat(fallback_destination).dev, File.stat(fallback_destination).ino ]
+    assert_equal [ File.stat(source).dev, File.stat(source).ino ],
+      [ File.stat(retry_destination).dev, File.stat(retry_destination).ino ]
+    assert_equal 2, File.stat(source).nlink
+  end
+
+  test "cp_noreplace keeps strict snapshots by default and permits hardlink fallback validation" do
+    source_root_path = File.join(@tmp_dir, "download")
+    source = File.join(source_root_path, "chapter.mp3")
+    strict_destination = File.join(@dest_dir, "strict.mp3")
+    fallback_destination = File.join(@dest_dir, "fallback.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "chapter")
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+    entries = snapshot.entries.transform_values(&:dup)
+    entries.fetch("chapter.mp3")[5] -= 1
+    stale_ctime_snapshot = FileCopyService::SourceRoot.new(
+      **snapshot.to_h.merge(entries: entries.freeze)
+    ).freeze
+
+    assert_raises(Errno::ESTALE) do
+      FileCopyService.cp_noreplace(
+        source,
+        strict_destination,
+        root: @dest_dir,
+        source_root: stale_ctime_snapshot
+      )
+    end
+    FileCopyService.cp_noreplace(
+      source,
+      fallback_destination,
+      root: @dest_dir,
+      source_root: stale_ctime_snapshot,
+      hardlink_mode: true
+    )
+
+    assert_not File.exist?(strict_destination)
+    assert_equal "chapter", File.binread(fallback_destination)
+    assert_not_equal [ File.stat(source).dev, File.stat(source).ino ],
+      [ File.stat(fallback_destination).dev, File.stat(fallback_destination).ino ]
+  end
+
+  test "hardlink_noreplace rejects source mode mutation from its stable snapshot" do
+    source_root_path = File.join(@tmp_dir, "download")
+    source = File.join(source_root_path, "chapter.mp3")
+    first_destination = File.join(@dest_dir, "chapter-one.mp3")
+    second_destination = File.join(@dest_dir, "chapter-two.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "chapter")
+    File.chmod(0o644, source)
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+    FileCopyService.hardlink_noreplace(
+      source,
+      first_destination,
+      root: @dest_dir,
+      source_root: snapshot
+    )
+    File.chmod(0o600, source)
+
+    assert_raises(Errno::ESTALE) do
+      FileCopyService.hardlink_noreplace(
+        source,
+        second_destination,
+        root: @dest_dir,
+        source_root: snapshot
+      )
+    end
+
+    assert_not File.exist?(second_destination)
+    assert_equal 0o600, File.stat(first_destination).mode & 0o7777
+    assert_equal [ "chapter-one.mp3" ], Dir.children(@dest_dir)
+  end
+
+  test "hardlink_noreplace detects stable source fields changed after publication" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    real_validate = FileCopyService.method(:validate_published_child!)
+
+    mutating_validate = lambda do |*args, **kwargs|
+      result = real_validate.call(*args, **kwargs)
+      stat = File.stat(@src_file)
+      File.binwrite(@src_file, "mutated source bytes")
+      File.utime(stat.atime, stat.mtime + 2, @src_file)
+      result
+    end
+
+    FileCopyService.stub(:validate_published_child!, mutating_validate) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
+      [ File.stat(destination).dev, File.stat(destination).ino ]
+    assert_equal "mutated source bytes", File.binread(destination)
+    assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
+  end
+
   test "cp_io_noreplace publishes from the caller's pinned descriptor" do
     destination = File.join(@dest_dir, "descriptor-output.txt")
 
@@ -85,6 +1102,143 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     assert_equal "test content", File.binread(destination)
     assert_equal 0o640, File.stat(destination).mode & 0o777
+  end
+
+  test "same_file_identity returns true for the same inode" do
+    destination = File.join(@dest_dir, "hardlink.txt")
+    File.link(@src_file, destination)
+
+    assert FileCopyService.same_file_identity?(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      source_root: nil
+    )
+  end
+
+  test "same_file_identity returns false for independent identical content" do
+    destination = File.join(@dest_dir, "copy.txt")
+    File.binwrite(destination, "test content")
+
+    assert_not FileCopyService.same_file_identity?(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      source_root: nil
+    )
+  end
+
+  test "same_file_identity returns false for missing symlink and unsafe destinations" do
+    missing = File.join(@dest_dir, "missing.txt")
+    symlink = File.join(@dest_dir, "symlink.txt")
+    directory = File.join(@dest_dir, "directory")
+    File.symlink(@src_file, symlink)
+    FileUtils.mkdir_p(directory)
+
+    [ missing, symlink, directory ].each do |destination|
+      assert_not FileCopyService.same_file_identity?(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+  end
+
+  test "same_file_identity uses hardlink-stable snapshot validation after link-count changes" do
+    source_root_path = File.join(@tmp_dir, "download")
+    source = File.join(source_root_path, "chapter.mp3")
+    destination = File.join(@dest_dir, "chapter.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "chapter")
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+    File.link(source, destination)
+
+    assert FileCopyService.same_file_identity?(
+      source,
+      destination,
+      root: @dest_dir,
+      source_root: snapshot,
+      hardlink_mode: true
+    )
+  end
+
+  test "same_file_identity rejects a destination pathname swap during revalidation" do
+    destination = File.join(@dest_dir, "hardlink.txt")
+    displaced = File.join(@dest_dir, "displaced-hardlink.txt")
+    File.link(@src_file, destination)
+    real_open = FileCopyService.method(:with_pinned_regular_child)
+    destination_opens = 0
+
+    swapping_open = lambda do |parent, basename, &operation|
+      result = real_open.call(parent, basename, &operation)
+      if basename == File.basename(destination)
+        destination_opens += 1
+        if destination_opens == 1
+          File.rename(destination, displaced)
+          File.binwrite(destination, "replacement")
+        end
+      end
+      result
+    end
+
+    FileCopyService.stub(:with_pinned_regular_child, swapping_open) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.same_file_identity?(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    end
+
+    assert_equal "replacement", File.binread(destination)
+    assert_equal "test content", File.binread(displaced)
+  end
+
+  test "secure_library_file_mode checks a pinned revalidated regular file" do
+    destination = File.join(@dest_dir, "library.txt")
+    symlink = File.join(@dest_dir, "library-link.txt")
+    File.binwrite(destination, "library")
+    File.chmod(FileCopyService::LIBRARY_FILE_MODE, destination)
+    File.symlink(destination, symlink)
+
+    assert FileCopyService.secure_library_file_mode?(destination, root: @dest_dir)
+    assert_not FileCopyService.secure_library_file_mode?(symlink, root: @dest_dir)
+    File.chmod(0o644, destination)
+    assert_not FileCopyService.secure_library_file_mode?(destination, root: @dest_dir)
+  end
+
+  test "secure_library_file_mode rejects a destination swap during revalidation" do
+    destination = File.join(@dest_dir, "library.txt")
+    displaced = File.join(@dest_dir, "displaced-library.txt")
+    File.binwrite(destination, "library")
+    File.chmod(FileCopyService::LIBRARY_FILE_MODE, destination)
+    real_open = FileCopyService.method(:with_pinned_regular_child)
+    destination_opens = 0
+
+    swapping_open = lambda do |parent, basename, &operation|
+      result = real_open.call(parent, basename, &operation)
+      if basename == File.basename(destination)
+        destination_opens += 1
+        if destination_opens == 1
+          File.rename(destination, displaced)
+          File.binwrite(destination, "replacement")
+          File.chmod(FileCopyService::LIBRARY_FILE_MODE, destination)
+        end
+      end
+      result
+    end
+
+    FileCopyService.stub(:with_pinned_regular_child, swapping_open) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.secure_library_file_mode?(destination, root: @dest_dir)
+      end
+    end
+
+    assert_equal "replacement", File.binread(destination)
+    assert_equal "library", File.binread(displaced)
   end
 
   test "same_io_content compares against a pinned destination and restores source position" do
@@ -782,5 +1936,23 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert File.exist?(File.join(copied_dir, ".hidden")), "Hidden file should be copied"
     assert_equal "hidden content", File.read(File.join(copied_dir, ".hidden"))
     assert_equal "visible content", File.read(File.join(copied_dir, "visible.txt"))
+  end
+
+  private
+
+  def write_copy_lock(token, temporary_stat)
+    lock = File.join(@dest_dir, ".shelfarr-copy-#{token}.lock")
+    File.binwrite(
+      lock,
+      "#{FileCopyService::COPY_LOCK_MAGIC}:#{token}:full:#{temporary_stat.dev}:#{temporary_stat.ino}"
+    )
+    lock
+  end
+
+  def copy_quarantine_path(expected_stat, token)
+    File.join(
+      @dest_dir,
+      ".shelfarr-copy-quarantine-#{expected_stat.dev.to_s(16)}-#{expected_stat.ino.to_s(16)}-#{token}"
+    )
   end
 end

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -10,7 +10,8 @@ class SettingsServiceTest < ActiveSupport::TestCase
     Setting.where(key: %w[
       indexer_provider indexer_search_scope indexer_custom_audiobook_categories indexer_custom_ebook_categories
       prowlarr_url prowlarr_api_key jackett_url jackett_api_key newznab_url newznab_api_key
-      preferred_download_type preferred_download_types move_completed_downloads split_audiobook_bundle_imports audiobook_path_template api_token
+      preferred_download_type preferred_download_types completed_download_import_mode move_completed_downloads
+      split_audiobook_bundle_imports audiobook_path_template api_token
       zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password gutenberg_enabled gutenberg_url librivox_enabled librivox_url
       ebooks_com_enabled ebooks_com_country_code ebooks_com_search_limit
       metadata_source metadata_provider_priority hardcover_enabled hardcover_api_token open_library_enabled google_books_enabled
@@ -122,8 +123,40 @@ class SettingsServiceTest < ActiveSupport::TestCase
     assert_equal 10, SettingsService.get(:post_processing_source_path_retries)
   end
 
-  test "move completed downloads defaults to disabled" do
-    assert_equal false, SettingsService.get(:move_completed_downloads)
+  test "completed download import mode defaults to copy" do
+    assert_equal "copy", SettingsService.get(:completed_download_import_mode)
+  end
+
+  test "completed download import mode accepts every supported mode" do
+    SettingsService::COMPLETED_DOWNLOAD_IMPORT_MODES.each do |mode|
+      assert_equal mode, SettingsService.set(:completed_download_import_mode, mode)
+
+      setting = Setting.find_by!(key: "completed_download_import_mode")
+      assert_equal mode, setting.value
+      assert_equal "string", setting.value_type
+    end
+  end
+
+  test "completed download import mode rejects invalid writes" do
+    SettingsService.set(:completed_download_import_mode, "move")
+
+    error = assert_raises(ArgumentError) do
+      SettingsService.set(:completed_download_import_mode, "rename")
+    end
+
+    assert_equal "Completed Download Import Mode must be one of: copy, move, hardlink", error.message
+    assert_equal "move", SettingsService.get(:completed_download_import_mode)
+  end
+
+  test "completed download import mode safely resolves corrupt persisted values to copy" do
+    Setting.create!(
+      key: "completed_download_import_mode",
+      value: "rename",
+      value_type: "string",
+      category: "download"
+    )
+
+    assert_equal "copy", SettingsService.get(:completed_download_import_mode)
   end
 
   test "split audiobook bundle imports defaults to disabled" do


### PR DESCRIPTION
## Summary
- replace the completed-download move boolean with copy, move, and hardlink import modes while preserving existing settings through migration
- add race-safe, no-clobber hardlink publication with source-permission preservation and automatic copy fallback for unsupported or cross-filesystem links
- make interrupted imports and fallback retries recoverable and idempotent, with privacy-safe import summaries
- document the required shared-filesystem layout and expose the mode in admin settings

## Test plan
- `bin/quality push`
- `bin/quality coverage`
- `bin/quality mutant "SettingsService*"`
- focused hardlink, post-processing, settings, controller, and migration tests: 396 runs, 1,653 assertions
- repeated adversarial code review with no actionable findings remaining

Closes #372