### PR TITLE
Fix settings tabs after Turbo navigation

### DIFF
--- a/app/javascript/controllers/settings_tabs_controller.js
+++ b/app/javascript/controllers/settings_tabs_controller.js
@@ -1,9 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Progressive enhancement for settings tabs.
-// Panels render visible by default so the page remains usable if JS fails.
+// Panels render visible and tab lists hidden by default so the page remains usable if JS fails.
 export default class extends Controller {
-  static targets = ["tab", "panel"]
+  static targets = ["tablist", "tab", "panel"]
   static values = {
     active: { type: String, default: "search" }
   }
@@ -31,7 +31,7 @@ export default class extends Controller {
     if (queryTab && this.panelTargets.some((panel) => panel.dataset.tab === queryTab)) {
       url.searchParams.delete("tab")
       url.hash = requestedTab
-      history.replaceState(null, "", url)
+      history.replaceState(history.state, "", url)
     }
 
     this.showTab()
@@ -62,7 +62,7 @@ export default class extends Controller {
 
     this.activeValue = tab
     this.showTab()
-    history.replaceState(null, "", `#${tab}`)
+    history.replaceState(history.state, "", `#${tab}`)
   }
 
   navigate(event) {
@@ -86,7 +86,7 @@ export default class extends Controller {
     const nextTab = this.tabTargets[nextIndex]
     this.activeValue = nextTab.dataset.tab
     this.showTab()
-    history.replaceState(null, "", `#${this.activeValue}`)
+    history.replaceState(history.state, "", `#${this.activeValue}`)
     nextTab.focus()
   }
 
@@ -121,6 +121,8 @@ export default class extends Controller {
 
   showTab() {
     const active = this.activeValue
+
+    this.tablistTargets.forEach((tablist) => tablist.classList.remove("hidden"))
 
     this.tabTargets.forEach((tab) => {
       const isActive = tab.dataset.tab === active

--- a/app/views/admin/owned_library_connections/index.html.erb
+++ b/app/views/admin/owned_library_connections/index.html.erb
@@ -63,13 +63,12 @@
   <% end %>
 
   <noscript>
-    <style>#audible-backup-tabs [role="tablist"] { display: none; }</style>
     <div class="mb-6 rounded-lg border border-blue-800 bg-blue-950/30 p-4 text-sm text-blue-200" role="status">
       JavaScript is disabled, so all settings sections are shown below. Background sign-in, sync, and backup jobs still run; refresh this page manually to see progress and completion.
     </div>
   </noscript>
 
-  <div class="mb-6 border-b border-gray-800">
+  <div class="hidden mb-6 border-b border-gray-800" data-settings-tabs-target="tablist">
     <nav class="-mb-px flex gap-1 overflow-x-auto" role="tablist" aria-label="Audible Backup settings">
       <% audible_tabs.each do |tab_key, label| %>
         <button

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -35,14 +35,13 @@
     </div>
 
     <noscript>
-      <style>#settings-tabs [role="tablist"] { display: none; }</style>
       <div class="mb-6 rounded-lg border border-blue-800 bg-blue-950/30 p-4 text-sm text-blue-200" role="status">
         JavaScript is disabled, so all settings sections are shown below. Use Save All to apply your changes.
       </div>
     </noscript>
 
     <%# Tab navigation %>
-    <div class="border-b border-gray-800 mb-6">
+    <div class="hidden border-b border-gray-800 mb-6" data-settings-tabs-target="tablist">
       <nav class="flex gap-1 -mb-px overflow-x-auto" role="tablist">
         <% tab_groups.each do |tab_key, tab_config| %>
           <button type="button"

--- a/bin/quality
+++ b/bin/quality
@@ -98,6 +98,7 @@ module Quality
     success &&= run("RuboCop", "bin/rubocop", "--force-exclusion", "--format", "quiet", "--fail-level", "warning")
     success &&= run_brakeman
     success &&= run("Tests", "bin/rails", "test")
+    success &&= run("System tests", "bin/rails", "test:system")
     success &&= run_coverage
     success ? 0 : 1
   end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,9 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ] do |options|
+    options.add_argument("--no-sandbox") if Process.uid.zero?
+  end
 
   def sign_in_as(user)
     session = user.sessions.create!

--- a/test/controllers/admin/owned_library_connections_controller_test.rb
+++ b/test/controllers/admin/owned_library_connections_controller_test.rb
@@ -44,6 +44,8 @@ class Admin::OwnedLibraryConnectionsControllerTest < ActionDispatch::Integration
 
     assert_response :success
     assert_select "noscript", text: /refresh this page manually/
+    assert_select "#audible-backup-tabs noscript style", count: 0
+    assert_select "#audible-backup-tabs [data-settings-tabs-target='tablist'].hidden [role='tablist']", count: 1
     assert_select "[role='tablist'] [role='tab'][class~='px-2'][class~='sm:px-4']", count: 4
     assert_select "label input#owned_library_connection_enabled[aria-describedby='audible-enabled-help']", count: 1
     assert_select "label[for='owned_library_connection_enabled']", count: 0

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -42,6 +42,8 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Settings"
     assert_select "#settings-tabs noscript", text: /Use Save All/
+    assert_select "#settings-tabs noscript style", count: 0
+    assert_select "#settings-tabs [data-settings-tabs-target='tablist'].hidden [role='tablist']", count: 1
   end
 
   test "index shows telegram group authorization only in integrations tab" do

--- a/test/system/third_party_integrations_test.rb
+++ b/test/system/third_party_integrations_test.rb
@@ -12,6 +12,36 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     SettingsService.set(:telegram_notification_events, "request_completed,request_failed,request_attention")
   end
 
+  test "admin opens integration settings after Turbo navigation" do
+    sign_in_as(@admin)
+
+    visit admin_root_path
+    click_link "Settings"
+
+    assert_selector "#settings-tabs [role='tablist']"
+    click_button "Integrations"
+    assert_field "Audiobookshelf URL"
+
+    click_link "Admin", match: :first
+    assert_current_path admin_root_path
+    page.go_back
+
+    assert_current_path admin_settings_path
+    assert_field "Audiobookshelf URL"
+  end
+
+  test "admin opens Audible Backup tabs after Turbo navigation" do
+    sign_in_as(@admin)
+
+    visit admin_root_path
+    click_link "Audible Backup (Beta)"
+
+    assert_selector "#audible-backup-tabs [role='tablist']"
+    click_button "Automation"
+    assert_text "Audible automation"
+    assert_no_field "Companion URL"
+  end
+
   test "admin configures Telegram settings and verifies the bot" do
     sign_in_as(@admin)
 
@@ -61,12 +91,14 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     sign_in_as(@admin)
 
     visit admin_settings_path
+    click_button "Integrations"
 
     assert_text "Telegram Group Authorization"
     fill_in "telegram_group_code", with: code
     click_button "Authorize Group"
 
     assert_text "Telegram group authorized: Book Club"
+    click_button "Integrations"
     assert_text "Authorized"
     assert TelegramChatAuthorization.find_by!(chat_id: "-100999").approved?
   end
@@ -81,22 +113,26 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     sign_in_as(@admin)
 
     visit admin_settings_path
+    click_button "Integrations"
 
     assert_text "Book Club"
     assert_text "Authorized"
 
     click_button "Pause Book Club"
     assert_text "Telegram group paused: Book Club"
+    click_button "Integrations"
     assert_text "Paused"
     assert authorization.reload.paused?
 
     click_button "Resume Book Club"
     assert_text "Telegram group resumed: Book Club"
+    click_button "Integrations"
     assert_text "Authorized"
     assert_not authorization.reload.paused?
 
     click_button "Delete Book Club"
     assert_text "Telegram group removed: Book Club"
+    click_button "Integrations"
     assert_no_text "-100999"
     assert_not TelegramChatAuthorization.exists?(authorization.id)
   end


### PR DESCRIPTION
## Summary
- replace Turbo-unsafe `noscript` styles with progressively enhanced hidden tab lists
- preserve Turbo history state when switching tabs so back/forward restoration remains reliable
- add browser regressions for Settings and Audible Backup navigation and run system tests in the push quality gate

## Test plan
- `bin/quality push`
- 7 system tests, 43 assertions
- 227 affected controller tests, 1,168 assertions
- manual Chromium verification of Turbo navigation, tab switching, Turbo render recovery, and no-JavaScript fallback

Closes #373