### PR TITLE
Fix post-processing on limited filesystems

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -11,6 +11,7 @@ class PostProcessingJob < ApplicationJob
   EBOOK_SIDECAR_EXTENSIONS = %w[jpg jpeg png webp opf nfo txt].freeze
   EBOOK_ALLOWED_EXTENSIONS = (EBOOK_FILE_EXTENSIONS + EBOOK_SIDECAR_EXTENSIONS).freeze
   MAX_FILENAME_BYTES = 255
+  POST_PROCESSING_LOCK_SLOTS = 256
   class BookAcquisitionConflictError < StandardError; end
 
   queue_as :default
@@ -36,6 +37,15 @@ class PostProcessingJob < ApplicationJob
     @reused_file_count = 0
     download = Download.find_by(id: download_id)
     return unless download&.completed?
+
+    with_post_processing_lock(download.id) do
+      perform_locked(download, source_path_retry_count, expected_owner_job_id)
+    end
+  end
+
+  def perform_locked(download, source_path_retry_count, expected_owner_job_id)
+    download.reload
+    return unless download.completed?
 
     request = download.request
     return unless claim_request_for_post_processing(download, request, expected_owner_job_id)
@@ -101,6 +111,16 @@ class PostProcessingJob < ApplicationJob
       Rails.logger.error "[PostProcessingJob] Download ##{download.id} failed: #{e.class}"
       mark_post_processing_failure!(download, request, e) unless acquisition_finalized
     end
+  end
+
+  def with_post_processing_lock(download_id, &operation)
+    tmp_root = Rails.root.join("tmp")
+    lock_root = tmp_root.join("post-processing-locks")
+    FileCopyService.ensure_directory(lock_root.to_s, root: tmp_root.to_s, mode: 0o700)
+    FileCopyService.secure_private_directory!(lock_root.to_s, root: tmp_root.to_s)
+    lock_slot = download_id % POST_PROCESSING_LOCK_SLOTS
+    lock_path = lock_root.join("#{lock_slot}.lock")
+    FileCopyService.with_private_lock(lock_path.to_s, root: lock_root.to_s, &operation)
   end
 
   def claim_request_for_post_processing(download, request, expected_owner_job_id)
@@ -653,7 +673,8 @@ class PostProcessingJob < ApplicationJob
         source,
         destination,
         root: @import_base_path,
-        source_root: @import_source_root
+        source_root: @import_source_root,
+        allow_compatibility_fallback: true
       )
     elsif hardlink_completed_downloads?
       begin
@@ -673,7 +694,8 @@ class PostProcessingJob < ApplicationJob
           destination,
           root: @import_base_path,
           source_root: @import_source_root,
-          hardlink_mode: true
+          hardlink_mode: true,
+          allow_compatibility_fallback: true
         )
         @hardlink_fallback_copied_count += 1
       end
@@ -682,7 +704,8 @@ class PostProcessingJob < ApplicationJob
         source,
         destination,
         root: @import_base_path,
-        source_root: @import_source_root
+        source_root: @import_source_root,
+        allow_compatibility_fallback: true
       )
     end
     destination

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -23,6 +23,8 @@ class FileCopyService
   COPY_LOCK_LEGACY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_LEGACY_MAGIC)}:([0-9a-f]{32})\z/
   COPY_LOCK_PENDING_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):pending\z/
   COPY_LOCK_RECORD_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):full:([0-9]+):([0-9]+)\z/
+  COPY_LOCK_COMPATIBILITY_PREPARED_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:prepared:([0-9]+):([0-9]+):([0-9a-f]+)\z/
+  COPY_LOCK_COMPATIBILITY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:(copying|complete):([0-9]+):([0-9]+):([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   COPY_QUARANTINE_ENTRY = "entry"
   COPY_QUARANTINE_STALE_AGE = 24 * 60 * 60
@@ -70,15 +72,29 @@ class FileCopyService
       buffered_copy(src, dest)
     end
 
-    # Copy a regular file without ever exposing partially-copied bytes at the
-    # final pathname. Bytes are written and fsynced to a private file in the
-    # destination directory, then published with an atomic no-replace link (or
-    # platform no-replace rename). Every destination component is opened from
-    # a pinned root descriptor with O_NOFOLLOW.
-    def cp_noreplace(src, dest, root: nil, source_root: nil, heartbeat: nil, hardlink_mode: false)
+    # Copy a regular file through a complete private file in the destination
+    # directory. Publication uses an atomic no-replace operation when the
+    # filesystem supports one, or an exclusive descriptor-backed copy with
+    # crash recovery on compatibility filesystems. Every destination component
+    # is opened from a pinned root descriptor with O_NOFOLLOW.
+    def cp_noreplace(
+      src,
+      dest,
+      root: nil,
+      source_root: nil,
+      heartbeat: nil,
+      hardlink_mode: false,
+      allow_compatibility_fallback: false
+    )
       source_opener = hardlink_mode ? :with_pinned_hardlink_source : :with_pinned_source
       send(source_opener, src, source_root: source_root) do |source, *_source_path|
-        publish_source_io_noreplace(source, dest, root: root, heartbeat: heartbeat)
+        publish_source_io_noreplace(
+          source,
+          dest,
+          root: root,
+          heartbeat: heartbeat,
+          allow_compatibility_fallback: allow_compatibility_fallback
+        )
       end
       dest
     end
@@ -114,10 +130,23 @@ class FileCopyService
     # Move with the same crash-safe publication as cp_noreplace. The source is
     # removed through its pinned parent descriptor only after its pathname,
     # descriptor identity, and parent identity have all been revalidated.
-    def mv_noreplace(src, dest, root: nil, source_root: nil, heartbeat: nil)
+    def mv_noreplace(
+      src,
+      dest,
+      root: nil,
+      source_root: nil,
+      heartbeat: nil,
+      allow_compatibility_fallback: false
+    )
       with_pinned_source(src, source_root: source_root) do |source, source_parent, source_basename, source_parent_path|
         source_identity = file_identity(source.stat)
-        publish_source_io_noreplace(source, dest, root: root, heartbeat: heartbeat)
+        publish_source_io_noreplace(
+          source,
+          dest,
+          root: root,
+          heartbeat: heartbeat,
+          allow_compatibility_fallback: allow_compatibility_fallback
+        )
         remove_pinned_source_after_publication!(
           source,
           source_parent,
@@ -991,7 +1020,13 @@ class FileCopyService
       relative
     end
 
-    def publish_source_io_noreplace(source, destination, root:, heartbeat: nil)
+    def publish_source_io_noreplace(
+      source,
+      destination,
+      root:,
+      heartbeat: nil,
+      allow_compatibility_fallback: false
+    )
       raise Errno::EINVAL, "source is not a regular file" unless source.stat.file?
 
       cleanup_interrupted_copies(File.dirname(destination), root: root)
@@ -1023,13 +1058,30 @@ class FileCopyService
               native_fchmod(temporary.fileno, LIBRARY_FILE_MODE)
               flush_and_sync(temporary)
 
-              publish_private_child_noreplace!(
-                parent,
-                temporary_basename,
-                basename,
-                temporary_identity
-              )
-              published_identity = temporary_identity
+              begin
+                publish_private_child_noreplace!(
+                  parent,
+                  temporary_basename,
+                  basename,
+                  temporary_identity
+                )
+                published_identity = temporary_identity
+              rescue AtomicPublicationUnsupportedError
+                raise unless allow_compatibility_fallback
+
+                Rails.logger.warn(
+                  "[FileCopyService] Atomic publication unsupported; using exclusive-copy compatibility mode"
+                )
+                published_identity = publish_private_child_by_copy_noreplace!(
+                  parent,
+                  temporary_basename,
+                  basename,
+                  temporary_identity,
+                  lock: lock,
+                  token: token,
+                  heartbeat: heartbeat
+                )
+              end
               validate_published_child!(parent, basename, published_identity)
               validate_current_directory_identity!(parent_path, parent)
               sync_io(parent)
@@ -1228,6 +1280,88 @@ class FileCopyService
       validate_published_child!(parent, destination_basename, identity, expected_mode: mode)
     end
 
+    def publish_private_child_by_copy_noreplace!(
+      parent,
+      temporary_basename,
+      destination_basename,
+      temporary_identity,
+      lock:,
+      token:,
+      heartbeat:,
+      mode: LIBRARY_FILE_MODE
+    )
+      destination_identity = nil
+      source_size = nil
+
+      begin
+        with_pinned_regular_child(parent, temporary_basename) do |source|
+          source_stat = source.stat
+          unless file_identity(source_stat) == temporary_identity
+            raise Errno::ESTALE, "private publication source changed"
+          end
+          source_size = source_stat.size
+
+          persist_copy_lock_compatibility!(
+            lock,
+            token,
+            :prepared,
+            temporary_identity,
+            destination_basename
+          )
+          with_created_regular_child(parent, destination_basename, 0o600) do |destination|
+            destination_identity = file_identity(destination.stat)
+            persist_copy_lock_compatibility!(
+              lock,
+              token,
+              :copying,
+              temporary_identity,
+              destination_basename,
+              destination_identity
+            )
+            sync_io(parent)
+
+            if heartbeat
+              copy_source_io(source, destination, heartbeat: heartbeat)
+            else
+              copy_source_io(source, destination)
+            end
+            native_fchmod(destination.fileno, mode)
+            flush_and_sync(destination)
+            unless file_identity(source.stat) == temporary_identity &&
+                source.stat.size == source_size && destination.stat.size == source_size
+              raise Errno::ESTALE, "file changed during compatibility publication"
+            end
+          end
+        end
+
+        with_pinned_regular_child(parent, temporary_basename) do |source|
+          unless file_identity(source.stat) == temporary_identity && source.stat.size == source_size
+            raise Errno::ESTALE, "private publication source changed"
+          end
+        end
+        validate_published_child!(
+          parent,
+          destination_basename,
+          destination_identity,
+          expected_mode: mode
+        )
+        sync_io(parent)
+        persist_copy_lock_compatibility!(
+          lock,
+          token,
+          :complete,
+          temporary_identity,
+          destination_basename,
+          destination_identity
+        )
+        destination_identity
+      rescue
+        remove_pinned_child_if_identity(parent, destination_basename, destination_identity)
+        sync_io(parent)
+        raise
+      end
+    end
+
     def validate_published_child!(
       parent,
       basename,
@@ -1275,10 +1409,12 @@ class FileCopyService
 
       with_pinned_regular_child(parent, lock_basename) do |lock|
         return unless lock.flock(File::LOCK_EX | File::LOCK_NB)
+        return unless lock.stat.uid == Process.euid
 
         lock_identity = file_identity(lock.stat)
         lock.rewind
-        state, expected_temporary_identity = copy_lock_cleanup_state(lock.read, token)
+        state, expected_temporary_identity, destination_basename,
+          expected_destination_identity = copy_lock_cleanup_state(lock.read, token)
         cleanup_result = case state
         when :full
           remove_pinned_child_if_identity(
@@ -1286,6 +1422,51 @@ class FileCopyService
             temporary_basename,
             expected_temporary_identity
           )
+        when :compatibility_copying
+          destination_cleanup = remove_pinned_child_if_identity(
+            parent,
+            destination_basename,
+            expected_destination_identity
+          )
+          if destination_cleanup.in?([ :removed, :missing ])
+            remove_pinned_child_if_identity(
+              parent,
+              temporary_basename,
+              expected_temporary_identity
+            )
+          else
+            destination_cleanup
+          end
+        when :compatibility_prepared
+          # The process exited before recording the final inode. Never remove
+          # an occupied path that cannot be proven to belong to this attempt.
+          if pinned_child_missing?(parent, destination_basename)
+            remove_pinned_child_if_identity(
+              parent,
+              temporary_basename,
+              expected_temporary_identity
+            )
+          else
+            :retained
+          end
+        when :compatibility_complete
+          destination_status = begin
+            pinned_child_identity(parent, destination_basename) == expected_destination_identity ?
+              :complete : :retained
+          rescue Errno::ENOENT
+            :missing
+          rescue Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+            :retained
+          end
+          if destination_status.in?([ :complete, :missing ])
+            remove_pinned_child_if_identity(
+              parent,
+              temporary_basename,
+              expected_temporary_identity
+            )
+          else
+            destination_status
+          end
         when :pending, :legacy
           remove_pinned_regular_child(parent, temporary_basename)
         else
@@ -1352,6 +1533,28 @@ class FileCopyService
       )
     end
 
+    def persist_copy_lock_compatibility!(
+      lock,
+      token,
+      state,
+      temporary_identity,
+      destination_basename,
+      destination_identity = nil
+    )
+      encoded_basename = destination_basename.b.unpack1("H*")
+      record = "#{COPY_LOCK_MAGIC}:#{token}:compatibility:#{state}:" \
+        "#{temporary_identity.first}:#{temporary_identity.last}:"
+      if destination_identity
+        record << "#{destination_identity.first}:#{destination_identity.last}:"
+      end
+      record << encoded_basename
+
+      checksum = Digest::SHA256.hexdigest(record)
+      lock.seek(0, IO::SEEK_END)
+      lock.write("\n#{record}:#{checksum}\n")
+      flush_and_sync(lock)
+    end
+
     def persist_copy_lock_record!(lock, record)
       lock.rewind
       lock.truncate(0)
@@ -1360,7 +1563,57 @@ class FileCopyService
     end
 
     def copy_lock_cleanup_state(contents, token)
-      if (record = COPY_LOCK_RECORD_PATTERN.match(contents)) && record[1] == token
+      contents.lines(chomp: true).reverse_each do |record|
+        if record.start_with?("#{COPY_LOCK_MAGIC}:#{token}:compatibility:")
+          journal_record, separator, checksum = record.rpartition(":")
+          next if separator.empty? || checksum.length != 64 ||
+            Digest::SHA256.hexdigest(journal_record) != checksum
+
+          record = journal_record
+        end
+
+        state = copy_lock_record_cleanup_state(record, token)
+        return state unless state.first == :malformed
+      end
+      [ :malformed, nil ]
+    end
+
+    def copy_lock_record_cleanup_state(contents, token)
+      if (record = COPY_LOCK_COMPATIBILITY_PATTERN.match(contents)) && record[1] == token
+        encoded_basename = record[7]
+        return [ :malformed, nil, nil, nil ] unless encoded_basename.length.even? &&
+          encoded_basename.length <= 510
+
+        destination_basename = [ encoded_basename ].pack("H*")
+        return [ :malformed, nil, nil, nil ] if destination_basename.empty? ||
+          destination_basename.include?(File::SEPARATOR) ||
+          destination_basename.include?("\0") ||
+          destination_basename.in?([ ".", ".." ])
+
+        [
+          record[2] == "complete" ? :compatibility_complete : :compatibility_copying,
+          [ record[3].to_i, record[4].to_i ],
+          destination_basename,
+          [ record[5].to_i, record[6].to_i ]
+        ]
+      elsif (record = COPY_LOCK_COMPATIBILITY_PREPARED_PATTERN.match(contents)) && record[1] == token
+        encoded_basename = record[4]
+        return [ :malformed, nil, nil, nil ] unless encoded_basename.length.even? &&
+          encoded_basename.length <= 510
+
+        destination_basename = [ encoded_basename ].pack("H*")
+        return [ :malformed, nil, nil, nil ] if destination_basename.empty? ||
+          destination_basename.include?(File::SEPARATOR) ||
+          destination_basename.include?("\0") ||
+          destination_basename.in?([ ".", ".." ])
+
+        [
+          :compatibility_prepared,
+          [ record[2].to_i, record[3].to_i ],
+          destination_basename,
+          nil
+        ]
+      elsif (record = COPY_LOCK_RECORD_PATTERN.match(contents)) && record[1] == token
         [ :full, [ record[2].to_i, record[3].to_i ] ]
       elsif (record = COPY_LOCK_PENDING_PATTERN.match(contents)) && record[1] == token
         [ :pending, nil ]

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -981,7 +981,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal "long-name audio", File.read(File.join(long_title_destination, duplicate_filename))
   end
 
-  test "publishes split imports when the destination filesystem rejects hard links" do
+  test "publishes split imports when the destination filesystem rejects atomic publication" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
     @book.update!(title: "Book Two")
@@ -990,7 +990,9 @@ class PostProcessingJobTest < ActiveJob::TestCase
     File.write(File.join(@temp_source, "Book Two.m4b"), "book two audio")
 
     FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EOPNOTSUPP, "hard links unavailable" }) do
-      PostProcessingJob.perform_now(@download.id)
+      FileCopyService.stub(:native_rename_noreplace, false) do
+        PostProcessingJob.perform_now(@download.id)
+      end
     end
 
     book_one_destination = File.join(@temp_dest_base, @book.author, "Book One", "Book One.m4b")
@@ -1926,6 +1928,57 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert duplicate.job_id.present?
     assert @download.claim_post_processing!(duplicate.job_id, expected_owner_job_id: owner.job_id)
     assert_equal duplicate.job_id, @download.reload.post_processing_job_id
+  end
+
+  test "duplicate delivery of one job cannot import concurrently" do
+    SettingsService.set(:audiobookshelf_url, "")
+    original_job = PostProcessingJob.new(@download.id)
+    duplicate_job = PostProcessingJob.deserialize(original_job.serialize)
+    real_copy = FileCopyService.method(:copy_source_io)
+    entered_copy = Queue.new
+    release_copy = Queue.new
+    paused = false
+    errors = Queue.new
+    first = nil
+    duplicate = nil
+
+    pausing_copy = lambda do |source, target, heartbeat: nil|
+      unless paused
+        paused = true
+        entered_copy << true
+        release_copy.pop
+      end
+      real_copy.call(source, target, heartbeat: heartbeat)
+    end
+
+    FileCopyService.stub(:copy_source_io, pausing_copy) do
+      first = Thread.new do
+        original_job.perform_now
+      rescue => error
+        errors << error
+      end
+      entered_copy.pop
+      duplicate = Thread.new do
+        duplicate_job.perform_now
+      rescue => error
+        errors << error
+      end
+
+      sleep 0.05
+      assert duplicate.alive?
+      release_copy << true
+      first.join
+      duplicate.join
+    end
+
+    expected_directory = File.join(@temp_dest_base, @book.author, @book.title)
+    flunk errors.pop.full_message unless errors.empty?
+    assert @request.reload.completed?
+    assert_equal [ "audiobook.mp3" ], Dir.children(expected_directory)
+  ensure
+    release_copy << true if release_copy && first&.alive?
+    first&.join
+    duplicate&.join
   end
 
   test "scheduled retry owns durable recovery and blocks cancellation" do

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -77,6 +77,118 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal 0o777, File.stat(@src_file).mode & 0o777
   end
 
+  test "cp_noreplace uses exclusive copy when atomic publication is unsupported" do
+    destination = File.join(@dest_dir, "compatible.txt")
+
+    without_atomic_file_publication do
+      FileCopyService.cp_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        allow_compatibility_fallback: true
+      )
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_equal 0o640, File.stat(destination).mode & 0o777
+    assert_empty Dir.children(@dest_dir) - [ "compatible.txt" ]
+  end
+
+  test "cp_noreplace remains strict unless compatibility publication is enabled" do
+    destination = File.join(@dest_dir, "strict.txt")
+
+    without_atomic_file_publication do
+      assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+        FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert_not File.exist?(destination)
+    assert_equal "test content", File.binread(@src_file)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "compatibility publication never overwrites an occupied destination" do
+    destination = File.join(@dest_dir, "occupied.txt")
+    raced = false
+
+    unsupported_link = lambda do |*|
+      unless raced
+        raced = true
+        File.binwrite(destination, "concurrent library bytes")
+      end
+      raise Errno::EOPNOTSUPP
+    end
+
+    FileCopyService.stub(:native_linkat, unsupported_link) do
+      FileCopyService.stub(:native_rename_noreplace, false) do
+        assert_raises(Errno::EEXIST) do
+          FileCopyService.cp_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            allow_compatibility_fallback: true
+          )
+        end
+      end
+    end
+
+    assert_equal "concurrent library bytes", File.binread(destination)
+    assert_equal "test content", File.binread(@src_file)
+    assert_equal [ "occupied.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "compatibility publication removes an interrupted partial destination" do
+    destination = File.join(@dest_dir, "partial.txt")
+    real_copy = FileCopyService.method(:copy_source_io)
+    copy_calls = 0
+    interrupted_copy = lambda do |source, target, heartbeat: nil|
+      copy_calls += 1
+      if copy_calls == 2
+        target.write("partial")
+        target.flush
+        raise IOError, "interrupted compatibility copy"
+      end
+
+      real_copy.call(source, target, heartbeat: heartbeat)
+    end
+
+    FileCopyService.stub(:copy_source_io, interrupted_copy) do
+      without_atomic_file_publication do
+        assert_raises(IOError) do
+          FileCopyService.cp_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            allow_compatibility_fallback: true
+          )
+        end
+      end
+    end
+
+    assert_equal 2, copy_calls
+    assert_not File.exist?(destination)
+    assert_equal "test content", File.binread(@src_file)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "mv_noreplace removes its source after compatibility publication" do
+    destination = File.join(@dest_dir, "moved-compatible.txt")
+
+    without_atomic_file_publication do
+      FileCopyService.mv_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        allow_compatibility_fallback: true
+      )
+    end
+
+    assert_not File.exist?(@src_file)
+    assert_equal "test content", File.binread(destination)
+    assert_empty Dir.children(@dest_dir) - [ "moved-compatible.txt" ]
+  end
+
   test "hardlink_noreplace publishes the source inode without removing or chmodding it" do
     destination = File.join(@dest_dir, "hardlinked.txt")
     File.chmod(0o754, @src_file)
@@ -542,6 +654,145 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
 
+    assert_not File.exist?(lock)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "interrupted cleanup removes a compatibility partial by recorded identity" do
+    token = "9" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    destination = File.join(@dest_dir, "partial-compatible.txt")
+    File.binwrite(temporary, "complete private bytes")
+    File.binwrite(destination, "partial")
+    lock = write_compatibility_copy_lock(
+      token,
+      File.stat(temporary),
+      destination,
+      File.stat(destination)
+    )
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(temporary)
+    assert_not File.exist?(destination)
+    assert_not File.exist?(lock)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "interrupted cleanup retains an unverified prepared compatibility destination" do
+    token = "7" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    destination = File.join(@dest_dir, "prepared-compatible.txt")
+    File.binwrite(temporary, "complete private bytes")
+    File.binwrite(destination, "")
+    File.chmod(0o600, destination)
+    lock = write_compatibility_copy_lock(
+      token,
+      File.stat(temporary),
+      destination,
+      File.stat(destination),
+      state: :prepared
+    )
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_equal "", File.binread(destination)
+    assert File.exist?(temporary)
+    assert File.exist?(lock)
+  end
+
+  test "prepared compatibility cleanup retains a nonempty destination" do
+    token = "5" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    destination = File.join(@dest_dir, "prepared-nonempty.txt")
+    File.binwrite(temporary, "complete private bytes")
+    File.binwrite(destination, "legitimate bytes")
+    File.chmod(0o600, destination)
+    lock = write_compatibility_copy_lock(
+      token,
+      File.stat(temporary),
+      destination,
+      File.stat(destination),
+      state: :prepared
+    )
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_equal "legitimate bytes", File.binread(destination)
+    assert File.exist?(temporary)
+    assert File.exist?(lock)
+  end
+
+  test "interrupted compatibility cleanup retains a destination replacement" do
+    token = "0" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    destination = File.join(@dest_dir, "replaced-compatible.txt")
+    displaced = File.join(@dest_dir, "original-partial")
+    File.binwrite(temporary, "complete private bytes")
+    File.binwrite(destination, "owned partial")
+    destination_stat = File.stat(destination)
+    lock = write_compatibility_copy_lock(
+      token,
+      File.stat(temporary),
+      destination,
+      destination_stat
+    )
+    File.rename(destination, displaced)
+    File.binwrite(destination, "replacement bytes")
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_equal "replacement bytes", File.binread(destination)
+    assert_equal "owned partial", File.binread(displaced)
+    assert File.exist?(temporary)
+    assert File.exist?(lock)
+  end
+
+  test "interrupted compatibility cleanup retains a completed destination" do
+    token = "8" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    destination = File.join(@dest_dir, "complete-compatible.txt")
+    File.binwrite(temporary, "complete bytes")
+    File.binwrite(destination, "complete bytes")
+    lock = write_compatibility_copy_lock(
+      token,
+      File.stat(temporary),
+      destination,
+      File.stat(destination),
+      state: :complete
+    )
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_equal "complete bytes", File.binread(destination)
+    assert_not File.exist?(temporary)
+    assert_not File.exist?(lock)
+    assert_equal [ "complete-compatible.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "interrupted compatibility cleanup uses the last valid journal record" do
+    token = "6" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    destination = File.join(@dest_dir, "torn-compatible.txt")
+    File.binwrite(temporary, "complete private bytes")
+    File.binwrite(destination, "complete private bytes")
+    lock = write_compatibility_copy_lock(
+      token,
+      File.stat(temporary),
+      destination,
+      File.stat(destination)
+    )
+    File.open(lock, "ab") do |file|
+      file.write(
+        "\n#{FileCopyService::COPY_LOCK_MAGIC}:#{token}:compatibility:complete:" \
+          "1:2:3:4:746f726e"
+      )
+    end
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(temporary)
+    assert_not File.exist?(destination)
     assert_not File.exist?(lock)
     assert_empty Dir.children(@dest_dir)
   end
@@ -1947,6 +2198,29 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       "#{FileCopyService::COPY_LOCK_MAGIC}:#{token}:full:#{temporary_stat.dev}:#{temporary_stat.ino}"
     )
     lock
+  end
+
+  def write_compatibility_copy_lock(token, temporary_stat, destination, destination_stat, state: :copying)
+    lock = File.join(@dest_dir, ".shelfarr-copy-#{token}.lock")
+    encoded_basename = File.basename(destination).b.unpack1("H*")
+    record = "#{FileCopyService::COPY_LOCK_MAGIC}:#{token}:compatibility:#{state}:" \
+      "#{temporary_stat.dev}:#{temporary_stat.ino}:"
+    unless state == :prepared
+      record << "#{destination_stat.dev}:#{destination_stat.ino}:"
+    end
+    record << encoded_basename
+    checksum = Digest::SHA256.hexdigest(record)
+    File.binwrite(
+      lock,
+      "#{record}:#{checksum}\n"
+    )
+    lock
+  end
+
+  def without_atomic_file_publication(&operation)
+    FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EOPNOTSUPP }) do
+      FileCopyService.stub(:native_rename_noreplace, false, &operation)
+    end
   end
 
   def copy_quarantine_path(expected_stat, token)


### PR DESCRIPTION
## Summary
- add an opt-in, no-clobber compatibility publication path for post-processing filesystems that support neither hard links nor no-replace rename
- journal prepared, copying, and complete states so interrupted compatibility copies can be recovered without deleting unverified paths
- keep direct download and archive publication strictly atomic, and serialize duplicate post-processing deliveries with bounded striped locks

## Test plan
- confirmed the regression test fails on unmodified `main` when `linkat` and `renameat2(RENAME_NOREPLACE)` are both unavailable
- ran focused post-processing, file-copy, direct-download, and archive tests
- ran `bin/quality push`
- completed adversarial review with no remaining actionable findings

A physical Windows-backed Docker/WSL mount was not available, so the regression test simulates the unsupported filesystem operations reported in the issue.

Fixes #378