### PR TITLE
fix: scope library match warnings by format

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,7 +3,16 @@
 class RequestsController < ApplicationController
   class UnsafeDownloadPathError < StandardError; end
   DownloadBoundary = Data.define(:target, :root, :device, :inode, :kind)
+  UnscopedLibraryMatch = Data.define(:match, :book_types)
   MAX_ARCHIVE_DOWNLOAD_FILENAME_BYTES = 120
+  LIBRARY_ID_SETTING_KEYS = %i[
+    audiobookshelf_audiobook_library_id
+    audiobookshelf_ebook_library_id
+    audiobookshelf_comicbook_library_id
+    audiobookshelf_audiobook_scan_library_ids
+    audiobookshelf_ebook_scan_library_ids
+    audiobookshelf_comicbook_scan_library_ids
+  ].freeze
 
   before_action :set_request, only: [ :show, :destroy, :retry, :manual_magnet, :manual_nzb ]
   before_action :set_request_for_download, only: [ :download ]
@@ -65,37 +74,38 @@ class RequestsController < ApplicationController
   end
 
   def library_ids_for_book_type(book_type)
-    all_configured_ids = [
-      SettingsService.get(:audiobookshelf_audiobook_library_id),
-      SettingsService.get(:audiobookshelf_ebook_library_id),
-      SettingsService.get(:audiobookshelf_comicbook_library_id),
-      SettingsService.get(:audiobookshelf_audiobook_scan_library_ids),
-      SettingsService.get(:audiobookshelf_ebook_scan_library_ids),
-      SettingsService.get(:audiobookshelf_comicbook_scan_library_ids)
-    ].flat_map { |id| id.to_s.split(",").map(&:strip) }.filter_map(&:presence)
+    settings = library_id_settings
+    return nil if settings.values.all?(&:empty?) # Preserve all-library matching after auto-discovery.
 
-    if all_configured_ids.empty?
-      return nil # Preserve all-library matching when synchronization used discovery
-    end
-
-    delivery_key, scan_key = case book_type.to_s
+    library_ids = case book_type.to_s
     when "audiobook"
-      [ :audiobookshelf_audiobook_library_id, :audiobookshelf_audiobook_scan_library_ids ]
+      settings[:audiobookshelf_audiobook_library_id] + settings[:audiobookshelf_audiobook_scan_library_ids]
     when "comicbook"
-      delivery_id = SettingsService.get(:audiobookshelf_comicbook_library_id).presence ||
-                    SettingsService.get(:audiobookshelf_ebook_library_id)
-      scan_ids = SettingsService.get(:audiobookshelf_comicbook_scan_library_ids)
-      return [ delivery_id, scan_ids ].flat_map { |id| id.to_s.split(",").map(&:strip) }.filter_map(&:presence).uniq
+      delivery_ids = settings[:audiobookshelf_comicbook_library_id].presence ||
+                     settings[:audiobookshelf_ebook_library_id]
+      delivery_ids + settings[:audiobookshelf_comicbook_scan_library_ids]
     else # ebook
-      [ :audiobookshelf_ebook_library_id, :audiobookshelf_ebook_scan_library_ids ]
+      settings[:audiobookshelf_ebook_library_id] + settings[:audiobookshelf_ebook_scan_library_ids]
     end
 
-    [
-      SettingsService.get(delivery_key),
-      SettingsService.get(scan_key)
-    ].flat_map { |id| id.to_s.split(",").map(&:strip) }.filter_map(&:presence).uniq
+    library_ids.uniq.sort
   end
-  private :library_ids_for_book_type
+
+  def library_id_settings
+    @library_id_settings ||= LIBRARY_ID_SETTING_KEYS.index_with do |key|
+      SettingsService.get(key).to_s.split(",").map(&:strip).filter_map(&:presence).uniq
+    end
+  end
+
+  def explicitly_assigned_library_ids_by_book_type
+    settings = library_id_settings
+    {
+      "audiobook" => settings[:audiobookshelf_audiobook_library_id] + settings[:audiobookshelf_audiobook_scan_library_ids],
+      "ebook" => settings[:audiobookshelf_ebook_library_id] + settings[:audiobookshelf_ebook_scan_library_ids],
+      "comicbook" => settings[:audiobookshelf_comicbook_library_id] + settings[:audiobookshelf_comicbook_scan_library_ids]
+    }.transform_values { |ids| ids.uniq.sort }
+  end
+  private :library_ids_for_book_type, :library_id_settings, :explicitly_assigned_library_ids_by_book_type
 
   def show
     @request_events = Current.user.admin? ? @request.request_events.recent.limit(10) : RequestEvent.none
@@ -136,6 +146,7 @@ class RequestsController < ApplicationController
       return
     end
 
+    load_synced_library_matches
     @default_language = SettingsService.get(:default_language)
     @enabled_languages = enabled_language_options
   end
@@ -492,6 +503,54 @@ class RequestsController < ApplicationController
 
       [ info[:name], code ]
     end.sort_by(&:first)
+  end
+
+  def load_synced_library_matches
+    @synced_library_matches_by_book_type = {}
+    @unscoped_synced_library_match_entries = []
+    return if @request_scope == "collection" || @available_book_types.empty?
+
+    matcher = AudiobookshelfLibraryMatcherService.new(cache_library_items: false)
+    all_library_scopes = %w[audiobook ebook comicbook].index_with do |book_type|
+      library_ids_for_book_type(book_type)
+    end
+
+    if all_library_scopes.values.all?(&:nil?)
+      match = matcher.matches_for(title: @title, author: @author, limit: 1).first
+      @unscoped_synced_library_match_entries << UnscopedLibraryMatch.new(
+        match: match,
+        book_types: @available_book_types
+      ) if match
+      return
+    end
+
+    library_scopes = all_library_scopes.slice(*@available_book_types)
+    overlapping_ids = explicitly_assigned_library_ids_by_book_type.values.flatten.tally.filter_map do |id, count|
+      id if count > 1
+    end
+    if library_id_settings[:audiobookshelf_comicbook_library_id].empty?
+      overlapping_ids |= library_id_settings[:audiobookshelf_ebook_library_id]
+    end
+    overlapping_ids &= library_scopes.values.compact.flatten
+    overlapping_ids.each do |library_id|
+      match = matcher.matches_for(
+        title: @title,
+        author: @author,
+        limit: 1,
+        library_ids: [ library_id ]
+      ).first
+      next unless match
+
+      book_types = library_scopes.filter_map do |book_type, library_ids|
+        book_type if Array(library_ids).include?(library_id)
+      end
+      @unscoped_synced_library_match_entries << UnscopedLibraryMatch.new(match: match, book_types: book_types)
+    end
+
+    @synced_library_matches_by_book_type = library_scopes.transform_values do |library_ids|
+      scoped_ids = Array(library_ids) - overlapping_ids
+      matcher.matches_for(title: @title, author: @author, limit: 1, library_ids: scoped_ids)
+    end
   end
 
   def request_handoff_metadata

--- a/app/models/library_item.rb
+++ b/app/models/library_item.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class LibraryItem < ApplicationRecord
+  MAX_DISPLAY_TEXT_CHARACTERS = 500
+  MAX_DISPLAY_TEXT_BYTES = MAX_DISPLAY_TEXT_CHARACTERS * 4
+  BIDI_CONTROL_PATTERN = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/
+
   validates :library_platform, presence: true, inclusion: { in: SettingsService::LIBRARY_PLATFORMS }
   validates :library_id, presence: true
   validates :audiobookshelf_id, presence: true
@@ -21,34 +25,67 @@ class LibraryItem < ApplicationRecord
   end
 
   def display_title
-    [ title, subtitle.presence ].compact.join(": ")
+    sanitized_text([ sanitized_text(title).presence, sanitized_text(subtitle).presence ].compact.join(": "))
+  end
+
+  def display_author
+    sanitized_text(author)
   end
 
   def series_label
-    return nil if series.blank?
-    return series if series_position.blank?
+    series_text = sanitized_text(series)
+    return nil if series_text.blank?
 
-    "#{series} ##{series_position}"
+    position_text = sanitized_text(series_position)
+    return series_text if position_text.blank?
+
+    sanitized_text("#{series_text} ##{position_text}")
   end
 
   def detail_badges
+    narrator_text = sanitized_text(narrator)
+    publisher_text = sanitized_text(publisher)
+    language_text = sanitized_text(language)
+
     [
       published_year,
       series_label,
-      narrator.present? ? "Narrated by #{narrator}" : nil,
-      publisher.presence,
-      language.present? ? language.upcase : nil
+      narrator_text.present? ? sanitized_text("Narrated by #{narrator_text}") : nil,
+      publisher_text.presence,
+      language_text.present? ? sanitized_text(language_text.upcase) : nil
     ].compact
   end
 
   def identifier_label
-    return "ISBN #{isbn}" if isbn.present?
-    return "ASIN #{asin}" if asin.present?
+    isbn_text = sanitized_text(isbn)
+    return sanitized_text("ISBN #{isbn_text}") if isbn_text.present?
+
+    asin_text = sanitized_text(asin)
+    return sanitized_text("ASIN #{asin_text}") if asin_text.present?
 
     nil
   end
 
   def sync_stale?(threshold:)
     synced_at.blank? || synced_at < threshold
+  end
+
+  def effective_synced_at
+    synced_at if synced_at.present? && synced_at <= Time.current
+  end
+
+  private
+
+  def sanitized_text(value)
+    raw = value.to_s
+    text = raw.byteslice(0, MAX_DISPLAY_TEXT_BYTES).to_s
+              .encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+              .gsub(BIDI_CONTROL_PATTERN, "")
+              .gsub(/[[:cntrl:]]/, " ")
+              .gsub(/\s+/, " ")
+              .strip
+    return text if text.length <= MAX_DISPLAY_TEXT_CHARACTERS && raw.bytesize <= MAX_DISPLAY_TEXT_BYTES
+
+    "#{text.slice(0, MAX_DISPLAY_TEXT_CHARACTERS - 3)}..."
   end
 end

--- a/app/services/audiobookshelf_library_matcher_service.rb
+++ b/app/services/audiobookshelf_library_matcher_service.rb
@@ -16,6 +16,11 @@ class AudiobookshelfLibraryMatcherService
   end
 
   FuzzyThreshold = 85
+  MaxMatchTextLength = 500
+
+  def initialize(cache_library_items: true)
+    @cache_library_items = cache_library_items
+  end
 
   def self.matches_for_many(results, limit_per_result: 3)
     results = Array(results)
@@ -32,43 +37,72 @@ class AudiobookshelfLibraryMatcherService
   end
 
   def matches_for(title:, author:, limit: 3, library_ids: nil)
-    return [] if library_items(library_ids).empty?
-    return [] if title.blank? && author.blank?
-
     query_title = normalize_text(title)
     query_author = normalize_text(author)
+    limit = limit.to_i
+    return [] if query_title.blank? || limit <= 0
 
-    matches = library_items(library_ids).each_with_object([]) do |item, acc|
+    matches = []
+    each_library_item(library_ids) do |item|
+      next if oversized_match_text?(item.title)
+
       item_title = normalize_text(item.title)
-      item_display_title = normalize_text(item.display_title)
-      item_author = normalize_text(item.author)
+      item_subtitle = oversized_match_text?(item.subtitle) ? "" : normalize_text(item.subtitle)
+      item_display_title = [ item_title, item_subtitle ].compact_blank.join(" ")
+      item_author = oversized_match_text?(item.author) ? "" : normalize_text(item.author)
       next if item_title.blank? && item_display_title.blank? && item_author.blank?
+      item_titles = [ item_title, item_display_title ].uniq
 
       score = match_score(
         query_title: query_title,
         query_author: query_author,
-        item_titles: [ item_title, item_display_title ].uniq,
+        item_titles: item_titles,
         item_author: item_author
       )
       next if score < FuzzyThreshold
 
-      match_type = score == 100 ? :likely : :possible
-      acc << Match.new(item: item, score: score, match_type: match_type)
+      exact_author = query_author.present? && item_author == query_author
+      match_type = item_titles.include?(query_title) && exact_author ? :likely : :possible
+      matches << Match.new(item: item, score: score, match_type: match_type)
+      matches.sort_by! { |match| match_sort_key(match) }
+      matches.pop if matches.size > limit
     end
 
-    matches.sort_by { |match| [-match.score, match.item.title.to_s.downcase] }.take(limit)
+    matches
   end
 
   private
 
   def library_ids_for_scope(library_ids)
     @library_items_by_ids ||= {}
-    @library_items_by_ids[library_ids] ||= LibraryItem.available_for_matching.for_libraries(library_ids).by_synced_at_desc.to_a
+    @library_items_by_ids[library_ids] ||= library_scope(library_ids).by_synced_at_desc.to_a
   end
 
   def library_items(library_ids = nil)
-    return @all_library_items ||= LibraryItem.available_for_matching.by_synced_at_desc.to_a if library_ids.nil?
+    return @all_library_items ||= library_scope.by_synced_at_desc.to_a if library_ids.nil?
     library_ids_for_scope(library_ids)
+  end
+
+  def each_library_item(library_ids, &block)
+    if @cache_library_items
+      library_items(library_ids).each(&block)
+    else
+      library_scope(library_ids).find_each(batch_size: 500, &block)
+    end
+  end
+
+  def library_scope(library_ids = nil)
+    scope = LibraryItem.available_for_matching
+    library_ids.nil? ? scope : scope.for_libraries(library_ids)
+  end
+
+  def match_sort_key(match)
+    synced_at = match.item.effective_synced_at || Time.at(0)
+    [ -match.score, match.likely? ? 0 : 1, -synced_at.to_f, normalize_text(match.item.title), match.item.id || 0 ]
+  end
+
+  def oversized_match_text?(text)
+    text.is_a?(String) && text.length > MaxMatchTextLength
   end
 
   def match_score(query_title:, query_author:, item_titles:, item_author:)
@@ -83,11 +117,15 @@ class AudiobookshelfLibraryMatcherService
   end
 
   def normalize_text(text)
-    return "" if text.blank?
+    return "" unless text.is_a?(String)
+    return "" if text.length > MaxMatchTextLength
 
     text
-      .downcase
-      .gsub(/[^a-z0-9\s]/, " ")
+      .encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "")
+      .unicode_normalize(:nfkd)
+      .gsub(/\p{Mn}/, "")
+      .downcase(:fold)
+      .gsub(/[^\p{Alnum}\s]/, " ")
       .gsub(/\s+/, " ")
       .strip
   end

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -269,8 +269,8 @@
                                   <span class="shrink-0 rounded-full bg-red-500/10 px-2 py-0.5 text-[10px] font-medium text-red-300">Missing</span>
                                 <% end %>
                               </div>
-                              <% if item.author.present? %>
-                                <p class="mt-1 text-[11px] text-gray-400"><%= item.author %></p>
+                              <% if item.display_author.present? %>
+                                <p class="mt-1 text-[11px] text-gray-400"><%= item.display_author %></p>
                               <% end %>
                               <% cache_details = [item.library_id, *item.detail_badges.first(4), item.identifier_label].compact %>
                               <% if cache_details.any? %>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -1,6 +1,9 @@
 <div class="mx-auto max-w-2xl">
   <% content_kind = ContentKinds.normalize(@content_kind, default: "book") %>
   <% requestable_book_types = RequestOptionPolicy.book_types_for(content_kind) %>
+  <% format_checks = requestable_book_types.index_with do |book_type| %>
+    <% DuplicateDetectionService.check(work_id: @work_id, source_work_ids: @source_work_ids, book_type: book_type) %>
+  <% end %>
   <h1 class="font-bold text-4xl mb-8 text-white">Request</h1>
 
   <div class="bg-gray-900 rounded-lg shadow p-6 border border-gray-800">
@@ -42,6 +45,29 @@
       </div>
     <% end %>
 
+    <%
+      unscoped_match_entry = @unscoped_synced_library_match_entries
+        .select { |entry| entry.book_types.any? { |book_type| !format_checks.fetch(book_type).block? } }
+        .max_by do |entry|
+          match = entry.match
+          [ match.likely? ? 1 : 0, match.score, match.item.effective_synced_at&.to_f || 0 ]
+        end
+    %>
+    <% if unscoped_match_entry %>
+      <% library_match = unscoped_match_entry.match %>
+      <% library_sync_time = library_match.item.effective_synced_at %>
+      <div class="mb-6 break-words rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-200"
+           data-synced-library-warning
+           data-library-format="unknown"
+           data-match-type="<%= library_match.match_type %>">
+        <span class="font-medium"><%= library_match.confidence_label %> in cached library inventory:</span>
+        <%= truncate(library_match.item.display_title, length: 80) %><% if library_match.item.display_author.present? %> by <%= truncate(library_match.item.display_author, length: 60) %><% end %>.
+        The format could not be determined. Inventory was synced <%= library_sync_time ? time_ago_in_words(library_sync_time) + " ago" : "at an unknown time" %>.
+        Search for this title in your library before requesting.
+        This inventory advisory does not block requests.
+      </div>
+    <% end %>
+
     <%= form_with url: requests_path, method: :post, class: "space-y-6" do |form| %>
       <%= hidden_field_tag :work_id, @work_id %>
       <%= hidden_field_tag :title, @title %>
@@ -63,9 +89,9 @@
         <%= hidden_field_tag "source_work_ids[]", source_work_id %>
       <% end %>
 
-      <div>
-        <label class="block text-sm font-medium text-gray-300 mb-3">Select format(s):</label>
-        <div class="grid gap-4 <%= requestable_book_types.one? ? 'grid-cols-1' : 'grid-cols-2' %>">
+      <fieldset>
+        <legend class="block text-sm font-medium text-gray-300 mb-3">Select format(s):</legend>
+        <div class="grid grid-cols-1 gap-4 <%= 'sm:grid-cols-2' unless requestable_book_types.one? %>">
           <%
             format_labels = {
               "audiobook" => [ "Audiobook", "Audio format for listening", "border-purple-500", "text-purple-400" ],
@@ -76,11 +102,12 @@
 
           <% requestable_book_types.each do |book_type| %>
             <%
-              check = DuplicateDetectionService.check(work_id: @work_id, source_work_ids: @source_work_ids, book_type: book_type)
+              check = format_checks.fetch(book_type)
+              library_match = Array(@synced_library_matches_by_book_type[book_type]).first
               label, description, border_class, text_class = format_labels.fetch(book_type)
               selected = params[:book_type] == book_type || params[:book_types]&.include?(book_type) || requestable_book_types.one?
             %>
-            <label class="relative flex cursor-pointer rounded-lg border p-4 shadow-sm focus:outline-none <%= check.block? ? 'bg-gray-800/50 border-gray-700 opacity-60 cursor-not-allowed' : 'bg-gray-800 border-gray-700 hover:' + border_class %>" data-format="<%= book_type %>" data-border-class="<%= border_class %>">
+            <label class="relative flex cursor-pointer rounded-lg border p-4 shadow-sm focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 focus-within:ring-offset-gray-900 <%= check.block? ? 'bg-gray-800/50 border-gray-700 opacity-60 cursor-not-allowed' : 'bg-gray-800 border-gray-700 hover:' + border_class %>" data-format="<%= book_type %>" data-border-class="<%= border_class %>">
               <input
                 type="checkbox"
                 name="book_types[]"
@@ -90,14 +117,29 @@
                 <%= 'checked' if selected && !check.block? %>
               >
               <span class="flex flex-1">
-                <span class="flex flex-col">
+                <span class="flex min-w-0 flex-col">
                   <span class="text-sm font-medium text-gray-200 <%= text_class %>"><%= label %></span>
                   <% if check.block? %>
                     <span class="mt-1 text-xs text-red-400"><%= check.message %></span>
-                  <% elsif check.warn? %>
-                    <span class="mt-1 text-xs text-yellow-400"><%= check.message %></span>
                   <% else %>
-                    <span class="mt-1 text-xs text-gray-500"><%= description %></span>
+                    <% if check.warn? %>
+                      <span class="mt-1 text-xs text-yellow-400"><%= check.message %></span>
+                    <% end %>
+                    <% if library_match %>
+                      <% library_sync_time = library_match.item.effective_synced_at %>
+                      <span class="mt-1 break-words text-xs text-amber-300"
+                            data-synced-library-warning
+                            data-library-format="<%= book_type %>"
+                            data-match-type="<%= library_match.match_type %>">
+                        <%= library_match.confidence_label %> in cached <%= label.downcase %> inventory:
+                        <%= truncate(library_match.item.display_title, length: 80) %><% if library_match.item.display_author.present? %> by <%= truncate(library_match.item.display_author, length: 60) %><% end %>.
+                        Synced <%= library_sync_time ? time_ago_in_words(library_sync_time) + " ago" : "at an unknown time" %>.
+                        You can still request this format.
+                      </span>
+                    <% end %>
+                    <% unless check.warn? || library_match %>
+                      <span class="mt-1 text-xs text-gray-500"><%= description %></span>
+                    <% end %>
                   <% end %>
                 </span>
               </span>
@@ -107,7 +149,7 @@
             </label>
           <% end %>
         </div>
-      </div>
+      </fieldset>
 
       <div>
         <label for="language" class="block text-sm font-medium text-gray-300 mb-1">Language</label>

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -121,8 +121,8 @@
           <li class="flex items-start justify-between gap-2 text-[11px]">
             <span class="min-w-0">
               <span class="block truncate text-amber-100"><%= match.item.display_title %></span>
-              <% if match.item.author.present? %>
-                <span class="block truncate text-amber-200/80"><%= match.item.author %></span>
+              <% if match.item.display_author.present? %>
+                <span class="block truncate text-amber-200/80"><%= match.item.display_author %></span>
               <% end %>
               <% detail_badges = match.item.detail_badges.first(3) %>
               <% if detail_badges.any? || match.item.identifier_label.present? %>

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -443,6 +443,399 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h2", "Test Book"
   end
 
+  test "new shows a nonblocking BookOrbit warning only for the matching format" do
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "audio-primary")
+    SettingsService.set(:audiobookshelf_audiobook_scan_library_ids, "audio-scifi")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "ebook-primary")
+    SettingsService.set(:audiobookshelf_ebook_scan_library_ids, "")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "audio-scifi",
+      audiobookshelf_id: "bookorbit-audio-warning",
+      title: "Scoped Inventory Match",
+      author: "Format & Author",
+      synced_at: Time.current
+    )
+    Book.create!(
+      title: "Scoped Inventory Match",
+      book_type: :ebook,
+      open_library_work_id: "OL_SCOPED_INVENTORY_MATCH"
+    )
+    navigation_params = RequestMetadataHandoff.params_for(
+      user: @user,
+      metadata: {
+        work_id: "OL_SCOPED_INVENTORY_MATCH",
+        title: "Scoped Inventory Match",
+        author: "Format & Author"
+      }
+    )
+
+    get new_request_path(navigation_params.merge(book_type: "audiobook"))
+
+    assert_response :success
+    assert_select "label[data-format='audiobook']" do
+      assert_select "[data-synced-library-warning][data-library-format='audiobook'][data-match-type='likely']",
+        text: /You can still request this format/
+      assert_select "span", text: /This title exists as an ebook/
+      assert_select "[data-synced-library-warning]", text: /by Format & Author/
+      assert_select "input[name='book_types[]'][value='audiobook'][checked]:not([disabled])"
+    end
+    assert_select "label[data-format='ebook'] [data-synced-library-warning]", count: 0
+  ensure
+    Rails.cache = original_cache
+  end
+
+  test "new shows one format-unknown warning for auto-discovered libraries" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "")
+    SettingsService.set(:audiobookshelf_audiobook_scan_library_ids, "")
+    SettingsService.set(:audiobookshelf_ebook_scan_library_ids, "")
+    SettingsService.set(:audiobookshelf_comicbook_scan_library_ids, "")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "auto-discovered-library",
+      audiobookshelf_id: "bookorbit-unscoped-warning",
+      title: "Unscoped Inventory Match",
+      author: "Discovery Author",
+      synced_at: Time.current
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_UNSCOPED_INVENTORY_MATCH",
+      title: "Unscoped Inventory Match",
+      author: "Discovery Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning][data-library-format='unknown']", count: 1,
+      text: /format could not be determined/i
+    assert_select "label[data-format] [data-synced-library-warning]", count: 0
+  end
+
+  test "new suppresses synced inventory warnings for collection requests" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "ebook-primary")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "ebook-primary",
+      audiobookshelf_id: "bookorbit-collection-warning",
+      title: "Inventory Collection",
+      author: "Collection Author",
+      synced_at: Time.current
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_INVENTORY_COLLECTION",
+      title: "Inventory Collection",
+      author: "Collection Author",
+      request_scope: "collection",
+      collection_source: "hardcover",
+      collection_id: "inventory-collection",
+      collection_title: "Inventory Collection"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning]", count: 0
+  end
+
+  test "create allows a request that matches synced inventory" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "audio-primary")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "audio-primary",
+      audiobookshelf_id: "bookorbit-allowed-request",
+      title: "Allowed Inventory Match",
+      author: "Request Author",
+      synced_at: Time.current
+    )
+
+    assert_difference [ "Book.count", "Request.count" ], 1 do
+      post requests_path, params: {
+        work_id: "OL_ALLOWED_INVENTORY_MATCH",
+        title: "Allowed Inventory Match",
+        author: "Request Author",
+        book_types: [ "audiobook" ]
+      }
+    end
+
+    assert_redirected_to request_path(Request.last)
+  end
+
+  test "new treats a library configured for multiple formats as format-unknown" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "shared-library")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "shared-library")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "shared-library",
+      audiobookshelf_id: "bookorbit-shared-format",
+      title: "Ambiguous Format Match",
+      author: "Shared Author",
+      synced_at: Time.current
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_AMBIGUOUS_FORMAT_MATCH",
+      title: "Ambiguous Format Match",
+      author: "Shared Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning][data-library-format='unknown']", count: 1
+    assert_select "label[data-format] [data-synced-library-warning]", count: 0
+  end
+
+  test "new detects shared libraries across different content kinds" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "cross-kind-library")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "cross-kind-library")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "cross-kind-library",
+      audiobookshelf_id: "bookorbit-cross-kind-format",
+      title: "Cross Kind Match",
+      author: "Shared Creator",
+      synced_at: Time.current
+    )
+
+    get new_request_path, params: {
+      work_id: "comic_vine:4000-cross-kind-match",
+      title: "Cross Kind Match",
+      author: "Shared Creator",
+      content_kind: "graphic"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning][data-library-format='unknown']", count: 1
+    assert_select "label[data-format='comicbook'] [data-synced-library-warning]", count: 0
+  end
+
+  test "new renders malformed cached match metadata safely" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "malformed-library")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "malformed-library",
+      audiobookshelf_id: "bookorbit-malformed-metadata",
+      title: "Malformed Match\xFF".dup.force_encoding(Encoding::UTF_8),
+      author: "Malformed Author\xFF".dup.force_encoding(Encoding::UTF_8),
+      synced_at: Time.current
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_MALFORMED_INVENTORY_MATCH",
+      title: "Malformed Match",
+      author: "Malformed Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning][data-library-format='audiobook']", count: 1,
+      text: /Malformed Match/
+  end
+
+  test "new hides an unscoped inventory advisory when every format is blocked" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "")
+    SettingsService.set(:audiobookshelf_audiobook_scan_library_ids, "")
+    SettingsService.set(:audiobookshelf_ebook_scan_library_ids, "")
+    SettingsService.set(:audiobookshelf_comicbook_scan_library_ids, "")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "blocked-auto-discovery",
+      audiobookshelf_id: "bookorbit-blocked-unscoped",
+      title: "Blocked Inventory Match",
+      author: "Blocked Author",
+      synced_at: Time.current
+    )
+    %i[audiobook ebook].each do |book_type|
+      Book.create!(
+        title: "Blocked Inventory Match",
+        book_type: book_type,
+        open_library_work_id: "OL_BLOCKED_INVENTORY_MATCH",
+        file_path: "/library/#{book_type}/blocked"
+      )
+    end
+
+    get new_request_path, params: {
+      work_id: "OL_BLOCKED_INVENTORY_MATCH",
+      title: "Blocked Inventory Match",
+      author: "Blocked Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning]", count: 0
+    assert_select "input[name='book_types[]'][disabled]", count: 2
+  end
+
+  test "new hides an unscoped advisory when only unrelated formats are requestable" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "audio-primary")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "ebook-comic-fallback")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "ebook-comic-fallback",
+      audiobookshelf_id: "bookorbit-partially-blocked-unscoped",
+      title: "Partially Blocked Match",
+      author: "Blocked Format Author",
+      synced_at: Time.current
+    )
+    Book.create!(
+      title: "Partially Blocked Match",
+      book_type: :ebook,
+      open_library_work_id: "OL_PARTIALLY_BLOCKED_MATCH",
+      file_path: "/library/ebook/partially-blocked"
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_PARTIALLY_BLOCKED_MATCH",
+      title: "Partially Blocked Match",
+      author: "Blocked Format Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning]", count: 0
+    assert_select "input[name='book_types[]'][value='ebook'][disabled]"
+    assert_select "input[name='book_types[]'][value='audiobook']:not([disabled])"
+  end
+
+  test "new derives unscoped applicability from the library that matched" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "overlap-audio")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "overlap-ebook")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "comic-primary")
+    SettingsService.set(:audiobookshelf_comicbook_scan_library_ids, "overlap-audio,overlap-ebook")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "overlap-audio",
+      audiobookshelf_id: "bookorbit-specific-overlap",
+      title: "Specific Overlap Match",
+      author: "Overlap Author",
+      synced_at: Time.current
+    )
+    Book.create!(
+      title: "Specific Overlap Match",
+      book_type: :audiobook,
+      open_library_work_id: "OL_SPECIFIC_OVERLAP_MATCH",
+      file_path: "/library/audiobook/specific-overlap"
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_SPECIFIC_OVERLAP_MATCH",
+      title: "Specific Overlap Match",
+      author: "Overlap Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning]", count: 0
+    assert_select "input[name='book_types[]'][value='audiobook'][disabled]"
+    assert_select "input[name='book_types[]'][value='ebook']:not([disabled])"
+  end
+
+  test "new keeps overlap warnings for requestable formats when a stronger match is blocked" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "overlap-blocked-audio")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "overlap-requestable-ebook")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "comic-primary")
+    SettingsService.set(
+      :audiobookshelf_comicbook_scan_library_ids,
+      "overlap-blocked-audio,overlap-requestable-ebook"
+    )
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "overlap-blocked-audio",
+      audiobookshelf_id: "bookorbit-blocked-overlap-copy",
+      title: "Multi Overlap Match",
+      subtitle: "Blocked Audio Copy",
+      author: "Overlap Author",
+      synced_at: Time.current
+    )
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "overlap-requestable-ebook",
+      audiobookshelf_id: "bookorbit-requestable-overlap-copy",
+      title: "Multi Overlap Match",
+      subtitle: "Requestable Ebook Copy",
+      author: "Overlap Author",
+      synced_at: 1.day.ago
+    )
+    Book.create!(
+      title: "Multi Overlap Match",
+      book_type: :audiobook,
+      open_library_work_id: "OL_MULTI_OVERLAP_MATCH",
+      file_path: "/library/audiobook/multi-overlap"
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_MULTI_OVERLAP_MATCH",
+      title: "Multi Overlap Match",
+      author: "Overlap Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning][data-library-format='unknown']", count: 1,
+      text: /Requestable Ebook Copy/
+    assert_select "input[name='book_types[]'][value='ebook']:not([disabled])"
+  end
+
+  test "new applies the ebook delivery fallback to comic inventory warnings" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "ebook-primary")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "")
+    SettingsService.set(:audiobookshelf_comicbook_scan_library_ids, "")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "ebook-primary",
+      audiobookshelf_id: "bookorbit-comic-fallback",
+      title: "Fallback Comic",
+      author: "Comic Creator",
+      synced_at: Time.current
+    )
+
+    get new_request_path, params: {
+      work_id: "comic_vine:4000-inventory-fallback",
+      title: "Fallback Comic",
+      author: "Comic Creator",
+      content_kind: "graphic"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning][data-library-format='unknown'][data-match-type='likely']", count: 1
+    assert_select "label[data-format='comicbook'] [data-synced-library-warning]", count: 0
+  end
+
+  test "new treats the comic fallback library as format-unknown for ebook requests" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "ebook-comic-fallback")
+    SettingsService.set(:audiobookshelf_comicbook_library_id, "")
+    LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "ebook-comic-fallback",
+      audiobookshelf_id: "bookorbit-ebook-fallback-ambiguity",
+      title: "Fallback Ebook",
+      author: "Fallback Author",
+      synced_at: Time.current
+    )
+
+    get new_request_path, params: {
+      work_id: "OL_EBOOK_FALLBACK_AMBIGUITY",
+      title: "Fallback Ebook",
+      author: "Fallback Author"
+    }
+
+    assert_response :success
+    assert_select "[data-synced-library-warning][data-library-format='unknown']", count: 1
+    assert_select "label[data-format='ebook'] [data-synced-library-warning]", count: 0
+  end
+
   test "compact metadata handoff preserves long descriptions through creation" do
     original_cache = Rails.cache
     Rails.cache = ActiveSupport::Cache::MemoryStore.new

--- a/test/models/library_item_test.rb
+++ b/test/models/library_item_test.rb
@@ -38,4 +38,41 @@ class LibraryItemTest < ActiveSupport::TestCase
 
     assert_equal "http://grimmory.example/book/book-1", item.audiobookshelf_url
   end
+
+  test "display metadata is bounded and strips unsafe controls" do
+    item = LibraryItem.new(
+      title: "t" * LibraryItem::MAX_DISPLAY_TEXT_CHARACTERS,
+      subtitle: "\u202ESubtitle only#{"x" * 1_000}",
+      author: "Author\nName",
+      narrator: "Narrator\xFF".dup.force_encoding(Encoding::UTF_8),
+      publisher: "Publisher\u202EName",
+      isbn: "978\n123"
+    )
+
+    assert_not item.display_title.start_with?(":")
+    assert_not_includes item.display_title, "\u202E"
+    assert_operator item.display_title.length, :<=, LibraryItem::MAX_DISPLAY_TEXT_CHARACTERS
+    assert_equal "Author Name", item.display_author
+    assert_equal "Narrated by Narrator�", item.detail_badges.last(2).first
+    assert_equal "PublisherName", item.detail_badges.last
+    assert_equal "ISBN 978 123", item.identifier_label
+  end
+
+  test "display title omits an empty title separator" do
+    item = LibraryItem.new(title: nil, subtitle: "Subtitle only")
+
+    assert_equal "Subtitle only", item.display_title
+  end
+
+  test "future sync times are treated as unknown" do
+    item = LibraryItem.new(synced_at: 1.hour.from_now)
+
+    assert_nil item.effective_synced_at
+  end
+
+  test "display badges remain bounded after Unicode case expansion" do
+    item = LibraryItem.new(language: "ß" * LibraryItem::MAX_DISPLAY_TEXT_CHARACTERS)
+
+    assert_operator item.detail_badges.first.length, :<=, LibraryItem::MAX_DISPLAY_TEXT_CHARACTERS
+  end
 end

--- a/test/services/audiobookshelf_library_matcher_service_test.rb
+++ b/test/services/audiobookshelf_library_matcher_service_test.rb
@@ -73,6 +73,230 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
     assert_equal "Possible match", matches.first.confidence_label
   end
 
+  test "uses a possible match label when an exact title lacks author confirmation" do
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "The Hobbit",
+      author: nil,
+      limit: 3
+    )
+
+    assert_equal 1, matches.size
+    assert_equal :possible, matches.first.match_type
+    assert_equal "Possible match", matches.first.confidence_label
+  end
+
+  test "does not match an author without a usable title" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-punctuation-only",
+      title: "---",
+      author: "J.R.R. Tolkien",
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "---",
+      author: "J.R.R. Tolkien",
+      limit: 3
+    )
+
+    assert_empty matches
+  end
+
+  test "matches exact non-Latin titles" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-unicode-title",
+      title: "Война и мир",
+      author: "Лев Толстой",
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "Война и мир",
+      author: "Лев Толстой",
+      limit: 3
+    )
+
+    assert_equal "ab-unicode-title", matches.first.item.audiobookshelf_id
+    assert matches.first.likely?
+  end
+
+  test "uses Unicode case folding" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-case-folded-title",
+      title: "Straße",
+      author: "Case Folded Author",
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "STRASSE",
+      author: "CASE FOLDED AUTHOR",
+      limit: 3
+    )
+
+    assert_equal "ab-case-folded-title", matches.first.item.audiobookshelf_id
+    assert matches.first.likely?
+  end
+
+  test "prefers a likely match over a possible match with the same score" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-authorless-hobbit",
+      title: "The Hobbit",
+      author: nil,
+      synced_at: 1.minute.from_now
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 1
+    )
+
+    assert_equal "ab-1", matches.first.item.audiobookshelf_id
+    assert matches.first.likely?
+  end
+
+  test "rejects non-scalar and oversized matcher input safely" do
+    assert_empty AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: [ "The Hobbit" ],
+      author: "J.R.R. Tolkien"
+    )
+
+    long_prefix = "a" * AudiobookshelfLibraryMatcherService::MaxMatchTextLength
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-oversized-title",
+      title: "#{long_prefix} first edition",
+      author: "Long Author",
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "#{long_prefix} second edition",
+      author: "Long Author"
+    )
+
+    assert_empty matches
+  end
+
+  test "sorts malformed cached titles safely" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-invalid-encoding",
+      title: "Dune\xFF".dup.force_encoding(Encoding::UTF_8),
+      author: "Frank Herbert",
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "Dune",
+      author: "Frank Herbert",
+      limit: 3
+    )
+
+    assert matches.any? { |match| match.item.audiobookshelf_id == "ab-invalid-encoding" }
+  end
+
+  test "ignores malformed subtitles while scanning unrelated items" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-invalid-subtitle",
+      title: "Unrelated",
+      subtitle: "bad\xFF".dup.force_encoding(Encoding::UTF_8),
+      author: "Other Author",
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "Dune",
+      author: "Frank Herbert",
+      limit: 3
+    )
+
+    assert_equal [ "ab-2" ], matches.map { |match| match.item.audiobookshelf_id }
+  end
+
+  test "streaming matches prefer the freshest equally ranked item" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-old-hobbit",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      synced_at: 2.years.ago
+    )
+    fresh = LibraryItem.find_by!(audiobookshelf_id: "ab-1")
+
+    matches = AudiobookshelfLibraryMatcherService.new(cache_library_items: false).matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 1
+    )
+
+    assert_equal fresh, matches.first.item
+  end
+
+  test "does not promote an oversized title's subtitle into a match" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-oversized-title-subtitle",
+      title: "x" * (AudiobookshelfLibraryMatcherService::MaxMatchTextLength + 1),
+      subtitle: "Dune",
+      author: "Frank Herbert",
+      synced_at: Time.current
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "Dune",
+      author: "Frank Herbert",
+      limit: 3
+    )
+
+    assert_equal [ "ab-2" ], matches.map { |match| match.item.audiobookshelf_id }
+  end
+
+  test "ignores oversized secondary metadata without suppressing an exact title" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-oversized-secondary-metadata",
+      title: "Dune",
+      subtitle: "x" * (AudiobookshelfLibraryMatcherService::MaxMatchTextLength + 1),
+      author: "x" * (AudiobookshelfLibraryMatcherService::MaxMatchTextLength + 1),
+      synced_at: 1.minute.from_now
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "Dune",
+      author: "Frank Herbert",
+      limit: 3
+    )
+
+    match = matches.find { |candidate| candidate.item.audiobookshelf_id == "ab-oversized-secondary-metadata" }
+    assert match
+    assert match.possible?
+  end
+
+  test "does not prefer future-dated matches" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-future-hobbit",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      synced_at: 1.year.from_now
+    )
+
+    matches = AudiobookshelfLibraryMatcherService.new(cache_library_items: false).matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 1
+    )
+
+    assert_equal "ab-1", matches.first.item.audiobookshelf_id
+  end
+
   test "matches against item subtitles when present" do
     matches = AudiobookshelfLibraryMatcherService.new.matches_for(
       title: "The Hobbit: There and Back Again",


### PR DESCRIPTION
## Summary

- show cached library inventory matches on the format-selection step without blocking requests
- scope warnings to audiobook, ebook, or comics libraries and use a format-unknown advisory for auto-discovery, shared libraries, and fallback ambiguity
- harden cached metadata matching and rendering for stale, malformed, oversized, and Unicode values while streaming request-page inventory scans
- preserve existing search, admin request-card, comic fallback, and manual-request behavior

Follow-up to #370 and #338.

## Test plan

- `bin/quality push`
- `bundle exec rails test test/models/library_item_test.rb test/services/audiobookshelf_library_matcher_service_test.rb test/controllers/requests_controller_test.rb test/controllers/search_controller_test.rb test/controllers/admin/settings_controller_test.rb`
- iterative adversarial review completed with no actionable findings