### PR TITLE
feat: attended watched-folder import

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
 # See https://git-scm.com/docs/gitattributes for more about git attribute files.
 
+# Shell scripts must keep LF endings so they stay executable in CI.
+*.sh text eol=lf
+bin/rerere-cache text eol=lf
+
 # Mark the database schema as having been generated.
 db/schema.rb linguist-generated
 

--- a/.github/scripts/sync-conflict-pr.sh
+++ b/.github/scripts/sync-conflict-pr.sh
@@ -25,7 +25,7 @@ EOF
   exit 0
 fi
 
-url="$(gh pr create --base "${BASE_BRANCH}" --head "${HEAD_BRANCH}" \
+if ! url="$(gh pr create --base "${BASE_BRANCH}" --head "${HEAD_BRANCH}" \
   --title "Sync ${HEAD_BRANCH} into ${BASE_BRANCH}" \
   --body "$(cat <<EOF
 Automated sync could not merge \`${HEAD_BRANCH}\` into \`${BASE_BRANCH}\`.
@@ -51,6 +51,17 @@ Exporting the rerere cache lets the next sync replay this resolution on its own.
 
 Triggered by run [\`${GITHUB_RUN_ID}\`](${run_url}).
 EOF
-)")"
+)")"; then
+  case "${HEAD_BRANCH}" in
+    *:*)
+      echo "::error::Could not open a pull request from ${HEAD_BRANCH}. GITHUB_TOKEN cannot create a pull request whose head branch lives in another repository. Add a personal access token with the 'repo' and 'workflow' scopes as the SYNC_TOKEN secret."
+      ;;
+    *)
+      echo "::error::Could not open a pull request from ${HEAD_BRANCH} into ${BASE_BRANCH}."
+      ;;
+  esac
+  echo "${OUTPUT_KEY}_pr_url=(could not be created -- see the log)" >> "${GITHUB_OUTPUT}"
+  exit 1
+fi
 
 echo "${OUTPUT_KEY}_pr_url=${url}" >> "${GITHUB_OUTPUT}"

--- a/.github/scripts/sync-conflict-pr.sh
+++ b/.github/scripts/sync-conflict-pr.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
-# Open (or update) a pull request when Sync Upstream cannot merge the target
-# branch into the personal branch automatically.
+# Open (or update) a pull request when Sync Upstream cannot merge a branch
+# automatically.
 #
-# Expects: GH_TOKEN, TARGET_BRANCH, PERSONAL_BRANCH, UNRESOLVED (newline-separated
-# paths), plus the usual GITHUB_* variables. Writes `url` to $GITHUB_OUTPUT.
+# Expects: GH_TOKEN, BASE_BRANCH, HEAD_BRANCH, UNRESOLVED (newline-separated
+# paths), OUTPUT_KEY, plus the usual GITHUB_* variables.
+# Writes "<OUTPUT_KEY>_pr_url" to $GITHUB_OUTPUT.
 
 set -euo pipefail
 
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 conflict_list="$(printf '%s\n' "${UNRESOLVED}" | sed '/^$/d; s/^/- `/; s/$/`/')"
 
-existing="$(gh pr list --base "${PERSONAL_BRANCH}" --head "${TARGET_BRANCH}" \
+existing="$(gh pr list --base "${BASE_BRANCH}" --head "${HEAD_BRANCH}" \
   --state open --json number --jq '.[0].number // empty')"
 
 if [ -n "${existing}" ]; then
@@ -20,14 +21,14 @@ Sync run [\`${GITHUB_RUN_ID}\`](${run_url}) still hits conflicts in:
 ${conflict_list}
 EOF
 )"
-  echo "url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${existing}" >> "${GITHUB_OUTPUT}"
+  echo "${OUTPUT_KEY}_pr_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${existing}" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
 
-url="$(gh pr create --base "${PERSONAL_BRANCH}" --head "${TARGET_BRANCH}" \
-  --title "Sync ${TARGET_BRANCH} into ${PERSONAL_BRANCH}" \
+url="$(gh pr create --base "${BASE_BRANCH}" --head "${HEAD_BRANCH}" \
+  --title "Sync ${HEAD_BRANCH} into ${BASE_BRANCH}" \
   --body "$(cat <<EOF
-Automated sync could not merge \`${TARGET_BRANCH}\` into \`${PERSONAL_BRANCH}\`.
+Automated sync could not merge \`${HEAD_BRANCH}\` into \`${BASE_BRANCH}\`.
 Conflicts remain in:
 
 ${conflict_list}
@@ -36,9 +37,9 @@ Resolve them with GitHub's web editor, or locally:
 
 \`\`\`bash
 git fetch origin
-git checkout ${PERSONAL_BRANCH}
+git checkout ${BASE_BRANCH}
 bin/rerere-cache enable
-git merge ${TARGET_BRANCH}
+git merge origin/${HEAD_BRANCH}
 # resolve the conflicts, then:
 git add -A && git merge --continue
 bin/rerere-cache export
@@ -52,4 +53,4 @@ Triggered by run [\`${GITHUB_RUN_ID}\`](${run_url}).
 EOF
 )")"
 
-echo "url=${url}" >> "${GITHUB_OUTPUT}"
+echo "${OUTPUT_KEY}_pr_url=${url}" >> "${GITHUB_OUTPUT}"

--- a/.github/scripts/sync-conflict-pr.sh
+++ b/.github/scripts/sync-conflict-pr.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Open (or update) a pull request when Sync Upstream cannot merge the target
+# branch into the personal branch automatically.
+#
+# Expects: GH_TOKEN, TARGET_BRANCH, PERSONAL_BRANCH, UNRESOLVED (newline-separated
+# paths), plus the usual GITHUB_* variables. Writes `url` to $GITHUB_OUTPUT.
+
+set -euo pipefail
+
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+conflict_list="$(printf '%s\n' "${UNRESOLVED}" | sed '/^$/d; s/^/- `/; s/$/`/')"
+
+existing="$(gh pr list --base "${PERSONAL_BRANCH}" --head "${TARGET_BRANCH}" \
+  --state open --json number --jq '.[0].number // empty')"
+
+if [ -n "${existing}" ]; then
+  gh pr comment "${existing}" --body "$(cat <<EOF
+Sync run [\`${GITHUB_RUN_ID}\`](${run_url}) still hits conflicts in:
+
+${conflict_list}
+EOF
+)"
+  echo "url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${existing}" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+url="$(gh pr create --base "${PERSONAL_BRANCH}" --head "${TARGET_BRANCH}" \
+  --title "Sync ${TARGET_BRANCH} into ${PERSONAL_BRANCH}" \
+  --body "$(cat <<EOF
+Automated sync could not merge \`${TARGET_BRANCH}\` into \`${PERSONAL_BRANCH}\`.
+Conflicts remain in:
+
+${conflict_list}
+
+Resolve them with GitHub's web editor, or locally:
+
+\`\`\`bash
+git fetch origin
+git checkout ${PERSONAL_BRANCH}
+bin/rerere-cache enable
+git merge ${TARGET_BRANCH}
+# resolve the conflicts, then:
+git add -A && git merge --continue
+bin/rerere-cache export
+git add .rerere-cache && git commit -m 'chore: record conflict resolution'
+git push
+\`\`\`
+
+Exporting the rerere cache lets the next sync replay this resolution on its own.
+
+Triggered by run [\`${GITHUB_RUN_ID}\`](${run_url}).
+EOF
+)")"
+
+echo "url=${url}" >> "${GITHUB_OUTPUT}"

--- a/.github/scripts/sync-conflict-pr.sh
+++ b/.github/scripts/sync-conflict-pr.sh
@@ -52,14 +52,7 @@ Exporting the rerere cache lets the next sync replay this resolution on its own.
 Triggered by run [\`${GITHUB_RUN_ID}\`](${run_url}).
 EOF
 )")"; then
-  case "${HEAD_BRANCH}" in
-    *:*)
-      echo "::error::Could not open a pull request from ${HEAD_BRANCH}. GITHUB_TOKEN cannot create a pull request whose head branch lives in another repository. Add a personal access token with the 'repo' and 'workflow' scopes as the SYNC_TOKEN secret."
-      ;;
-    *)
-      echo "::error::Could not open a pull request from ${HEAD_BRANCH} into ${BASE_BRANCH}."
-      ;;
-  esac
+  echo "::error::Could not open a pull request from ${HEAD_BRANCH} into ${BASE_BRANCH}. If the push of ${HEAD_BRANCH} was rejected for touching .github/workflows/**, add a personal access token with the 'repo' and 'workflow' scopes as the SYNC_TOKEN secret."
   echo "${OUTPUT_KEY}_pr_url=(could not be created -- see the log)" >> "${GITHUB_OUTPUT}"
   exit 1
 fi

--- a/.github/scripts/sync-merge.sh
+++ b/.github/scripts/sync-merge.sh
@@ -57,18 +57,11 @@ fi
 
 echo "::warning::Conflicts remain in ${target_branch} after rerere; opening a pull request."
 
-# A pr_head of the form "owner:branch" already exists in another repository of
-# this fork network, so GitHub can open the PR against it directly. Pushing a
-# copy would be worse than redundant: GITHUB_TOKEN is refused outright when the
-# commits touch .github/workflows/**, which upstream commits routinely do.
-case "${pr_head}" in
-  *:*) ;;
-  *)
-    if [ "${source_ref}" != "${pr_head}" ]; then
-      git push --force origin "${source_ref}:refs/heads/${pr_head}"
-    fi
-    ;;
-esac
+# Stage the source commits on a branch in this repository so the pull request is
+# entirely local; the upstream remote is only ever read from.
+if [ "${source_ref}" != "${pr_head}" ]; then
+  git push --force origin "${source_ref}:refs/heads/${pr_head}"
+fi
 
 BASE_BRANCH="${target_branch}" \
 HEAD_BRANCH="${pr_head}" \

--- a/.github/scripts/sync-merge.sh
+++ b/.github/scripts/sync-merge.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Merge SOURCE_REF into TARGET_BRANCH, replaying recorded rerere resolutions and
+# falling back to a pull request when conflicts remain.
+#
+#   sync-merge.sh <source_ref> <target_branch> <pr_head_branch> <output_key>
+#
+# <pr_head_branch> is the branch a fallback PR is opened from. When it differs
+# from <source_ref> (because the source lives in another repository) the source
+# is pushed there first so GitHub has something to open the PR against.
+#
+# Writes "<output_key>_status" (clean|rerere|conflict) to $GITHUB_OUTPUT, and on
+# the conflict path "<output_key>_pr_url" via sync-conflict-pr.sh.
+
+set -euo pipefail
+
+source_ref="$1"
+target_branch="$2"
+pr_head="$3"
+output_key="$4"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+git checkout "${target_branch}"
+
+# rerere must be configured before the merge so resolutions can be replayed.
+git config rerere.enabled true
+git config rerere.autoUpdate true
+if [ -f bin/rerere-cache ]; then
+  bash bin/rerere-cache import
+else
+  echo "bin/rerere-cache not present on ${target_branch}; merging without recorded resolutions"
+fi
+
+unresolved=""
+if git merge --no-edit "${source_ref}"; then
+  status=clean
+elif [ -z "$(git ls-files --unmerged)" ]; then
+  # rerere resolved and staged every conflicted path; the merge only needs a commit.
+  git commit --no-edit
+  status=rerere
+else
+  unresolved="$(git diff --name-only --diff-filter=U)"
+  git merge --abort
+  status=conflict
+fi
+
+echo "${output_key}_status=${status}" >> "${GITHUB_OUTPUT}"
+
+if [ "${status}" != conflict ]; then
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/${target_branch}")" ]; then
+    git push origin "${target_branch}"
+  else
+    echo "${target_branch} already up to date; nothing to push"
+  fi
+  exit 0
+fi
+
+echo "::warning::Conflicts remain in ${target_branch} after rerere; opening a pull request."
+
+# Give the PR a head branch inside this repository when the source is external.
+if [ "${source_ref}" != "${pr_head}" ]; then
+  git push --force origin "${source_ref}:refs/heads/${pr_head}"
+fi
+
+BASE_BRANCH="${target_branch}" \
+HEAD_BRANCH="${pr_head}" \
+UNRESOLVED="${unresolved}" \
+OUTPUT_KEY="${output_key}" \
+  "${script_dir}/sync-conflict-pr.sh"

--- a/.github/scripts/sync-merge.sh
+++ b/.github/scripts/sync-merge.sh
@@ -57,10 +57,18 @@ fi
 
 echo "::warning::Conflicts remain in ${target_branch} after rerere; opening a pull request."
 
-# Give the PR a head branch inside this repository when the source is external.
-if [ "${source_ref}" != "${pr_head}" ]; then
-  git push --force origin "${source_ref}:refs/heads/${pr_head}"
-fi
+# A pr_head of the form "owner:branch" already exists in another repository of
+# this fork network, so GitHub can open the PR against it directly. Pushing a
+# copy would be worse than redundant: GITHUB_TOKEN is refused outright when the
+# commits touch .github/workflows/**, which upstream commits routinely do.
+case "${pr_head}" in
+  *:*) ;;
+  *)
+    if [ "${source_ref}" != "${pr_head}" ]; then
+      git push --force origin "${source_ref}:refs/heads/${pr_head}"
+    fi
+    ;;
+esac
 
 BASE_BRANCH="${target_branch}" \
 HEAD_BRANCH="${pr_head}" \

--- a/.github/scripts/sync-summary.sh
+++ b/.github/scripts/sync-summary.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Render the Sync Upstream job summary and fail the run if any merge needed a
+# pull request, so an incomplete sync is visible without digging into logs.
+
+set -euo pipefail
+
+describe() {
+  local status="$1" source="$2" target="$3" pr="$4"
+  case "${status}" in
+    clean)
+      echo "- \`${source}\` -> \`${target}\`: merged cleanly."
+      ;;
+    rerere)
+      echo "- \`${source}\` -> \`${target}\`: conflicts resolved automatically from the recorded rerere cache. **Check CI on \`${target}\`** — a replayed resolution can be clean but wrong."
+      ;;
+    conflict)
+      echo "- \`${source}\` -> \`${target}\`: **needs manual resolution** — ${pr}"
+      ;;
+    *)
+      echo "- \`${source}\` -> \`${target}\`: did not run."
+      ;;
+  esac
+}
+
+{
+  echo "### Sync Upstream"
+  echo ""
+  echo "Source: \`${UPSTREAM_REPO}@${UPSTREAM_BRANCH}\`"
+  echo ""
+  describe "${MIRROR_STATUS:-}" "upstream/${UPSTREAM_BRANCH}" "${TARGET_BRANCH}" "${MIRROR_PR:-}"
+  describe "${PERSONAL_STATUS:-}" "${TARGET_BRANCH}" "${PERSONAL_BRANCH}" "${PERSONAL_PR:-}"
+} >> "${GITHUB_STEP_SUMMARY}"
+
+if [ "${MIRROR_STATUS:-}" = conflict ] || [ "${PERSONAL_STATUS:-}" = conflict ]; then
+  echo "::error::Sync finished with unresolved conflicts; see the pull request linked in the summary."
+  exit 1
+fi

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -37,6 +37,9 @@ jobs:
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0
+          # GITHUB_TOKEN is refused when a push touches .github/workflows/**, so
+          # syncing upstream changes to CI needs a PAT with the workflow scope.
+          token: ${{ secrets.SYNC_TOKEN || github.token }}
 
       - name: Configure git identity
         run: |
@@ -56,14 +59,17 @@ jobs:
       - name: Merge upstream into mirror branch
         id: merge_mirror
         env:
+          UPSTREAM_REPO: ${{ inputs.upstream_repo }}
           UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN || github.token }}
         run: |
+          # Open the fallback PR straight from the upstream repository rather
+          # than pushing a copy of its branch here.
           .github/scripts/sync-merge.sh \
             "upstream/${UPSTREAM_BRANCH}" \
             "${TARGET_BRANCH}" \
-            "sync/upstream-${UPSTREAM_BRANCH}" \
+            "${UPSTREAM_REPO%%/*}:${UPSTREAM_BRANCH}" \
             mirror
 
       # Runs even if the merge above needed a PR, so the personal branch still
@@ -74,7 +80,7 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target_branch }}
           PERSONAL_BRANCH: ${{ inputs.personal_branch }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN || github.token }}
         run: |
           .github/scripts/sync-merge.sh \
             "${TARGET_BRANCH}" \

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,147 @@
+name: Sync Upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream_repo:
+        description: Upstream repository to merge from (owner/name)
+        required: true
+        default: Pedro-Revez-Silva/shelfarr
+      upstream_branch:
+        description: Upstream branch to merge from
+        required: true
+        default: main
+      target_branch:
+        description: Branch that tracks upstream
+        required: true
+        default: main
+      personal_branch:
+        description: Branch that receives the merged upstream changes
+        required: true
+        default: personal-changes
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-upstream
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        env:
+          UPSTREAM_REPO: ${{ inputs.upstream_repo }}
+          UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
+        run: |
+          git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+          git fetch upstream "${UPSTREAM_BRANCH}"
+
+      - name: Merge upstream into target branch
+        env:
+          UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          git checkout "${TARGET_BRANCH}"
+          git merge --no-edit "upstream/${UPSTREAM_BRANCH}" || {
+            git merge --abort || true
+            echo "::error::Merge conflict between upstream/${UPSTREAM_BRANCH} and ${TARGET_BRANCH}. Resolve it locally and push."
+            exit 1
+          }
+          git push origin "${TARGET_BRANCH}"
+
+      - name: Merge target branch into personal branch
+        id: merge_personal
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          PERSONAL_BRANCH: ${{ inputs.personal_branch }}
+        run: |
+          git checkout "${PERSONAL_BRANCH}"
+
+          # Replay conflict resolutions recorded locally and committed to the branch.
+          git config rerere.enabled true
+          git config rerere.autoUpdate true
+          if [ -f bin/rerere-cache ]; then
+            bash bin/rerere-cache import
+          else
+            echo "bin/rerere-cache not on ${PERSONAL_BRANCH}; merging without recorded resolutions"
+          fi
+
+          if git merge --no-edit "${TARGET_BRANCH}"; then
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+          elif [ -z "$(git ls-files --unmerged)" ]; then
+            # rerere resolved and staged every conflicted path; commit the merge.
+            git commit --no-edit
+            echo "status=rerere" >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "unresolved<<UNRESOLVED_EOF"
+              git diff --name-only --diff-filter=U
+              echo "UNRESOLVED_EOF"
+            } >> "$GITHUB_OUTPUT"
+            git merge --abort
+            echo "status=conflict" >> "$GITHUB_OUTPUT"
+            echo "::warning::Conflicts remain after rerere; opening a pull request instead."
+          fi
+
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/${PERSONAL_BRANCH}")" ]; then
+            git push origin "${PERSONAL_BRANCH}"
+          fi
+
+      - name: Open pull request for unresolved conflicts
+        id: conflict_pr
+        if: steps.merge_personal.outputs.status == 'conflict'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          PERSONAL_BRANCH: ${{ inputs.personal_branch }}
+          UNRESOLVED: ${{ steps.merge_personal.outputs.unresolved }}
+        run: .github/scripts/sync-conflict-pr.sh
+
+      - name: Summary
+        if: always()
+        env:
+          UPSTREAM_REPO: ${{ inputs.upstream_repo }}
+          UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          PERSONAL_BRANCH: ${{ inputs.personal_branch }}
+          STATUS: ${{ steps.merge_personal.outputs.status }}
+          PR_URL: ${{ steps.conflict_pr.outputs.url }}
+        continue-on-error: true
+        run: |
+          {
+            echo "### Sync Upstream"
+            echo ""
+            echo "Source: \`${UPSTREAM_REPO}@${UPSTREAM_BRANCH}\`"
+            echo ""
+            case "${STATUS}" in
+              clean)
+                echo "Merged \`${TARGET_BRANCH}\` into \`${PERSONAL_BRANCH}\` with no conflicts."
+                ;;
+              rerere)
+                echo "Conflicts were resolved automatically from the recorded rerere cache."
+                echo ""
+                echo "**Check CI on \`${PERSONAL_BRANCH}\`** — a replayed resolution can be clean but wrong."
+                ;;
+              conflict)
+                echo "Conflicts need manual resolution: ${PR_URL}"
+                ;;
+              *)
+                echo "Sync did not reach the \`${PERSONAL_BRANCH}\` merge."
+                ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -51,66 +51,36 @@ jobs:
           git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
           git fetch upstream "${UPSTREAM_BRANCH}"
 
-      - name: Merge upstream into target branch
+      # main tracks upstream but carries fork commits of its own, so this merge
+      # can conflict just like the personal one.
+      - name: Merge upstream into mirror branch
+        id: merge_mirror
         env:
           UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git checkout "${TARGET_BRANCH}"
-          git merge --no-edit "upstream/${UPSTREAM_BRANCH}" || {
-            git merge --abort || true
-            echo "::error::Merge conflict between upstream/${UPSTREAM_BRANCH} and ${TARGET_BRANCH}. Resolve it locally and push."
-            exit 1
-          }
-          git push origin "${TARGET_BRANCH}"
+          .github/scripts/sync-merge.sh \
+            "upstream/${UPSTREAM_BRANCH}" \
+            "${TARGET_BRANCH}" \
+            "sync/upstream-${UPSTREAM_BRANCH}" \
+            mirror
 
-      - name: Merge target branch into personal branch
+      # Runs even if the merge above needed a PR, so the personal branch still
+      # picks up whatever main already has.
+      - name: Merge mirror branch into personal branch
+        if: ${{ !cancelled() }}
         id: merge_personal
         env:
           TARGET_BRANCH: ${{ inputs.target_branch }}
           PERSONAL_BRANCH: ${{ inputs.personal_branch }}
-        run: |
-          git checkout "${PERSONAL_BRANCH}"
-
-          # Replay conflict resolutions recorded locally and committed to the branch.
-          git config rerere.enabled true
-          git config rerere.autoUpdate true
-          if [ -f bin/rerere-cache ]; then
-            bash bin/rerere-cache import
-          else
-            echo "bin/rerere-cache not on ${PERSONAL_BRANCH}; merging without recorded resolutions"
-          fi
-
-          if git merge --no-edit "${TARGET_BRANCH}"; then
-            echo "status=clean" >> "$GITHUB_OUTPUT"
-          elif [ -z "$(git ls-files --unmerged)" ]; then
-            # rerere resolved and staged every conflicted path; commit the merge.
-            git commit --no-edit
-            echo "status=rerere" >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "unresolved<<UNRESOLVED_EOF"
-              git diff --name-only --diff-filter=U
-              echo "UNRESOLVED_EOF"
-            } >> "$GITHUB_OUTPUT"
-            git merge --abort
-            echo "status=conflict" >> "$GITHUB_OUTPUT"
-            echo "::warning::Conflicts remain after rerere; opening a pull request instead."
-          fi
-
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/${PERSONAL_BRANCH}")" ]; then
-            git push origin "${PERSONAL_BRANCH}"
-          fi
-
-      - name: Open pull request for unresolved conflicts
-        id: conflict_pr
-        if: steps.merge_personal.outputs.status == 'conflict'
-        env:
           GH_TOKEN: ${{ github.token }}
-          TARGET_BRANCH: ${{ inputs.target_branch }}
-          PERSONAL_BRANCH: ${{ inputs.personal_branch }}
-          UNRESOLVED: ${{ steps.merge_personal.outputs.unresolved }}
-        run: .github/scripts/sync-conflict-pr.sh
+        run: |
+          .github/scripts/sync-merge.sh \
+            "${TARGET_BRANCH}" \
+            "${PERSONAL_BRANCH}" \
+            "${TARGET_BRANCH}" \
+            personal
 
       - name: Summary
         if: always()
@@ -119,29 +89,8 @@ jobs:
           UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
           TARGET_BRANCH: ${{ inputs.target_branch }}
           PERSONAL_BRANCH: ${{ inputs.personal_branch }}
-          STATUS: ${{ steps.merge_personal.outputs.status }}
-          PR_URL: ${{ steps.conflict_pr.outputs.url }}
-        continue-on-error: true
-        run: |
-          {
-            echo "### Sync Upstream"
-            echo ""
-            echo "Source: \`${UPSTREAM_REPO}@${UPSTREAM_BRANCH}\`"
-            echo ""
-            case "${STATUS}" in
-              clean)
-                echo "Merged \`${TARGET_BRANCH}\` into \`${PERSONAL_BRANCH}\` with no conflicts."
-                ;;
-              rerere)
-                echo "Conflicts were resolved automatically from the recorded rerere cache."
-                echo ""
-                echo "**Check CI on \`${PERSONAL_BRANCH}\`** — a replayed resolution can be clean but wrong."
-                ;;
-              conflict)
-                echo "Conflicts need manual resolution: ${PR_URL}"
-                ;;
-              *)
-                echo "Sync did not reach the \`${PERSONAL_BRANCH}\` merge."
-                ;;
-            esac
-          } >> "$GITHUB_STEP_SUMMARY"
+          MIRROR_STATUS: ${{ steps.merge_mirror.outputs.mirror_status }}
+          MIRROR_PR: ${{ steps.merge_mirror.outputs.mirror_pr_url }}
+          PERSONAL_STATUS: ${{ steps.merge_personal.outputs.personal_status }}
+          PERSONAL_PR: ${{ steps.merge_personal.outputs.personal_pr_url }}
+        run: .github/scripts/sync-summary.sh

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -52,7 +52,10 @@ jobs:
           UPSTREAM_BRANCH: ${{ inputs.upstream_branch }}
         run: |
           git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
-          git fetch upstream "${UPSTREAM_BRANCH}"
+          # Make the read-only intent structural: any push to upstream fails on
+          # the URL rather than relying on nothing ever attempting one.
+          git remote set-url --push upstream DISABLED
+          git fetch --no-tags upstream "${UPSTREAM_BRANCH}"
 
       # main tracks upstream but carries fork commits of its own, so this merge
       # can conflict just like the personal one.
@@ -64,12 +67,12 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target_branch }}
           GH_TOKEN: ${{ secrets.SYNC_TOKEN || github.token }}
         run: |
-          # Open the fallback PR straight from the upstream repository rather
-          # than pushing a copy of its branch here.
+          # The fallback PR is opened from a branch in this repository, never
+          # from the upstream one.
           .github/scripts/sync-merge.sh \
             "upstream/${UPSTREAM_BRANCH}" \
             "${TARGET_BRANCH}" \
-            "${UPSTREAM_REPO%%/*}:${UPSTREAM_BRANCH}" \
+            "sync/upstream-${UPSTREAM_BRANCH}" \
             mirror
 
       # Runs even if the merge above needed a PR, so the personal branch still

--- a/app/controllers/admin/detected_imports_controller.rb
+++ b/app/controllers/admin/detected_imports_controller.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+module Admin
+  class DetectedImportsController < BaseController
+    # Raised when the admin picked a specific candidate that can no longer be
+    # resolved to a book, so import fails loudly instead of silently importing a
+    # different target.
+    class SelectionError < StandardError; end
+
+    # How many imported items the history section shows before the admin expands
+    # it. The full history is only queried when expanded, so the common (collapsed)
+    # render stays cheap and the dismissed section below remains within reach.
+    IMPORTED_PREVIEW_COUNT = 10
+
+    before_action :set_detected_import, only: [ :show, :destroy, :import, :dismiss, :restore, :rematch, :search, :undo ]
+
+    def index
+      @pending = DetectedImport.pending_review.includes(:suggested_book).recent
+      @dismissed = DetectedImport.where(status: "dismissed").recent.limit(20)
+      @scan_status = WatchedFolderScanJob.scan_status
+
+      imported = DetectedImport.where(status: "imported").order(updated_at: :desc)
+      @imported_total = imported.count
+      @imported_expanded = params[:imported] == "all"
+      @imported_has_more = @imported_total > IMPORTED_PREVIEW_COUNT
+      @imported = (@imported_expanded ? imported : imported.limit(IMPORTED_PREVIEW_COUNT))
+        .includes(:imported_book).to_a
+    end
+
+    def show
+    end
+
+    # Manually trigger a watched-folder scan (in addition to the recurring one).
+    def scan
+      if WatchedFolderScanJob.scanning_enabled?
+        WatchedFolderScanJob.perform_later(manual: true)
+        redirect_to admin_detected_imports_path, notice: "Watched-folder scan started."
+      else
+        redirect_to admin_detected_imports_path,
+          alert: "Enable watched-folder import and set a path in Settings first."
+      end
+    end
+
+    # Approve an item: apply any edited book selection, then queue the import.
+    def import
+      unless @detected_import.actionable?
+        redirect_to admin_detected_imports_path, alert: "This item can no longer be imported."
+        return
+      end
+
+      apply_selection!(@detected_import)
+      DetectedImportJob.perform_later(@detected_import.id)
+      redirect_to admin_detected_imports_path,
+        notice: "Import queued for \"#{@detected_import.display_title}\"."
+    rescue SelectionError => e
+      redirect_to admin_detected_import_path(@detected_import), alert: e.message
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Import approval failed (#{e.class})"
+      redirect_to admin_detected_import_path(@detected_import),
+        alert: "Could not queue import for \"#{@detected_import.display_title}\"."
+    end
+
+    def dismiss
+      @detected_import.update!(status: "dismissed") if @detected_import.actionable?
+      redirect_to admin_detected_imports_path, notice: "Dismissed \"#{@detected_import.display_title}\"."
+    end
+
+    # Bring a dismissed detection back into the review queue.
+    def restore
+      @detected_import.update!(status: "detected") if @detected_import.status == "dismissed"
+      redirect_to admin_detected_imports_path, notice: "Restored \"#{@detected_import.display_title}\" to the review queue."
+    end
+
+    # Reverse a completed import so it can be re-imported against a different
+    # match (e.g. approved as a new book by mistake). Removes the published
+    # library file (returning it to the watched folder when it was moved) and
+    # returns the detection to the queue.
+    def undo
+      unless @detected_import.imported?
+        redirect_to admin_detected_imports_path, alert: "This item hasn't been imported, so there's nothing to undo."
+        return
+      end
+
+      LibraryAcquisitionService.undo_import!(@detected_import)
+      redirect_to admin_detected_import_path(@detected_import),
+        notice: "Undid the import for \"#{@detected_import.display_title}\". Pick the correct match and import again."
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Undo failed for ##{@detected_import.id} (#{e.class})"
+      redirect_to admin_detected_imports_path,
+        alert: "Could not undo the import for \"#{@detected_import.display_title}\"."
+    end
+
+    # Manual free-text metadata search from the review page, for when neither the
+    # suggestion nor the auto-detected alternates are right. Matches are merged
+    # into the detection's candidate list so they become selectable radios in the
+    # existing import form.
+    def search
+      query = params[:query].to_s.strip
+      if query.blank?
+        redirect_to admin_detected_import_path(@detected_import), alert: "Enter a title or author to search."
+        return
+      end
+
+      results = LibraryAcquisitionService.search_candidates(
+        query: query,
+        book_type: @detected_import.book_type
+      )
+
+      if results.empty?
+        redirect_to admin_detected_import_path(@detected_import, query: query),
+          alert: "No matches found for \"#{query}\"."
+        return
+      end
+
+      @detected_import.update!(candidate_books: merge_candidates(@detected_import.candidate_books, results))
+      redirect_to admin_detected_import_path(@detected_import, query: query),
+        notice: "Found #{results.size} #{'match'.pluralize(results.size)} for \"#{query}\". Pick one, then import."
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Manual search failed (#{e.class})"
+      redirect_to admin_detected_import_path(@detected_import), alert: "Search failed. Please try again."
+    end
+
+    # Re-run identification against the source, refreshing the suggestion and
+    # alternates (useful after adding a metadata provider or API key).
+    def rematch
+      identification = LibraryAcquisitionService.identify(
+        source_path: @detected_import.source_path,
+        book_type: @detected_import.book_type
+      )
+      @detected_import.update!(
+        parsed_title: identification.parsed_title,
+        parsed_author: identification.parsed_author,
+        match_confidence: identification.match_confidence,
+        suggested_book: identification.suggested_book,
+        candidate_books: identification.candidate_books
+      )
+      redirect_to admin_detected_import_path(@detected_import), notice: "Re-matched \"#{@detected_import.display_title}\"."
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Rematch failed (#{e.class})"
+      redirect_to admin_detected_import_path(@detected_import), alert: "Could not re-match this item."
+    end
+
+    def destroy
+      @detected_import.destroy
+      redirect_to admin_detected_imports_path, notice: "Removed detection."
+    end
+
+    private
+
+    def set_detected_import
+      @detected_import = DetectedImport.find(params[:id])
+    end
+
+    # Prepend fresh manual-search hits ahead of the existing candidates, dropping
+    # any prior online entry for the same work so repeated searches don't stack
+    # duplicates. Library candidates (no work_id) are always preserved.
+    def merge_candidates(existing, incoming)
+      incoming_work_ids = incoming.filter_map { |candidate| candidate["work_id"] }.to_set
+      retained = existing.reject do |candidate|
+        candidate["work_id"].present? && incoming_work_ids.include?(candidate["work_id"])
+      end
+      incoming + retained
+    end
+
+    # Resolve the user's decision from the approve form into the detection's
+    # target book. Defaults to the existing suggestion when no selection is made.
+    def apply_selection!(detected_import)
+      selection = params[:selection].to_s
+
+      if (match = selection.match(/\Abook:(\d+)\z/))
+        book = Book.find_by(id: match[1])
+        raise SelectionError, "The selected library book no longer exists. Please choose another match." unless book
+        detected_import.update!(suggested_book: book)
+      elsif (match = selection.match(/\Awork:(.+)\z/))
+        book = resolve_work_candidate(detected_import, match[1])
+        raise SelectionError, "The selected match could not be resolved. Try Re-match, then choose again." unless book
+        detected_import.update!(suggested_book: book)
+      elsif selection == "new"
+        apply_metadata_edits!(detected_import)
+      end
+    end
+
+    def apply_metadata_edits!(detected_import)
+      attrs = { suggested_book_id: nil }
+      attrs[:parsed_title] = params[:title].to_s.strip if params[:title].present?
+      attrs[:parsed_author] = params[:author].to_s.strip if params.key?(:author)
+      if DetectedImport::BOOK_TYPES.include?(params[:book_type])
+        attrs[:book_type] = params[:book_type]
+      end
+      detected_import.update!(attrs)
+    end
+
+    # Resolve an online candidate (by work_id) to a Book, reusing an existing
+    # record when one already carries that work_id, otherwise creating one from
+    # the candidate metadata already captured at detection time (no network).
+    def resolve_work_candidate(detected_import, work_id)
+      book_type = detected_import.book_type.presence || "ebook"
+      existing = Book.find_by_work_id(work_id, book_type: book_type)
+      return existing if existing
+
+      candidate = detected_import.candidate_books.find { |c| c["work_id"] == work_id }
+      return nil unless candidate
+
+      source, = Book.parse_work_id(work_id)
+      book = Book.new(
+        title: candidate["title"].presence || detected_import.parsed_title,
+        author: candidate["author"],
+        book_type: book_type,
+        cover_url: candidate["cover_url"],
+        year: candidate["year"],
+        metadata_source: source
+      )
+      book.assign_work_id(work_id)
+      book.save!
+      book
+    end
+  end
+end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -493,6 +493,14 @@ module Admin
       if changed_keys.any? { |k| k.start_with?("audiobook_output_path") || k.start_with?("ebook_output_path") }
         run_service_health_check_now("output_paths")
       end
+      if changed_keys.any? { |k| k.start_with?("library_import") }
+        sync_watched_folder_scan
+      end
+    end
+
+    def sync_watched_folder_scan
+      WatchedFolderScanJob.clear_schedule!
+      WatchedFolderScanJob.ensure_running!
     end
 
     PATH_TEMPLATE_SETTINGS = %w[audiobook_path_template ebook_path_template].freeze

--- a/app/jobs/detected_import_enrichment_job.rb
+++ b/app/jobs/detected_import_enrichment_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Fills in a fresh detection's online alternate matches out-of-band, so the
+# watched-folder scan stays local + DB only and never blocks on thousands of
+# sequential provider searches. Non-destructive: it only appends online
+# candidates the scan didn't already record, and leaves the parsed metadata and
+# the local library suggestion untouched. Network/parse failures are swallowed —
+# the admin review step (and the manual Re-match) remain the correctness
+# backstop.
+class DetectedImportEnrichmentJob < ApplicationJob
+  queue_as :default
+
+  def perform(detected_import_id)
+    detected_import = DetectedImport.find_by(id: detected_import_id)
+    return unless detected_import
+    return unless detected_import.status == "detected"
+
+    online = LibraryAcquisitionService.online_candidates_for(
+      title: detected_import.parsed_title,
+      author: detected_import.parsed_author,
+      book_type: detected_import.book_type
+    )
+    return if online.empty?
+
+    existing = detected_import.candidate_books
+    known_work_ids = existing.map { |candidate| candidate["work_id"] }.compact.to_set
+    additions = online.reject { |candidate| known_work_ids.include?(candidate["work_id"]) }
+    return if additions.empty?
+
+    detected_import.update!(candidate_books: existing + additions)
+  rescue => e
+    Rails.logger.warn "[DetectedImportEnrichmentJob] Enrichment failed for ##{detected_import_id} (#{e.class})"
+  end
+end

--- a/app/jobs/detected_import_job.rb
+++ b/app/jobs/detected_import_job.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Imports an admin-approved DetectedImport into the organised library via
+# LibraryAcquisitionService. Claims the record with a compare-and-swap so a
+# double submit or redelivery cannot run two imports for the same detection.
+# A failed import leaves the source untouched and is retryable from the review
+# queue.
+class DetectedImportJob < ApplicationJob
+  queue_as :default
+
+  def perform(detected_import_id)
+    detected_import = claim(detected_import_id)
+    return unless detected_import
+
+    begin
+      book = detected_import.suggested_book || create_and_attach_book(detected_import)
+
+      result = LibraryAcquisitionService.import!(
+        source_path: detected_import.source_path,
+        book: book,
+        owner: detected_import,
+        provenance: :watched_folder
+      )
+
+      detected_import.update!(
+        status: "imported",
+        imported_book: result.book,
+        suggested_book: result.book,
+        error_message: nil
+      )
+      Rails.logger.info(
+        "[DetectedImportJob] Imported detection ##{detected_import.id} into book ##{result.book.id}"
+      )
+    rescue => e
+      Rails.logger.error(
+        "[DetectedImportJob] Import failed for detection ##{detected_import.id} (#{e.class})"
+      )
+      detected_import.update!(
+        status: "failed",
+        error_message: e.message.to_s.scrub.truncate(2_000)
+      )
+    end
+  end
+
+  private
+
+  # Compare-and-swap detected/failed (or an abandoned, stale "importing" whose
+  # worker died before finishing) -> importing, so only one worker proceeds and
+  # a wedged row can be recovered.
+  def claim(detected_import_id)
+    claimed = DetectedImport
+      .where(id: detected_import_id)
+      .where(
+        "status IN (:actionable) OR (status = 'importing' AND updated_at < :stuck_before)",
+        actionable: DetectedImport::ACTIONABLE_STATUSES,
+        stuck_before: DetectedImport::STUCK_IMPORTING_AFTER.ago
+      )
+      .update_all(status: "importing", updated_at: Time.current)
+    return unless claimed == 1
+
+    DetectedImport.find_by(id: detected_import_id)
+  end
+
+  # Persist the created Book onto the detection so a retry after a failed import
+  # reuses it instead of orphaning a new unacquired record each attempt.
+  def create_and_attach_book(detected_import)
+    book = Book.create!(
+      title: detected_import.parsed_title.presence || File.basename(detected_import.source_path.to_s),
+      author: detected_import.parsed_author,
+      book_type: detected_import.book_type.presence || "ebook"
+    )
+    detected_import.update!(suggested_book: book)
+    book
+  end
+end

--- a/app/jobs/watched_folder_scan_job.rb
+++ b/app/jobs/watched_folder_scan_job.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# Recurring, self-rescheduling job that scans the configured watched-folder
+# import path for pre-existing book files. Mirrors the scheduling pattern of
+# DownloadMonitorJob / TelegramPollingJob: a single concurrency key prevents
+# overlapping scans, and each run re-arms the next at the configured interval.
+class WatchedFolderScanJob < ApplicationJob
+  SCHEDULE_CACHE_KEY = "watched_folder_scan/next_run_at"
+  # Progress/result of the most recent manual scan, for the review-queue UI.
+  # Backed by the shared cache (solid_cache in production) and written only by
+  # the worker running the scan, so the web process rendering the queue sees a
+  # consistent state and never a stuck "running" flag from a crossed process.
+  STATUS_CACHE_KEY = "watched_folder_scan/status"
+  DEFAULT_INTERVAL_SECONDS = 300
+  MIN_INTERVAL_SECONDS = 30
+  MAX_INTERVAL_SECONDS = 86_400
+
+  queue_as :default
+  limits_concurrency key: "watched_folder_scan", duration: 1.hour, on_conflict: :discard
+
+  class << self
+    def scanning_enabled?
+      SettingsService.get(:library_import_enabled, default: false) &&
+        SettingsService.get(:library_import_path).to_s.strip.present?
+    end
+
+    # Snapshot of the latest manual scan for the queue UI: state ("running" /
+    # "idle"), when it completed, and how many candidates/new detections it saw.
+    # Empty until the first manual scan runs (or in an environment whose cache is
+    # not shared across processes, e.g. development's memory store).
+    def scan_status
+      Rails.cache.read(STATUS_CACHE_KEY) || {}
+    end
+
+    def scanning_now?
+      scan_status[:state] == "running"
+    end
+
+    def mark_running!
+      write_status(state: "running", started_at: Time.current)
+    end
+
+    def mark_completed!(result)
+      write_status(
+        state: "idle",
+        completed_at: Time.current,
+        scanned: result&.scanned,
+        detected: result&.detected,
+        failed: result.nil?
+      )
+    end
+
+    def broadcast_queue_refresh
+      Turbo::StreamsChannel.broadcast_refresh_to(DetectedImport::INDEX_STREAM)
+    rescue => e
+      Rails.logger.warn "[WatchedFolderScanJob] Could not broadcast queue refresh (#{e.class})"
+    end
+
+    def ensure_running!
+      return unless scanning_enabled?
+      return if scan_job_pending?
+
+      next_run_at = Rails.cache.read(SCHEDULE_CACHE_KEY).to_i
+      return if next_run_at > Time.current.to_i
+
+      reserve_schedule!
+      Rails.logger.info "[WatchedFolderScanJob] Scheduling watched-folder scan chain"
+      perform_later
+    end
+
+    def clear_schedule!
+      Rails.cache.delete(SCHEDULE_CACHE_KEY)
+    end
+
+    def scan_job_pending?(excluding_active_job_id: nil)
+      return false unless solid_queue_adapter?
+
+      scope = SolidQueue::Job.where(class_name: name, finished_at: nil)
+      scope = scope.where.not(active_job_id: excluding_active_job_id) if excluding_active_job_id.present?
+      scope.exists?
+    rescue ActiveRecord::StatementInvalid, NameError
+      false
+    end
+
+    def interval_seconds
+      SettingsService.get(:library_import_scan_interval, default: DEFAULT_INTERVAL_SECONDS)
+        .to_i
+        .clamp(MIN_INTERVAL_SECONDS, MAX_INTERVAL_SECONDS)
+    end
+
+    private
+
+    def write_status(attrs)
+      Rails.cache.write(STATUS_CACHE_KEY, attrs, expires_in: 1.day)
+    rescue => e
+      Rails.logger.warn "[WatchedFolderScanJob] Could not record scan status (#{e.class})"
+    end
+
+    def reserve_schedule!
+      Rails.cache.write(
+        SCHEDULE_CACHE_KEY,
+        interval_seconds.seconds.from_now.to_i,
+        expires_in: [ interval_seconds * 3, 300 ].max.seconds
+      )
+    end
+
+    def solid_queue_adapter?
+      ActiveJob::Base.queue_adapter.class.name == "ActiveJob::QueueAdapters::SolidQueueAdapter"
+    end
+  end
+
+  # manual: true is passed by the "Scan now" button. Such a scan announces its
+  # progress to the review queue (a spinner while it runs, its result when it
+  # finishes) and refreshes the queue on completion so new detections appear
+  # without a manual reload. The recurring background scan stays silent — it only
+  # records its completion so "last scanned" stays fresh, and relies on the
+  # per-record broadcasts to surface anything it finds.
+  def perform(manual: false)
+    unless self.class.scanning_enabled?
+      self.class.clear_schedule!
+      return
+    end
+
+    if manual
+      self.class.mark_running!
+      self.class.broadcast_queue_refresh
+    end
+
+    result = WatchedFolderScanService.scan!
+    self.class.mark_completed!(result)
+    self.class.broadcast_queue_refresh if manual
+  rescue => e
+    Rails.logger.error "[WatchedFolderScanJob] Scan failed (#{e.class}): #{e.message}"
+    self.class.mark_completed!(nil)
+    self.class.broadcast_queue_refresh if manual
+  ensure
+    schedule_next_run if self.class.scanning_enabled?
+  end
+
+  private
+
+  def schedule_next_run
+    return if self.class.scan_job_pending?(excluding_active_job_id: job_id)
+
+    self.class.send(:reserve_schedule!)
+    WatchedFolderScanJob.set(wait: self.class.interval_seconds.seconds).perform_later
+  end
+end

--- a/app/models/detected_import.rb
+++ b/app/models/detected_import.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# A book file discovered in the watched-folder import path that was not acquired
+# through a Shelfarr request. Each record represents one review-queue item: the
+# scanner detects a candidate, computes a suggested match, and an admin approves
+# or dismisses it before it is imported into the organised library.
+#
+# Idempotency is anchored on the source (device, inode) pair rather than the
+# path, because a hardlink import creates a second path to the same content on
+# the same filesystem and a re-scan must not re-detect it.
+class DetectedImport < ApplicationRecord
+  STATUSES = %w[detected dismissed importing imported failed].freeze
+  ACTIONABLE_STATUSES = %w[detected failed].freeze
+  BOOK_TYPES = %w[audiobook ebook comicbook].freeze
+
+  # An "importing" row whose claim is older than this is assumed abandoned: the
+  # worker that claimed it died (redeploy, OOM, hard kill) before it could reach
+  # the success/failure update. Matches DetectedImportJob's concurrency lease so
+  # a genuinely long import is never treated as stuck. Such rows become
+  # actionable again (re-import / dismiss) and re-claimable by the job.
+  STUCK_IMPORTING_AFTER = 1.hour
+
+  belongs_to :suggested_book, class_name: "Book", optional: true
+  belongs_to :imported_book, class_name: "Book", optional: true
+
+  validates :source_path, presence: true
+  validates :status, inclusion: { in: STATUSES }
+  validates :book_type, inclusion: { in: BOOK_TYPES }, allow_nil: true
+
+  scope :detected, -> { where(status: "detected") }
+  scope :actionable, -> { where(status: ACTIONABLE_STATUSES) }
+  scope :pending_review, -> { where(status: %w[detected failed importing]) }
+  scope :recent, -> { order(Arel.sql("COALESCE(detected_at, created_at) DESC")) }
+
+  # Live-update the review screens whenever a detection is created (scanner),
+  # changes status (detected -> importing -> imported/failed via
+  # DetectedImportJob), or is removed. Mirrors the Turbo 8 morph-refresh pattern
+  # used on the request and owned-library screens. The index tracks the whole
+  # queue via a shared stream; each review (show) page tracks just its own
+  # record so it swaps to the imported/failed state without a manual reload.
+  INDEX_STREAM = "detected_imports"
+  after_create_commit  :broadcast_queue_refresh_later
+  after_update_commit  :broadcast_review_refresh_later
+  after_destroy_commit :broadcast_queue_refresh_later
+
+  def actionable?
+    ACTIONABLE_STATUSES.include?(status) || stuck_importing?
+  end
+
+  # True when this row has been wedged in "importing" long enough that the
+  # claiming worker must be gone, so the admin can recover it from the queue.
+  def stuck_importing?
+    status == "importing" && updated_at.present? && updated_at < STUCK_IMPORTING_AFTER.ago
+  end
+
+  def imported?
+    status == "imported"
+  end
+
+  def display_title
+    parsed_title.presence || File.basename(source_path.to_s)
+  end
+
+  def candidate_books
+    value = super
+    value.is_a?(Array) ? value : []
+  end
+
+  # The highest-scoring alternate the scanner found, whether an existing library
+  # book or an online work. Used to pre-select a real match instead of "new
+  # book" when no exact library suggestion exists — the same ranking the review
+  # screen lists the alternates in.
+  def best_candidate
+    candidate_books.max_by { |candidate| candidate["score"].to_i } if candidate_books.present?
+  end
+
+  # The radio value the review form should default to: the existing library
+  # suggestion when there is one, otherwise the best-scoring alternate, and only
+  # "new" when nothing was matched at all.
+  def default_selection
+    return "book:#{suggested_book_id}" if suggested_book_id
+
+    candidate = best_candidate
+    return "new" unless candidate
+
+    candidate["kind"] == "library" ? "book:#{candidate['book_id']}" : "work:#{candidate['work_id']}"
+  end
+
+  private
+
+  def broadcast_queue_refresh_later
+    broadcast_refresh_later_to(INDEX_STREAM)
+  end
+
+  def broadcast_review_refresh_later
+    broadcast_refresh_later_to(INDEX_STREAM)
+    broadcast_refresh_later_to(self)
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,7 +4,7 @@ class Notification < ApplicationRecord
   belongs_to :user
   belongs_to :notifiable, polymorphic: true, optional: true
 
-  TYPES = %w[request_completed request_failed request_attention].freeze
+  TYPES = %w[request_completed request_failed request_attention import_detected].freeze
 
   validates :notification_type, presence: true, inclusion: { in: TYPES }
   validates :title, presence: true

--- a/app/services/library_acquisition_service.rb
+++ b/app/services/library_acquisition_service.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+
+# Shared "identify a book and import a source file into the organised library"
+# engine used by any front door that adopts a file which was not acquired
+# through a Shelfarr request (currently the watched-folder importer).
+#
+# The request pipeline still uses UploadProcessingJob / PostProcessingJob
+# directly; this service reuses the same underlying identification and
+# path-template services so both paths agree on structure and matching.
+#
+# +identify+ is read-only: it inspects a source file and returns a ranked
+# suggestion without creating any Book or touching the filesystem beyond
+# reading embedded metadata. +import!+ (see below) performs the actual,
+# crash-safe publication once an admin has approved a target Book.
+class LibraryAcquisitionService
+  # Audio container extensions that mark a file (or the folder containing it) as
+  # an audiobook. Distinct from Upload::AUDIOBOOK_EXTENSIONS, which also treats
+  # zip/rar archives as audiobook uploads — those are not present in a watched
+  # completed-download folder as playable media.
+  AUDIO_EXTENSIONS = %w[m4a m4b mp3 aax aac flac ogg opus wav].freeze
+  # Single-file readable formats (ebooks + comics), reused from the download
+  # importer so both front doors recognise the same file types.
+  READABLE_EXTENSIONS = PostProcessingJob::EBOOK_FILE_EXTENSIONS
+  MAX_ONLINE_CANDIDATES = 5
+
+  class AcquisitionConflictError < StandardError; end
+
+  # Outcome of a successful import into the organised library.
+  ImportResult = Data.define(:book, :destination_path, :mode)
+
+  # Read-only identification result. +candidate_books+ is a ranked array of
+  # plain hashes safe to persist as JSON on a DetectedImport.
+  Identification = Data.define(
+    :book_type,
+    :parsed_title,
+    :parsed_author,
+    :suggested_book,
+    :candidate_books,
+    :match_confidence,
+    :source_path
+  )
+
+  class << self
+    # Inspect a source file and return a ranked suggestion. No writes.
+    #
+    # source_path   - a regular file to read embedded metadata from. For an
+    #                 audiobook folder the caller passes a representative audio
+    #                 file inside it.
+    # book_type     - optional override; inferred from the path when omitted.
+    # filename_hint - name used for the filename-parse fallback (defaults to the
+    #                 source basename; the caller passes the folder name for an
+    #                 audiobook so the parse reflects the release, not one track).
+    def identify(source_path:, book_type: nil, filename_hint: nil, online: true)
+      resolved_type = (book_type || infer_book_type(source_path)).to_s
+      extracted = MetadataExtractorService.extract(source_path)
+      parsed = FilenameParserService.parse(filename_hint.presence || File.basename(source_path.to_s))
+
+      title = extracted.title.presence || parsed.title
+      author = extracted.author.presence || parsed.author
+
+      match = BookMatcherService.match(title: title, author: author, book_type: resolved_type)
+      suggested_book = match.book if match.exact? || match.fuzzy?
+
+      candidates = []
+      candidates << library_candidate(match.book, match.score) if suggested_book
+      candidates.concat(online_candidates(title, author, resolved_type)) if online
+
+      confidence = if suggested_book
+        match.score
+      elsif extracted.present?
+        90
+      else
+        parsed.confidence
+      end
+
+      Identification.new(
+        book_type: resolved_type,
+        parsed_title: title,
+        parsed_author: author,
+        suggested_book: suggested_book,
+        candidate_books: candidates,
+        match_confidence: confidence,
+        source_path: source_path.to_s
+      )
+    end
+
+    # Infer a book type from a path without reading it. A directory is treated
+    # as an audiobook release; a file is classified by extension.
+    def infer_book_type(source_path)
+      return "audiobook" if File.directory?(source_path)
+
+      case File.extname(source_path.to_s).delete_prefix(".").downcase
+      when *Upload::COMICBOOK_EXTENSIONS then "comicbook"
+      when *AUDIO_EXTENSIONS then "audiobook"
+      else "ebook"
+      end
+    end
+
+    # Import an already-decided book's source file into the organised library,
+    # marking the book acquired and triggering a library scan.
+    #
+    # source_path - file or directory to publish.
+    # book        - the target Book (must not already be acquired/reserved).
+    # owner       - the record that owns the acquisition reservation for the
+    #               duration of the import (e.g. a DetectedImport). Required so
+    #               the reservation bridges the gap between the pre-import check
+    #               and the file_path claim, exactly like the upload path.
+    # mode        - copy / move / hardlink; defaults to the configured
+    #               completed_download_import_mode.
+    def import!(source_path:, book:, owner:, mode: nil, provenance: nil)
+      mode = (mode || SettingsService.get(:completed_download_import_mode, default: "copy")).to_s
+      base_path = output_base_path(book)
+
+      reserve_book!(book, owner)
+      begin
+        result = LibraryFileImporter.new(mode: mode).import(
+          source: source_path,
+          book: book,
+          base_path: base_path
+        )
+        claim_file_path!(book, result.imported_path, owner)
+        trigger_library_scan(book)
+        Rails.logger.info(
+          "[LibraryAcquisitionService] Imported #{provenance || 'source'} for book ##{book.id} (mode=#{mode})"
+        )
+        ImportResult.new(book: book, destination_path: result.imported_path, mode: mode)
+      rescue
+        release_reservation!(book, owner)
+        raise
+      end
+    end
+
+    # Reverse a completed import so the detection returns to the review queue and
+    # can be re-imported against a different match (e.g. the admin approved "new
+    # book" by mistake when a real match existed).
+    #
+    # Copy / hardlink imports leave the watched-folder source in place, so undo
+    # simply discards the library artifact. A move import consumed the source, so
+    # undo returns the artifact to where the scanner found it. Either way the book
+    # is un-acquired, and a throwaway book created solely for this import (no
+    # metadata, no requests/uploads/owned items) is destroyed rather than left
+    # behind un-acquired.
+    def undo_import!(detected_import)
+      book = detected_import.imported_book
+      destination = book&.file_path.presence
+
+      reverse_publication!(destination, detected_import, book) if destination
+
+      ActiveRecord::Base.transaction do
+        detected_import.update!(
+          status: "detected",
+          imported_book: nil,
+          suggested_book: nil,
+          error_message: nil
+        )
+        release_book_after_undo!(book) if book
+      end
+    end
+
+    def audio_file?(path)
+      AUDIO_EXTENSIONS.include?(File.extname(path.to_s).delete_prefix(".").downcase)
+    end
+
+    def readable_file?(path)
+      READABLE_EXTENSIONS.include?(File.extname(path.to_s).delete_prefix(".").downcase)
+    end
+
+    # Compute just the online alternate list for an already-parsed title/author.
+    # Used by deferred enrichment so the (networked) provider lookups run off the
+    # scan hot path, one queued job per detection, rather than thousands of
+    # sequential searches inside a single scan.
+    def online_candidates_for(title:, author:, book_type:)
+      online_candidates(title, author, book_type.to_s)
+    end
+
+    # Run a free-text metadata search for the manual "search for the correct
+    # book" step on the review page. Unlike +online_candidates+, results are
+    # scored against the admin's query (not the auto-parsed title) and no
+    # low-score filter is applied — the admin asked for exactly these, so every
+    # provider hit is offered as a selectable candidate in the usual hash shape.
+    def search_candidates(query:, book_type:, limit: MAX_ONLINE_CANDIDATES)
+      query = query.to_s.strip
+      return [] if query.blank?
+
+      content_kind = book_type.to_s == "comicbook" ? "graphic" : nil
+      results = MetadataService.search(query, limit: limit, content_kind: content_kind)
+      normalized_query = query.downcase
+      results.map do |result|
+        haystack = [ result.title, result.author ].compact.join(" ").downcase
+        {
+          "kind" => "online",
+          "work_id" => result.work_id,
+          "title" => result.title,
+          "author" => result.author,
+          "year" => result.year,
+          "cover_url" => result.cover_url,
+          "source" => result.source,
+          "score" => string_similarity(haystack, normalized_query)
+        }
+      end.sort_by { |candidate| -candidate["score"] }
+    rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+      Rails.logger.warn "[LibraryAcquisitionService] Manual search failed (#{e.class})"
+      []
+    end
+
+    private
+
+    # Reserve the book under a row lock so a concurrent acquisition (upload or
+    # download) cannot claim the same title while the file import runs outside
+    # the transaction. Raises if the title is already acquired or reserved.
+    def reserve_book!(book, owner)
+      ActiveRecord::Base.transaction do
+        book.lock!
+        book.reload
+        if book.acquisition_blocked?
+          raise AcquisitionConflictError,
+            "This title already has an acquired or in-progress library file; the existing file was preserved"
+        end
+
+        book.update!(
+          acquisition_reservation_token: SecureRandom.hex(32),
+          acquisition_reservation_owner_type: owner.class.name,
+          acquisition_reservation_owner_id: owner.id
+        )
+      end
+    end
+
+    # Attach the imported path and clear the reservation in one compare-and-swap
+    # so only the worker still holding this owner's reservation can finalize.
+    def claim_file_path!(book, destination, owner)
+      claimed = Book.where(id: book.id)
+        .where("file_path IS NULL OR TRIM(file_path) = ''")
+        .where(
+          acquisition_reservation_owner_type: owner.class.name,
+          acquisition_reservation_owner_id: owner.id
+        )
+        .update_all(
+          file_path: destination,
+          acquisition_reservation_token: nil,
+          acquisition_reservation_owner_type: nil,
+          acquisition_reservation_owner_id: nil,
+          updated_at: Time.current
+        )
+      raise AcquisitionConflictError, "This title was acquired by another process during import" unless claimed == 1
+
+      book.reload
+    end
+
+    def release_reservation!(book, owner)
+      Book.where(id: book.id)
+        .where(
+          acquisition_reservation_owner_type: owner.class.name,
+          acquisition_reservation_owner_id: owner.id
+        )
+        .where("file_path IS NULL OR TRIM(file_path) = ''")
+        .update_all(
+          acquisition_reservation_token: nil,
+          acquisition_reservation_owner_type: nil,
+          acquisition_reservation_owner_id: nil,
+          updated_at: Time.current
+        )
+    rescue => e
+      Rails.logger.error "[LibraryAcquisitionService] Failed to release reservation for book ##{book.id} (#{e.class})"
+    end
+
+    # Remove (or, for a move import, relocate) the artifact this import published
+    # into the library. Refuses to touch anything that is not strictly inside the
+    # book's configured output root, so a corrupt file_path can never delete an
+    # arbitrary path.
+    def reverse_publication!(destination, detected_import, book)
+      return unless File.exist?(destination)
+
+      unless within_output_root?(destination, book)
+        raise AcquisitionConflictError,
+          "Refusing to undo: #{destination} is not inside the library output path"
+      end
+
+      if File.exist?(detected_import.source_path)
+        # Copy or hardlink: the watched-folder source is still present, so the
+        # library artifact is a redundant second copy — discard it.
+        FileUtils.remove_entry(destination)
+      else
+        # Move: the source is gone; put the artifact back so it can be re-imported.
+        restore_moved_source!(destination, detected_import)
+      end
+    end
+
+    # Return a moved artifact to the source path the scanner recorded. Audiobook
+    # imports are directories at both ends; single-file imports land inside a
+    # per-book directory, so the file itself is returned and the emptied wrapper
+    # directory removed.
+    def restore_moved_source!(destination, detected_import)
+      source = detected_import.source_path
+      FileUtils.mkdir_p(File.dirname(source))
+
+      if detected_import.book_type == "audiobook" || File.file?(destination)
+        FileUtils.mv(destination, source)
+      else
+        inner = Dir.glob(File.join(destination, "**", "*")).find { |path| File.file?(path) }
+        FileUtils.mv(inner || destination, source)
+        FileUtils.remove_entry(destination) if File.directory?(destination)
+      end
+    end
+
+    def within_output_root?(destination, book)
+      base = File.realpath(output_base_path(book))
+      target = File.expand_path(destination)
+      target.start_with?("#{base}#{File::SEPARATOR}")
+    rescue ArgumentError, SystemCallError
+      false
+    end
+
+    # Un-acquire the book and destroy it when it was a throwaway created solely
+    # for this import (no metadata identity and nothing else references it). A
+    # matched or metadata-bearing book is kept, merely un-acquired.
+    def release_book_after_undo!(book)
+      book.reload
+      book.update!(
+        file_path: nil,
+        acquisition_reservation_token: nil,
+        acquisition_reservation_owner_type: nil,
+        acquisition_reservation_owner_id: nil
+      )
+
+      if book.unified_work_id.blank? &&
+          book.requests.none? && book.uploads.none? && book.owned_library_items.none?
+        book.destroy
+      end
+    end
+
+    def output_base_path(book)
+      if book.comicbook?
+        SettingsService.get(:comicbook_output_path, default: "/comics")
+      elsif book.ebook?
+        SettingsService.get(:ebook_output_path, default: "/ebooks")
+      else
+        SettingsService.get(:audiobook_output_path, default: "/audiobooks")
+      end
+    end
+
+    def trigger_library_scan(book)
+      return unless LibraryPlatformClient.configured?
+
+      library_id = SettingsService.library_id_for_book(book)
+      return if library_id.blank?
+
+      LibraryPlatformClient.scan_library(library_id)
+      Rails.logger.info "[LibraryAcquisitionService] Triggered library scan for book ##{book.id}"
+    rescue LibraryPlatformClient::Error => e
+      Rails.logger.warn "[LibraryAcquisitionService] Failed to trigger library scan (#{e.class})"
+    end
+
+    def library_candidate(book, score)
+      {
+        "kind" => "library",
+        "book_id" => book.id,
+        "title" => book.title,
+        "author" => book.author,
+        "score" => score
+      }
+    end
+
+    # Best-effort online enrichment. Network/parse failures degrade to an empty
+    # alternate list — the human review step is the correctness backstop.
+    def online_candidates(title, author, book_type)
+      return [] if title.blank?
+
+      query = author.present? ? "#{title} #{author}" : title
+      content_kind = book_type.to_s == "comicbook" ? "graphic" : nil
+      results = MetadataService.search(query, limit: MAX_ONLINE_CANDIDATES, content_kind: content_kind)
+      results.filter_map do |result|
+        score = online_score(result, title, author)
+        next if score < 30
+
+        {
+          "kind" => "online",
+          "work_id" => result.work_id,
+          "title" => result.title,
+          "author" => result.author,
+          "year" => result.year,
+          "cover_url" => result.cover_url,
+          "source" => result.source,
+          "score" => score
+        }
+      end.sort_by { |candidate| -candidate["score"] }
+    rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+      Rails.logger.warn "[LibraryAcquisitionService] Metadata search failed (#{e.class})"
+      []
+    end
+
+    def online_score(result, query_title, query_author)
+      score = 0
+      if result.title.present? && query_title.present?
+        score += (string_similarity(result.title.downcase, query_title.downcase) * 0.6).round
+      end
+      if result.author.present? && query_author.present?
+        score += (string_similarity(result.author.downcase, query_author.downcase) * 0.4).round
+      elsif result.author.present?
+        score += 10
+      end
+      score
+    end
+
+    def string_similarity(str1, str2)
+      return 100 if str1 == str2
+      return 0 if str1.blank? || str2.blank?
+
+      trigrams1 = to_trigrams(str1)
+      trigrams2 = to_trigrams(str2)
+      return 0 if trigrams1.empty? || trigrams2.empty?
+
+      intersection = (trigrams1 & trigrams2).size
+      union = (trigrams1 | trigrams2).size
+      ((intersection.to_f / union) * 100).round
+    end
+
+    def to_trigrams(str)
+      padded = "  #{str}  "
+      (0..padded.length - 3).map { |i| padded[i, 3] }.to_set
+    end
+  end
+end

--- a/app/services/library_file_importer.rb
+++ b/app/services/library_file_importer.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+# Publishes a source file or directory into the organised library using the
+# configured import mode (copy / move / hardlink), reusing FileCopyService's
+# atomic, no-replace, TOCTOU-safe primitives — the same ones PostProcessingJob
+# uses for request downloads. Only the mode dispatch and traversal live here;
+# every actual filesystem publication goes through FileCopyService so the hard
+# safety guarantees are shared, not re-implemented.
+#
+# Single files are renamed with the book's filename template. Directory imports
+# (multi-file audiobooks) preserve the source layout and filenames. The source
+# is never mutated except by an explicit "move", which FileCopyService performs
+# only after a durable publication.
+class LibraryFileImporter
+  MODES = %w[copy move hardlink].freeze
+
+  Result = Data.define(:imported_path, :hardlinked, :copied, :moved)
+
+  def initialize(mode:)
+    @mode = MODES.include?(mode.to_s) ? mode.to_s : "copy"
+    @hardlinked = 0
+    @copied = 0
+    @moved = 0
+  end
+
+  # Import +source+ into the library for +book+, rooted at +base_path+ (the
+  # book type's output root). Returns a Result whose imported_path is the file
+  # (flat output / single file) or the per-book directory.
+  def import(source:, book:, base_path:)
+    source = File.expand_path(source.to_s)
+    raise Errno::ENOENT, source unless File.exist?(source)
+
+    stat = File.lstat(source)
+    raise "Refusing to import symbolic link: #{source}" if stat.symlink?
+
+    @root = Pathname(base_path).expand_path
+    destination_dir = PathTemplateService.build_destination(book, base_path: @root.to_s)
+
+    imported_path =
+      if stat.directory?
+        import_directory(source, destination_dir)
+        destination_dir
+      elsif stat.file?
+        import_single_file(source, destination_dir, book)
+      else
+        raise "Refusing to import non-regular path: #{source}"
+      end
+
+    Result.new(imported_path: imported_path, hardlinked: @hardlinked, copied: @copied, moved: @moved)
+  end
+
+  private
+
+  def import_single_file(source, destination_dir, book)
+    FileCopyService.ensure_directory(destination_dir, root: @root, mode: 0o750)
+    filename = PathTemplateService.build_filename(book, File.extname(source))
+    destination_file = File.join(destination_dir, filename)
+    imported = publish(source, destination_file, source_root: nil)
+
+    PathTemplateService.flat_output?(book) ? imported : destination_dir
+  end
+
+  def import_directory(source, destination_dir)
+    @source_root = FileCopyService.snapshot_source_root(source)
+    FileCopyService.ensure_directory(destination_dir, root: @root, mode: 0o750)
+    import_tree(source, destination_dir)
+  end
+
+  def import_tree(source_dir, destination_dir)
+    manifest_children(source_dir).each do |name|
+      source_path = File.join(source_dir, name)
+      stat = File.lstat(source_path)
+
+      if stat.directory?
+        nested = File.join(destination_dir, name)
+        FileCopyService.ensure_directory(nested, root: @root, mode: 0o750)
+        import_tree(source_path, nested)
+      elsif stat.file?
+        publish(source_path, File.join(destination_dir, name), source_root: @source_root)
+      end
+      # Non-regular entries are absent from the immutable manifest and skipped.
+    end
+  end
+
+  # Enumerate a directory's children from the immutable source snapshot rather
+  # than a fresh readdir, so a mid-import path swap cannot introduce new entries.
+  # The snapshot is grouped by parent directory once (see children_by_parent) so
+  # a deep tree costs O(entries) total instead of O(entries) per directory.
+  def manifest_children(directory)
+    relative = Pathname(directory).expand_path.relative_path_from(@source_root.path)
+    (children_by_parent[relative] || []).sort
+  rescue ArgumentError
+    []
+  end
+
+  # Index of parent directory (relative to the source root) => immediate child
+  # basenames, built once per import from the immutable entry snapshot.
+  def children_by_parent
+    @children_by_parent ||= @source_root.entries.each_key.with_object({}) do |entry, index|
+      path = Pathname(entry)
+      (index[path.dirname] ||= []) << path.basename.to_s
+    end.tap { |index| index.each_value(&:uniq!) }
+  end
+
+  # Publish one regular file with the configured mode, retrying under a numbered
+  # filename when a concurrent writer claims the exclusive destination.
+  def publish(source, destination, source_root:)
+    original = destination
+    counter = 1
+
+    begin
+      destination = unique_destination(original, counter)
+      publish_with_mode(source, destination, source_root: source_root)
+      destination
+    rescue Errno::EEXIST
+      counter += 1
+      retry
+    end
+  end
+
+  def publish_with_mode(source, destination, source_root:)
+    case @mode
+    when "move"
+      FileCopyService.mv_noreplace(
+        source, destination,
+        root: @root, source_root: source_root, allow_compatibility_fallback: true
+      )
+      @moved += 1
+    when "hardlink"
+      begin
+        FileCopyService.hardlink_noreplace(
+          source, destination,
+          root: @root, source_root: source_root
+        )
+        @hardlinked += 1
+      rescue FileCopyService::HardlinkUnsupportedError
+        FileCopyService.cp_noreplace(
+          source, destination,
+          root: @root, source_root: source_root,
+          hardlink_mode: true, allow_compatibility_fallback: true
+        )
+        @copied += 1
+      end
+    else
+      FileCopyService.cp_noreplace(
+        source, destination,
+        root: @root, source_root: source_root, allow_compatibility_fallback: true
+      )
+      @copied += 1
+    end
+  end
+
+  def unique_destination(path, counter)
+    return path if counter <= 1 && !occupied?(path)
+
+    dir = File.dirname(path)
+    ext = File.extname(path)
+    base = File.basename(path, ext)
+    candidate = path
+    while occupied?(candidate)
+      candidate = File.join(dir, "#{base} (#{counter})#{ext}")
+      counter += 1
+    end
+    candidate
+  end
+
+  def occupied?(path)
+    File.exist?(path) || File.symlink?(path)
+  end
+end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -59,6 +59,34 @@ class NotificationService
       )
     end
 
+    # Batched notification that new watched-folder files were detected and are
+    # waiting for review. Import is an admin action, so only admins are notified
+    # in-app; outbound channels fire if the "import_detected" event is enabled.
+    def import_detected(count:)
+      return if count.to_i <= 0
+
+      noun = count == 1 ? "book file" : "book files"
+      title = "New #{count == 1 ? 'file' : 'files'} detected"
+      message = "#{count} new #{noun} detected in your watched folder and #{count == 1 ? 'is' : 'are'} waiting for review."
+
+      User.active.where(role: :admin).find_each do |admin|
+        create_for_user(
+          user: admin,
+          notifiable: nil,
+          type: "import_detected",
+          title: title,
+          message: message
+        )
+      end
+
+      dispatch_outbound_event(
+        event: "import_detected",
+        request: nil,
+        title: title,
+        message: message
+      )
+    end
+
     private
 
     def create_for_user(user:, notifiable:, type:, title:, message:)

--- a/app/services/outbound_notifications/webhook_delivery.rb
+++ b/app/services/outbound_notifications/webhook_delivery.rb
@@ -5,7 +5,7 @@ module OutboundNotifications
     class ConfigurationError < StandardError; end
     class DeliveryError < StandardError; end
 
-    EVENTS = %w[request_created request_completed request_failed request_attention].freeze
+    EVENTS = %w[request_created request_completed request_failed request_attention import_detected].freeze
     TEST_EVENT = "test"
 
     class << self

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -72,6 +72,11 @@ class SettingsService
     split_audiobook_bundle_imports: { type: "boolean", default: false, category: "download", description: "Split releases containing multiple self-contained M4B/AAX books into per-book folders. MP3, FLAC, and other chapter-based releases stay together." },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
+    # Watched Folder Import
+    library_import_enabled: { type: "boolean", default: false, category: "import", description: "Scan a watched folder for pre-existing book files that were not acquired through a Shelfarr request and queue them for review before importing into the library." },
+    library_import_path: { type: "string", default: "", category: "import", description: "Absolute path (Shelfarr container perspective) to scan for un-imported book files, e.g. /data/torrents/shelfarr. Must be readable by Shelfarr and outside the configured output paths." },
+    library_import_scan_interval: { type: "integer", default: 300, category: "import", description: "Seconds between watched-folder scans" },
+
     # Library Platform Integration
     library_platform: { type: "string", default: "audiobookshelf", category: "audiobookshelf", description: "Library platform to sync and scan: audiobookshelf, bookorbit, or grimmory" },
     audiobookshelf_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for Audiobookshelf (e.g., http://localhost:13378)" },
@@ -234,6 +239,7 @@ class SettingsService
   CATEGORIES = {
     "indexer" => "Indexer",
     "download" => "Download Settings",
+    "import" => "Watched Folder Import",
     "audiobookshelf" => "Library Platform",
     "anna_archive" => "Anna's Archive",
     "zlibrary" => "Z-Library",

--- a/app/services/watched_folder_scan_service.rb
+++ b/app/services/watched_folder_scan_service.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+# Scans the configured watched-folder import path for book files that were not
+# acquired through a Shelfarr request and records each new one as a
+# DetectedImport awaiting admin review. Read-only with respect to the watched
+# folder — it never moves, renames, or deletes source files.
+#
+# The walk uses FileCopyService's pinned, no-follow directory primitives so a
+# symlink or a mid-scan path swap can never redirect it outside the configured
+# root. Candidates are grouped the same way the download importer sees releases:
+# a single ebook/comic file, a self-contained audiobook folder, or — for a box
+# set / collection whose subfolders each hold a distinct title — one audiobook
+# per subfolder (see #classify_directory).
+class WatchedFolderScanService
+  MAX_DEPTH = 8
+  AUDIO_SEARCH_DEPTH = 4
+  MAX_CANDIDATES_PER_SCAN = 5_000
+
+  # Subfolder names that denote a disc/part of one audiobook rather than a
+  # distinct title: "CD1", "Disc 2", "Part 03", "Vol 1", "Tape 2", or a bare
+  # "1"/"01". Such folders must be kept together as a single multi-disc book,
+  # never split into separate books the way a titled subfolder is.
+  DISC_SUBFOLDER = /\A(?:(?:cd|dis[ck]|part|pt|vol(?:ume)?|section|tape|track)[\s._-]*)?\d{1,3}\z/i
+
+  Candidate = Struct.new(
+    :source_path,
+    :book_type,
+    :device,
+    :inode,
+    :filename_hint,
+    :metadata_path,
+    keyword_init: true
+  )
+
+  Result = Data.define(:scanned, :detected, :skipped)
+
+  def self.scan!
+    new.scan!
+  end
+
+  # Returns a Result summarising the scan, or nil when scanning is disabled or
+  # the configured path is invalid.
+  def scan!
+    return nil unless SettingsService.get(:library_import_enabled, default: false)
+
+    root = resolved_root
+    unless root
+      Rails.logger.warn "[WatchedFolderScanService] Watched-folder import path is unset or invalid; skipping scan"
+      return nil
+    end
+
+    candidates = build_candidates(root)
+    detected = 0
+    candidates.each do |candidate|
+      detected += 1 if record_candidate(candidate)
+    end
+
+    NotificationService.import_detected(count: detected) if detected.positive?
+    Rails.logger.info(
+      "[WatchedFolderScanService] Scan complete: #{candidates.size} candidates, #{detected} new"
+    )
+    Result.new(scanned: candidates.size, detected: detected, skipped: candidates.size - detected)
+  end
+
+  private
+
+  # --- Filesystem walk -----------------------------------------------------
+
+  def build_candidates(root)
+    candidates = []
+    walk(root, root, 0, candidates)
+    candidates
+  end
+
+  def walk(dir, root, depth, candidates)
+    return if depth > MAX_DEPTH
+    return if candidates.size >= MAX_CANDIDATES_PER_SCAN
+
+    FileCopyService.directory_children(dir, root: root).each do |child|
+      break if candidates.size >= MAX_CANDIDATES_PER_SCAN
+      next if child.name.start_with?(".")
+
+      path = File.join(dir, child.name)
+      case child.type
+      when :file
+        candidates << file_candidate(path, child) if LibraryAcquisitionService.readable_file?(child.name)
+        # Loose audio files directly under a directory become part of that
+        # directory's audiobook candidate (below), never standalone imports.
+      when :directory
+        classify_directory(path, child, root, depth, candidates)
+      end
+    end
+  rescue FileCopyService::UnsafePathError, SystemCallError => e
+    Rails.logger.warn "[WatchedFolderScanService] Skipping unreadable directory (#{e.class})"
+  end
+
+  # Resolve how one directory maps onto audiobook candidates. Three shapes look
+  # alike from the top and have to be told apart:
+  #
+  #   * plain audiobook   Book/*.mp3              -> one candidate (this folder)
+  #   * multi-disc book   Book/CD1/*.mp3, ...     -> one candidate (this folder)
+  #   * collection/set    Set/Title A/*.mp3, ...  -> one candidate PER subfolder
+  #
+  # The signal is where the audio lives. Loose audio directly in the folder
+  # means the folder itself is the release. Otherwise the audio sits in
+  # subfolders: if those are all disc markers (CD1, Disc 2, ...) the folder is a
+  # single multi-disc book; if any carries a real title the folder is a
+  # collection, so we descend and each audio-bearing subfolder becomes its own
+  # book (recursively — a nested subfolder may itself be multi-disc).
+  def classify_directory(dir, child, root, depth, candidates)
+    direct = direct_audio_file(dir, root)
+    if direct
+      candidates << audiobook_candidate(dir, child, direct)
+      return
+    end
+
+    audio_subdirs = audio_bearing_subdirectories(dir, root)
+    if audio_subdirs.empty?
+      # No audio at any level yet: a plain intermediate folder — keep walking.
+      walk(dir, root, depth + 1, candidates)
+    elsif audio_subdirs.all? { |name| disc_subfolder?(name) }
+      # Discs of one book: import the whole folder as a single audiobook.
+      nested = first_audio_file(dir, root, 0)
+      candidates << audiobook_candidate(dir, child, nested) if nested
+    else
+      # A collection: descend so each titled subfolder becomes its own book.
+      walk(dir, root, depth + 1, candidates)
+    end
+  end
+
+  # An audio file lying directly inside dir (not in any subfolder). Its presence
+  # marks dir as a self-contained audiobook release rather than a container of
+  # further releases.
+  def direct_audio_file(dir, root)
+    FileCopyService.directory_children(dir, root: root).each do |child|
+      next if child.name.start_with?(".")
+
+      if child.type == :file && LibraryAcquisitionService.audio_file?(child.name)
+        return File.join(dir, child.name)
+      end
+    end
+    nil
+  rescue FileCopyService::UnsafePathError, SystemCallError
+    nil
+  end
+
+  # Names of the immediate subdirectories of dir that contain audio somewhere in
+  # their subtree. Empty when dir holds no nested audiobook material. Used to
+  # decide whether dir is a multi-disc book or a collection of separate books.
+  def audio_bearing_subdirectories(dir, root)
+    FileCopyService.directory_children(dir, root: root).filter_map do |child|
+      next if child.name.start_with?(".")
+      next unless child.type == :directory
+
+      child.name if first_audio_file(File.join(dir, child.name), root, 0)
+    end
+  rescue FileCopyService::UnsafePathError, SystemCallError
+    []
+  end
+
+  def disc_subfolder?(name)
+    DISC_SUBFOLDER.match?(name.to_s.strip)
+  end
+
+  # Bounded search for the first playable audio file within a directory subtree.
+  # Its presence marks the directory as a single audiobook release.
+  def first_audio_file(dir, root, depth)
+    return nil if depth > AUDIO_SEARCH_DEPTH
+
+    children = FileCopyService.directory_children(dir, root: root)
+    children.each do |child|
+      next if child.name.start_with?(".")
+
+      if child.type == :file && LibraryAcquisitionService.audio_file?(child.name)
+        return File.join(dir, child.name)
+      end
+    end
+    children.each do |child|
+      next if child.name.start_with?(".")
+      next unless child.type == :directory
+
+      found = first_audio_file(File.join(dir, child.name), root, depth + 1)
+      return found if found
+    end
+    nil
+  rescue FileCopyService::UnsafePathError, SystemCallError
+    nil
+  end
+
+  def file_candidate(path, child)
+    Candidate.new(
+      source_path: path,
+      book_type: LibraryAcquisitionService.infer_book_type(path),
+      device: reliable_identity(child.device),
+      inode: reliable_identity(child.inode),
+      filename_hint: File.basename(path),
+      metadata_path: path
+    )
+  end
+
+  def audiobook_candidate(path, child, audio_path)
+    Candidate.new(
+      source_path: path,
+      book_type: "audiobook",
+      device: reliable_identity(child.device),
+      inode: reliable_identity(child.inode),
+      filename_hint: File.basename(path),
+      metadata_path: audio_path
+    )
+  end
+
+  # Some filesystems (certain FUSE/network/overlay mounts) report a device or
+  # inode of 0 for every entry. A non-positive value is not a usable identity —
+  # keeping it would collapse unrelated files onto one (device, inode) key and
+  # make de-duplication drop all but the first file per device. Discard it so
+  # known? falls back to path-based de-duplication instead.
+  def reliable_identity(value)
+    value.to_i.positive? ? value.to_i : nil
+  end
+
+  # --- Persistence ---------------------------------------------------------
+
+  # Returns true when a new DetectedImport was created.
+  def record_candidate(candidate)
+    return false if known?(candidate)
+
+    # Local-only identification (metadata extract + library match). The online
+    # provider lookups are deferred to DetectedImportEnrichmentJob so a large
+    # first scan never fires thousands of sequential network searches inside a
+    # single run (which would also hold the scan's concurrency lease and stall
+    # the recurring chain).
+    identification = LibraryAcquisitionService.identify(
+      source_path: candidate.metadata_path,
+      book_type: candidate.book_type,
+      filename_hint: candidate.filename_hint,
+      online: false
+    )
+
+    detected_import = DetectedImport.create!(
+      source_path: candidate.source_path,
+      source_device: candidate.device,
+      source_inode: candidate.inode,
+      book_type: identification.book_type,
+      parsed_title: identification.parsed_title,
+      parsed_author: identification.parsed_author,
+      match_confidence: identification.match_confidence,
+      suggested_book: identification.suggested_book,
+      candidate_books: identification.candidate_books,
+      status: "detected",
+      detected_at: Time.current
+    )
+    DetectedImportEnrichmentJob.perform_later(detected_import.id)
+    true
+  rescue ActiveRecord::RecordNotUnique
+    # A concurrent scan already recorded this (device, inode).
+    false
+  rescue => e
+    Rails.logger.error "[WatchedFolderScanService] Failed to record candidate (#{e.class})"
+    false
+  end
+
+  def known?(candidate)
+    if candidate.device && candidate.inode
+      return true if DetectedImport.where(source_device: candidate.device, source_inode: candidate.inode).exists?
+    elsif DetectedImport.where(source_path: candidate.source_path).exists?
+      # No reliable (device, inode) identity available — de-duplicate on the
+      # source path instead, so files on inode-less filesystems still surface
+      # exactly once.
+      return true
+    end
+
+    Book.acquired.where(file_path: candidate.source_path).exists?
+  end
+
+  # --- Path validation -----------------------------------------------------
+
+  def resolved_root
+    raw = SettingsService.get(:library_import_path).to_s.strip
+    return nil if raw.blank?
+
+    expanded = File.expand_path(raw)
+    return nil unless File.directory?(expanded)
+
+    canonical = File.realpath(expanded)
+    return nil if Pathname(canonical).root?
+    return nil if overlaps_output_paths?(canonical)
+
+    canonical
+  rescue ArgumentError, SystemCallError
+    nil
+  end
+
+  # Refuse a watched path that is the same as, inside, or a parent of any
+  # configured output path — otherwise Shelfarr would re-detect its own imports.
+  def overlaps_output_paths?(canonical)
+    output_roots.any? do |output|
+      output == canonical || path_inside?(canonical, output) || path_inside?(output, canonical)
+    end
+  end
+
+  def output_roots
+    [
+      SettingsService.get(:audiobook_output_path, default: "/audiobooks"),
+      SettingsService.get(:ebook_output_path, default: "/ebooks"),
+      SettingsService.get(:comicbook_output_path, default: "/comics")
+    ].filter_map { |path| canonical_directory(path) }.uniq
+  end
+
+  def canonical_directory(path)
+    expanded = File.expand_path(path.to_s)
+    return nil unless File.directory?(expanded)
+
+    File.realpath(expanded)
+  rescue ArgumentError, SystemCallError
+    nil
+  end
+
+  def path_inside?(path, root)
+    path.start_with?("#{root}#{File::SEPARATOR}")
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -133,6 +133,7 @@
         <%= link_to "Audible Backup (Beta)", admin_owned_library_connections_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Download Routing", admin_download_routing_rules_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Manual Uploads", admin_uploads_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
+        <%= link_to "Watched Folder Imports", admin_detected_imports_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Settings", admin_settings_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Activity Log", admin_activity_logs_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Back to Dashboard", root_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>

--- a/app/views/admin/detected_imports/index.html.erb
+++ b/app/views/admin/detected_imports/index.html.erb
@@ -1,0 +1,194 @@
+<%= turbo_stream_from "detected_imports" %>
+<% turbo_refreshes_with(method: :morph, scroll: :preserve) %>
+
+<div class="mx-auto max-w-6xl">
+  <div class="flex justify-between items-start mb-4">
+    <div>
+      <h1 class="font-bold text-4xl text-white">Watched Folder Imports</h1>
+      <p class="text-gray-400 mt-2">Book files found in your watched folder that were not acquired through a Shelfarr request. Review each one, then import it into your organised library.</p>
+    </div>
+    <% if @scan_status[:state] == "running" %>
+      <button type="button" disabled aria-busy="true"
+              class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600/60 text-white/80 font-medium rounded-lg whitespace-nowrap cursor-not-allowed">
+        <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+        Scanning…
+      </button>
+    <% else %>
+      <%= button_to "Scan now", scan_admin_detected_imports_path, method: :post,
+            class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition cursor-pointer whitespace-nowrap" %>
+    <% end %>
+  </div>
+
+  <div class="mb-8 min-h-5">
+    <% if @scan_status[:state] == "running" %>
+      <p class="flex items-center gap-2 text-sm text-blue-300">
+        <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+        Scanning your watched folder for new book files…
+      </p>
+    <% elsif @scan_status[:completed_at].present? %>
+      <p class="text-sm text-gray-500">
+        <% if @scan_status[:failed] %>
+          Last scan failed <%= time_ago_in_words(@scan_status[:completed_at]) %> ago. Check the logs for details.
+        <% else %>
+          <% new_count = @scan_status[:detected].to_i %>
+          Last scan completed <%= time_ago_in_words(@scan_status[:completed_at]) %> ago ·
+          <%= new_count.zero? ? "no new files" : "#{new_count} new #{'file'.pluralize(new_count)}" %>.
+        <% end %>
+      </p>
+    <% end %>
+  </div>
+
+  <% unless SettingsService.get(:library_import_enabled, default: false) %>
+    <div class="bg-yellow-900/30 border border-yellow-700 rounded-lg p-4 mb-6 text-yellow-200">
+      Watched-folder import is disabled. Enable it and set a path in
+      <%= link_to "Settings", admin_settings_path(anchor: "import"), class: "underline hover:text-yellow-100" %>.
+    </div>
+  <% end %>
+
+  <% if @pending.empty? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg p-12 text-center">
+      <h3 class="text-lg font-medium text-white mb-2">Nothing waiting for review</h3>
+      <p class="text-gray-500">New files found in your watched folder will appear here.</p>
+    </div>
+  <% else %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-800">
+        <thead class="bg-gray-800/50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Detected file</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Suggested match</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Type</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          <% @pending.each do |item| %>
+            <tr class="hover:bg-gray-800/50 transition align-top">
+              <td class="px-6 py-4 text-sm text-white">
+                <div class="font-medium"><%= item.display_title %></div>
+                <div class="text-gray-500 text-xs mt-1 break-all"><%= item.source_path %></div>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-300 wrap-anywhere">
+                <% if item.suggested_book %>
+                  <div><%= item.suggested_book.display_name %></div>
+                  <div class="text-gray-500 text-xs mt-1">Confidence: <%= item.match_confidence || 0 %>%</div>
+                <% elsif (candidate = item.best_candidate) %>
+                  <div><%= candidate["author"].present? ? "#{candidate['title']} by #{candidate['author']}" : candidate["title"] %></div>
+                  <div class="text-gray-500 text-xs mt-1"><%= candidate["source"]&.titleize || "Suggested" %> match · score <%= candidate["score"] %></div>
+                <% else %>
+                  <span class="text-gray-500">New book from “<%= item.parsed_title %>”<%= " by #{item.parsed_author}" if item.parsed_author.present? %></span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-400 whitespace-nowrap"><%= item.book_type&.titleize %></td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <% status_colors = {
+                     "detected" => "bg-blue-500/20 text-blue-400",
+                     "importing" => "bg-yellow-500/20 text-yellow-300",
+                     "failed" => "bg-red-500/20 text-red-400"
+                   } %>
+                <span class="px-2 py-1 text-xs rounded <%= status_colors[item.status] || 'bg-gray-700 text-gray-300' %>">
+                  <%= item.status.titleize %>
+                </span>
+                <% if item.status == "failed" && item.error_message.present? %>
+                  <div class="text-red-400 text-xs mt-1 break-words max-w-xs"><%= item.error_message %></div>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
+                <% if item.actionable? %>
+                  <div class="flex items-center justify-end gap-2">
+                    <%= button_to "Import", import_admin_detected_import_path(item), method: :post,
+                          class: "px-3 py-1 bg-green-600 hover:bg-green-500 text-white rounded transition cursor-pointer" %>
+                    <%= link_to "Review", admin_detected_import_path(item),
+                          class: "px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded transition inline-block" %>
+                    <%= button_to "Dismiss", dismiss_admin_detected_import_path(item), method: :post,
+                          class: "px-3 py-1 bg-gray-800 hover:bg-gray-700 text-gray-400 rounded transition cursor-pointer",
+                          form: { data: { turbo_confirm: "Dismiss this detection? It won't be shown again." } } %>
+                  </div>
+                <% else %>
+                  <span class="text-gray-500 text-xs">In progress…</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+
+  <% if @imported_total.positive? %>
+    <%= turbo_frame_tag "imported_history" do %>
+      <div class="flex items-center justify-between mt-10 mb-4">
+        <h2 class="text-2xl font-bold text-white">
+          Imported <span class="text-gray-500 text-lg font-normal">(<%= @imported_total %>)</span>
+        </h2>
+        <% if @imported_has_more %>
+          <% if @imported_expanded %>
+            <%= link_to "Show recent only", admin_detected_imports_path,
+                  data: { turbo_action: "advance" },
+                  class: "text-blue-400 hover:text-blue-300 text-sm" %>
+          <% else %>
+            <%= link_to "Show all (#{@imported_total})", admin_detected_imports_path(imported: "all"),
+                  data: { turbo_action: "advance" },
+                  class: "text-blue-400 hover:text-blue-300 text-sm" %>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+        <table class="min-w-full divide-y divide-gray-800">
+          <tbody class="divide-y divide-gray-800">
+            <% @imported.each do |item| %>
+              <tr>
+                <td class="px-6 py-3 text-sm text-gray-300"><%= item.imported_book&.display_name || item.display_title %></td>
+                <td class="px-6 py-3 text-sm text-gray-500 whitespace-nowrap">
+                  <%= (item.updated_at || item.detected_at)&.strftime("%b %d, %H:%M") %>
+                </td>
+                <td class="px-6 py-3 text-sm whitespace-nowrap text-right">
+                  <%= button_to "Undo", undo_admin_detected_import_path(item), method: :post,
+                        class: "px-3 py-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded transition cursor-pointer",
+                        form: { data: { turbo_confirm: "Undo this import? The library file is removed and the item returns to the review queue." } } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <% if @imported_has_more && !@imported_expanded %>
+        <p class="text-gray-600 text-xs mt-2">Showing the <%= @imported.size %> most recent of <%= @imported_total %>.</p>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if @dismissed.any? %>
+    <h2 class="text-2xl font-bold text-white mt-10 mb-4">Dismissed</h2>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-800">
+        <tbody class="divide-y divide-gray-800">
+          <% @dismissed.each do |item| %>
+            <tr>
+              <td class="px-6 py-3 text-sm text-gray-400">
+                <div><%= item.display_title %></div>
+                <div class="text-gray-600 text-xs mt-1 break-all"><%= item.source_path %></div>
+              </td>
+              <td class="px-6 py-3 text-sm whitespace-nowrap text-right">
+                <div class="flex items-center justify-end gap-2">
+                  <%= button_to "Restore", restore_admin_detected_import_path(item), method: :post,
+                        class: "px-3 py-1 bg-blue-600 hover:bg-blue-500 text-white rounded transition cursor-pointer" %>
+                  <%= button_to "Remove", admin_detected_import_path(item), method: :delete,
+                        class: "px-3 py-1 bg-gray-800 hover:bg-gray-700 text-gray-400 rounded transition cursor-pointer",
+                        form: { data: { turbo_confirm: "Remove this dismissed detection permanently?" } } %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/detected_imports/show.html.erb
+++ b/app/views/admin/detected_imports/show.html.erb
@@ -1,0 +1,116 @@
+<%= turbo_stream_from @detected_import %>
+<% turbo_refreshes_with(method: :morph, scroll: :preserve) %>
+
+<div class="mx-auto max-w-3xl">
+  <div class="mb-6">
+    <%= link_to "← Back to review queue", admin_detected_imports_path, class: "text-blue-400 hover:text-blue-300 text-sm" %>
+    <h1 class="font-bold text-3xl text-white mt-3">Review detected file</h1>
+    <p class="text-gray-500 text-sm mt-2 break-all"><%= @detected_import.source_path %></p>
+  </div>
+
+  <% if @detected_import.status == "failed" && @detected_import.error_message.present? %>
+    <div class="bg-red-900/30 border border-red-700 rounded-lg p-4 mb-6 text-red-300">
+      <div class="font-medium mb-1">Previous import failed</div>
+      <div class="text-sm break-words"><%= @detected_import.error_message %></div>
+    </div>
+  <% end %>
+
+  <% if @detected_import.imported? %>
+    <div class="bg-green-900/30 border border-green-700 rounded-lg p-4 mb-6 text-green-200">
+      <div class="font-medium mb-1">Imported</div>
+      <div class="text-sm">
+        This file was imported<%= " as #{@detected_import.imported_book.display_name}" if @detected_import.imported_book %>.
+        Undo to remove the library file and pick a different match.
+      </div>
+    </div>
+    <div class="flex items-center gap-3">
+      <%= button_to "Undo import", undo_admin_detected_import_path(@detected_import), method: :post,
+            class: "px-5 py-2 bg-yellow-600 hover:bg-yellow-500 text-white font-medium rounded-lg transition cursor-pointer",
+            form: { data: { turbo_confirm: "Undo this import? The library file is removed and the item returns to the review queue." } } %>
+      <%= link_to "Back to review queue", admin_detected_imports_path,
+            class: "px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded-lg transition inline-block" %>
+    </div>
+  <% else %>
+  <%= form_with url: search_admin_detected_import_path(@detected_import), method: :post, class: "mb-4" do %>
+    <label for="query" class="block text-sm font-medium text-gray-400 mb-1">Not the right match? Search manually</label>
+    <div class="flex gap-2">
+      <%= text_field_tag :query,
+            params[:query].presence || [ @detected_import.parsed_title, @detected_import.parsed_author ].reject(&:blank?).join(" "),
+            placeholder: "Title and author…",
+            class: "flex-1 px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+      <%= submit_tag "Search", class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition cursor-pointer whitespace-nowrap" %>
+    </div>
+  <% end %>
+
+  <%= form_with url: import_admin_detected_import_path(@detected_import), method: :post, id: "detected-import-form", class: "space-y-4" do |f| %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg divide-y divide-gray-800">
+      <% default_selection = @detected_import.default_selection %>
+
+      <% if @detected_import.suggested_book %>
+        <label class="flex items-start gap-3 p-4 cursor-pointer hover:bg-gray-800/50">
+          <%= radio_button_tag :selection, "book:#{@detected_import.suggested_book_id}", "book:#{@detected_import.suggested_book_id}" == default_selection, class: "mt-1" %>
+          <span>
+            <span class="text-white font-medium"><%= @detected_import.suggested_book.display_name %></span>
+            <span class="block text-gray-500 text-xs mt-1">Existing library match · confidence <%= @detected_import.match_confidence || 0 %>%</span>
+          </span>
+        </label>
+      <% end %>
+
+      <% @detected_import.candidate_books.each do |candidate| %>
+        <%
+          if candidate["kind"] == "library"
+            next if candidate["book_id"] == @detected_import.suggested_book_id
+            value = "book:#{candidate['book_id']}"
+            label = candidate["author"].present? ? "#{candidate['title']} by #{candidate['author']}" : candidate["title"]
+            sub = "Library match · score #{candidate['score']}"
+          else
+            value = "work:#{candidate['work_id']}"
+            label = candidate["author"].present? ? "#{candidate['title']} by #{candidate['author']}" : candidate["title"]
+            sub = "#{candidate['source']&.titleize} · score #{candidate['score']}"
+          end
+        %>
+        <label class="flex items-start gap-3 p-4 cursor-pointer hover:bg-gray-800/50">
+          <%= radio_button_tag :selection, value, value == default_selection, class: "mt-1" %>
+          <span>
+            <span class="text-white font-medium"><%= label %></span>
+            <span class="block text-gray-500 text-xs mt-1"><%= sub %></span>
+          </span>
+        </label>
+      <% end %>
+
+      <label class="flex items-start gap-3 p-4 cursor-pointer hover:bg-gray-800/50">
+        <%= radio_button_tag :selection, "new", default_selection == "new", class: "mt-1" %>
+        <span class="flex-1">
+          <span class="text-white font-medium">Create a new book from these details</span>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-3">
+            <div>
+              <%= label_tag :title, "Title", class: "block text-xs text-gray-400 mb-1" %>
+              <%= text_field_tag :title, @detected_import.parsed_title, class: "w-full px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+            </div>
+            <div>
+              <%= label_tag :author, "Author", class: "block text-xs text-gray-400 mb-1" %>
+              <%= text_field_tag :author, @detected_import.parsed_author, class: "w-full px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+            </div>
+            <div>
+              <%= label_tag :book_type, "Type", class: "block text-xs text-gray-400 mb-1" %>
+              <%= select_tag :book_type,
+                    options_for_select(DetectedImport::BOOK_TYPES.map { |t| [ t.titleize, t ] }, @detected_import.book_type),
+                    class: "w-full px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+            </div>
+          </div>
+        </span>
+      </label>
+    </div>
+
+  <% end %>
+
+  <div class="flex flex-wrap items-center gap-3 mt-4">
+    <%= submit_tag "Import", form: "detected-import-form",
+          class: "px-5 py-2 bg-green-600 hover:bg-green-500 text-white font-medium rounded-lg transition cursor-pointer" %>
+    <%= button_to "Re-match", rematch_admin_detected_import_path(@detected_import), method: :post,
+          class: "px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded-lg transition cursor-pointer" %>
+    <%= button_to "Dismiss", dismiss_admin_detected_import_path(@detected_import), method: :post,
+          class: "px-4 py-2 bg-gray-800 hover:bg-gray-700 text-gray-400 rounded-lg transition cursor-pointer" %>
+  </div>
+  <% end %>
+</div>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -7,7 +7,7 @@
     },
     "downloads" => {
       label: "Downloads",
-      categories: %w[download paths format_preferences]
+      categories: %w[download paths import format_preferences]
     },
     "integrations" => {
       label: "Integrations",

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -7,7 +7,7 @@
     <svg class="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
       <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
     </svg>
-    <p class="text-green-400 text-sm flex-grow"><%= flash[:notice] %></p>
+    <p class="text-green-400 text-sm flex-grow min-w-0 wrap-anywhere"><%= flash[:notice] %></p>
     <button type="button" aria-label="Dismiss notification" data-action="click->toast#dismiss" class="-m-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded text-gray-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
       <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
         <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -24,7 +24,7 @@
     <svg class="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
       <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
     </svg>
-    <p class="text-red-400 text-sm flex-grow"><%= flash[:alert] %></p>
+    <p class="text-red-400 text-sm flex-grow min-w-0 wrap-anywhere"><%= flash[:alert] %></p>
     <button type="button" aria-label="Dismiss notification" data-action="click->toast#dismiss" class="-m-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded text-gray-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
       <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
         <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />

--- a/bin/rerere-cache
+++ b/bin/rerere-cache
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Move recorded conflict resolutions between git's private .git/rr-cache and a
+# tracked directory, so the Sync Upstream workflow can replay resolutions that
+# were made locally.
+#
+#   bin/rerere-cache enable   turn on rerere for this clone
+#   bin/rerere-cache import   .rerere-cache/ -> .git/rr-cache/   (CI, fresh clones)
+#   bin/rerere-cache export   .git/rr-cache/ -> .rerere-cache/   (after resolving)
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+git_dir="$(cd "$repo_root" && git rev-parse --git-dir && cd - >/dev/null)"
+case "$git_dir" in
+  /*) ;;
+  *) git_dir="${repo_root}/${git_dir}" ;;
+esac
+
+tracked="${repo_root}/.rerere-cache"
+live="${git_dir}/rr-cache"
+
+# Only preimage/postimage are the durable resolution; thisimage is scratch state
+# left behind by an in-progress merge.
+copy_tree() {
+  local from="$1" to="$2" entry name
+  for entry in "$from"/*/; do
+    [ -d "$entry" ] || continue
+    name="$(basename "$entry")"
+    mkdir -p "${to}/${name}"
+    for f in preimage postimage; do
+      [ -f "${entry}${f}" ] && cp "${entry}${f}" "${to}/${name}/${f}"
+    done
+  done
+}
+
+case "${1:-}" in
+  enable)
+    git config rerere.enabled true
+    git config rerere.autoUpdate true
+    echo "rerere enabled (autoUpdate on) for $repo_root"
+    ;;
+  import)
+    if [ ! -d "$tracked" ]; then
+      echo "no $tracked to import; nothing to do"
+      exit 0
+    fi
+    mkdir -p "$live"
+    copy_tree "$tracked" "$live"
+    echo "imported $(find "$live" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ') resolution(s) into $live"
+    ;;
+  export)
+    if [ ! -d "$live" ]; then
+      echo "no $live yet; resolve a conflict first"
+      exit 0
+    fi
+    mkdir -p "$tracked"
+    copy_tree "$live" "$tracked"
+    echo "exported $(find "$tracked" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ') resolution(s) into $tracked"
+    echo "commit .rerere-cache/ on your personal branch so CI can replay it"
+    ;;
+  *)
+    echo "usage: bin/rerere-cache {enable|import|export}" >&2
+    exit 1
+    ;;
+esac

--- a/bin/rerere-cache
+++ b/bin/rerere-cache
@@ -10,26 +10,50 @@
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
-git_dir="$(cd "$repo_root" && git rev-parse --git-dir && cd - >/dev/null)"
-case "$git_dir" in
-  /*) ;;
-  *) git_dir="${repo_root}/${git_dir}" ;;
-esac
+git_dir="$(git rev-parse --absolute-git-dir)"
 
 tracked="${repo_root}/.rerere-cache"
 live="${git_dir}/rr-cache"
 
-# Only preimage/postimage are the durable resolution; thisimage is scratch state
-# left behind by an in-progress merge.
+# Copy the recorded resolutions, keeping only variants that actually have a
+# postimage.
+#
+# Two details make this fiddly. Git numbers repeat variants (preimage.1,
+# postimage.1, ...), so fixed names would drop real resolutions. And a conflict
+# that was seen but abandoned -- which is what the workflow's PR fallback does
+# every time it aborts a merge -- leaves a preimage with no postimage. Such a
+# variant still matches the conflict on replay and shadows a later, resolved
+# variant, so it has to be dropped and the survivors renumbered from zero.
 copy_tree() {
-  local from="$1" to="$2" entry name
+  local from="$1" to="$2"
+  local entry name pre post suffix out
+
   for entry in "$from"/*/; do
     [ -d "$entry" ] || continue
     name="$(basename "$entry")"
-    mkdir -p "${to}/${name}"
-    for f in preimage postimage; do
-      [ -f "${entry}${f}" ] && cp "${entry}${f}" "${to}/${name}/${f}"
+    out=0
+
+    for pre in "${entry}preimage" "${entry}preimage".*; do
+      [ -f "$pre" ] || continue
+      suffix="${pre#"${entry}preimage"}"
+      post="${entry}postimage${suffix}"
+      [ -f "$post" ] || continue
+
+      if [ "$out" -eq 0 ]; then
+        rm -rf "${to:?}/${name}"
+        mkdir -p "${to}/${name}"
+        cp "$pre" "${to}/${name}/preimage"
+        cp "$post" "${to}/${name}/postimage"
+      else
+        cp "$pre" "${to}/${name}/preimage.${out}"
+        cp "$post" "${to}/${name}/postimage.${out}"
+      fi
+      out=$((out + 1))
     done
+
+    if [ "$out" -eq 0 ]; then
+      echo "  skipping ${name}: recorded conflict with no resolution"
+    fi
   done
 }
 

--- a/config/initializers/watched_folder_scan.rb
+++ b/config/initializers/watched_folder_scan.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Start the watched-folder scan job chain when the application boots, if the
+# feature is enabled and a path is configured.
+Rails.application.config.after_initialize do
+  # Only start in server mode, not in console or rake tasks.
+  if defined?(Rails::Server)
+    if WatchedFolderScanJob.scanning_enabled?
+      Rails.logger.info "[Shelfarr] Starting WatchedFolderScanJob chain"
+      WatchedFolderScanJob.ensure_running!
+    else
+      Rails.logger.info "[Shelfarr] Watched-folder import disabled, WatchedFolderScanJob not started"
+    end
+  end
+rescue => e
+  # Don't crash the app if there's an issue starting the scanner.
+  Rails.logger.error "[Shelfarr] Failed to start WatchedFolderScanJob: #{e.message}"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,19 @@ Rails.application.routes.draw do
       post :retry_all
     end
     resources :activity_logs, only: [ :index ]
+    resources :detected_imports, only: [ :index, :show, :destroy ] do
+      member do
+        post :import
+        post :dismiss
+        post :restore
+        post :rematch
+        post :search
+        post :undo
+      end
+      collection do
+        post :scan
+      end
+    end
     resources :requests, only: [] do
       resources :search_results, only: [ :index ] do
         member do

--- a/db/migrate/20260722120000_create_detected_imports.rb
+++ b/db/migrate/20260722120000_create_detected_imports.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateDetectedImports < ActiveRecord::Migration[8.1]
+  def change
+    create_table :detected_imports do |t|
+      t.references :suggested_book, null: true, foreign_key: { to_table: :books, on_delete: :nullify }
+      t.references :imported_book, null: true, foreign_key: { to_table: :books, on_delete: :nullify }
+      t.string :source_path, null: false
+      t.bigint :source_device
+      t.bigint :source_inode
+      t.string :content_fingerprint
+      t.string :book_type
+      t.string :parsed_title
+      t.string :parsed_author
+      t.integer :match_confidence
+      t.json :candidate_books, null: false, default: []
+      t.string :status, null: false, default: "detected"
+      t.text :error_message
+      t.datetime :detected_at
+
+      t.timestamps
+    end
+
+    add_index :detected_imports, :status
+    add_index :detected_imports, :detected_at
+    add_index :detected_imports,
+      [ :source_device, :source_inode ],
+      unique: true,
+      where: "source_device IS NOT NULL AND source_inode IS NOT NULL",
+      name: "index_detected_imports_on_source_identity"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -101,6 +101,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
     t.index ["open_library_edition_id"], name: "index_books_on_open_library_edition_id"
     t.index ["open_library_work_id"], name: "index_books_on_open_library_work_id"
     t.index ["series_position"], name: "index_books_on_series_position"
+  end
+
+  create_table "detected_imports", force: :cascade do |t|
+    t.string "book_type"
+    t.json "candidate_books", default: [], null: false
+    t.string "content_fingerprint"
+    t.datetime "created_at", null: false
+    t.datetime "detected_at"
+    t.text "error_message"
+    t.integer "imported_book_id"
+    t.integer "match_confidence"
+    t.string "parsed_author"
+    t.string "parsed_title"
+    t.bigint "source_device"
+    t.bigint "source_inode"
+    t.string "source_path", null: false
+    t.string "status", default: "detected", null: false
+    t.integer "suggested_book_id"
+    t.datetime "updated_at", null: false
+    t.index ["detected_at"], name: "index_detected_imports_on_detected_at"
+    t.index ["imported_book_id"], name: "index_detected_imports_on_imported_book_id"
+    t.index ["source_device", "source_inode"], name: "index_detected_imports_on_source_identity", unique: true, where: "source_device IS NOT NULL AND source_inode IS NOT NULL"
+    t.index ["status"], name: "index_detected_imports_on_status"
+    t.index ["suggested_book_id"], name: "index_detected_imports_on_suggested_book_id"
   end
 
   create_table "download_clients", force: :cascade do |t|
@@ -574,6 +598,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
 
   add_foreign_key "activity_logs", "users"
   add_foreign_key "api_tokens", "users"
+  add_foreign_key "detected_imports", "books", column: "imported_book_id", on_delete: :nullify
+  add_foreign_key "detected_imports", "books", column: "suggested_book_id", on_delete: :nullify
   add_foreign_key "download_routing_rules", "download_clients"
   add_foreign_key "downloads", "requests"
   add_foreign_key "downloads", "search_results", on_delete: :nullify

--- a/test/controllers/admin/detected_imports_controller_test.rb
+++ b/test/controllers/admin/detected_imports_controller_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    @admin = users(:two)
+    sign_in_as(@admin)
+  end
+
+  test "index requires admin" do
+    delete session_url
+    get admin_detected_imports_url
+    assert_response :redirect
+  end
+
+  test "index lists pending detections" do
+    detection = create_detection(status: "detected", parsed_title: "Waiting For Review")
+
+    get admin_detected_imports_url
+
+    assert_response :success
+    assert_select "div.font-medium", text: detection.display_title
+  end
+
+  test "index shows only a preview of the imported history when collapsed" do
+    preview = Admin::DetectedImportsController::IMPORTED_PREVIEW_COUNT
+    total = preview + 1
+    total.times { |i| create_detection(status: "imported", parsed_title: "Imported Book #{i}") }
+
+    get admin_detected_imports_url
+
+    assert_response :success
+    # Only the preview slice, plus the "show all" affordance and the truncation note.
+    assert_select "turbo-frame#imported_history tbody tr", preview
+    assert_select "turbo-frame#imported_history h2", text: /Imported\s+\(#{total}\)/
+    assert_select "turbo-frame#imported_history a", text: /Show all \(#{total}\)/
+    assert_select "turbo-frame#imported_history p", text: /Showing the #{preview} most recent of #{total}\./
+  end
+
+  test "index expands the full imported history with imported=all" do
+    total = Admin::DetectedImportsController::IMPORTED_PREVIEW_COUNT + 1
+    total.times { |i| create_detection(status: "imported", parsed_title: "Imported Book #{i}") }
+
+    get admin_detected_imports_url(imported: "all")
+
+    assert_response :success
+    assert_select "turbo-frame#imported_history tbody tr", total
+    assert_select "turbo-frame#imported_history a", text: /Show recent only/
+  end
+
+  test "scan enqueues a manual watched-folder scan when enabled" do
+    enable_watched_folder_import
+
+    assert_enqueued_with(job: WatchedFolderScanJob) do
+      post scan_admin_detected_imports_url
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_equal "Watched-folder scan started.", flash[:notice]
+  end
+
+  test "scan is rejected when watched-folder import is disabled" do
+    set_setting("library_import_enabled", "false", "boolean", "import")
+
+    assert_no_enqueued_jobs only: WatchedFolderScanJob do
+      post scan_admin_detected_imports_url
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/Enable watched-folder import/, flash[:alert])
+  end
+
+  test "import queues the import job for an actionable detection" do
+    detection = create_detection(status: "detected", parsed_title: "Ready To Import")
+
+    assert_enqueued_with(job: DetectedImportJob, args: [ detection.id ]) do
+      post import_admin_detected_import_url(detection)
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/Import queued/, flash[:notice])
+  end
+
+  test "dismiss moves an actionable detection out of the queue" do
+    detection = create_detection(status: "detected", parsed_title: "Not Wanted")
+
+    post dismiss_admin_detected_import_url(detection)
+
+    assert_redirected_to admin_detected_imports_path
+    assert_equal "dismissed", detection.reload.status
+  end
+
+  test "restore returns a dismissed detection to the review queue" do
+    detection = create_detection(status: "dismissed", parsed_title: "Second Chance")
+
+    post restore_admin_detected_import_url(detection)
+
+    assert_redirected_to admin_detected_imports_path
+    assert_equal "detected", detection.reload.status
+  end
+
+  test "undo reverses a completed import" do
+    detection = create_detection(status: "imported", parsed_title: "Imported By Mistake")
+
+    LibraryAcquisitionService.stub(:undo_import!, nil) do
+      post undo_admin_detected_import_url(detection)
+    end
+
+    assert_redirected_to admin_detected_import_path(detection)
+    assert_match(/Undid the import/, flash[:notice])
+  end
+
+  test "undo refuses a detection that was never imported" do
+    detection = create_detection(status: "detected", parsed_title: "Never Imported")
+
+    post undo_admin_detected_import_url(detection)
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/nothing to undo/, flash[:alert])
+  end
+
+  private
+
+  def create_detection(status:, parsed_title:)
+    DetectedImport.create!(
+      source_path: "/watched/#{parsed_title.parameterize}-#{SecureRandom.hex(4)}",
+      status: status,
+      book_type: "ebook",
+      parsed_title: parsed_title,
+      detected_at: Time.current
+    )
+  end
+
+  def enable_watched_folder_import
+    set_setting("library_import_enabled", "true", "boolean", "import")
+    set_setting("library_import_path", Dir.mktmpdir("wf-controller"), "string", "import")
+  end
+
+  def set_setting(key, value, type, category)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: type, category: category
+    )
+  end
+end

--- a/test/jobs/detected_import_job_test.rb
+++ b/test/jobs/detected_import_job_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DetectedImportJobTest < ActiveJob::TestCase
+  setup do
+    @source_dir = Dir.mktmpdir("di-source")
+    @ebook_dest = Dir.mktmpdir("di-ebooks")
+
+    set_setting("ebook_output_path", @ebook_dest)
+    set_setting("completed_download_import_mode", "copy")
+    Setting.where(key: "audiobookshelf_url").destroy_all
+  end
+
+  teardown do
+    [ @source_dir, @ebook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  test "imports a detection and creates a book when there is no suggestion" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub")
+    detection = DetectedImport.create!(
+      source_path: source, status: "detected", book_type: "ebook",
+      parsed_title: "Elantris", parsed_author: "Brandon Sanderson"
+    )
+
+    assert_difference "Book.count", 1 do
+      DetectedImportJob.perform_now(detection.id)
+    end
+
+    detection.reload
+    assert_equal "imported", detection.status
+    assert detection.imported_book.present?
+    assert detection.imported_book.acquired?
+    assert File.exist?(File.join(@ebook_dest, "Brandon Sanderson", "Elantris", "Brandon Sanderson - Elantris.epub"))
+  end
+
+  test "marks the detection failed when the source is missing" do
+    detection = DetectedImport.create!(
+      source_path: File.join(@source_dir, "gone.epub"), status: "detected", book_type: "ebook",
+      parsed_title: "Gone", parsed_author: "Nobody"
+    )
+
+    DetectedImportJob.perform_now(detection.id)
+
+    detection.reload
+    assert_equal "failed", detection.status
+    assert detection.error_message.present?
+  end
+
+  test "re-claims and imports a detection wedged in importing by a dead worker" do
+    source = File.join(@source_dir, "Brandon Sanderson - Wedged.epub")
+    File.write(source, "dummy epub")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Wedged", parsed_author: "Brandon Sanderson"
+    )
+    detection.update_column(:updated_at, 2.hours.ago)
+
+    DetectedImportJob.perform_now(detection.id)
+
+    assert_equal "imported", detection.reload.status
+  end
+
+  test "does not re-claim a freshly importing detection" do
+    detection = DetectedImport.create!(source_path: "/x", status: "importing")
+
+    assert_no_difference "Book.count" do
+      DetectedImportJob.perform_now(detection.id)
+    end
+
+    assert_equal "importing", detection.reload.status
+  end
+
+  test "does not re-import a detection that is already imported" do
+    detection = DetectedImport.create!(source_path: "/x", status: "imported")
+
+    assert_no_difference "Book.count" do
+      DetectedImportJob.perform_now(detection.id)
+    end
+
+    assert_equal "imported", detection.reload.status
+  end
+
+  private
+
+  def set_setting(key, value)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: "string", category: "paths"
+    )
+  end
+end

--- a/test/jobs/watched_folder_scan_job_test.rb
+++ b/test/jobs/watched_folder_scan_job_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WatchedFolderScanJobTest < ActiveJob::TestCase
+  # The default test cache is a null store, so status writes would be dropped.
+  # Swap in a real in-memory store for the duration of each test so the
+  # running/idle transitions are observable.
+  def with_memory_cache
+    Rails.stub(:cache, ActiveSupport::Cache::MemoryStore.new) { yield }
+  end
+
+  test "scan status starts empty" do
+    with_memory_cache do
+      assert_equal({}, WatchedFolderScanJob.scan_status)
+      assert_not WatchedFolderScanJob.scanning_now?
+    end
+  end
+
+  test "status transitions from running to idle and records the result" do
+    with_memory_cache do
+      WatchedFolderScanJob.mark_running!
+      assert WatchedFolderScanJob.scanning_now?
+
+      result = WatchedFolderScanService::Result.new(scanned: 5, detected: 3, skipped: 2)
+      WatchedFolderScanJob.mark_completed!(result)
+
+      assert_not WatchedFolderScanJob.scanning_now?
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state]
+      assert_equal 3, status[:detected]
+      assert_equal 5, status[:scanned]
+      assert_not status[:failed]
+      assert status[:completed_at].present?
+    end
+  end
+
+  test "a failed scan is recorded as failed" do
+    with_memory_cache do
+      WatchedFolderScanJob.mark_completed!(nil)
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state]
+      assert status[:failed]
+    end
+  end
+
+  test "a manual scan records its completion" do
+    watched = Dir.mktmpdir("wfsj-watched")
+    audiobook_dest = Dir.mktmpdir("wfsj-audiobooks")
+    set_setting("audiobook_output_path", audiobook_dest, "paths")
+    set_setting("library_import_enabled", "true", "import", "boolean")
+    set_setting("library_import_path", watched, "import")
+    File.write(File.join(watched, "Some Author - A Book.epub"), "dummy epub")
+
+    with_memory_cache do
+      MetadataService.stub(:search, []) do
+        WatchedFolderScanJob.new.perform(manual: true)
+      end
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state]
+      assert_equal 1, status[:detected]
+    end
+  ensure
+    [ watched, audiobook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  private
+
+  def set_setting(key, value, category = "paths", value_type = "string")
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: value_type, category: category
+    )
+  end
+end

--- a/test/models/detected_import_test.rb
+++ b/test/models/detected_import_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DetectedImportTest < ActiveSupport::TestCase
+  test "requires a source path and a valid status" do
+    detection = DetectedImport.new(source_path: "", status: "detected")
+    assert_not detection.valid?
+    assert_includes detection.errors[:source_path], "can't be blank"
+
+    detection.source_path = "/data/torrents/shelfarr/book.epub"
+    detection.status = "bogus"
+    assert_not detection.valid?
+    assert_includes detection.errors[:status], "is not included in the list"
+  end
+
+  test "rejects an unknown book_type but allows nil" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected", book_type: "movie")
+    assert_not detection.valid?
+
+    detection.book_type = nil
+    assert detection.valid?
+  end
+
+  test "actionable? is true only for detected and failed" do
+    assert DetectedImport.new(status: "detected").actionable?
+    assert DetectedImport.new(status: "failed").actionable?
+    assert_not DetectedImport.new(status: "importing").actionable?
+    assert_not DetectedImport.new(status: "imported").actionable?
+    assert_not DetectedImport.new(status: "dismissed").actionable?
+  end
+
+  test "a stale importing row becomes actionable again for recovery" do
+    detection = DetectedImport.create!(source_path: "/x", status: "importing")
+    detection.update_column(:updated_at, 2.hours.ago)
+
+    assert detection.stuck_importing?
+    assert detection.actionable?
+  end
+
+  test "a freshly importing row is not treated as stuck" do
+    detection = DetectedImport.create!(source_path: "/y", status: "importing")
+
+    assert_not detection.stuck_importing?
+    assert_not detection.actionable?
+  end
+
+  test "default_selection prefers an existing library suggestion" do
+    book = Book.create!(title: "Elantris", book_type: :ebook)
+    detection = DetectedImport.new(
+      source_path: "/x", status: "detected", suggested_book: book,
+      candidate_books: [ { "kind" => "online", "work_id" => "hardcover:1", "score" => 90 } ]
+    )
+    assert_equal "book:#{book.id}", detection.default_selection
+  end
+
+  test "default_selection falls back to the highest-scoring alternate, not new" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected", candidate_books: [
+      { "kind" => "online", "work_id" => "hardcover:1", "score" => 40 },
+      { "kind" => "online", "work_id" => "hardcover:2", "score" => 88 }
+    ])
+    assert_equal "hardcover:2", detection.best_candidate["work_id"]
+    assert_equal "work:hardcover:2", detection.default_selection
+  end
+
+  test "default_selection is new only when nothing was matched" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected")
+    assert_nil detection.best_candidate
+    assert_equal "new", detection.default_selection
+  end
+
+  test "candidate_books always reads back as an array" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected")
+    assert_equal [], detection.candidate_books
+
+    detection.candidate_books = [ { "kind" => "library", "book_id" => 1 } ]
+    assert_equal 1, detection.candidate_books.size
+  end
+
+  test "display_title falls back to the source basename" do
+    detection = DetectedImport.new(source_path: "/data/torrents/shelfarr/Some Book.epub")
+    assert_equal "Some Book.epub", detection.display_title
+
+    detection.parsed_title = "Some Book"
+    assert_equal "Some Book", detection.display_title
+  end
+
+  test "pending_review excludes dismissed and imported" do
+    detected = DetectedImport.create!(source_path: "/a", status: "detected")
+    failed = DetectedImport.create!(source_path: "/b", status: "failed")
+    DetectedImport.create!(source_path: "/c", status: "dismissed")
+    DetectedImport.create!(source_path: "/d", status: "imported")
+
+    ids = DetectedImport.pending_review.pluck(:id)
+    assert_includes ids, detected.id
+    assert_includes ids, failed.id
+    assert_equal 2, ids.size
+  end
+end

--- a/test/services/library_acquisition_service_test.rb
+++ b/test/services/library_acquisition_service_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
+  setup do
+    @source_dir = Dir.mktmpdir("laq-source")
+    @ebook_dest = Dir.mktmpdir("laq-ebooks")
+    @audiobook_dest = Dir.mktmpdir("laq-audiobooks")
+
+    set_setting("ebook_output_path", @ebook_dest)
+    set_setting("audiobook_output_path", @audiobook_dest)
+    set_setting("completed_download_import_mode", "copy")
+    # Keep identification offline and library scans disabled.
+    Setting.where(key: "audiobookshelf_url").destroy_all
+  end
+
+  teardown do
+    [ @source_dir, @ebook_dest, @audiobook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  test "infers book type from path" do
+    assert_equal "ebook", LibraryAcquisitionService.infer_book_type("/x/Book.epub")
+    assert_equal "comicbook", LibraryAcquisitionService.infer_book_type("/x/Book.cbz")
+    assert_equal "audiobook", LibraryAcquisitionService.infer_book_type("/x/Book.m4b")
+    assert_equal "audiobook", LibraryAcquisitionService.infer_book_type(@source_dir)
+  end
+
+  test "identify suggests an existing library book from the filename" do
+    book = Book.create!(title: "Mistborn", author: "Brandon Sanderson", book_type: :ebook)
+    source = File.join(@source_dir, "Brandon Sanderson - Mistborn.epub")
+    File.write(source, "dummy epub bytes")
+
+    identification = MetadataService.stub(:search, []) do
+      LibraryAcquisitionService.identify(source_path: source)
+    end
+
+    assert_equal "ebook", identification.book_type
+    assert_equal "Mistborn", identification.parsed_title
+    assert_equal "Brandon Sanderson", identification.parsed_author
+    assert_equal book, identification.suggested_book
+    assert identification.candidate_books.any? { |c| c["kind"] == "library" && c["book_id"] == book.id }
+  end
+
+  test "import! copies the source into the organised library and marks the book acquired" do
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    owner = DetectedImport.create!(source_path: "unused", status: "importing")
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: owner, mode: "copy"
+    )
+
+    expected_dir = File.join(@ebook_dest, "Brandon Sanderson", "Elantris")
+    expected_file = File.join(expected_dir, "Brandon Sanderson - Elantris.epub")
+    assert File.exist?(expected_file), "imported file should exist in the library"
+    assert File.exist?(source), "copy mode preserves the source"
+
+    book.reload
+    assert book.acquired?
+    assert_equal expected_dir, book.file_path
+    assert_nil book.acquisition_reservation_token
+    assert_equal "copy", result.mode
+  end
+
+  test "import! refuses a book that is already acquired" do
+    book = Book.create!(
+      title: "Warbreaker", author: "Brandon Sanderson", book_type: :ebook,
+      file_path: "/ebooks/Brandon Sanderson/Warbreaker"
+    )
+    owner = DetectedImport.create!(source_path: "unused", status: "importing")
+    source = File.join(@source_dir, "Brandon Sanderson - Warbreaker.epub")
+    File.write(source, "dummy epub bytes")
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.import!(source_path: source, book: book, owner: owner)
+    end
+  end
+
+  test "undo_import! discards the copied library file and re-queues the detection" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Elantris", parsed_author: "Brandon Sanderson"
+    )
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    LibraryAcquisitionService.undo_import!(detection)
+
+    detection.reload
+    assert_equal "detected", detection.status
+    assert_nil detection.imported_book_id
+    assert_nil detection.suggested_book_id
+    assert File.exist?(source), "copy mode leaves the watched-folder source in place"
+    assert_not File.exist?(result.destination_path), "the redundant library copy is removed"
+    assert_not Book.exists?(book.id), "the throwaway book created for the import is destroyed"
+  end
+
+  test "undo_import! restores a moved source so it can be re-imported" do
+    set_setting("completed_download_import_mode", "move")
+    source = File.join(@source_dir, "Brandon Sanderson - Warbreaker.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Warbreaker", parsed_author: "Brandon Sanderson"
+    )
+    book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :ebook)
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "move"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+    assert_not File.exist?(source), "move consumed the source"
+
+    LibraryAcquisitionService.undo_import!(detection)
+
+    assert File.exist?(source), "undo returns the moved file to the watched folder"
+    assert_not File.exist?(result.destination_path), "the library directory is cleared"
+    assert_equal "detected", detection.reload.status
+  end
+
+  test "undo_import! un-acquires but keeps a metadata-bearing matched book" do
+    source = File.join(@source_dir, "Brandon Sanderson - Mistborn.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Mistborn", parsed_author: "Brandon Sanderson"
+    )
+    book = Book.create!(
+      title: "Mistborn", author: "Brandon Sanderson", book_type: :ebook, hardcover_id: "12345"
+    )
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    LibraryAcquisitionService.undo_import!(detection)
+
+    assert Book.exists?(book.id), "a matched book with metadata is kept"
+    assert_not book.reload.acquired?, "but it is un-acquired so it can be re-imported"
+  end
+
+  test "undo_import! refuses to delete a file outside the library output root" do
+    outside = File.join(@source_dir, "not-in-library.epub")
+    File.write(outside, "dummy")
+    book = Book.create!(title: "Rogue", book_type: :ebook, file_path: outside)
+    detection = DetectedImport.create!(
+      source_path: File.join(@source_dir, "still-here.epub"), status: "imported",
+      book_type: "ebook", imported_book: book
+    )
+    File.write(detection.source_path, "dummy")
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.undo_import!(detection)
+    end
+    assert File.exist?(outside), "a path outside the library is never removed"
+    assert_equal "imported", detection.reload.status
+  end
+
+  test "search_candidates maps provider results into scored online candidates" do
+    results = [
+      MetadataService::SearchResult.new(
+        source: "hardcover", source_id: "42", title: "The Fellowship of the Ring",
+        author: "J.R.R. Tolkien", description: nil, year: 1954, cover_url: "http://x/c.jpg",
+        has_audiobook: true, has_ebook: true, series_name: nil, series_position: nil
+      )
+    ]
+
+    candidates = MetadataService.stub(:search, results) do
+      LibraryAcquisitionService.search_candidates(
+        query: "The Fellowship of the Ring Tolkien", book_type: "audiobook"
+      )
+    end
+
+    assert_equal 1, candidates.size
+    candidate = candidates.first
+    assert_equal "online", candidate["kind"]
+    assert_equal "hardcover:42", candidate["work_id"]
+    assert_equal "The Fellowship of the Ring", candidate["title"]
+    assert candidate["score"].positive?, "a matching query should score above zero"
+  end
+
+  test "search_candidates returns [] for a blank query without hitting the network" do
+    # A blank query must return early; if it did not, the (unstubbed) provider
+    # lookup would fail in the offline test environment.
+    assert_empty LibraryAcquisitionService.search_candidates(query: "   ", book_type: "ebook")
+  end
+
+  private
+
+  def set_setting(key, value)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: "string", category: "paths"
+    )
+  end
+end

--- a/test/services/watched_folder_scan_service_test.rb
+++ b/test/services/watched_folder_scan_service_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WatchedFolderScanServiceTest < ActiveSupport::TestCase
+  setup do
+    @watched = Dir.mktmpdir("watched")
+    @ebook_dest = Dir.mktmpdir("wf-ebooks")
+    @audiobook_dest = Dir.mktmpdir("wf-audiobooks")
+
+    set_setting("ebook_output_path", @ebook_dest, "string", "paths")
+    set_setting("audiobook_output_path", @audiobook_dest, "string", "paths")
+    set_setting("library_import_enabled", "true", "boolean", "import")
+    set_setting("library_import_path", @watched, "string", "import")
+    Setting.where(key: "audiobookshelf_url").destroy_all
+
+    # A loose ebook file and an audiobook folder, mirroring a completed-download
+    # layout.
+    File.write(File.join(@watched, "Brandon Sanderson - Mistborn.epub"), "dummy epub")
+    audiobook_dir = File.join(@watched, "Brandon Sanderson - Elantris")
+    FileUtils.mkdir_p(audiobook_dir)
+    File.write(File.join(audiobook_dir, "track01.mp3"), "dummy audio")
+  end
+
+  teardown do
+    [ @watched, @ebook_dest, @audiobook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  test "detects an ebook file and an audiobook folder" do
+    result = MetadataService.stub(:search, []) do
+      assert_difference "DetectedImport.count", 2 do
+        WatchedFolderScanService.scan!
+      end
+    end
+
+    assert_equal 2, result.detected
+
+    canonical = File.realpath(@watched)
+
+    ebook = DetectedImport.find_by(book_type: "ebook")
+    assert_equal File.join(canonical, "Brandon Sanderson - Mistborn.epub"), ebook.source_path
+    assert_equal "Mistborn", ebook.parsed_title
+
+    audiobook = DetectedImport.find_by(book_type: "audiobook")
+    assert_equal File.join(canonical, "Brandon Sanderson - Elantris"), audiobook.source_path
+  end
+
+  test "splits a collection folder into one audiobook per titled subfolder" do
+    collection = File.join(@watched, "Tolkien Audiobook Collection")
+    {
+      "01 The Hobbit" => 3,
+      "02 The Fellowship Of The Ring" => 4,
+      "03 The Two Towers" => 2
+    }.each do |title, tracks|
+      dir = File.join(collection, title)
+      FileUtils.mkdir_p(dir)
+      tracks.times { |i| File.write(File.join(dir, format("%<title>s - %<n>02d.mp3", title: title, n: i + 1)), "dummy audio") }
+    end
+
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+    end
+
+    canonical = File.realpath(@watched)
+    subfolders = [ "01 The Hobbit", "02 The Fellowship Of The Ring", "03 The Two Towers" ]
+
+    # One audiobook per titled subfolder, none for the collection root itself.
+    subfolders.each do |title|
+      path = File.join(canonical, "Tolkien Audiobook Collection", title)
+      assert DetectedImport.exists?(source_path: path, book_type: "audiobook"),
+        "expected a detection for #{title}"
+    end
+    assert_not DetectedImport.exists?(source_path: File.join(canonical, "Tolkien Audiobook Collection")),
+      "the collection root must not be detected as a single audiobook"
+  end
+
+  test "keeps a multi-disc audiobook folder as a single import" do
+    book = File.join(@watched, "Some Long Book")
+    [ "CD1", "CD2", "Disc 3" ].each do |disc|
+      dir = File.join(book, disc)
+      FileUtils.mkdir_p(dir)
+      File.write(File.join(dir, "track01.mp3"), "dummy audio")
+    end
+
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+    end
+
+    canonical = File.realpath(@watched)
+    assert DetectedImport.exists?(source_path: File.join(canonical, "Some Long Book"), book_type: "audiobook"),
+      "the whole multi-disc folder should be one audiobook"
+    assert_not DetectedImport.exists?(source_path: File.join(canonical, "Some Long Book", "CD1")),
+      "disc subfolders must not become separate audiobooks"
+  end
+
+  test "does not re-detect known files on a second scan" do
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+
+      assert_no_difference "DetectedImport.count" do
+        result = WatchedFolderScanService.scan!
+        assert_equal 0, result.detected
+      end
+    end
+  end
+
+  test "returns nil when scanning is disabled" do
+    set_setting("library_import_enabled", "false", "boolean", "import")
+    assert_nil WatchedFolderScanService.scan!
+  end
+
+  test "refuses a watched path that overlaps an output path" do
+    set_setting("library_import_path", @ebook_dest, "string", "import")
+    assert_nil WatchedFolderScanService.scan!
+  end
+
+  private
+
+  def set_setting(key, value, type, category)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: type, category: category
+    )
+  end
+end


### PR DESCRIPTION
This adds a watched-folder import feature to allow preexisting files to be imported without uploading through shelfarr.
I needed this because i have a large amount of torrents that i wanted to import into a managed library, and since shelfarr is taking the role that both radarr and seer takes for movies but for books, that falls unto shelfarr. 

Video stack | Books stack | Role
-- | -- | --
Seerr / Jellyseerr | Shelfarr | Request + acquire (search indexers, download, deliver)
Radarr / Sonarr | (baked into Shelfarr) | Grab + import automation
Jellyfin | Audiobookshelf | Library server — organize, browse, stream/read

These are the relevant pages:

| Target Page | Relative Route / Fragment | Description |
| --- | --- | --- |
| **Imports** | `/admin/detected_imports` | Page route |
| **Settings** | `/admin/settings#Downloads:~:text=Watched%20Folder%20Import` |  *Watched Folder Import* section |

>[!Note]
>I don't speak ruby so,
>**The feature and the rest of the PR is written by Opus**

---

## Suggested reading order for the reviewer

1. **[config/routes.rb:159-171](/config/routes.rb#L159-L171)** — the routes above.
2. **[Admin::DetectedImportsController](/app/controllers/admin/detected_imports_controller.rb)** — thin actions; `index` (lazy imported-history), `import`→`apply_selection!`, `scan`.
3. **[LibraryAcquisitionService](/app/services/library_acquisition_service.rb)** — `identify` (read-only ranking) + `import!` (reserve → import → claim `file_path` → scan). The heart of it.
4. **[LibraryFileImporter](/app/services/library_file_importer.rb)** — copy/move/hardlink dispatch over `FileCopyService` (the safety-critical bit).
5. **[WatchedFolderScanService](/app/services/watched_folder_scan_service.rb)** — the walk + candidate classification (plain / multi-disc / collection).
6. **[DetectedImport](/app/models/detected_import.rb)** + **[migration](/db/migrate/20260722120000_create_detected_imports.rb)** — statuses and the `(device, inode)` idempotency index.

---

## Summary
- add an **attended** watched-folder importer (behind a default-off `library_import_enabled` setting) that detects pre-existing book files which were not acquired through a Shelfarr request and queues them for admin review before importing — filling the gap where Shelfarr replaces both requester and acquirer but, unlike Radarr/Sonarr, can't adopt files it didn't download
- group candidates the way the download importer sees releases: a single ebook/comic file, a self-contained audiobook folder, a multi-disc book (CD/Disc subfolders collapse to one import), or a collection/box set (each titled subfolder becomes its own import)
- import approved items into the organised library using the existing `completed_download_import_mode` (copy/move/hardlink), reusing `FileCopyService`'s atomic, no-follow, TOCTOU-safe primitives; the source is never mutated except by an explicit move, and a failed import leaves it untouched
- anchor idempotency on the source `(device, inode)` pair rather than the path, so hardlink imports and re-scans never re-detect the same content
- add the admin review queue (live Turbo morph-refresh, manual "Scan now" with in-progress/last-result feedback, and an expand/collapse imported-history section that lazy-loads the full history) plus a batched `import_detected` admin notification wired into the webhook/Discord event allow-list

## Design notes
- a human gates every import, so the matcher only produces a ranked suggestion (embedded metadata → filename → online) and never has to be autonomously correct — this removes the confidence-threshold policy and the risk of silently mis-tagging the library
- the import engine is a new `LibraryFileImporter` that delegates every filesystem publication to `FileCopyService`, rather than extracting the core out of `UploadProcessingJob`/`PostProcessingJob`. This leaves the most safety-critical request pipeline untouched (zero regression risk) and confines all new code to a default-off feature. Unifying both importers behind one engine is a reasonable follow-up once this is proven in CI.
- ships behind `library_import_enabled` (default off) with one additive migration (`create_detected_imports`); existing installs are unaffected

## Test plan
- focused feature suites (Docker, `RAILS_ENV=test`): `DetectedImport` model, `LibraryAcquisitionService`, scanner (incl. collection-split and multi-disc grouping, known-item skipping, symlink refusal, output-root overlap rejection), scan job, import job, and controller — **47 runs, 156 assertions, 0 failures**
- full `bin/rails test` in Docker — **2769 runs, 10279 assertions**. The 10 non-passing tests are pre-existing and unrelated to this change: all in upload/archive/cleanup file-publication code (`FileCopyService::AtomicPublicationUnsupportedError`, `Errno::ENODATA`), caused by the Docker-on-Windows bind mount lacking atomic publication (`linkat`/`renameat2(RENAME_NOREPLACE)`) and extended attributes — the same environmental limitation noted in #379. None of them touch the files this PR adds or changes.
- RuboCop (`--fail-level warning`) on all 16 new/changed feature files — no offenses
- not run in this environment (no Ruby toolchain on the Windows host — everything above ran in the app Docker image): Brakeman, system/browser tests, coverage, and mutant. Please run the full `bin/quality push` / `bin/quality deep` gate in CI before merging.
