### PR TITLE
Fix settings autofill autosave loops

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -36,63 +36,72 @@ module Admin
     def bulk_update
       errors = []
       changed_keys = []
+      validate_submitted_setting_keys!
+      validate_autosave_setting_keys!
+      validate_manual_setting_keys!
 
+      entries = []
       params[:settings]&.each do |key, value|
         next if SettingsService.env_managed?(key)
+        next if autosave? && !autosave_setting_keys.include?(key.to_s)
+        next if autosave? && SettingsService.manual_save_setting_key?(key)
+        next if manual_setting_manifest? && SettingsService.manual_save_setting_key?(key) && !manual_setting_keys.include?(key.to_s)
         next if preserve_blank_secret?(key, value)
 
         value = normalize_setting_value(key, value)
         error = validate_setting_value(key, value)
-        if error
-          errors << "#{SettingsService.label_for(key)}: #{error}"
-        else
-          SettingsService.set(key, value)
-          changed_keys << key.to_s
+        errors << "#{SettingsService.label_for(key)}: #{error}" if error
+        entries << {
+          key: key,
+          value: value,
+          error: error
+        }
+      end
+
+      unless errors.any?
+        Setting.transaction do
+          entries.each do |entry|
+            key = entry[:key]
+            SettingsService.set(key, entry[:value])
+            changed_keys << key.to_s
+          end
         end
       end
 
-      handle_settings_side_effects(changed_keys)
-
-      @settings_by_category = SettingsService.all_by_category
-      @audiobookshelf_libraries = fetch_audiobookshelf_libraries
-      load_telegram_chat_authorizations
-      load_audiobookshelf_cache_summary
+      side_effect_error = handle_settings_side_effects(changed_keys)
 
       respond_to do |format|
         if errors.any?
           format.html { redirect_to admin_settings_path, alert: errors.join(". ") }
           format.turbo_stream do
             flash.now[:alert] = errors.join(". ")
-            render turbo_stream: [
-              turbo_stream.update("settings-form", partial: "admin/settings/form"),
-              turbo_stream.update("flash", partial: "shared/flash")
-            ]
+            render turbo_stream: turbo_stream.update("flash", partial: "shared/flash"), status: :unprocessable_entity
+          end
+        elsif side_effect_error
+          message = "Settings saved, but a follow-up action failed: #{side_effect_error.message}"
+          format.html { redirect_to admin_settings_path, alert: message }
+          format.turbo_stream do
+            flash.now[:alert] = message
+            render turbo_stream: turbo_stream.update("flash", partial: "shared/flash")
           end
         else
           format.html { redirect_to admin_settings_path, notice: "Settings updated successfully." }
           format.turbo_stream do
-            flash.now[:notice] = "Settings updated successfully."
-            render turbo_stream: [
-              turbo_stream.update("settings-form", partial: "admin/settings/form"),
-              turbo_stream.update("flash", partial: "shared/flash")
-            ]
+            if autosave?
+              head :no_content
+            else
+              flash.now[:notice] = "Settings updated successfully."
+              render turbo_stream: turbo_stream.update("flash", partial: "shared/flash")
+            end
           end
         end
       end
     rescue ArgumentError => e
-      @settings_by_category = SettingsService.all_by_category
-      @audiobookshelf_libraries = fetch_audiobookshelf_libraries
-      load_telegram_chat_authorizations
-      load_audiobookshelf_cache_summary
-
       respond_to do |format|
         format.html { redirect_to admin_settings_path, alert: e.message }
         format.turbo_stream do
           flash.now[:alert] = e.message
-          render turbo_stream: [
-            turbo_stream.update("settings-form", partial: "admin/settings/form"),
-            turbo_stream.update("flash", partial: "shared/flash")
-          ]
+          render turbo_stream: turbo_stream.update("flash", partial: "shared/flash"), status: :unprocessable_entity
         end
       end
     end
@@ -416,6 +425,55 @@ module Admin
 
     private
 
+    def autosave?
+      params[:autosave] == "true"
+    end
+
+    def autosave_setting_keys
+      @autosave_setting_keys ||= params[:autosave_keys].to_s.split(",")
+    end
+
+    def manual_setting_manifest?
+      params.key?(:manual_keys)
+    end
+
+    def manual_setting_keys
+      @manual_setting_keys ||= params[:manual_keys].to_s.split(",").reject(&:blank?)
+    end
+
+    def validate_submitted_setting_keys!
+      settings = params[:settings]
+      return if settings.nil?
+      raise ArgumentError, "Settings must be submitted as key-value pairs" unless settings.is_a?(ActionController::Parameters)
+
+      unknown_key = settings.keys.find do |key|
+        !SettingsService::DEFINITIONS.key?(key.to_sym)
+      end
+      raise ArgumentError, "Unknown setting: #{unknown_key}" if unknown_key
+    end
+
+    def validate_autosave_setting_keys!
+      return unless autosave?
+
+      settings = params[:settings]
+      invalid = settings.nil? || autosave_setting_keys.empty? || autosave_setting_keys.any? do |key|
+        !SettingsService::DEFINITIONS.key?(key.to_sym) ||
+          SettingsService.manual_save_setting_key?(key) ||
+          !settings.key?(key)
+      end
+      raise ArgumentError, "Invalid autosave setting manifest" if invalid
+    end
+
+    def validate_manual_setting_keys!
+      return unless manual_setting_manifest?
+
+      settings = params[:settings] || ActionController::Parameters.new
+      invalid = manual_setting_keys.any? do |key|
+        !SettingsService.manual_save_setting_key?(key) || !settings.key?(key)
+      end
+      raise ArgumentError, "Invalid manual setting manifest" if invalid
+    end
+
     def telegram_chat_label(authorization)
       authorization.chat_title.presence || authorization.chat_id
     end
@@ -493,6 +551,10 @@ module Admin
       if changed_keys.any? { |k| k.start_with?("audiobook_output_path") || k.start_with?("ebook_output_path") }
         run_service_health_check_now("output_paths")
       end
+      nil
+    rescue StandardError => e
+      Rails.logger.error("[SettingsController] Settings saved but a follow-up action failed: #{e.class}: #{e.message}")
+      e
     end
 
     PATH_TEMPLATE_SETTINGS = %w[audiobook_path_template ebook_path_template].freeze
@@ -509,10 +571,27 @@ module Admin
     end
 
     def validate_setting_value(key, value)
-      validate_completed_download_import_mode(key, value) ||
+      validate_setting_type(key, value) ||
+        validate_completed_download_import_mode(key, value) ||
         validate_path_template(key, value) ||
         validate_indexer_url(key, value) ||
         validate_ebooks_com_setting(key, value)
+    end
+
+    def validate_setting_type(key, value)
+      type = SettingsService::DEFINITIONS.dig(key.to_sym, :type)
+      case type
+      when "boolean"
+        return nil if [ true, false, 1, 0, "1", "0", "true", "false" ].include?(value)
+
+        "must be true or false"
+      when "integer"
+        "must be an integer" unless Integer(value.to_s, 10, exception: false)
+      when "string"
+        "must be a scalar value" if value.is_a?(Array) || value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
+      when "json"
+        "must be a scalar or list" if value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
+      end
     end
 
     def validate_completed_download_import_mode(key, value)
@@ -569,14 +648,17 @@ module Admin
     end
 
     def ebooks_com_enabled_for_validation?
-      submitted = params[:settings]&.[](:ebooks_com_enabled) || params[:settings]&.[]("ebooks_com_enabled")
-      value = submitted.nil? ? SettingsService.get(:ebooks_com_enabled) : submitted
-      ActiveModel::Type::Boolean.new.cast(value)
+      ActiveModel::Type::Boolean.new.cast(setting_value_for_validation(:ebooks_com_enabled))
     end
 
     def ebooks_com_country_for_validation
-      submitted = params[:settings]&.[](:ebooks_com_country_code) || params[:settings]&.[]("ebooks_com_country_code")
-      (submitted.nil? ? SettingsService.get(:ebooks_com_country_code) : submitted).to_s.strip
+      setting_value_for_validation(:ebooks_com_country_code).to_s.strip
+    end
+
+    def setting_value_for_validation(key)
+      settings = params[:settings]
+      submitted = settings&.key?(key.to_s) && (!autosave? || autosave_setting_keys.include?(key.to_s))
+      submitted ? settings[key.to_s] : SettingsService.get(key)
     end
 
     def indexer_url_validation_message(error)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "settings_navigation_guard"
 import "@hotwired/turbo-rails"
 import "controllers"

--- a/app/javascript/controllers/settings_form_controller.js
+++ b/app/javascript/controllers/settings_form_controller.js
@@ -4,6 +4,9 @@ export default class extends Controller {
   static targets = [
     "form",
     "status",
+    "autosaveSubmit",
+    "autosaveKeys",
+    "manualKeys",
     "indexerProvider",
     "prowlarrFields",
     "jackettFields",
@@ -12,19 +15,61 @@ export default class extends Controller {
 
   connect() {
     this.saveTimeout = null;
+    this.pendingSettingKeys = new Set();
+    this.inFlightSettingKeys = new Set();
+    this.explicitInFlightSettingKeys = new Set();
+    this.autosaveInFlight = false;
+    this.explicitSubmitInFlight = false;
+    this.manualChangesPending = false;
+    this.manualSettingKeys = new Set();
+    this.deferredAction = null;
+    this.historyIndex = window.history.state?.turbo?.restorationIndex;
+    this.revertingHistory = false;
+    this.replayingHistory = false;
+    if (this.hasManualKeysTarget) this.manualKeysTarget.name = "manual_keys";
 
     // Listen for Turbo events to manage status
     this.boundHandleSubmitEnd = this.handleSubmitEnd.bind(this);
+    this.boundHandleBeforeVisit = this.handleBeforeVisit.bind(this);
+    this.boundHandleBeforeRender = this.handleBeforeRender.bind(this);
+    this.boundHandleActionClick = this.handleActionClick.bind(this);
+    this.boundHandleExternalSubmit = this.handleExternalSubmit.bind(this);
+    this.boundHandleManualChange = this.handleManualChange.bind(this);
+    this.boundHandleManualInput = this.handleManualInput.bind(this);
+    this.boundHandleBeforeUnload = this.handleBeforeUnload.bind(this);
+    this.boundHandlePopState = this.handlePopState.bind(this);
     document.addEventListener("turbo:submit-end", this.boundHandleSubmitEnd);
+    document.addEventListener("turbo:before-visit", this.boundHandleBeforeVisit);
+    document.addEventListener("turbo:before-render", this.boundHandleBeforeRender);
+    this.element.addEventListener("click", this.boundHandleActionClick, true);
+    this.element.addEventListener("submit", this.boundHandleExternalSubmit, true);
+    this.element.addEventListener("change", this.boundHandleManualChange, true);
+    this.element.addEventListener("beforeinput", this.boundHandleManualInput, true);
+    window.addEventListener("beforeunload", this.boundHandleBeforeUnload);
+    window.settingsNavigationGuard = this.boundHandlePopState;
 
     this.toggleIndexerProvider();
   }
 
   disconnect() {
+    this.clearSaveTimeout();
     document.removeEventListener("turbo:submit-end", this.boundHandleSubmitEnd);
+    document.removeEventListener("turbo:before-visit", this.boundHandleBeforeVisit);
+    document.removeEventListener("turbo:before-render", this.boundHandleBeforeRender);
+    this.element.removeEventListener("click", this.boundHandleActionClick, true);
+    this.element.removeEventListener("submit", this.boundHandleExternalSubmit, true);
+    this.element.removeEventListener("change", this.boundHandleManualChange, true);
+    this.element.removeEventListener("beforeinput", this.boundHandleManualInput, true);
+    window.removeEventListener("beforeunload", this.boundHandleBeforeUnload);
+    if (window.settingsNavigationGuard === this.boundHandlePopState) delete window.settingsNavigationGuard;
   }
 
   autoSave(event) {
+    const settingKey = this.settingKey(event?.target?.name);
+    if (!settingKey) return;
+
+    this.pendingSettingKeys.add(settingKey);
+
     // Clear any pending save
     if (this.saveTimeout) {
       clearTimeout(this.saveTimeout);
@@ -55,11 +100,6 @@ export default class extends Controller {
       return;
     }
 
-    this.autoSave(event);
-  }
-
-  handleIndexerProviderChange(event) {
-    this.toggleIndexerProvider();
     this.autoSave(event);
   }
 
@@ -108,18 +148,424 @@ export default class extends Controller {
   }
 
   submitForm() {
-    if (!this.hasFormTarget) return;
+    if (!this.hasFormTarget || !this.hasAutosaveSubmitTarget || !this.hasAutosaveKeysTarget) return;
+    if (this.autosaveInFlight || this.explicitSubmitInFlight || this.pendingSettingKeys.size === 0) return;
 
     // Server-side validation is authoritative for bulk auto-save. Full-form
     // HTML5 constraint validation would block unrelated settings when an
     // indexer URL is mid-edit or on a hidden tab (where the browser bubble is
     // easy to miss). The form uses novalidate; type="url" remains a soft hint.
-    this.formTarget.requestSubmit();
+    this.inFlightSettingKeys = new Set(this.pendingSettingKeys);
+    this.autosaveKeysTarget.value = [...this.inFlightSettingKeys].join(",");
+    this.pendingSettingKeys.clear();
+    this.saveTimeout = null;
+    this.autosaveInFlight = true;
+    this.formTarget.requestSubmit(this.autosaveSubmitTarget);
+    this.setFormBusy(true);
+  }
+
+  handleSubmit(event) {
+    if (event.submitter === this.autosaveSubmitTarget) return;
+
+    const saveAll = event.submitter?.name === "commit";
+    if (!saveAll && this.manualChangesPending) {
+      event.preventDefault();
+      this.showUnsavedManualChanges();
+      return;
+    }
+
+    if (this.autosaveInFlight || this.explicitSubmitInFlight || (!saveAll && this.pendingSettingKeys.size > 0)) {
+      event.preventDefault();
+      this.deferAction({ type: "submitter", submitter: event.submitter });
+      if (!this.autosaveInFlight && !this.explicitSubmitInFlight) {
+        this.clearSaveTimeout();
+        this.saveTimeout = setTimeout(() => this.submitForm(), 0);
+      }
+      return;
+    }
+
+    this.clearSaveTimeout();
+    if (saveAll && this.hasManualKeysTarget) {
+      const submittedKeys = new Set(
+        [...new FormData(this.formTarget).keys()].map((name) => this.settingKey(name)).filter(Boolean)
+      );
+      this.manualKeysTarget.value = [...this.manualSettingKeys].filter((key) => submittedKeys.has(key)).join(",");
+    }
+    this.explicitInFlightSettingKeys = saveAll ? new Set(this.pendingSettingKeys) : new Set();
+    if (saveAll) {
+      this.pendingSettingKeys.clear();
+    }
+    this.explicitSubmitInFlight = true;
+    this.showStatus("Saving...");
+    this.setFormBusy(true);
   }
 
   handleSubmitEnd(event) {
-    // Hide the saving indicator when form submission completes
+    if (!event.target.matches("[data-settings-form-target~='form']")) return;
+
+    const submitter = event.detail?.formSubmission?.submitter;
+    const succeeded = event.detail?.success === true;
+    if (submitter === this.autosaveSubmitTarget) {
+      this.autosaveInFlight = false;
+      if (!succeeded) {
+        this.inFlightSettingKeys.forEach((key) => this.pendingSettingKeys.add(key));
+      }
+      this.inFlightSettingKeys.clear();
+
+      if (!succeeded && this.deferredAction?.type === "submitter" && this.deferredAction.submitter?.name === "commit") {
+        this.setFormBusy(false);
+        this.runDeferredAction();
+        return;
+      }
+      if (this.pendingSettingKeys.size > 0) {
+        if (!succeeded) {
+          this.discardDeferredActionAfterFailure();
+          this.setFormBusy(false);
+          this.showStatus("Autosave failed. Change the setting to retry.");
+          return;
+        }
+        this.setFormBusy(false);
+        this.submitForm();
+        return;
+      }
+      if (succeeded && this.runDeferredAction()) return;
+    } else {
+      this.explicitSubmitInFlight = false;
+      if (!succeeded) {
+        this.explicitInFlightSettingKeys.forEach((key) => this.pendingSettingKeys.add(key));
+      }
+      this.explicitInFlightSettingKeys.clear();
+      this.setFormBusy(false);
+
+      if (!succeeded) {
+        this.discardDeferredActionAfterFailure();
+        this.showStatus("Save failed. Review the errors and try again.");
+        return;
+      }
+      if (submitter?.name === "commit") {
+        this.discardManualChanges();
+        this.clearSecretFields();
+      }
+      if (this.pendingSettingKeys.size > 0) {
+        this.submitForm();
+        return;
+      }
+      if (this.runDeferredAction()) return;
+    }
+
+    this.setFormBusy(false);
+    this.finishStatus();
+  }
+
+  handleActionClick(event) {
+    const link = event.target.closest("a[data-turbo-method]");
+    if (!link) return;
+
+    if (this.manualChangesPending && !this.explicitSubmitInFlight) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      this.showUnsavedManualChanges();
+      return;
+    }
+    if (!this.hasSaveWork()) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.deferAction({ type: "link", link });
+    this.ensureAutosaveScheduled();
+  }
+
+  handleExternalSubmit(event) {
+    if (event.target === this.formTarget) return;
+
+    if (this.manualChangesPending && !this.explicitSubmitInFlight) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      this.showUnsavedManualChanges();
+      return;
+    }
+    if (!this.hasSaveWork()) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.deferAction({ type: "form", form: event.target, submitter: event.submitter });
+    this.ensureAutosaveScheduled();
+  }
+
+  handleBeforeVisit(event) {
+    if (this.manualChangesPending && !this.explicitSubmitInFlight) {
+      const discardChanges = window.confirm("Leave this page and discard settings that have not been saved?");
+      if (!discardChanges) {
+        event.preventDefault();
+        return;
+      }
+      this.discardManualChanges();
+    }
+    if (!this.hasSaveWork()) return;
+
+    event.preventDefault();
+    if (!this.deferAction({ type: "visit", url: event.detail.url })) return;
+    this.ensureAutosaveScheduled();
+  }
+
+  handleBeforeRender(event) {
+    if (!this.hasSaveWork()) return;
+
+    event.preventDefault();
+    if (!this.deferAction({ type: "render", resume: event.detail.resume })) return;
+    this.ensureAutosaveScheduled();
+  }
+
+  handleManualChange(event) {
+    if (!event.target.matches("[data-settings-form-manual-save]")) return;
+    if (!event.target.matches('select, input[type="checkbox"], input[type="radio"], input[type="hidden"]')) return;
+
+    this.markManualField(event.target);
+  }
+
+  handleManualInput(event) {
+    if (!event.target.matches("[data-settings-form-manual-save]") || event.target !== document.activeElement) return;
+
+    this.markManualField(event.target);
+  }
+
+  handleBeforeUnload(event) {
+    if (!this.manualChangesPending) return;
+
+    event.preventDefault();
+    event.returnValue = "";
+  }
+
+  handlePopState(event) {
+    const targetIndex = event.state?.turbo?.restorationIndex;
+    if (targetIndex == null || this.historyIndex == null) return;
+
+    if (this.replayingHistory) {
+      this.replayingHistory = false;
+      event.stopImmediatePropagation();
+      window.location.reload();
+      return;
+    }
+
+    if (this.revertingHistory) {
+      this.revertingHistory = false;
+      event.stopImmediatePropagation();
+      if (this.pendingHistoryVisit) {
+        const visit = this.pendingHistoryVisit;
+        this.pendingHistoryVisit = null;
+        if (this.autosaveInFlight || this.explicitSubmitInFlight) {
+          this.deferAction({ type: "history", visit });
+        } else {
+          this.submitHistoryAutosave(visit);
+        }
+      }
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    if (activeElement && this.formTarget.contains(activeElement) && activeElement.dataset.action?.includes("settings-form#autoSave")) {
+      this.autoSave({ target: activeElement });
+    }
+
+    if (this.manualChangesPending) {
+      if (window.confirm("Leave this page and discard settings that have not been saved?")) {
+        this.discardManualChanges();
+      } else {
+        event.stopImmediatePropagation();
+        this.reverseHistoryNavigation(targetIndex);
+        return;
+      }
+    }
+
+    if (!this.hasSaveWork()) return;
+
+    event.stopImmediatePropagation();
+    this.pendingHistoryVisit = { url: window.location.href, targetIndex };
+    this.reverseHistoryNavigation(targetIndex);
+  }
+
+  reverseHistoryNavigation(targetIndex) {
+    const delta = this.historyIndex - targetIndex;
+    if (delta !== 0) {
+      this.revertingHistory = true;
+      window.history.go(delta);
+    }
+  }
+
+  async submitHistoryAutosave(visit) {
+    this.clearSaveTimeout();
+    if (this.pendingSettingKeys.size === 0) {
+      this.resumeHistoryNavigation(visit);
+      return;
+    }
+
+    this.inFlightSettingKeys = new Set(this.pendingSettingKeys);
+    this.autosaveKeysTarget.value = [...this.inFlightSettingKeys].join(",");
+    this.pendingSettingKeys.clear();
+    this.autosaveInFlight = true;
+    this.setFormBusy(true);
+
+    try {
+      const response = await window.fetch(this.formTarget.action, {
+        method: this.formTarget.method,
+        body: new FormData(this.formTarget, this.autosaveSubmitTarget),
+        credentials: "same-origin",
+        headers: { Accept: "text/vnd.turbo-stream.html" }
+      });
+      const body = await response.text();
+      if (body) window.Turbo.renderStreamMessage(body);
+
+      if (!response.ok) {
+        this.inFlightSettingKeys.forEach((key) => this.pendingSettingKeys.add(key));
+        this.showStatus("Autosave failed. Change the setting to retry.");
+        return;
+      }
+
+      this.hideStatus();
+      this.resumeHistoryNavigation(visit);
+    } catch (_error) {
+      this.inFlightSettingKeys.forEach((key) => this.pendingSettingKeys.add(key));
+      this.showStatus("Autosave failed. Change the setting to retry.");
+    } finally {
+      this.inFlightSettingKeys.clear();
+      this.autosaveInFlight = false;
+      this.setFormBusy(false);
+    }
+  }
+
+  resumeHistoryNavigation(visit) {
+    const delta = visit.targetIndex - this.historyIndex;
+    if (delta === 0) {
+      window.location.assign(visit.url);
+      return;
+    }
+
+    this.replayingHistory = true;
+    window.history.go(delta);
+  }
+
+  hasSaveWork() {
+    return this.autosaveInFlight || this.explicitSubmitInFlight || this.pendingSettingKeys.size > 0;
+  }
+
+  ensureAutosaveScheduled() {
+    if (this.autosaveInFlight || this.explicitSubmitInFlight || this.pendingSettingKeys.size === 0) return;
+
+    this.clearSaveTimeout();
+    this.submitForm();
+  }
+
+  runDeferredAction() {
+    const action = this.deferredAction;
+    this.deferredAction = null;
+    if (!action) return false;
+
+    this.setFormBusy(false);
     this.hideStatus();
+
+    if (action.type === "submitter" && action.submitter?.isConnected) {
+      this.formTarget.requestSubmit(action.submitter);
+    } else if (action.type === "link" && action.link.isConnected) {
+      action.link.click();
+    } else if (action.type === "form" && action.form.isConnected) {
+      action.form.requestSubmit(action.submitter?.isConnected ? action.submitter : undefined);
+    } else if (action.type === "visit") {
+      if (window.Turbo?.visit) {
+        window.Turbo.visit(action.url);
+      } else {
+        window.location.assign(action.url);
+      }
+    } else if (action.type === "history") {
+      this.resumeHistoryNavigation(action.visit);
+    } else if (action.type === "render") {
+      action.resume();
+    }
+    return true;
+  }
+
+  deferAction(action) {
+    if (this.deferredAction?.type === "render" && action.type !== "render") return false;
+
+    this.deferredAction = action;
+    return true;
+  }
+
+  discardDeferredActionAfterFailure() {
+    if (this.deferredAction?.type !== "render") this.deferredAction = null;
+  }
+
+  showUnsavedManualChanges() {
+    this.showStatus("Save all changes before running this action.");
+  }
+
+  markManualField(field) {
+    const key = this.settingKey(field.name);
+    if (!key) return;
+
+    this.manualSettingKeys.add(key);
+    this.manualChangesPending = true;
+    if (this.hasManualKeysTarget) this.manualKeysTarget.value = [...this.manualSettingKeys].join(",");
+    this.showStatus("Unsaved changes. Click Save All.");
+  }
+
+  discardManualChanges() {
+    this.manualSettingKeys.clear();
+    this.manualChangesPending = false;
+    if (this.hasManualKeysTarget) this.manualKeysTarget.value = "";
+  }
+
+  finishStatus() {
+    if (this.manualChangesPending) {
+      this.showStatus("Unsaved changes. Click Save All.");
+    } else {
+      this.hideStatus();
+    }
+  }
+
+  clearSecretFields() {
+    this.formTarget.querySelectorAll('input[type="password"]').forEach((field) => {
+      field.value = "";
+    });
+  }
+
+  setFormBusy(busy) {
+    if (!this.hasFormTarget) return;
+
+    if (busy) {
+      const activeElement = document.activeElement;
+      if (activeElement && this.formTarget.contains(activeElement)) {
+        this.focusedControl = {
+          id: activeElement.id,
+          selectionStart: activeElement.selectionStart,
+          selectionEnd: activeElement.selectionEnd
+        };
+      }
+    }
+
+    this.element.querySelectorAll("form").forEach((form) => { form.inert = busy; });
+    this.formTarget.setAttribute("aria-busy", busy ? "true" : "false");
+
+    if (!busy && this.focusedControl?.id) {
+      const control = document.getElementById(this.focusedControl.id);
+      if (control) {
+        control.focus({ preventScroll: true });
+        if (this.focusedControl.selectionStart != null && control.setSelectionRange) {
+          control.setSelectionRange(this.focusedControl.selectionStart, this.focusedControl.selectionEnd);
+        }
+      }
+      this.focusedControl = null;
+    }
+  }
+
+  clearSaveTimeout() {
+    if (!this.saveTimeout) return;
+
+    clearTimeout(this.saveTimeout);
+    this.saveTimeout = null;
+  }
+
+  settingKey(name) {
+    return name?.match(/^settings\[([^\]]+)\](?:\[\])?$/)?.[1];
   }
 
   showStatus(message) {

--- a/app/javascript/settings_navigation_guard.js
+++ b/app/javascript/settings_navigation_guard.js
@@ -1,0 +1,3 @@
+window.addEventListener("popstate", (event) => {
+  window.settingsNavigationGuard?.(event);
+}, true);

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -1,4 +1,35 @@
 class SettingsService
+  MANUAL_SAVE_SETTING_GROUPS = {
+    indexer: %w[
+      indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key
+      newznab_url newznab_api_key prowlarr_tags jackett_indexer_filter
+    ],
+    library_platform: %w[
+      library_platform audiobookshelf_url audiobookshelf_api_key
+      bookorbit_url bookorbit_username bookorbit_password
+      grimmory_url grimmory_username grimmory_password
+      audiobookshelf_audiobook_library_id audiobookshelf_ebook_library_id
+      audiobookshelf_comicbook_library_id audiobookshelf_audiobook_scan_library_ids
+      audiobookshelf_ebook_scan_library_ids audiobookshelf_comicbook_scan_library_ids
+    ],
+    anna_archive: %w[anna_archive_enabled anna_archive_url anna_archive_api_key],
+    zlibrary: %w[zlibrary_enabled zlibrary_url zlibrary_email zlibrary_password],
+    hardcover: %w[hardcover_enabled hardcover_api_token],
+    google_books: %w[google_books_enabled google_books_api_key],
+    comic_vine: %w[comic_vine_enabled comic_vine_api_key],
+    discord: %w[discord_enabled discord_webhook_url],
+    oidc: %w[
+      oidc_enabled oidc_auto_redirect oidc_provider_name oidc_issuer oidc_client_id
+      oidc_client_secret oidc_scopes oidc_link_existing_users oidc_auto_create_users
+      oidc_default_role
+    ],
+    webhook: %w[webhook_enabled webhook_url webhook_token],
+    telegram: %w[
+      telegram_enabled telegram_update_mode telegram_bot_token telegram_bot_username
+      telegram_webhook_secret telegram_request_username
+    ]
+  }.freeze
+  MANUAL_SAVE_SETTING_KEYS = MANUAL_SAVE_SETTING_GROUPS.values.flatten.uniq.freeze
   DEFAULT_ANNA_ARCHIVE_URL = "https://annas-archive.gl"
   DEFAULT_ZLIBRARY_URLS = "https://z-library.sk\nhttps://z-library.bz\nhttps://z-library.rs"
   ENV_OVERRIDE_PREFIX = "SHELFARR_SETTING_"
@@ -316,6 +347,10 @@ class SettingsService
     def secret_setting_key?(key)
       key = key.to_s
       key == "discord_webhook_url" || key.include?("password") || key.include?("api_key") || key.include?("token") || key.include?("secret")
+    end
+
+    def manual_save_setting_key?(key)
+      secret_setting_key?(key) || MANUAL_SAVE_SETTING_KEYS.include?(key.to_s)
     end
 
     # Primary getter with default fallback

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -25,11 +25,13 @@
 %>
 
 <div id="settings-tabs" data-controller="settings-tabs" data-settings-tabs-active-value="search">
-  <%= form_with url: bulk_update_admin_settings_path, method: :patch, html: { novalidate: true }, data: { settings_form_target: "form" } do |form| %>
+  <%= form_with url: bulk_update_admin_settings_path, method: :patch, html: { novalidate: true, autocomplete: "off", aria: { busy: "false" } }, data: { settings_form_target: "form", action: "submit->settings-form#handleSubmit" } do |form| %>
+    <%= hidden_field_tag :autosave_keys, "", data: { settings_form_target: "autosaveKeys" } %>
+    <%= tag.input type: "hidden", value: "", data: { settings_form_target: "manualKeys" } %>
     <div class="flex justify-between items-center mb-6">
       <h1 class="font-bold text-4xl text-white">Settings</h1>
       <div class="flex items-center gap-4">
-        <span data-settings-form-target="status" class="text-sm text-gray-500 hidden">Saving...</span>
+        <span data-settings-form-target="status" role="status" aria-live="polite" class="text-sm text-gray-500 hidden">Saving...</span>
         <%= form.submit "Save All", class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
       </div>
     </div>
@@ -99,7 +101,8 @@
                           <p class="mt-2 text-sm text-yellow-500">Warning: This removes password and 2FA authentication. Confirm carefully.</p>
                         <% else %>
                         <label class="inline-flex items-center cursor-pointer">
-                          <%= form.check_box "settings[#{key}]", { checked: data[:value] == true || data[:value] == "true", id: "settings_#{key}", class: "w-5 h-5 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-2", data: { action: "change->settings-form#autoSave" } }, "true", "false" %>
+                          <% boolean_data = SettingsService.manual_save_setting_key?(key) ? { settings_form_manual_save: true } : { action: "change->settings-form#autoSave" } %>
+                          <%= form.check_box "settings[#{key}]", { checked: data[:value] == true || data[:value] == "true", id: "settings_#{key}", class: "w-5 h-5 rounded border-gray-600 bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-2", data: boolean_data }, "true", "false" %>
                         </label>
                         <% end %>
                       <% when "integer" %>
@@ -119,7 +122,7 @@
                             <p>Hardlinked names share content, ownership, and permissions; edits through either name affect both.</p>
                           </div>
                         <% elsif key.to_s == "library_platform" %>
-                          <%= form.select "settings[#{key}]", options_for_select([["Audiobookshelf", "audiobookshelf"], ["BookOrbit", "bookorbit"], ["Grimmory", "grimmory"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.select "settings[#{key}]", options_for_select([["Audiobookshelf", "audiobookshelf"], ["BookOrbit", "bookorbit"], ["Grimmory", "grimmory"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                         <% elsif key.to_s.end_with?("_scan_library_ids") && @audiobookshelf_libraries.any? %>
                           <% selected_ids = data[:value].to_s.split(",").map(&:strip).reject(&:blank?) %>
                           <% library_options = @audiobookshelf_libraries.map { |lib| ["#{lib.name} (#{lib.media_type})", lib.id] } %>
@@ -127,28 +130,28 @@
                           <% missing_selected_ids.each do |missing_id| %>
                             <% library_options << ["#{missing_id} (Unavailable)", missing_id] %>
                           <% end %>
-                          <%= form.select "settings[#{key}]", options_for_select(library_options, selected_ids), { include_blank: "Select libraries to scan for duplicates..." }, { id: "settings_#{key}", multiple: true, class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2 min-h-[80px]", data: { action: "change->settings-form#autoSave" } } %>
+                          <%= form.select "settings[#{key}]", options_for_select(library_options, selected_ids), { include_blank: "Select libraries to scan for duplicates..." }, { id: "settings_#{key}", multiple: true, class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2 min-h-[80px]", data: { settings_form_manual_save: true } } %>
                           <p class="mt-1 text-xs text-gray-500">Additional libraries scanned for duplicate detection. Delivery still goes to the single library selected above.</p>
                         <% elsif key.to_s.end_with?("_scan_library_ids") %>
-                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure library platform connection details first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure library platform connection details first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                           <p class="mt-1 text-xs text-yellow-500">Enter active platform connection details above to select from available libraries</p>
                         <% elsif key.to_s.end_with?("_library_id") && @audiobookshelf_libraries.any? %>
                           <% library_options = @audiobookshelf_libraries.map { |lib| ["#{lib.name} (#{lib.media_type})", lib.id] } %>
                           <% if data[:value].present? && !@audiobookshelf_libraries.any? { |lib| lib.id == data[:value] } %>
                             <% library_options << ["#{data[:value]} (Unavailable)", data[:value]] %>
                           <% end %>
-                          <%= form.select "settings[#{key}]", options_for_select([["Select a library...", ""]] + library_options, data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.select "settings[#{key}]", options_for_select([["Select a library...", ""]] + library_options, data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                         <% elsif key.to_s.end_with?("_library_id") %>
-                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure library platform connection details first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", placeholder: "Configure library platform connection details first", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                           <p class="mt-1 text-xs text-yellow-500">Enter active platform connection details above to select from available libraries</p>
                         <% elsif key.to_s == "oidc_default_role" %>
-                          <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.select "settings[#{key}]", options_for_select([["User", "user"], ["Admin", "admin"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                         <% elsif key.to_s == "metadata_source" %>
                           <%= form.select "settings[#{key}]", options_for_select([["Auto", "auto"], ["Hardcover", "hardcover"], ["Google Books", "google_books"], ["Open Library", "openlibrary"], ["Comic Vine", "comic_vine"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% elsif key.to_s == "telegram_update_mode" %>
-                          <%= form.select "settings[#{key}]", options_for_select([["Polling", "polling"], ["Webhook", "webhook"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.select "settings[#{key}]", options_for_select([["Polling", "polling"], ["Webhook", "webhook"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                         <% elsif key.to_s == "discord_webhook_url" %>
-                          <%= form.password_field "settings[#{key}]", value: "", placeholder: data[:value].present? ? "********" : "https://discord.com/api/webhooks/...", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.password_field "settings[#{key}]", value: "", placeholder: data[:value].present? ? "********" : "https://discord.com/api/webhooks/...", id: "settings_#{key}", autocomplete: "new-password", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                         <% elsif %w[anna_archive_url zlibrary_url].include?(key.to_s) %>
                           <% url_list_urls = data[:value].to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?).uniq %>
                           <% url_list_name = key.to_s == "zlibrary_url" ? "Z-Library" : "Anna's Archive" %>
@@ -161,7 +164,7 @@
                                 id: "settings_#{key}",
                                 data: {
                                   url_list_field: true,
-                                  action: "change->settings-form#autoSave"
+                                  settings_form_manual_save: true
                                 } %>
                             <div class="flex flex-wrap gap-2" data-url-list-list>
                               <% url_list_urls.each do |url| %>
@@ -207,8 +210,10 @@
                               spellcheck: false,
                               class: "w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 uppercase text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500",
                               data: { action: "change->settings-form#autoSave" } %>
+                        <% elsif SettingsService.manual_save_setting_key?(key) && !SettingsService.secret_setting_key?(key) %>
+                          <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", autocomplete: "off", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                         <% elsif SettingsService.secret_setting_key?(key) %>
-                          <%= form.password_field "settings[#{key}]", value: "", placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+                          <%= form.password_field "settings[#{key}]", value: "", placeholder: data[:value].present? ? "********" : "", id: "settings_#{key}", autocomplete: "new-password", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
                         <% else %>
                           <%= form.text_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
                         <% end %>
@@ -414,6 +419,7 @@
         <% end %>
       </div>
     <% end %>
+    <%= form.button "", type: "submit", name: "autosave", value: "true", hidden: true, tabindex: -1, aria: { hidden: true }, data: { settings_form_target: "autosaveSubmit" } %>
   <% end %>
 
   <div data-settings-tabs-target="panel"

--- a/app/views/admin/settings/_indexer_section.html.erb
+++ b/app/views/admin/settings/_indexer_section.html.erb
@@ -17,7 +17,7 @@
           {},
           id: "settings_indexer_provider",
           class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2",
-          data: { settings_form_target: "indexerProvider", action: "change->settings-form#handleIndexerProviderChange" } %>
+          data: { settings_form_target: "indexerProvider", settings_form_manual_save: true, action: "change->settings-form#toggleIndexerProvider" } %>
         <p class="mt-1 text-xs text-gray-500">Existing installs fall back to Prowlarr automatically until this is explicitly changed.</p>
       </div>
     </div>
@@ -65,7 +65,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:prowlarr_url, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.url_field "settings[prowlarr_url]", value: settings.dig(:prowlarr_url, :value), id: "settings_prowlarr_url", disabled: selected_provider != "prowlarr", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.url_field "settings[prowlarr_url]", value: settings.dig(:prowlarr_url, :value), id: "settings_prowlarr_url", disabled: selected_provider != "prowlarr", autocomplete: "off", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
 
@@ -75,7 +75,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:prowlarr_api_key, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.password_field "settings[prowlarr_api_key]", value: "", placeholder: settings.dig(:prowlarr_api_key, :value).present? ? "********" : "", id: "settings_prowlarr_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.password_field "settings[prowlarr_api_key]", value: "", placeholder: settings.dig(:prowlarr_api_key, :value).present? ? "********" : "", id: "settings_prowlarr_api_key", autocomplete: "new-password", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
 
@@ -85,7 +85,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:prowlarr_tags, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.text_field "settings[prowlarr_tags]", value: settings.dig(:prowlarr_tags, :value), id: "settings_prowlarr_tags", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.text_field "settings[prowlarr_tags]", value: settings.dig(:prowlarr_tags, :value), id: "settings_prowlarr_tags", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
     </div>
@@ -97,7 +97,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:jackett_url, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.url_field "settings[jackett_url]", value: settings.dig(:jackett_url, :value), id: "settings_jackett_url", disabled: selected_provider != "jackett", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.url_field "settings[jackett_url]", value: settings.dig(:jackett_url, :value), id: "settings_jackett_url", disabled: selected_provider != "jackett", autocomplete: "off", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
 
@@ -107,7 +107,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:jackett_api_key, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.password_field "settings[jackett_api_key]", value: "", placeholder: settings.dig(:jackett_api_key, :value).present? ? "********" : "", id: "settings_jackett_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.password_field "settings[jackett_api_key]", value: "", placeholder: settings.dig(:jackett_api_key, :value).present? ? "********" : "", id: "settings_jackett_api_key", autocomplete: "new-password", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
 
@@ -117,7 +117,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:jackett_indexer_filter, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.text_field "settings[jackett_indexer_filter]", value: settings.dig(:jackett_indexer_filter, :value), id: "settings_jackett_indexer_filter", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.text_field "settings[jackett_indexer_filter]", value: settings.dig(:jackett_indexer_filter, :value), id: "settings_jackett_indexer_filter", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
     </div>
@@ -129,7 +129,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:newznab_url, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.url_field "settings[newznab_url]", value: settings.dig(:newznab_url, :value), id: "settings_newznab_url", disabled: selected_provider != "newznab", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.url_field "settings[newznab_url]", value: settings.dig(:newznab_url, :value), id: "settings_newznab_url", disabled: selected_provider != "newznab", autocomplete: "off", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
 
@@ -139,7 +139,7 @@
           <p class="text-sm text-gray-500"><%= settings.dig(:newznab_api_key, :definition, :description) %></p>
         </div>
         <div class="md:w-2/3">
-          <%= form.password_field "settings[newznab_api_key]", value: "", placeholder: settings.dig(:newznab_api_key, :value).present? ? "********" : "", id: "settings_newznab_api_key", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>
+          <%= form.password_field "settings[newznab_api_key]", value: "", placeholder: settings.dig(:newznab_api_key, :value).present? ? "********" : "", id: "settings_newznab_api_key", autocomplete: "new-password", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>
         </div>
       </div>
     </div>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <div class="mx-auto max-w-4xl" data-controller="settings-form">
   <div id="settings-form">
     <%= render "admin/settings/form" %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,7 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
+pin "settings_navigation_guard"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@rails/actioncable", to: "actioncable.esm.js"
 pin "@rails/actioncable/src", to: "actioncable.esm.js"

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -67,15 +67,17 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     get admin_settings_url
 
     assert_response :success
-    assert_select "select[name='settings[indexer_provider]']"
+    assert_select "select[name='settings[indexer_provider]'][data-action='change->settings-form#toggleIndexerProvider']"
     assert_select "option[value='prowlarr']", text: "Prowlarr"
     assert_select "option[value='jackett']", text: "Jackett"
     assert_select "option[value='newznab']", text: "NZBHydra2 / Newznab"
-    assert_select "input[type='url'][name='settings[prowlarr_url]']:not([disabled])"
-    assert_select "input[type='url'][name='settings[jackett_url]'][disabled]"
-    assert_select "input[type='url'][name='settings[newznab_url]'][disabled]"
+    assert_select "input[type='url'][name='settings[prowlarr_url]'][autocomplete='off']:not([disabled]):not([data-action])"
+    assert_select "input[type='url'][name='settings[jackett_url]'][autocomplete='off'][disabled]:not([data-action])"
+    assert_select "input[type='url'][name='settings[newznab_url]'][autocomplete='off'][disabled]:not([data-action])"
     assert_select "input[name='settings[newznab_api_key]']"
-    assert_select "input[type='password'][name='settings[prowlarr_api_key]'][value='']"
+    assert_select "input[type='password'][name='settings[prowlarr_api_key]'][value=''][autocomplete='new-password']:not([data-action])"
+    assert_select "input[type='password'][name='settings[jackett_api_key]'][value=''][autocomplete='new-password']:not([data-action])"
+    assert_select "input[type='password'][name='settings[newznab_api_key]'][value=''][autocomplete='new-password']:not([data-action])"
     assert_no_match /stored-prowlarr-secret/, @response.body
   end
 
@@ -127,6 +129,39 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_not SettingsService.get(:ebooks_com_enabled)
   end
 
+  test "autosave validates only values authorized by its dirty keys" do
+    patch bulk_update_admin_settings_url,
+      params: {
+        autosave: "true",
+        autosave_keys: "ebooks_com_enabled",
+        settings: {
+          ebooks_com_enabled: "true",
+          ebooks_com_country_code: "US"
+        }
+      },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :unprocessable_entity
+    assert_match "requires a valid ISO 3166-1 Buyer Country Code", response.body
+    assert_not SettingsService.get(:ebooks_com_enabled)
+    assert_equal "", SettingsService.get(:ebooks_com_country_code)
+
+    patch bulk_update_admin_settings_url,
+      params: {
+        autosave: "true",
+        autosave_keys: "ebooks_com_enabled,ebooks_com_country_code",
+        settings: {
+          ebooks_com_enabled: "true",
+          ebooks_com_country_code: "US"
+        }
+      },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert SettingsService.get(:ebooks_com_enabled)
+    assert_equal "US", SettingsService.get(:ebooks_com_country_code)
+  end
+
   test "bulk_update normalizes a valid eBooks.com country and validates the offer limit" do
     patch bulk_update_admin_settings_url, params: {
       settings: {
@@ -147,7 +182,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to admin_settings_path
-    assert_match(/between 1 and #{EbooksComClient::MAX_RESULTS}/, flash[:alert])
+    assert_match(/must be an integer/, flash[:alert])
     assert_equal 3, SettingsService.get(:ebooks_com_search_limit)
 
     patch bulk_update_admin_settings_url, params: {
@@ -310,7 +345,8 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "move", SettingsService.get(:completed_download_import_mode)
   end
 
-  test "bulk_update collects an invalid import mode while saving valid settings and running side effects" do
+  test "bulk_update persists nothing and skips side effects when one setting is invalid" do
+    SettingsService.set(:flaresolverr_url, "http://old.example.com:8191")
     reset_called = false
 
     FlaresolverrClient.stub(:reset_connection!, -> { reset_called = true }) do
@@ -324,12 +360,12 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
         headers: { "Accept" => "text/vnd.turbo-stream.html" }
     end
 
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_match "turbo-stream", response.body
     assert_match "Completed Download Import Mode: must be one of: copy, move, hardlink", response.body
     assert_equal "copy", SettingsService.get(:completed_download_import_mode)
-    assert_equal "http://localhost:8191", SettingsService.get(:flaresolverr_url)
-    assert reset_called
+    assert_equal "http://old.example.com:8191", SettingsService.get(:flaresolverr_url)
+    assert_not reset_called
   end
 
   test "index shows library picker dropdown when audiobookshelf configured" do
@@ -397,6 +433,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "label[for='settings_library_platform']", text: "Active Library Platform"
+    assert_select "select[name='settings[library_platform]']:not([data-action])"
     assert_select "label[for='settings_audiobookshelf_url']", text: "Audiobookshelf URL"
     assert_select "label[for='settings_audiobookshelf_api_key']", text: "Audiobookshelf API Key"
     assert_select "label[for='settings_bookorbit_url']", text: "BookOrbit URL"
@@ -535,10 +572,130 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     get admin_settings_url
 
     assert_response :success
-    assert_select "input[type='password'][name='settings[grimmory_password]'][value='']"
-    assert_select "input[type='password'][name='settings[discord_webhook_url]'][value='']"
+    assert_select "form[autocomplete='off'][data-action='submit->settings-form#handleSubmit']"
+    assert_select "input[type='hidden'][name='autosave_keys'][data-settings-form-target='autosaveKeys']"
+    assert_select "input[type='hidden'][data-settings-form-target='manualKeys']:not([name])"
+    assert_select "button[type='submit'][name='autosave'][value='true'][hidden][data-settings-form-target='autosaveSubmit']"
+    submit_controls = css_select("form[data-settings-form-target='form'] [type='submit']")
+    assert_equal "commit", submit_controls.first["name"]
+    assert_equal "autosave", submit_controls.last["name"]
+    assert_select "input[type='password'][name='settings[grimmory_password]'][value=''][autocomplete='new-password']:not([data-action])"
+    assert_select "input[type='password'][name='settings[discord_webhook_url]'][value=''][autocomplete='new-password']:not([data-action])"
+    assert_select "input[name='settings[bookorbit_username]'][autocomplete='off']:not([data-action])"
+    assert_select "input[name='settings[zlibrary_email]'][autocomplete='off']:not([data-action])"
+    assert_select "input[name='settings[oidc_client_id]'][autocomplete='off']:not([data-action])"
+    assert_select "select[name='settings[oidc_default_role]'][data-settings-form-manual-save]:not([data-action])"
+    assert_select "input[name='settings[telegram_bot_username]'][autocomplete='off']:not([data-action])"
+    assert_select "input[name='settings[telegram_request_username]'][autocomplete='off']:not([data-action])"
+    assert_select "[data-settings-form-manual-save][data-action*='autoSave']", count: 0
     assert_no_match "existing-secret", response.body
     assert_no_match "https://discord.com/api/webhooks/existing", response.body
+  end
+
+  test "autosave rejects manual settings in its dirty manifest" do
+    SettingsService.set(:library_platform, "audiobookshelf")
+    SettingsService.set(:bookorbit_username, "existing-user")
+    SettingsService.set(:bookorbit_password, "existing-password")
+
+    patch bulk_update_admin_settings_url,
+      params: {
+        autosave: "true",
+        autosave_keys: "max_retries,library_platform,bookorbit_username,bookorbit_password",
+        settings: {
+          max_retries: "23",
+          library_platform: "bookorbit",
+          bookorbit_username: "autofilled-user",
+          bookorbit_password: "autofilled-password"
+        }
+      },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :unprocessable_entity
+    assert_match "Invalid autosave setting manifest", response.body
+    assert_equal 10, SettingsService.get(:max_retries)
+    assert_equal "audiobookshelf", SettingsService.get(:library_platform)
+    assert_equal "existing-user", SettingsService.get(:bookorbit_username)
+    assert_equal "existing-password", SettingsService.get(:bookorbit_password)
+    assert_select "turbo-stream[target='flash']", count: 1
+    assert_select "turbo-stream[target='settings-form']", count: 0
+  end
+
+  test "manual manifest excludes untouched password manager values from explicit save" do
+    SettingsService.set(:bookorbit_username, "existing-user")
+    SettingsService.set(:bookorbit_password, "existing-password")
+
+    patch bulk_update_admin_settings_url, params: {
+      manual_keys: "bookorbit_username",
+      settings: {
+        max_retries: "23",
+        bookorbit_username: "deliberate-user",
+        bookorbit_password: "autofilled-password"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal 23, SettingsService.get(:max_retries)
+    assert_equal "deliberate-user", SettingsService.get(:bookorbit_username)
+    assert_equal "existing-password", SettingsService.get(:bookorbit_password)
+  end
+
+  test "explicit save persists manual-save credentials" do
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        bookorbit_url: "https://bookorbit.example.com",
+        bookorbit_username: "book-admin",
+        bookorbit_password: "new-password"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_equal "https://bookorbit.example.com", SettingsService.get(:bookorbit_url)
+    assert_equal "book-admin", SettingsService.get(:bookorbit_username)
+    assert_equal "new-password", SettingsService.get(:bookorbit_password)
+  end
+
+  test "bulk update rejects unknown settings before persisting known values" do
+    SettingsService.set(:max_retries, 10)
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: { max_retries: "24", unknown_setting: "value" }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_match "Unknown setting: unknown_setting", flash[:alert]
+    assert_equal 10, SettingsService.get(:max_retries)
+  end
+
+  test "bulk update rejects a malformed settings container" do
+    patch bulk_update_admin_settings_url, params: { settings: "not-a-key-value-map" }
+
+    assert_redirected_to admin_settings_path
+    assert_equal "Settings must be submitted as key-value pairs", flash[:alert]
+  end
+
+  test "bulk update rejects malformed typed values" do
+    SettingsService.set(:auth_disabled, false)
+    SettingsService.set(:max_retries, 10)
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: { auth_disabled: "invalid", max_retries: "not-a-number" }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_match "Auth Disabled: must be true or false", flash[:alert]
+    assert_match "Max Retries: must be an integer", flash[:alert]
+    assert_not SettingsService.get(:auth_disabled)
+    assert_equal 10, SettingsService.get(:max_retries)
+  end
+
+  test "autosave requires a valid nonempty dirty manifest" do
+    patch bulk_update_admin_settings_url,
+      params: { autosave: "true", autosave_keys: "", settings: { max_retries: "24" } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :unprocessable_entity
+    assert_match "Invalid autosave setting manifest", response.body
+    assert_equal 10, SettingsService.get(:max_retries)
   end
 
   test "index renders env managed settings as read-only and masks secret values" do
@@ -789,6 +946,41 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "bulk_update is atomic when any submitted setting is invalid" do
+    SettingsService.set(:indexer_provider, "prowlarr")
+    SettingsService.set(:bookorbit_username, "old-bookorbit-user")
+    {
+      prowlarr: "https://prowlarr.example.com",
+      jackett: "https://jackett.example.com",
+      newznab: "https://newznab.example.com"
+    }.each do |provider, url|
+      SettingsService.set("#{provider}_url", url)
+      SettingsService.set("#{provider}_api_key", "old-#{provider}-key")
+    end
+
+    patch bulk_update_admin_settings_url, params: {
+      settings: {
+        indexer_provider: "jackett",
+        prowlarr_url: "prowlarr.example.com:9696",
+        prowlarr_api_key: "new-prowlarr-key",
+        jackett_url: "https://new-jackett.example.com",
+        jackett_api_key: "new-jackett-key",
+        newznab_url: "https://new-newznab.example.com",
+        newznab_api_key: "new-newznab-key",
+        bookorbit_username: "new-bookorbit-user"
+      }
+    }
+
+    assert_redirected_to admin_settings_path
+    assert_match "must be a valid HTTP or HTTPS URL", flash[:alert]
+    assert_equal "prowlarr", SettingsService.get(:indexer_provider)
+    %i[prowlarr jackett newznab].each do |provider|
+      assert_equal "https://#{provider}.example.com", SettingsService.get("#{provider}_url")
+      assert_equal "old-#{provider}-key", SettingsService.get("#{provider}_api_key")
+    end
+    assert_equal "old-bookorbit-user", SettingsService.get(:bookorbit_username)
+  end
+
   test "bulk_update reports malformed indexer URL in turbo response" do
     SettingsService.set(:jackett_url, "https://jackett.example.com")
 
@@ -796,7 +988,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
       params: { settings: { jackett_url: "jackett.example.com:9117" } },
       headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_match "turbo-stream", response.body
     assert_match "Jackett URL: must be a valid HTTP or HTTPS URL (include http:// or https://)", response.body
     assert_equal "https://jackett.example.com", SettingsService.get(:jackett_url)
@@ -1627,18 +1819,77 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match "turbo-stream", response.body
-    assert_match "settings-form", response.body
+    assert_select "turbo-stream[target='flash']", count: 1
+    assert_select "turbo-stream[target='settings-form']", count: 0
     assert_equal 25, SettingsService.get(:max_retries)
   end
 
-  test "bulk_update turbo stream shows error on validation failure" do
+  test "successful autosave does not replace the settings form" do
+    SettingsService.set(:rate_limit_delay, 5)
+
     patch bulk_update_admin_settings_url,
-      params: { settings: { audiobook_path_template: "{invalid_var}" } },
+      params: {
+        autosave: "true",
+        autosave_keys: "max_retries",
+        settings: { max_retries: "24", rate_limit_delay: "2" }
+      },
       headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
-    assert_match "turbo-stream", response.body
-    assert_match "flash", response.body
+    assert_response :no_content
+    assert_empty response.body
+    assert_equal 24, SettingsService.get(:max_retries)
+    assert_equal 5, SettingsService.get(:rate_limit_delay)
+  end
+
+  test "side effect failure reports a warning without retrying persisted settings" do
+    FlaresolverrClient.stub(:reset_connection!, -> { raise "reset failed" }) do
+      patch bulk_update_admin_settings_url,
+        params: { settings: { flaresolverr_url: "http://new.example.com:8191" } },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_match "Settings saved, but a follow-up action failed: reset failed", response.body
+    assert_equal "http://new.example.com:8191", SettingsService.get(:flaresolverr_url)
+  end
+
+  test "bulk_update turbo stream shows error on validation failure" do
+    original_template = SettingsService.get(:audiobook_path_template)
+
+    patch bulk_update_admin_settings_url,
+      params: {
+        autosave: "true",
+        autosave_keys: "audiobook_path_template",
+        settings: { audiobook_path_template: "{invalid_var}" }
+      },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :unprocessable_entity
+    assert_select "turbo-stream[target='flash']", count: 1
+    assert_select "turbo-stream[target='settings-form']", count: 0
+    assert_match "Audiobook Path Template", response.body
+    assert_equal original_template, SettingsService.get(:audiobook_path_template)
+  end
+
+  test "explicit turbo save preserves the live form and persists nothing on validation failure" do
+    original_template = SettingsService.get(:audiobook_path_template)
+    SettingsService.set(:bookorbit_username, "old-bookorbit-user")
+
+    patch bulk_update_admin_settings_url,
+      params: {
+        settings: {
+          audiobook_path_template: "{invalid_var}",
+          bookorbit_username: "new-bookorbit-user"
+        }
+      },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :unprocessable_entity
+    assert_select "turbo-stream[target='flash']", count: 1
+    assert_select "turbo-stream[target='settings-form']", count: 0
+    assert_equal original_template, SettingsService.get(:audiobook_path_template)
+    assert_equal "old-bookorbit-user", SettingsService.get(:bookorbit_username)
   end
 
   test "bulk_update accepts optional template syntax for filename templates" do
@@ -1770,6 +2021,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
 
       assert_response :redirect
       assert_equal "http://new.example.com", SettingsService.get(:audiobookshelf_url)
+      LibraryPlatformClient.libraries
       # If reset didn't work, it would have tried old.example.com and failed
       assert_requested(:get, "http://new.example.com/api/libraries")
     end
@@ -2179,7 +2431,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
       patch bulk_update_admin_settings_url, params: {
         settings: {
           audiobookshelf_audiobook_library_id: "lib-unavailable-delivery",
-          audiobookshelf_audiobook_scan_library_ids: ["lib-audio", "lib-unavailable-scan"]
+          audiobookshelf_audiobook_scan_library_ids: [ "lib-audio", "lib-unavailable-scan" ]
         }
       }
 

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -38,6 +38,32 @@ class SettingsServiceTest < ActiveSupport::TestCase
     assert SettingsService.active_indexer_configured?
   end
 
+  test "manual save settings include secrets and account identities" do
+    grouped_keys = %w[
+      anna_archive_api_key anna_archive_enabled anna_archive_url audiobookshelf_api_key
+      audiobookshelf_audiobook_library_id audiobookshelf_audiobook_scan_library_ids
+      audiobookshelf_comicbook_library_id audiobookshelf_comicbook_scan_library_ids
+      audiobookshelf_ebook_library_id audiobookshelf_ebook_scan_library_ids audiobookshelf_url
+      bookorbit_password bookorbit_url bookorbit_username grimmory_password grimmory_url
+      grimmory_username indexer_provider jackett_api_key jackett_indexer_filter jackett_url library_platform
+      newznab_api_key newznab_url oidc_auto_create_users oidc_auto_redirect oidc_client_id
+      oidc_client_secret oidc_default_role oidc_enabled oidc_issuer oidc_link_existing_users
+      oidc_provider_name oidc_scopes prowlarr_api_key prowlarr_tags prowlarr_url telegram_bot_token telegram_bot_username telegram_enabled
+      telegram_request_username telegram_update_mode telegram_webhook_secret webhook_enabled
+      webhook_token webhook_url zlibrary_email zlibrary_enabled zlibrary_password zlibrary_url
+      hardcover_api_token hardcover_enabled google_books_api_key google_books_enabled
+      comic_vine_api_key comic_vine_enabled discord_enabled discord_webhook_url
+    ]
+
+    assert_equal grouped_keys.sort, SettingsService::MANUAL_SAVE_SETTING_KEYS.sort
+    (grouped_keys + [ "discord_webhook_url" ]).each do |key|
+      assert SettingsService.manual_save_setting_key?(key), "expected #{key} to require an explicit save"
+    end
+
+    assert_not SettingsService.manual_save_setting_key?(:max_retries)
+    assert_not SettingsService.manual_save_setting_key?(:rate_limit_delay)
+  end
+
   test "active_indexer_provider respects explicit jackett selection" do
     SettingsService.set(:prowlarr_url, "http://localhost:9696")
     SettingsService.set(:prowlarr_api_key, "legacy-key")

--- a/test/system/third_party_integrations_test.rb
+++ b/test/system/third_party_integrations_test.rb
@@ -10,6 +10,14 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     SettingsService.set(:telegram_webhook_secret, "")
     SettingsService.set(:telegram_allowed_chat_ids, "")
     SettingsService.set(:telegram_notification_events, "request_completed,request_failed,request_attention")
+    SettingsService.set(:bookorbit_username, "")
+    SettingsService.set(:bookorbit_password, "")
+    SettingsService.set(:max_retries, 10)
+    SettingsService.set(:rate_limit_delay, 2)
+    SettingsService.set(:audiobook_path_template, "{author}/{title}")
+    SettingsService.set(:ebooks_com_enabled, false)
+    SettingsService.set(:ebooks_com_country_code, "")
+    SettingsService.set(:open_library_enabled, false)
   end
 
   test "admin opens integration settings after Turbo navigation" do
@@ -28,6 +36,112 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
 
     assert_current_path admin_settings_path
     assert_field "Audiobookshelf URL"
+  end
+
+  test "history navigation waits for a pending autosave" do
+    sign_in_as(@admin)
+    visit admin_root_path
+    click_link "Settings"
+    click_button "Queue & System"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      window.fetch = (input, options) => {
+        const url = typeof input === "string" ? input : input.url
+        if (!url.includes("/admin/settings/bulk_update")) return originalFetch(input, options)
+
+        document.querySelector("[data-settings-form-target='form']").dataset.historyAutosaveStarted = "true"
+        return new Promise((resolve) => {
+          window.releaseHistoryAutosave = () => resolve(originalFetch(input, options))
+        })
+      }
+    JAVASCRIPT
+
+    fill_in "Max Retries", with: "29"
+    page.go_back
+
+    assert_current_path admin_settings_path
+    assert_selector "form[data-history-autosave-started='true']"
+    assert_no_text "Admin Dashboard"
+    page.execute_script("window.releaseHistoryAutosave()")
+    assert_text "Admin Dashboard"
+    assert_equal 29, SettingsService.get(:max_retries)
+
+    page.go_forward
+    assert_current_path admin_settings_path
+    assert_selector "form[data-settings-form-target='form']:not([inert])[aria-busy='false']", visible: :all
+    assert_selector "[data-settings-form-target='status'].hidden", visible: :all
+  end
+
+  test "Turbo visit waits for a pending autosave" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Queue & System"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      window.fetch = (input, options) => {
+        const url = typeof input === "string" ? input : input.url
+        if (!url.includes("/admin/settings/bulk_update")) return originalFetch(input, options)
+
+        document.querySelector("[data-settings-form-target='form']").dataset.visitAutosaveStarted = "true"
+        return new Promise((resolve) => {
+          window.releaseVisitAutosave = () => resolve(originalFetch(input, options))
+        })
+      }
+    JAVASCRIPT
+
+    fill_in "Max Retries", with: "32"
+    find("h1", text: "Settings").click
+    click_link "Admin", match: :first
+
+    assert_current_path admin_settings_path
+    assert_selector "form[data-visit-autosave-started='true']"
+    assert_no_text "Admin Dashboard"
+    page.execute_script("window.releaseVisitAutosave()")
+
+    assert_text "Admin Dashboard"
+    assert_current_path admin_root_path
+    assert_equal 32, SettingsService.get(:max_retries)
+  end
+
+  test "Turbo visit confirms deliberate unsaved credential changes" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Integrations"
+    fill_in "BookOrbit Username", with: "manual-draft"
+
+    dismiss_confirm do
+      click_link "Admin", match: :first
+    end
+
+    assert_current_path admin_settings_path
+    assert_field "BookOrbit Username", with: "manual-draft"
+
+    accept_confirm do
+      click_link "Admin", match: :first
+    end
+
+    assert_current_path admin_root_path
+    assert_equal "", SettingsService.get(:bookorbit_username)
+  end
+
+  test "history navigation confirms deliberate unsaved credential changes" do
+    sign_in_as(@admin)
+    visit admin_root_path
+    click_link "Settings"
+    click_button "Integrations"
+    fill_in "BookOrbit Username", with: "history-draft"
+
+    dismiss_confirm { page.go_back }
+
+    assert_current_path admin_settings_path
+    assert_field "BookOrbit Username", with: "history-draft"
+
+    accept_confirm { page.go_back }
+
+    assert_current_path admin_root_path
+    assert_equal "", SettingsService.get(:bookorbit_username)
   end
 
   test "admin opens Audible Backup tabs after Turbo navigation" do
@@ -61,6 +175,9 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     fill_in "Telegram Allowed Chat Ids", with: "-100123"
     fill_in "Telegram Notification Events", with: "request_completed,request_failed"
 
+    click_link "Test Telegram Bot"
+    assert_text "Save all changes before running this action."
+
     click_button "Save All"
 
     assert_text "Settings updated successfully."
@@ -81,6 +198,379 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     assert_text "Telegram connection successful: @ShelfarrBot"
   end
 
+  test "settings autosave ignores autofilled credentials and preserves the live form" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Integrations"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      window.settingsBulkUpdateCount = 0
+      window.fetch = (input, options) => {
+        const url = typeof input === "string" ? input : input.url
+        if (url.includes("/admin/settings/bulk_update")) window.settingsBulkUpdateCount += 1
+        return originalFetch(input, options)
+      }
+      document.querySelector("#settings-form").dataset.autofillTestNode = "original"
+
+      const username = document.querySelector("#settings_bookorbit_username")
+      const password = document.querySelector("#settings_bookorbit_password")
+      username.value = "autofilled-user"
+      password.value = "autofilled-password"
+      username.dispatchEvent(new Event("change", { bubbles: true }))
+      password.dispatchEvent(new Event("change", { bubbles: true }))
+    JAVASCRIPT
+
+    sleep 1
+    assert_equal 0, page.evaluate_script("window.settingsBulkUpdateCount")
+    assert_selector "#settings-form[data-autofill-test-node='original']"
+
+    click_button "Queue & System"
+    page.execute_script <<~JAVASCRIPT
+      const staleDraft = document.querySelector("#settings_rate_limit_delay")
+      staleDraft.value = "7"
+      staleDraft.dispatchEvent(new Event("input", { bubbles: true }))
+    JAVASCRIPT
+    fill_in "Max Retries", with: "22"
+    find("h1", text: "Settings").click
+
+    assert_selector "[data-settings-form-target='status'].hidden", visible: :all
+    assert_no_text "Settings updated successfully."
+    assert_equal 22, SettingsService.get(:max_retries)
+    assert_equal 2, SettingsService.get(:rate_limit_delay)
+    assert_equal "", SettingsService.get(:bookorbit_username)
+    assert_equal "", SettingsService.get(:bookorbit_password)
+    assert_field "Rate Limit Delay", with: "7"
+    assert_equal 1, page.evaluate_script("window.settingsBulkUpdateCount")
+    assert_selector "#settings-form[data-autofill-test-node='original']"
+
+    click_button "Integrations"
+    assert_field "BookOrbit Username", with: "autofilled-user"
+    assert_field "BookOrbit Password", with: "autofilled-password"
+    page.execute_script <<~JAVASCRIPT
+      document.querySelector("[data-settings-form-target='form']").addEventListener("submit", (event) => {
+        window.lastSettingsSubmit = {
+          submitter: event.submitter?.name,
+          fields: Array.from(new FormData(event.target, event.submitter).keys())
+        }
+      })
+    JAVASCRIPT
+
+    click_button "Save All"
+
+    assert_text "Settings updated successfully."
+    submission = page.evaluate_script("window.lastSettingsSubmit")
+    assert_equal "commit", submission.fetch("submitter")
+    assert_not_includes submission.fetch("fields"), "autosave"
+    assert_equal "", SettingsService.get(:bookorbit_username)
+    assert_equal "", SettingsService.get(:bookorbit_password)
+    assert_field "BookOrbit Password", with: ""
+    assert_equal 2, page.evaluate_script("window.settingsBulkUpdateCount")
+    assert_selector "#settings-form[data-autofill-test-node='original']"
+    find("button[aria-label='Dismiss notification']", visible: :all).click
+
+    fill_in "BookOrbit Username", with: "deliberate-user"
+    fill_in "BookOrbit Password", with: "deliberate-password"
+    assert_text "Unsaved changes. Click Save All."
+    click_button "Save All"
+
+    assert_text "Settings updated successfully."
+    assert_equal "deliberate-user", SettingsService.get(:bookorbit_username)
+    assert_equal "deliberate-password", SettingsService.get(:bookorbit_password)
+    assert_equal 3, page.evaluate_script("window.settingsBulkUpdateCount")
+  end
+
+  test "switching indexer provider ignores a touched field that becomes disabled" do
+    SettingsService.set(:indexer_provider, "prowlarr")
+    SettingsService.set(:prowlarr_url, "https://prowlarr.example.com")
+    sign_in_as(@admin)
+    visit admin_settings_path
+
+    fill_in "Prowlarr Url", with: "https://draft-prowlarr.example.com"
+    select "Jackett", from: "Provider"
+    click_button "Save All"
+
+    assert_text "Settings updated successfully."
+    assert_equal "jackett", SettingsService.get(:indexer_provider)
+    assert_equal "https://prowlarr.example.com", SettingsService.get(:prowlarr_url)
+  end
+
+  test "settings form blocks overlapping edits while an autosave is in flight" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Integrations"
+    fill_in "BookOrbit Username", with: "manual-user"
+    fill_in "BookOrbit Password", with: "manual-password"
+    click_button "Queue & System"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      let activeRequests = 0
+      window.settingsFetchCount = 0
+      window.settingsMaxConcurrentFetches = 0
+      window.fetch = (input, options) => {
+        const url = typeof input === "string" ? input : input.url
+        if (!url.includes("/admin/settings/bulk_update")) return originalFetch(input, options)
+
+        window.settingsFetchCount += 1
+        activeRequests += 1
+        window.settingsMaxConcurrentFetches = Math.max(window.settingsMaxConcurrentFetches, activeRequests)
+        document.documentElement.dataset.settingsFetchCount = window.settingsFetchCount
+        const performFetch = () => originalFetch(input, options).finally(() => { activeRequests -= 1 })
+        if (window.settingsFetchCount > 1) return performFetch()
+
+        return new Promise((resolve) => {
+          window.releaseSettingsAutosave = () => resolve(performFetch())
+        })
+      }
+    JAVASCRIPT
+
+    fill_in "Max Retries", with: "21"
+    find_field("Rate Limit Delay").click
+
+    assert_selector "html[data-settings-fetch-count='1']"
+    assert_selector "form[data-settings-form-target='form'][inert][aria-busy='true']", visible: :all
+    page.execute_script <<~JAVASCRIPT
+      const field = document.querySelector("#settings_rate_limit_delay")
+      field.value = "4"
+      field.dispatchEvent(new Event("change", { bubbles: true }))
+      const outsideLink = Array.from(document.querySelectorAll("a")).find((link) => link.textContent.trim() === "Admin")
+      outsideLink.id = "outside-focus-target"
+      outsideLink.focus()
+    JAVASCRIPT
+    assert_equal "outside-focus-target", page.evaluate_script("document.activeElement.id")
+    assert_equal 1, page.evaluate_script("window.settingsFetchCount")
+    page.execute_script("window.releaseSettingsAutosave()")
+
+    assert_text "Unsaved changes. Click Save All."
+    assert_selector "form[data-settings-form-target='form']:not([inert])[aria-busy='false']", visible: :all
+    assert_equal "settings_rate_limit_delay", page.evaluate_script("document.activeElement.id")
+    assert_equal 21, SettingsService.get(:max_retries)
+    assert_equal 4, SettingsService.get(:rate_limit_delay)
+    assert_equal 2, page.evaluate_script("window.settingsFetchCount")
+    assert_equal 1, page.evaluate_script("window.settingsMaxConcurrentFetches")
+
+    click_button "Save All"
+
+    assert_selector "form[data-settings-form-target='form']:not([inert])[aria-busy='false']", visible: :all
+    assert_equal "manual-user", SettingsService.get(:bookorbit_username)
+    assert_equal "manual-password", SettingsService.get(:bookorbit_password)
+  end
+
+  test "in-form connection test waits for pending autosave" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Queue & System"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      window.settingsRequestOrder = []
+      window.fetch = (input, options) => {
+        const url = new URL(typeof input === "string" ? input : input.url, window.location.origin)
+        if (!url.pathname.includes("/admin/settings/")) return originalFetch(input, options)
+
+        window.settingsRequestOrder.push(url.pathname)
+        document.documentElement.dataset.settingsRequestOrder = window.settingsRequestOrder.join(",")
+        if (url.pathname !== "/admin/settings/bulk_update") return originalFetch(input, options)
+
+        return new Promise((resolve) => {
+          window.releaseSettingsAutosave = () => resolve(originalFetch(input, options))
+        })
+      }
+    JAVASCRIPT
+
+    fill_in "Max Retries", with: "26"
+    find("h1", text: "Settings").click
+    click_button "Search"
+    click_button "Test eBooks.com Catalog"
+
+    assert_selector "html[data-settings-request-order='/admin/settings/bulk_update']"
+    assert_equal [ "/admin/settings/bulk_update" ], page.evaluate_script("window.settingsRequestOrder")
+    page.execute_script("window.releaseSettingsAutosave()")
+
+    assert_text "Enable eBooks.com and enter a valid two-letter buyer country code first.", wait: 10
+    assert_selector "[data-settings-form-target='status'].hidden", visible: :all
+    assert_equal 26, SettingsService.get(:max_retries)
+    assert_equal [
+      "/admin/settings/bulk_update",
+      "/admin/settings/test_ebooks_com"
+    ], page.evaluate_script("window.settingsRequestOrder")
+  end
+
+  test "Turbo method link waits for pending autosave" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Queue & System"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      window.settingsRequestOrder = []
+      window.fetch = (input, options) => {
+        const url = new URL(typeof input === "string" ? input : input.url, window.location.origin)
+        if (!url.pathname.includes("/admin/settings/")) return originalFetch(input, options)
+
+        window.settingsRequestOrder.push(url.pathname)
+        document.documentElement.dataset.settingsRequestOrder = window.settingsRequestOrder.join(",")
+        if (url.pathname !== "/admin/settings/bulk_update") return originalFetch(input, options)
+
+        return new Promise((resolve) => {
+          window.releaseSettingsAutosave = () => resolve(originalFetch(input, options))
+        })
+      }
+    JAVASCRIPT
+
+    fill_in "Max Retries", with: "30"
+    click_button "Integrations"
+    click_link "Test Open Library Connection"
+
+    assert_selector "html[data-settings-request-order='/admin/settings/bulk_update']"
+    assert_equal [ "/admin/settings/bulk_update" ], page.evaluate_script("window.settingsRequestOrder")
+    page.execute_script("window.releaseSettingsAutosave()")
+
+    assert_text "Open Library is not enabled."
+    assert_equal 30, SettingsService.get(:max_retries)
+    assert_equal [
+      "/admin/settings/bulk_update",
+      "/admin/settings/test_open_library"
+    ], page.evaluate_script("window.settingsRequestOrder")
+  end
+
+  test "failed autosave retries its dirty keys with the next change" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Queue & System"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      let failed = false
+      window.fetch = (input, options) => {
+        const url = typeof input === "string" ? input : input.url
+        if (!failed && url.includes("/admin/settings/bulk_update")) {
+          failed = true
+          return Promise.reject(new TypeError("simulated network failure"))
+        }
+        return originalFetch(input, options)
+      }
+    JAVASCRIPT
+
+    fill_in "Max Retries", with: "27"
+    find("h1", text: "Settings").click
+    assert_selector "[data-settings-form-target='status']:not(.hidden)", visible: :all
+    assert_text "Autosave failed. Change the setting to retry."
+    assert_equal 10, SettingsService.get(:max_retries)
+
+    fill_in "Rate Limit Delay", with: "4"
+    find("h1", text: "Settings").click
+
+    assert_selector "[data-settings-form-target='status'].hidden", visible: :all
+    assert_equal 27, SettingsService.get(:max_retries)
+    assert_equal 4, SettingsService.get(:rate_limit_delay)
+  end
+
+  test "failed explicit save keeps drafts and retries the full form" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Queue & System"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      let failed = false
+      window.fetch = (input, options) => {
+        const url = typeof input === "string" ? input : input.url
+        if (!failed && url.includes("/admin/settings/bulk_update")) {
+          failed = true
+          document.documentElement.dataset.explicitSaveFailed = "true"
+          return Promise.reject(new TypeError("simulated network failure"))
+        }
+        return originalFetch(input, options)
+      }
+    JAVASCRIPT
+
+    fill_in "Max Retries", with: "28"
+    click_button "Integrations"
+    fill_in "BookOrbit Username", with: "retry-user"
+    fill_in "BookOrbit Password", with: "retry-password"
+    click_button "Save All"
+
+    assert_selector "html[data-explicit-save-failed='true']"
+    assert_selector "form[data-settings-form-target='form']:not([inert])[aria-busy='false']", visible: :all
+    assert_equal 10, SettingsService.get(:max_retries)
+    assert_equal "", SettingsService.get(:bookorbit_username)
+    assert_field "BookOrbit Username", with: "retry-user"
+    assert_field "BookOrbit Password", with: "retry-password"
+
+    click_button "Save All"
+
+    assert_text "Settings updated successfully."
+    assert_equal 28, SettingsService.get(:max_retries)
+    assert_equal "retry-user", SettingsService.get(:bookorbit_username)
+    assert_equal "retry-password", SettingsService.get(:bookorbit_password)
+  end
+
+  test "invalid explicit save is atomic and preserves the live form" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    click_button "Downloads"
+    fill_in "Audiobook Path Template", with: "{title}/{invalid_var}"
+    click_button "Integrations"
+    fill_in "BookOrbit Username", with: "draft-user"
+
+    click_button "Save All"
+
+    assert_text "Audiobook Path Template"
+    assert_text "Unknown variables: {invalid_var}"
+    assert_equal "{author}/{title}", SettingsService.get(:audiobook_path_template)
+    assert_equal "", SettingsService.get(:bookorbit_username)
+    assert_field "BookOrbit Username", with: "draft-user"
+    click_button "Downloads"
+    assert_field "Audiobook Path Template", with: "{title}/{invalid_var}"
+
+    fill_in "Audiobook Path Template", with: "{author}/{title}/{year}"
+    click_button "Save All"
+
+    assert_text "Settings updated successfully."
+    assert_equal "{author}/{title}/{year}", SettingsService.get(:audiobook_path_template)
+    assert_equal "draft-user", SettingsService.get(:bookorbit_username)
+  end
+
+  test "validation failure retries rejected dependencies after correction" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+
+    check "Show DRM-free eBooks.com Offers"
+
+    assert_text "requires a valid ISO 3166-1 Buyer Country Code"
+    assert_text "Autosave failed. Change the setting to retry."
+    assert_not SettingsService.get(:ebooks_com_enabled)
+
+    fill_in "Buyer Country Code", with: "US"
+    find("h1", text: "Settings").click
+
+    assert_selector "[data-settings-form-target='status'].hidden", visible: :all
+    assert SettingsService.get(:ebooks_com_enabled)
+    assert_equal "US", SettingsService.get(:ebooks_com_country_code)
+  end
+
+  test "failed autosave cancels deferred navigation until correction" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+
+    check "Show DRM-free eBooks.com Offers"
+    click_link "Admin", match: :first
+
+    assert_current_path admin_settings_path
+    assert_text "requires a valid ISO 3166-1 Buyer Country Code"
+    assert_not SettingsService.get(:ebooks_com_enabled)
+
+    fill_in "Buyer Country Code", with: "US"
+    find("h1", text: "Settings").click
+    assert_selector "[data-settings-form-target='status'].hidden", visible: :all
+    assert SettingsService.get(:ebooks_com_enabled)
+
+    click_link "Admin", match: :first
+    assert_current_path admin_root_path
+  end
+
   test "admin authorizes a Telegram group with a pairing code" do
     _authorization, code = TelegramChatAuthorization.issue!(
       chat_id: "-100999",
@@ -91,13 +581,34 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     sign_in_as(@admin)
 
     visit admin_settings_path
+    click_button "Queue & System"
+    fill_in "Max Retries", with: "31"
     click_button "Integrations"
+
+    page.execute_script <<~JAVASCRIPT
+      const originalFetch = window.fetch.bind(window)
+      window.fetch = (input, options) => {
+        const url = typeof input === "string" ? input : input.url
+        if (!url.includes("/admin/settings/bulk_update")) return originalFetch(input, options)
+
+        document.documentElement.dataset.telegramAutosaveStarted = "true"
+        return new Promise((resolve) => {
+          window.releaseTelegramAutosave = () => resolve(originalFetch(input, options))
+        })
+      }
+    JAVASCRIPT
 
     assert_text "Telegram Group Authorization"
     fill_in "telegram_group_code", with: code
     click_button "Authorize Group"
 
+    assert_selector "html[data-telegram-autosave-started='true']"
+    assert_not TelegramChatAuthorization.find_by!(chat_id: "-100999").approved?
+    assert_no_text "Telegram group authorized: Book Club"
+    page.execute_script("window.releaseTelegramAutosave()")
+
     assert_text "Telegram group authorized: Book Club"
+    assert_equal 31, SettingsService.get(:max_retries)
     click_button "Integrations"
     assert_text "Authorized"
     assert TelegramChatAuthorization.find_by!(chat_id: "-100999").approved?


### PR DESCRIPTION
## Summary
- restrict autosave to deliberately changed non-sensitive settings without replacing the live form
- keep credentials and dependent connection settings behind explicit touched-field saves with atomic validation
- serialize saves, settings actions, and navigation while preserving drafts across failures and history traversal
- add controller, service, and browser regressions for autofill, retries, ordering, focus, and navigation

## Test plan
- `bin/quality push`
- `bundle exec rails test:system test/system/third_party_integrations_test.rb`

Closes #385