### PR TITLE
fix: restore OIDC sign-in origin

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,10 +27,10 @@ module Shelfarr
     # Set RAILS_RELATIVE_URL_ROOT environment variable to configure
     config.relative_url_root = ENV.fetch("RAILS_RELATIVE_URL_ROOT", "/")
 
-    # Covers and store links are supplied by external catalog providers. Never
-    # disclose a self-hosted Shelfarr URL (which may contain a private hostname
-    # or path prefix) when a browser fetches one of those resources.
-    config.action_dispatch.default_headers["Referrer-Policy"] = "no-referrer"
+    # Covers and store links are supplied by external catalog providers. Avoid
+    # disclosing a self-hosted Shelfarr URL while retaining the origin for
+    # same-origin form submissions such as the OIDC handoff.
+    config.action_dispatch.default_headers["Referrer-Policy"] = "same-origin"
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/test/controllers/library_controller_test.rb
+++ b/test/controllers/library_controller_test.rb
@@ -21,7 +21,7 @@ class LibraryControllerTest < ActionDispatch::IntegrationTest
 
     get library_index_path
     assert_response :success
-    assert_equal "no-referrer", response.headers["Referrer-Policy"]
+    assert_equal "same-origin", response.headers["Referrer-Policy"]
     assert_select "h1", "Library"
     assert_select "a[href='#{library_path(@acquired_audiobook)}']"
     assert_select "[data-library-card][data-library-source='shelfarr'][class~='motion-reduce:transition-none'][class~='motion-reduce:hover:scale-100']"


### PR DESCRIPTION
## Summary
- change the global referrer policy from `no-referrer` to `same-origin`
- preserve cross-origin referrer privacy while allowing Rails to validate the OIDC handoff POST
- update the response-header regression expectation

Closes #381

## Test plan
- reproduced the null-origin failure on unmodified `main` with production-mode Chromium
- verified the patched OIDC handoff reaches the Google authorization endpoint without the null-origin error
- `bin/quality commit --staged`
- `bin/quality push`