### PR TITLE
fix: support root-squashed NFS imports

### DIFF
--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -26,6 +26,7 @@ class FileCopyService
   COPY_LOCK_LEGACY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_LEGACY_MAGIC)}:([0-9a-f]{32})\z/
   COPY_LOCK_PENDING_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):pending\z/
   COPY_LOCK_RECORD_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):full:([0-9]+):([0-9]+)\z/
+  OWNER_PROBE_PATTERN = /\A\.shelfarr-owner-probe-[0-9a-f]{32}\.tmp\z/
   COPY_LOCK_COMPATIBILITY_PREPARED_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:prepared:([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_LOCK_COMPATIBILITY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:(copying|complete):([0-9]+):([0-9]+):([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
@@ -298,7 +299,7 @@ class FileCopyService
 
     def secure_private_directory!(path, root:)
       with_pinned_directory(path, root: root, create: true, mode: 0o700) do |directory|
-        unless directory.stat.uid == Process.euid
+        unless private_entry_owned_by_process?(directory.stat, directory)
           raise UnsafePathError, "private staging directory is owned by another user"
         end
         apply_directory_mode!(directory, 0o700)
@@ -313,7 +314,7 @@ class FileCopyService
       end
 
       with_pinned_directory(parent_path, root: root, create: true, mode: 0o700) do |parent|
-        unless parent.stat.uid == Process.euid
+        unless private_entry_owned_by_process?(parent.stat, parent)
           raise UnsafePathError, "private staging parent is owned by another user"
         end
         apply_directory_mode!(parent, 0o700)
@@ -359,7 +360,7 @@ class FileCopyService
       end
 
       with_pinned_directory(parent_path, root: root, create: false, mode: 0o700) do |parent|
-        unless parent.stat.uid == Process.euid
+        unless private_entry_owned_by_process?(parent.stat, parent)
           raise UnsafePathError, "private staging directory is owned by another user"
         end
 
@@ -429,7 +430,7 @@ class FileCopyService
         lock = File.for_fd(descriptor, "r+b", autoclose: true)
         begin
           stat = lock.stat
-          unless stat.file? && stat.uid == Process.euid
+          unless stat.file? && private_entry_owned_by_process?(stat, parent)
             raise UnsafePathError, "private lock is not an application-owned regular file"
           end
 
@@ -1284,6 +1285,8 @@ class FileCopyService
               entry,
               [ match[1].to_i(16), match[2].to_i(16) ]
             )
+          elsif OWNER_PROBE_PATTERN.match?(entry)
+            cleanup_interrupted_owner_probe(parent, entry)
           end
         end
         validate_current_directory_identity!(parent_path, parent)
@@ -1336,6 +1339,39 @@ class FileCopyService
     end
 
     private
+
+    # root_squash changes the UID reported for root-created entries. Discover
+    # that mapping from an exclusive entry on the same filesystem.
+    def private_entry_owned_by_process?(stat, parent)
+      effective_uid = Process.euid
+      return true if stat.uid == effective_uid
+      return false unless effective_uid.zero?
+
+      probe_basename = ".shelfarr-owner-probe-#{SecureRandom.hex(16)}.tmp"
+      probe_identity = nil
+      probe_uid = nil
+      trusted = false
+      begin
+        with_created_regular_child(parent, probe_basename, 0o600) do |probe|
+          probe_stat = probe.stat
+          probe_identity = file_identity(probe_stat)
+          probe_uid = probe_stat.uid
+          trusted = probe_stat.dev == stat.dev && probe_uid == stat.uid
+        end
+      ensure
+        if probe_identity
+          cleanup = remove_pinned_child_if_identity(
+            parent,
+            probe_basename,
+            probe_identity,
+            expected_owner_uid: probe_uid
+          )
+          trusted = false unless cleanup.in?([ :removed, :missing ])
+          cleanup_interrupted_owner_probes(parent, probe_uid)
+        end
+      end
+      trusted
+    end
 
     def safe_relative_path(path)
       relative = Pathname(path.to_s)
@@ -1807,7 +1843,7 @@ class FileCopyService
 
       with_pinned_regular_child(parent, lock_basename) do |lock|
         return unless lock.flock(File::LOCK_EX | File::LOCK_NB)
-        return unless lock.stat.uid == Process.euid
+        return unless private_entry_owned_by_process?(lock.stat, parent)
 
         lock_identity = file_identity(lock.stat)
         lock.rewind
@@ -1879,11 +1915,44 @@ class FileCopyService
       nil
     end
 
+    def cleanup_interrupted_owner_probes(parent, expected_owner_uid)
+      pinned_directory_children(parent).each do |entry|
+        next unless OWNER_PROBE_PATTERN.match?(entry)
+
+        cleanup_interrupted_owner_probe(parent, entry, expected_owner_uid: expected_owner_uid)
+      end
+    rescue Errno::ENOENT, Errno::EACCES, IOError
+      nil
+    end
+
+    def cleanup_interrupted_owner_probe(parent, basename, expected_owner_uid: nil)
+      identity = nil
+      with_pinned_regular_child(parent, basename) do |probe|
+        stat = probe.stat
+        owner_trusted = if expected_owner_uid
+          stat.uid == expected_owner_uid
+        else
+          private_entry_owned_by_process?(stat, parent)
+        end
+        return unless owner_trusted
+
+        identity = file_identity(stat)
+      end
+      remove_pinned_child_if_identity(
+        parent,
+        basename,
+        identity,
+        expected_owner_uid: expected_owner_uid
+      )
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, IOError, UnsafePathError
+      nil
+    end
+
     def cleanup_interrupted_quarantine(parent, basename, expected_identity)
       quarantine = open_pinned_directory_child(parent, basename)
       begin
         stat = quarantine.stat
-        return unless stat.uid == Process.euid && (stat.mode & 0o777) == 0o700
+        return unless private_entry_owned_by_process?(stat, parent) && (stat.mode & 0o777) == 0o700
 
         quarantine_identity = file_identity(stat)
         children = pinned_directory_children(quarantine)
@@ -2634,7 +2703,8 @@ class FileCopyService
       expected_identity,
       expected_manifest: nil,
       before_remove: nil,
-      quarantine_kind: :copy
+      quarantine_kind: :copy,
+      expected_owner_uid: nil
     )
       return :mismatch unless expected_identity
 
@@ -2652,7 +2722,8 @@ class FileCopyService
       quarantine, quarantine_basename, quarantine_identity = create_cleanup_quarantine(
         parent,
         expected_identity,
-        kind: quarantine_kind
+        kind: quarantine_kind,
+        expected_owner_uid: expected_owner_uid
       )
       moved = false
       begin
@@ -2737,7 +2808,7 @@ class FileCopyService
       :retained
     end
 
-    def create_cleanup_quarantine(parent, expected_identity, kind: :copy)
+    def create_cleanup_quarantine(parent, expected_identity, kind: :copy, expected_owner_uid: nil)
       prefix = kind == :source ? ".shelfarr-source-quarantine" : ".shelfarr-copy-quarantine"
       loop do
         basename = "#{prefix}-#{expected_identity.first.to_s(16)}-" \
@@ -2751,7 +2822,12 @@ class FileCopyService
         quarantine = open_pinned_directory_child(parent, basename)
         begin
           stat = quarantine.stat
-          unless stat.uid == Process.euid
+          owner_trusted = if expected_owner_uid
+            stat.uid == expected_owner_uid
+          else
+            private_entry_owned_by_process?(stat, parent)
+          end
+          unless owner_trusted
             raise UnsafePathError, "cleanup quarantine is owned by another user"
           end
 
@@ -2808,7 +2884,7 @@ class FileCopyService
 
         quarantine = open_pinned_directory_child(parent, basename)
         begin
-          next unless quarantine.stat.uid == Process.euid
+          next unless private_entry_owned_by_process?(quarantine.stat, parent)
           next unless pinned_directory_children(quarantine) == [ COPY_QUARANTINE_ENTRY ]
 
           matches = false
@@ -2857,7 +2933,7 @@ class FileCopyService
 
         quarantine = open_pinned_directory_child(parent, basename)
         begin
-          next false unless quarantine.stat.uid == Process.euid
+          next false unless private_entry_owned_by_process?(quarantine.stat, parent)
           next false unless pinned_directory_children(quarantine) == [ COPY_QUARANTINE_ENTRY ]
 
           matches = false

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,15 @@
 require "test_helper"
 
+module ChromeStaleNodeVisibilityRetry
+  def visible?
+    super
+  rescue Selenium::WebDriver::Error::UnknownError => error
+    raise unless error.message.include?("Node with given id does not belong to the document")
+
+    raise Selenium::WebDriver::Error::StaleElementReferenceError, error.message
+  end
+end
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ],
     options: { native_displayed: true } do |options|
@@ -16,3 +26,5 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     page.driver.browser.manage.add_cookie(name: "session_id", value: signed_session_id, path: "/")
   end
 end
+
+Capybara::Selenium::ChromeNode.prepend(ChromeStaleNodeVisibilityRetry)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ] do |options|
+  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ],
+    options: { native_displayed: true } do |options|
     options.add_argument("--no-sandbox") if Process.uid.zero?
   end
 

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -1992,7 +1992,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_empty Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*"))
   end
 
-  test "remove_source_file recovers a source quarantined by a hard interruption" do
+  test "remove_source_file recovers a root-squashed source quarantine after a hard interruption" do
     snapshot = FileCopyService.snapshot_source_file(@src_file)
     real_unlink = FileCopyService.method(:native_unlinkat)
     interrupted = false
@@ -2010,9 +2010,12 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       assert_raises(Interrupt) { FileCopyService.remove_source_file(snapshot) }
     end
     assert_not File.exist?(@src_file)
-    assert_equal 1, Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*")).size
+    quarantine = Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*")).sole
+    chown_for_root_squash(quarantine)
 
-    assert FileCopyService.remove_source_file(snapshot)
+    with_root_squashed_creation(@tmp_dir) do
+      assert FileCopyService.remove_source_file(snapshot)
+    end
     assert_empty Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*"))
   end
 
@@ -2050,12 +2053,16 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     File.binwrite(replacement, "replacement source")
     File.symlink(replacement, @src_file)
     File.binwrite(destination, "changed destination")
+    quarantine = Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*")).sole
+    chown_for_root_squash(quarantine)
 
-    assert_not FileCopyService.remove_source_file(
-      source_snapshot,
-      destination_snapshot: destination_snapshot
-    )
-    assert FileCopyService.source_file_quarantined?(source_snapshot)
+    with_root_squashed_creation(@tmp_dir) do
+      assert_not FileCopyService.remove_source_file(
+        source_snapshot,
+        destination_snapshot: destination_snapshot
+      )
+      assert FileCopyService.source_file_quarantined?(source_snapshot)
+    end
     assert_equal "replacement source", File.binread(@src_file)
   end
 

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -363,6 +363,26 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_empty Dir.children(@dest_dir) - [ "hardlinked.txt" ]
   end
 
+  test "copy and hardlink publication allow root-squashed cleanup ownership" do
+    copied = File.join(@dest_dir, "copied.txt")
+    hardlinked = File.join(@dest_dir, "hardlinked.txt")
+
+    with_root_squashed_creation(@dest_dir) do
+      FileCopyService.cp_noreplace(@src_file, copied, root: @dest_dir)
+      FileCopyService.hardlink_noreplace(
+        @src_file,
+        hardlinked,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert_equal "test content", File.binread(copied)
+    assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
+      [ File.stat(hardlinked).dev, File.stat(hardlinked).ino ]
+    assert_equal [ "copied.txt", "hardlinked.txt" ], Dir.children(@dest_dir).sort
+  end
+
   test "hardlink_noreplace never overwrites an occupied destination" do
     destination = File.join(@dest_dir, "hardlinked.txt")
     File.binwrite(destination, "existing library bytes")
@@ -808,6 +828,47 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
 
     assert_not File.exist?(lock)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "private locks and interrupted cleanup allow root-squashed ownership" do
+    private_lock = File.join(@dest_dir, ".archive-build-slot-00")
+    File.binwrite(private_lock, "")
+    chown_for_root_squash(private_lock)
+    acquired = false
+
+    with_root_squashed_creation(@dest_dir) do
+      FileCopyService.with_private_lock(private_lock, root: @dest_dir) do
+        acquired = true
+      end
+    end
+    assert acquired
+
+    FileUtils.rm_f(private_lock)
+    token = "a" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    File.binwrite(temporary, "interrupted bytes")
+    lock = write_copy_lock(token, File.stat(temporary))
+    chown_for_root_squash(temporary)
+    chown_for_root_squash(lock)
+
+    with_root_squashed_creation(@dest_dir) do
+      FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+    end
+
+    assert_not File.exist?(temporary)
+    assert_not File.exist?(lock)
+    assert_empty Dir.children(@dest_dir)
+
+    abandoned_probe = File.join(@dest_dir, ".shelfarr-owner-probe-#{'b' * 32}.tmp")
+    File.binwrite(abandoned_probe, "")
+    chown_for_root_squash(abandoned_probe)
+
+    with_root_squashed_creation(@dest_dir) do
+      FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+    end
+
+    assert_not File.exist?(abandoned_probe)
     assert_empty Dir.children(@dest_dir)
   end
 
@@ -2184,6 +2245,60 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal 0o700, File.stat(created.name).mode & 0o777
   end
 
+  test "private staging allows a root-squashed directory owner" do
+    parent = File.join(@dest_dir, "private-staging")
+    abandoned_probe = File.join(parent, ".shelfarr-owner-probe-#{'c' * 32}.tmp")
+    FileUtils.mkdir_p(parent)
+    chown_for_root_squash(parent)
+    File.binwrite(abandoned_probe, "")
+    chown_for_root_squash(abandoned_probe)
+
+    with_root_squashed_creation(parent) do
+      FileCopyService.secure_private_directory!(parent, root: @dest_dir)
+      created = FileCopyService.create_private_directory(
+        parent,
+        root: @dest_dir,
+        prefix: "download-42-"
+      )
+      private_file = FileCopyService.create_private_file(
+        parent,
+        root: @dest_dir,
+        prefix: "archive-",
+        suffix: ".zip"
+      )
+
+      private_file.io.close
+      assert File.directory?(created.name)
+      assert File.file?(private_file.name)
+      assert_not File.exist?(abandoned_probe)
+    end
+  end
+
+  test "private staging rejects an unrelated owner when running as local root" do
+    skip "requires root to create an unrelated owner" unless Process.uid.zero?
+
+    parent = File.join(@dest_dir, "private-staging")
+    FileUtils.mkdir_p(parent)
+    chown_for_root_squash(parent)
+
+    Process.stub(:euid, 0) do
+      assert_raises(FileCopyService::UnsafePathError) do
+        FileCopyService.secure_private_directory!(parent, root: @dest_dir)
+      end
+    end
+  end
+
+  test "private staging rejects a different owner for a non-root process" do
+    parent = File.join(@dest_dir, "private-staging")
+    FileUtils.mkdir_p(parent)
+
+    Process.stub(:euid, File.stat(parent).uid + 1) do
+      assert_raises(FileCopyService::UnsafePathError) do
+        FileCopyService.secure_private_directory!(parent, root: @dest_dir)
+      end
+    end
+  end
+
   test "create_private_directory detects a swapped staging parent" do
     parent = File.join(@dest_dir, "private-staging")
     moved = File.join(@dest_dir, "pinned-private-staging")
@@ -2612,5 +2727,36 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       @dest_dir,
       ".shelfarr-copy-quarantine-#{expected_stat.dev.to_s(16)}-#{expected_stat.ino.to_s(16)}-#{token}"
     )
+  end
+
+  def with_root_squashed_creation(directory, &operation)
+    real_mkdir = FileCopyService.method(:native_mkdirat)
+    real_open = FileCopyService.method(:native_openat)
+    squashed_mkdir = lambda do |directory_fd, basename, mode|
+      result = real_mkdir.call(directory_fd, basename, mode)
+      chown_for_root_squash(File.join(directory, basename))
+      result
+    end
+    squashed_open = lambda do |directory_fd, basename, flags, mode|
+      descriptor = real_open.call(directory_fd, basename, flags, mode)
+      chown_descriptor_for_root_squash(descriptor) if (flags & File::CREAT).positive?
+      descriptor
+    end
+
+    FileCopyService.stub(:native_mkdirat, squashed_mkdir) do
+      FileCopyService.stub(:native_openat, squashed_open) do
+        Process.stub(:euid, 0, &operation)
+      end
+    end
+  end
+
+  def chown_for_root_squash(path)
+    File.chown(65_534, -1, path) if Process.uid.zero?
+  end
+
+  def chown_descriptor_for_root_squash(descriptor)
+    return unless Process.uid.zero?
+
+    File.for_fd(descriptor, "r+b", autoclose: false).chown(65_534, -1)
   end
 end


### PR DESCRIPTION
## Summary
- detect the UID assigned to root-created entries on root-squashed filesystems using an exclusive same-filesystem probe
- apply mapped ownership validation to private staging, locks, copy/source quarantine cleanup, and interrupted-copy recovery
- add regression coverage for copy, hardlink, and source cleanup while preserving strict non-root ownership checks
- normalize Chrome 150 detached-node visibility errors so Capybara retries Turbo DOM replacements

## Test plan
- `bin/quality commit --staged`
- `PARALLEL_WORKERS=1 bin/quality push`
- focused security review of the final rebased commits
- GitHub Actions quality, security, validate, Docker, and CodeQL checks

Closes #383