### PR TITLE
fix: harden post-processing filesystem cleanup

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -13,6 +13,7 @@ class PostProcessingJob < ApplicationJob
   MAX_FILENAME_BYTES = 255
   POST_PROCESSING_LOCK_SLOTS = 256
   class BookAcquisitionConflictError < StandardError; end
+  class DestructiveImportOverlapError < StandardError; end
 
   queue_as :default
 
@@ -92,19 +93,35 @@ class PostProcessingJob < ApplicationJob
       if source_path_unavailable?(source_path)
         return retry_source_path_later(download, request, source_path, source_path_retry_count)
       end
-      validate_download_specific_source_path!(source_path, source_resolution[:authorized_roots], download)
+      source_authorization = validate_download_specific_source_path!(
+        source_path,
+        source_resolution[:authorized_roots],
+        download
+      )
 
-      source_cleanup = import_files(source_path, destination, book: book, base_path: base_path)
+      remove_usenet_download = usenet_cleanup_requested?(download)
+      source_cleanup = import_files(
+        source_path,
+        destination,
+        book: book,
+        base_path: base_path,
+        require_durable: move_completed_downloads? || remove_usenet_download,
+        source_authorization: source_authorization
+      )
 
       book_path = imported_book_path(book, destination)
-      acquisition_finalized = finalize_acquisition!(download, request, book, book_path)
+      cleanup_state = source_cleanup&.fetch(:state)
+      acquisition_finalized = finalize_acquisition!(download, request, book, book_path, cleanup_state)
       return unless acquisition_finalized
 
       # Destructive source/client cleanup happens only after Book, Request, and
       # Download ownership commit together. A hard kill before that commit can
       # therefore retry the idempotent import without losing its source.
-      remove_import_source(source_cleanup)
-      cleanup_usenet_download(download)
+      cleanup_outcome = remove_import_source(source_cleanup)
+      if cleanup_state && cleanup_outcome != :retry
+        clear_source_cleanup_state(download, cleanup_state)
+      end
+      cleanup_usenet_download(download) if remove_usenet_download && cleanup_outcome == :complete
 
       run_completion_side_effects(request, download, book, book_path)
     rescue => e
@@ -145,7 +162,7 @@ class PostProcessingJob < ApplicationJob
     false
   end
 
-  def finalize_acquisition!(download, request, book, imported_path)
+  def finalize_acquisition!(download, request, book, imported_path, cleanup_state = nil)
     finalized = request.with_acquisition_transition_lock do
       download.reload
       book.reload
@@ -178,7 +195,10 @@ class PostProcessingJob < ApplicationJob
       # both crash windows: recovery never sees a completed Request with an
       # outstanding owner, nor a processing Request whose Book path was already
       # committed by this job.
-      download.update!(post_processing_job_id: nil)
+      download.update!(
+        post_processing_job_id: nil,
+        post_processing_cleanup_state: cleanup_state
+      )
       request.complete!
       true
     end
@@ -236,10 +256,16 @@ class PostProcessingJob < ApplicationJob
     detail = case error
     when BookAcquisitionConflictError
       error.message
+    when FileCopyService::UnsafeFilePermissionsError
+      "The library filesystem cannot enforce safe file permissions; it must support mode 0600 or 0640"
+    when FileCopyService::DurabilityUnsupportedError
+      "The library filesystem cannot safely complete destructive imports because fsync is unsupported; use another filesystem or retain the download source"
     when FileCopyService::UnsafePathError
       "The download contains a symbolic link or non-regular path, or changed during its safety checks"
     when AudiobookBundleImportPlanner::UnsafeDestinationError
       "The configured audiobook bundle destination overlaps the download source"
+    when DestructiveImportOverlapError
+      "The configured library destination overlaps the download source"
     when Errno::ENOSPC
       "The library filesystem ran out of space"
     when Errno::EACCES, Errno::EPERM
@@ -295,9 +321,32 @@ class PostProcessingJob < ApplicationJob
         "The download client must report a download-specific file or directory."
     end
 
-    return if roots.any? { |root| path_inside_root?(source, root) }
+    unless roots.any? { |root| path_inside_root?(source, root) }
+      raise "Refusing to import source outside a configured download root."
+    end
 
-    raise "Refusing to import source outside a configured download root."
+    source_stat = File.lstat(source_path)
+    snapshot = if source_stat.directory?
+      FileCopyService.snapshot_source_root(source_path)
+    elsif source_stat.file?
+      FileCopyService.snapshot_source_file(source_path)
+    else
+      raise "Refusing to import non-regular path"
+    end
+    snapshotted_path = if source_stat.directory?
+      snapshot.canonical_path.to_s
+    else
+      snapshot.canonical_parent_path.join(snapshot.path.basename).to_s
+    end
+    if shared_roots.include?(snapshotted_path)
+      raise "Refusing to import shared download root. " \
+        "The download client must report a download-specific file or directory."
+    end
+    unless roots.any? { |root| path_inside_root?(snapshotted_path, root) }
+      raise "Refusing to import source outside a configured download root."
+    end
+
+    { directory: source_stat.directory?, snapshot: snapshot }
   end
 
   def shared_download_roots(download)
@@ -372,15 +421,17 @@ class PostProcessingJob < ApplicationJob
   end
 
   def cleanup_usenet_download(download)
-    return unless SettingsService.get(:remove_completed_usenet_downloads, default: true)
-    return unless download.download_client&.usenet_client?
-    return unless download.external_id.present?
-
     Rails.logger.info "[PostProcessingJob] Removing usenet download ##{download.id}"
     download.download_client.adapter.remove_torrent(download.external_id, delete_files: true)
     Rails.logger.info "[PostProcessingJob] Usenet download removed successfully"
   rescue => e
     Rails.logger.warn "[PostProcessingJob] Usenet cleanup failed for download ##{download.id}: #{e.class}"
+  end
+
+  def usenet_cleanup_requested?(download)
+    SettingsService.get(:remove_completed_usenet_downloads, default: true) &&
+      download.download_client&.usenet_client? &&
+      download.external_id.present?
   end
 
   def build_destination_path(book, base_path: nil)
@@ -416,7 +467,14 @@ class PostProcessingJob < ApplicationJob
     SettingsService.library_id_for_book(book)
   end
 
-  def import_files(source, destination, book: nil, base_path: nil)
+  def import_files(
+    source,
+    destination,
+    book: nil,
+    base_path: nil,
+    require_durable: false,
+    source_authorization: nil
+  )
     unless source.present?
       Rails.logger.error "[PostProcessingJob] Source path is blank - download client may not have reported the path"
       raise "Source path is blank. Check download client configuration and ensure the download completed successfully."
@@ -427,17 +485,19 @@ class PostProcessingJob < ApplicationJob
       raise source_path_not_found_message(source)
     end
 
-    source_stat = File.lstat(source)
-    unless source_stat.directory? || source_stat.file?
-      raise "Refusing to import non-regular path: #{source}"
-    end
-    directory_source = source_stat.directory?
-    @import_source_root = FileCopyService.snapshot_source_root(source) if directory_source
+    source_authorization ||= authorize_import_source(source)
+    directory_source = source_authorization.fetch(:directory)
+    source_snapshot = source_authorization.fetch(:snapshot)
+    @import_source_root = source_snapshot if directory_source
+    @import_source_file_snapshot = source_snapshot unless directory_source
     @imported_renamed_files = []
     @imported_source_files = Set.new
+    @verified_library_snapshots = Hash.new { |snapshots, path| snapshots[path] = [] }
     @imported_book_path_override = nil
     @import_base_path = Pathname(base_path || get_base_path(book)).expand_path
-    @defer_source_removal = directory_source && move_completed_downloads?
+    @defer_source_removal = move_completed_downloads?
+    @require_durable_import = require_durable
+    validate_destructive_import_paths!(source_snapshot, destination) if require_durable
     action = {
       "copy" => "Copying",
       "move" => "Moving",
@@ -451,13 +511,46 @@ class PostProcessingJob < ApplicationJob
       import_directory(source, destination, book: book, base_path: base_path)
       source_root = @import_source_root
       imported_source_files = @imported_source_files.dup.freeze
-      source_cleanup = lambda do
-        remove_import_source_tree(source_root, imported_source_files)
-      end if move_completed_downloads?
+      destination_snapshots = @verified_library_snapshots.values.flatten.freeze
+      if move_completed_downloads?
+        source_cleanup = {
+          operation: lambda do
+            remove_import_source_tree(source_root, imported_source_files, destination_snapshots)
+          end,
+          state: nil,
+          source_snapshot: nil
+        }
+      elsif require_durable
+        source_cleanup = {
+          operation: -> { destination_snapshots_current?(destination_snapshots) },
+          state: nil,
+          source_snapshot: nil
+        }
+      end
     else
       # Import single file with renamed filename based on template
       ensure_real_import_directory!(destination)
       import_renamed_file(source, destination, book)
+      source_snapshot = @import_source_file_snapshot
+      if source_snapshot && move_completed_downloads?
+        destination_snapshot = @verified_library_snapshots.fetch(Pathname(source).expand_path.to_s).sole
+        cleanup_state = JSON.generate(
+          "source" => FileCopyService.serialize_file_snapshot(source_snapshot),
+          "destination" => FileCopyService.serialize_file_snapshot(destination_snapshot)
+        )
+        source_cleanup = {
+          operation: -> { remove_import_source_file(source_snapshot, destination_snapshot) },
+          state: cleanup_state,
+          source_snapshot: source_snapshot
+        }
+      elsif require_durable
+        destination_snapshot = @verified_library_snapshots.fetch(Pathname(source).expand_path.to_s).sole
+        source_cleanup = {
+          operation: -> { destination_snapshots_current?([ destination_snapshot ]) },
+          state: nil,
+          source_snapshot: nil
+        }
+      end
     end
 
     if hardlink_completed_downloads?
@@ -475,6 +568,46 @@ class PostProcessingJob < ApplicationJob
     remove_instance_variable(:@defer_source_removal) if instance_variable_defined?(:@defer_source_removal)
     remove_instance_variable(:@import_base_path) if instance_variable_defined?(:@import_base_path)
     remove_instance_variable(:@import_source_root) if instance_variable_defined?(:@import_source_root)
+    remove_instance_variable(:@import_source_file_snapshot) if instance_variable_defined?(:@import_source_file_snapshot)
+    remove_instance_variable(:@verified_library_snapshots) if instance_variable_defined?(:@verified_library_snapshots)
+    remove_instance_variable(:@require_durable_import) if instance_variable_defined?(:@require_durable_import)
+  end
+
+  def authorize_import_source(source)
+    stat = File.lstat(source)
+    if stat.directory?
+      { directory: true, snapshot: FileCopyService.snapshot_source_root(source) }
+    elsif stat.file?
+      { directory: false, snapshot: FileCopyService.snapshot_source_file(source) }
+    else
+      raise "Refusing to import non-regular path: #{source}"
+    end
+  end
+
+  def validate_destructive_import_paths!(source_snapshot, destination)
+    source_path = if source_snapshot.is_a?(FileCopyService::SourceRoot)
+      source_snapshot.canonical_path
+    else
+      source_snapshot.canonical_parent_path.join(source_snapshot.path.basename)
+    end
+    expanded_destination = Pathname(destination).expand_path
+    relative_destination = expanded_destination.relative_path_from(@import_base_path)
+    canonical_destination = @import_base_path.realpath.join(relative_destination)
+
+    if paths_overlap?(source_path, canonical_destination)
+      raise DestructiveImportOverlapError,
+        "destructive import destination overlaps the download source"
+    end
+  rescue ArgumentError
+    raise FileCopyService::UnsafePathError,
+      "destructive import destination is outside the configured library root"
+  end
+
+  def paths_overlap?(left, right)
+    left = Pathname(left).expand_path.to_s
+    right = Pathname(right).expand_path.to_s
+    left == right || left.start_with?("#{right}#{File::SEPARATOR}") ||
+      right.start_with?("#{left}#{File::SEPARATOR}")
   end
 
   def import_directory(source, destination, book:, base_path:)
@@ -665,24 +798,18 @@ class PostProcessingJob < ApplicationJob
     Rails.logger.info "[PostProcessingJob] Applying the configured library filename template"
     destination_file = import_file_without_duplicate_content(source, destination_file)
     @imported_renamed_files << destination_file
+    destination_file
   end
 
   def import_file(source, destination)
-    if move_completed_downloads? && !@defer_source_removal
-      FileCopyService.mv_noreplace(
-        source,
-        destination,
-        root: @import_base_path,
-        source_root: @import_source_root,
-        allow_compatibility_fallback: true
-      )
-    elsif hardlink_completed_downloads?
+    if hardlink_completed_downloads?
       begin
         FileCopyService.hardlink_noreplace(
           source,
           destination,
           root: @import_base_path,
-          source_root: @import_source_root
+          source_root: @import_source_root,
+          require_durable: @require_durable_import
         )
         @hardlinked_file_count += 1
       rescue FileCopyService::HardlinkUnsupportedError
@@ -695,7 +822,8 @@ class PostProcessingJob < ApplicationJob
           root: @import_base_path,
           source_root: @import_source_root,
           hardlink_mode: true,
-          allow_compatibility_fallback: true
+          allow_compatibility_fallback: true,
+          require_durable: @require_durable_import
         )
         @hardlink_fallback_copied_count += 1
       end
@@ -705,7 +833,9 @@ class PostProcessingJob < ApplicationJob
         destination,
         root: @import_base_path,
         source_root: @import_source_root,
-        allow_compatibility_fallback: true
+        source_snapshot: @import_source_file_snapshot,
+        allow_compatibility_fallback: true,
+        require_durable: @require_durable_import
       )
     end
     destination
@@ -723,15 +853,19 @@ class PostProcessingJob < ApplicationJob
       if already_imported
         if hardlink_completed_downloads?
           @reused_file_count += 1
-        else
-          FileCopyService.secure_library_file!(destination, root: @import_base_path)
         end
+        verify_imported_destination!(
+          source,
+          destination,
+          require_durable: @require_durable_import
+        )
         record_imported_source!(source)
         Rails.logger.info "[PostProcessingJob] Reusing one identical previously imported file"
         return destination
       end
 
       imported = import_file(source, destination)
+      verify_imported_destination!(source, imported, require_durable: true) if @require_durable_import
       record_imported_source!(source)
       return imported
     rescue Errno::EEXIST
@@ -782,8 +916,24 @@ class PostProcessingJob < ApplicationJob
       destination,
       root: @import_base_path,
       source_root: @import_source_root,
+      source_snapshot: @import_source_file_snapshot,
       hardlink_mode: hardlink_completed_downloads?
     )
+  end
+
+  def verify_imported_destination!(source, destination, require_durable:)
+    snapshot = FileCopyService.verified_library_file_snapshot(
+      source,
+      destination,
+      root: @import_base_path,
+      source_root: @import_source_root,
+      source_snapshot: @import_source_file_snapshot,
+      hardlink_mode: hardlink_completed_downloads?,
+      require_durable: require_durable
+    )
+    raise Errno::ESTALE, "library file changed after import" unless snapshot
+
+    @verified_library_snapshots[Pathname(source).expand_path.to_s] << snapshot
   end
 
   def import_directory_entry(source, destination)
@@ -829,12 +979,32 @@ class PostProcessingJob < ApplicationJob
   end
 
   def remove_import_source(source_cleanup)
-    source_cleanup&.call
+    return :complete unless source_cleanup
+
+    removed = source_cleanup.fetch(:operation).call
+    return :complete unless removed == false
+
+    source_snapshot = source_cleanup.fetch(:source_snapshot)
+    if source_snapshot && FileCopyService.source_file_quarantined?(source_snapshot)
+      :retry
+    else
+      :retained
+    end
   rescue => e
     Rails.logger.warn "[PostProcessingJob] Import-source cleanup failed: #{e.class}"
+    :retry
   end
 
-  def remove_import_source_tree(source_root, imported_source_files)
+  def remove_import_source_file(source_snapshot, destination_snapshot)
+    removed = FileCopyService.remove_source_file(
+      source_snapshot,
+      destination_snapshot: destination_snapshot
+    )
+    Rails.logger.warn "[PostProcessingJob] Source file changed; it was retained" unless removed
+    removed
+  end
+
+  def remove_import_source_tree(source_root, imported_source_files, destination_snapshots)
     expected_files = source_root.entries.filter_map do |relative, manifest|
       relative if manifest[2] == :file
     end.sort
@@ -845,9 +1015,29 @@ class PostProcessingJob < ApplicationJob
       return false
     end
 
+    unless destination_snapshots_current?(destination_snapshots)
+      Rails.logger.warn(
+        "[PostProcessingJob] An imported library file changed; the source directory was retained"
+      )
+      return false
+    end
+
     removed = FileCopyService.remove_source_tree(source_root)
     Rails.logger.warn "[PostProcessingJob] Source directory changed; it was retained" unless removed
     removed
+  end
+
+  def destination_snapshots_current?(snapshots)
+    snapshots.all? do |snapshot|
+      FileCopyService.file_snapshot_current?(snapshot, require_durable: true)
+    end
+  end
+
+  def clear_source_cleanup_state(download, cleanup_state)
+    Download.where(
+      id: download.id,
+      post_processing_cleanup_state: cleanup_state
+    ).update_all(post_processing_cleanup_state: nil, updated_at: Time.current)
   end
 
   def source_manifest_children(directory)

--- a/app/jobs/post_processing_recovery_job.rb
+++ b/app/jobs/post_processing_recovery_job.rb
@@ -51,6 +51,7 @@ class PostProcessingRecoveryJob < ApplicationJob
   end
 
   def perform
+    cleanup_downloads.each { |download| recover_source_cleanup(download) }
     stale_downloads.each { |download| recover(download) }
   end
 
@@ -66,8 +67,53 @@ class PostProcessingRecoveryJob < ApplicationJob
       .limit(BATCH_SIZE)
   end
 
+  def cleanup_downloads
+    Download.completed
+      .joins(:request)
+      .where(requests: { status: Request.statuses[:completed] })
+      .where.not(post_processing_cleanup_state: [ nil, "" ])
+      .order(:updated_at, :id)
+      .limit(BATCH_SIZE)
+  end
+
+  def recover_source_cleanup(download)
+    cleanup_state = download.post_processing_cleanup_state
+    payload = JSON.parse(cleanup_state)
+    source_snapshot = FileCopyService.deserialize_file_snapshot(payload.fetch("source"))
+    destination_snapshot = FileCopyService.deserialize_file_snapshot(payload.fetch("destination"))
+    removed = FileCopyService.remove_source_file(
+      source_snapshot,
+      destination_snapshot: destination_snapshot
+    )
+    unless removed
+      Rails.logger.warn(
+        "[PostProcessingRecoveryJob] Source cleanup was no longer safe for download ##{download.id}; it was retained"
+      )
+    end
+    if !removed && FileCopyService.source_file_quarantined?(source_snapshot)
+      Download.where(
+        id: download.id,
+        post_processing_cleanup_state: cleanup_state
+      ).update_all(updated_at: Time.current)
+      return
+    end
+
+    Download.where(
+      id: download.id,
+      post_processing_cleanup_state: cleanup_state
+    ).update_all(post_processing_cleanup_state: nil, updated_at: Time.current)
+  rescue StandardError => error
+    Rails.logger.error(
+      "[PostProcessingRecoveryJob] Source cleanup recovery failed for download ##{download.id}: #{error.class}"
+    )
+    Download.where(id: download.id).update_all(updated_at: Time.current)
+  end
+
   def recover(download)
-    return if self.class.processing_job_pending?(download.id)
+    if self.class.processing_job_pending?(download.id)
+      download.touch
+      return
+    end
 
     expected_owner = download.post_processing_job_id.presence
     replacement = PostProcessingJob.new(download.id, 0, expected_owner)

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -53,6 +53,12 @@ class Book < ApplicationRecord
   def post_processing_recovery_pending?
     return false unless persisted?
 
+    cleanup_pending = requests
+      .joins(:downloads)
+      .merge(Download.completed.where.not(post_processing_cleanup_state: [ nil, "" ]))
+      .exists?
+    return true if cleanup_pending
+
     requests
       .where.not(status: Request.statuses[:completed])
       .joins(:downloads)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -487,6 +487,7 @@ class Request < ApplicationRecord
   # already-acquired books after upgrading.
   def post_processing_recovery_pending?
     return false unless persisted?
+    return true if downloads.completed.where.not(post_processing_cleanup_state: [ nil, "" ]).exists?
     return false if completed?
 
     downloads.completed.where.not(post_processing_job_id: [ nil, "" ]).exists?

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -287,8 +287,10 @@ class FileCopyService
     # Create a destination directory relative to a trusted output root while
     # rejecting symlinks and non-directories in every path component.
     def ensure_directory(path, root:, mode: DIRECTORY_MODE)
+      expanded_path = Pathname(path).expand_path
+      expanded_root = Pathname(root).expand_path
       with_pinned_directory(path, root: root, create: true, mode: mode) do |directory|
-        apply_directory_mode!(directory, mode)
+        apply_directory_mode!(directory, mode) unless expanded_path == expanded_root
         sync_io(directory)
       end
       path

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -16,7 +16,10 @@ require "digest"
 class FileCopyService
   BUFFER_SIZE = 1024 * 1024 # 1 MB
   LIBRARY_FILE_MODE = 0o640
+  SAFE_LIBRARY_FILE_MODES = [ 0o600, LIBRARY_FILE_MODE ].freeze
+  HARDLINK_FALLBACK_FILE_MODES = SAFE_LIBRARY_FILE_MODES
   DIRECTORY_MODE = 0o750
+  SAFE_LIBRARY_DIRECTORY_MODES = [ 0o700, DIRECTORY_MODE ].freeze
   COPY_LOCK_LEGACY_MAGIC = "shelfarr-copy-v1"
   COPY_LOCK_MAGIC = "shelfarr-copy-v2"
   COPY_LOCK_PATTERN = /\A\.shelfarr-copy-([0-9a-f]{32})\.lock\z/
@@ -26,6 +29,7 @@ class FileCopyService
   COPY_LOCK_COMPATIBILITY_PREPARED_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:prepared:([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_LOCK_COMPATIBILITY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:(copying|complete):([0-9]+):([0-9]+):([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
+  SOURCE_QUARANTINE_PATTERN = /\A\.shelfarr-source-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   COPY_QUARANTINE_ENTRY = "entry"
   COPY_QUARANTINE_STALE_AGE = 24 * 60 * 60
   LINUX_RENAME_NOREPLACE = 0x1
@@ -33,8 +37,19 @@ class FileCopyService
   AT_REMOVEDIR = RUBY_PLATFORM.include?("darwin") ? 0x80 : 0x200
 
   class UnsafePathError < StandardError; end
+  class UnsafeFilePermissionsError < UnsafePathError; end
   class AtomicPublicationUnsupportedError < StandardError; end
+  class DurabilityUnsupportedError < StandardError; end
   class HardlinkUnsupportedError < StandardError; end
+  SourceFileSnapshot = Struct.new(
+    :path,
+    :parent_path,
+    :canonical_parent_path,
+    :parent_device,
+    :parent_inode,
+    :manifest,
+    keyword_init: true
+  )
   SourceRoot = Struct.new(
     :path,
     :canonical_path,
@@ -82,19 +97,44 @@ class FileCopyService
       dest,
       root: nil,
       source_root: nil,
+      source_snapshot: nil,
       heartbeat: nil,
       hardlink_mode: false,
-      allow_compatibility_fallback: false
+      allow_compatibility_fallback: false,
+      require_durable: false
     )
-      source_opener = hardlink_mode ? :with_pinned_hardlink_source : :with_pinned_source
-      send(source_opener, src, source_root: source_root) do |source, *_source_path|
-        publish_source_io_noreplace(
-          source,
-          dest,
-          root: root,
-          heartbeat: heartbeat,
-          allow_compatibility_fallback: allow_compatibility_fallback
-        )
+      if hardlink_mode
+        with_pinned_hardlink_source(src, source_root: source_root) do |source, parent, basename, parent_path, manifest|
+          validator = -> { validate_hardlink_source!(source, parent, basename, parent_path, manifest) }
+          publish_source_io_noreplace(
+            source,
+            dest,
+            root: root,
+            heartbeat: heartbeat,
+            allow_compatibility_fallback: allow_compatibility_fallback,
+            source_validator: validator,
+            accepted_modes: HARDLINK_FALLBACK_FILE_MODES,
+            require_durable: require_durable
+          )
+        end
+      else
+        source_operation = if source_snapshot
+          ->(&operation) { with_pinned_source_snapshot(source_snapshot, &operation) }
+        else
+          ->(&operation) { with_pinned_source(src, source_root: source_root, &operation) }
+        end
+        source_operation.call do |source, _parent, _basename, _parent_path, validator|
+          publish_source_io_noreplace(
+            source,
+            dest,
+            root: root,
+            heartbeat: heartbeat,
+            allow_compatibility_fallback: allow_compatibility_fallback,
+            source_validator: validator,
+            accepted_modes: SAFE_LIBRARY_FILE_MODES,
+            require_durable: require_durable
+          )
+        end
       end
       dest
     end
@@ -103,7 +143,7 @@ class FileCopyService
     # source race. The source name is first linked to a private destination
     # entry, which must match the already-open source descriptor before the
     # existing no-replace publication protocol can make it final.
-    def hardlink_noreplace(src, dest, root:, source_root:)
+    def hardlink_noreplace(src, dest, root:, source_root:, require_durable: false)
       with_pinned_hardlink_source(src, source_root: source_root) do |source, source_parent, source_basename, source_parent_path, source_manifest|
         publish_hardlink_noreplace(
           source,
@@ -112,7 +152,8 @@ class FileCopyService
           source_parent_path,
           source_manifest,
           dest,
-          root: root
+          root: root,
+          require_durable: require_durable
         )
       end
       dest
@@ -138,23 +179,29 @@ class FileCopyService
       heartbeat: nil,
       allow_compatibility_fallback: false
     )
-      with_pinned_source(src, source_root: source_root) do |source, source_parent, source_basename, source_parent_path|
-        source_identity = file_identity(source.stat)
-        publish_source_io_noreplace(
-          source,
-          dest,
-          root: root,
-          heartbeat: heartbeat,
-          allow_compatibility_fallback: allow_compatibility_fallback
-        )
-        remove_pinned_source_after_publication!(
-          source,
-          source_parent,
-          source_basename,
-          source_parent_path,
-          source_identity
-        )
+      source_snapshot = snapshot_source_file(src, source_root: source_root)
+      cp_noreplace(
+        src,
+        dest,
+        root: root,
+        source_root: source_root,
+        source_snapshot: source_snapshot,
+        heartbeat: heartbeat,
+        allow_compatibility_fallback: allow_compatibility_fallback,
+        require_durable: true
+      )
+      destination_snapshot = verified_library_file_snapshot(
+        src,
+        dest,
+        root: root,
+        source_snapshot: source_snapshot,
+        require_durable: true
+      )
+      raise Errno::ESTALE, "destination changed after no-clobber move" unless destination_snapshot
+      unless remove_source_file(source_snapshot, destination_snapshot: destination_snapshot)
+        raise Errno::ESTALE, "source changed after no-clobber move"
       end
+
       dest
     end
 
@@ -241,6 +288,7 @@ class FileCopyService
     # rejecting symlinks and non-directories in every path component.
     def ensure_directory(path, root:, mode: DIRECTORY_MODE)
       with_pinned_directory(path, root: root, create: true, mode: mode) do |directory|
+        apply_directory_mode!(directory, mode)
         sync_io(directory)
       end
       path
@@ -251,7 +299,7 @@ class FileCopyService
         unless directory.stat.uid == Process.euid
           raise UnsafePathError, "private staging directory is owned by another user"
         end
-        native_fchmod(directory.fileno, 0o700)
+        apply_directory_mode!(directory, 0o700)
         sync_io(directory)
       end
       path
@@ -266,7 +314,7 @@ class FileCopyService
         unless parent.stat.uid == Process.euid
           raise UnsafePathError, "private staging parent is owned by another user"
         end
-        native_fchmod(parent.fileno, 0o700)
+        apply_directory_mode!(parent, 0o700)
 
         loop do
           basename = "#{prefix}#{SecureRandom.hex(16)}"
@@ -277,7 +325,7 @@ class FileCopyService
           end
           child = open_pinned_directory_child(parent, basename)
           begin
-            native_fchmod(child.fileno, 0o700)
+            apply_directory_mode!(child, 0o700)
             sync_io(child)
             sync_io(parent)
             stat = child.stat
@@ -640,7 +688,7 @@ class FileCopyService
 
       with_pinned_directory(staging_path, root: root, create: false, mode: 0o700) do |staging|
         with_pinned_relative_directory(staging, relative, create: true, mode: 0o700) do |directory|
-          native_fchmod(directory.fileno, 0o700)
+          apply_directory_mode!(directory, 0o700)
           sync_io(directory)
           validate_current_directory_identity!(staging_path, staging)
           validate_current_directory_identity!(staging_path.join(relative), directory)
@@ -738,10 +786,23 @@ class FileCopyService
     # Compare regular files through pinned descriptors. This is used by retry
     # reconciliation so a path swap cannot trick an import into reusing an
     # unrelated library file.
-    def same_file_content?(source_path, destination_path, root: nil, source_root: nil, hardlink_mode: false)
-      source_opener = hardlink_mode ? :with_pinned_hardlink_source : :with_pinned_source
+    def same_file_content?(
+      source_path,
+      destination_path,
+      root: nil,
+      source_root: nil,
+      source_snapshot: nil,
+      hardlink_mode: false
+    )
       result = nil
-      send(source_opener, source_path, source_root: source_root) do |source, *_source_path|
+      source_operation = if hardlink_mode
+        ->(&operation) { with_pinned_hardlink_source(source_path, source_root: source_root, &operation) }
+      elsif source_snapshot
+        ->(&operation) { with_pinned_source_snapshot(source_snapshot, &operation) }
+      else
+        ->(&operation) { with_pinned_source(source_path, source_root: source_root, &operation) }
+      end
+      source_operation.call do |source, *_source_path|
         result = same_io_content?(source, destination_path, root: root)
       end
       result
@@ -788,7 +849,7 @@ class FileCopyService
           stat = file.stat
           expected_identity = file_identity(stat)
           expected_mode = stat.mode & 0o7777
-          result = expected_mode == LIBRARY_FILE_MODE
+          result = expected_mode.in?(HARDLINK_FALLBACK_FILE_MODES)
         end
         with_pinned_regular_child(parent, basename) do |current|
           stat = current.stat
@@ -833,6 +894,44 @@ class FileCopyService
       end
     end
 
+    def snapshot_source_file(path, source_root: nil)
+      if source_root
+        snapshot = nil
+        with_pinned_source(path, source_root: source_root) do |source, parent, _basename, parent_path|
+          parent_stat = parent.stat
+          snapshot = SourceFileSnapshot.new(
+            path: Pathname(path).expand_path,
+            parent_path: parent_path,
+            canonical_parent_path: parent_path.realpath,
+            parent_device: parent_stat.dev,
+            parent_inode: parent_stat.ino,
+            manifest: file_manifest_entry(source.stat).freeze
+          ).freeze
+        end
+        return snapshot
+      end
+
+      expanded = Pathname(path).expand_path
+      parent_path = expanded.parent
+      canonical_parent = parent_path.realpath
+      with_pinned_absolute_directory(canonical_parent) do |parent|
+        validate_current_directory_identity!(parent_path, parent)
+        with_pinned_regular_child(parent, expanded.basename.to_s) do |source|
+          parent_stat = parent.stat
+          return SourceFileSnapshot.new(
+            path: expanded,
+            parent_path: parent_path,
+            canonical_parent_path: canonical_parent,
+            parent_device: parent_stat.dev,
+            parent_inode: parent_stat.ino,
+            manifest: file_manifest_entry(source.stat).freeze
+          ).freeze
+        end
+      end
+    rescue Errno::ELOOP, Errno::ENOTDIR => error
+      raise UnsafePathError, "source path contains a symbolic link or non-directory: #{error.message}"
+    end
+
     # Snapshot and validate a directory tree through no-follow descriptors.
     # Later source opens can use the returned token to reject root replacement
     # and symlink swaps in every relative component.
@@ -873,6 +972,56 @@ class FileCopyService
         "source tree contains a symbolic link or non-regular path: #{error.message}"
     rescue Errno::ENOENT, Errno::EACCES => error
       raise UnsafePathError, "source tree is not safely accessible: #{error.message}"
+    end
+
+    # Atomically quarantine a source file, verify the exact snapshotted entry,
+    # and only then remove it. A raced replacement is restored or retained.
+    def remove_source_file(source_snapshot, destination_snapshot: nil)
+      expanded = source_snapshot.path
+      destination_validator = if destination_snapshot
+        -> { file_snapshot_current?(destination_snapshot, require_durable: true) }
+      end
+
+      with_pinned_absolute_directory(source_snapshot.canonical_parent_path) do |parent|
+        unless file_identity(parent.stat) == [ source_snapshot.parent_device, source_snapshot.parent_inode ]
+          raise Errno::ESTALE, "source parent identity changed during cleanup"
+        end
+        validate_current_directory_identity!(source_snapshot.parent_path, parent)
+        result = remove_pinned_child_if_identity(
+          parent,
+          expanded.basename.to_s,
+          source_snapshot.manifest.first(2),
+          expected_manifest: source_snapshot.manifest,
+          before_remove: destination_validator,
+          quarantine_kind: :source
+        )
+        if result.in?([ :missing, :mismatch, :retained ])
+          quarantined_result = remove_quarantined_source_snapshot(
+            parent,
+            expanded.basename.to_s,
+            source_snapshot,
+            before_remove: destination_validator
+          )
+          result = quarantined_result unless quarantined_result == :missing
+        end
+        if result == :missing && destination_validator && !destination_validator.call
+          result = :mismatch
+        end
+        sync_io(parent)
+        result.in?([ :removed, :missing ])
+      end
+    rescue Errno::ENOENT, Errno::ESTALE
+      false
+    end
+
+    def source_file_quarantined?(source_snapshot)
+      with_pinned_absolute_directory(source_snapshot.canonical_parent_path) do |parent|
+        return false unless file_identity(parent.stat) == [ source_snapshot.parent_device, source_snapshot.parent_inode ]
+
+        quarantined_source_snapshot_present?(parent, source_snapshot)
+      end
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, Errno::ENOTDIR, Errno::ESTALE, UnsafePathError
+      false
     end
 
     # Atomically quarantine the current directory entry, verify that it is the
@@ -931,16 +1080,190 @@ class FileCopyService
       false
     end
 
-    def secure_library_file!(path, root: nil)
+    def secure_library_file!(path, root: nil, require_durable: false)
       with_pinned_destination_parent(path, root: root) do |parent, basename, parent_path|
+        expected_identity = nil
+        expected_mode = nil
+        file_durable = false
         with_pinned_regular_child(parent, basename) do |file|
-          native_fchmod(file.fileno, LIBRARY_FILE_MODE)
-          sync_io(file)
+          expected_mode = apply_file_mode!(
+            file,
+            LIBRARY_FILE_MODE,
+            accepted_modes: SAFE_LIBRARY_FILE_MODES
+          )
+          file_durable = sync_io(file)
+          expected_identity = file_identity(file.stat)
+        end
+        with_pinned_regular_child(parent, basename) do |current|
+          stat = current.stat
+          unless file_identity(stat) == expected_identity && (stat.mode & 0o7777) == expected_mode
+            raise Errno::ESTALE, "library file changed during permission validation"
+          end
         end
         validate_current_directory_identity!(parent_path, parent)
-        sync_io(parent)
+        parent_durable = sync_io(parent)
+        if require_durable && !(file_durable && parent_durable)
+          raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
+        end
       end
       path
+    end
+
+    # Compare source and destination through pinned descriptors, enforce the
+    # destination mode where appropriate, and return the exact library entry
+    # that was verified. Destructive callers carry this snapshot into cleanup.
+    def verified_library_file_snapshot(
+      source_path,
+      destination_path,
+      root:,
+      source_root: nil,
+      source_snapshot: nil,
+      hardlink_mode: false,
+      require_durable: false
+    )
+      result = nil
+      source_operation = if hardlink_mode
+        lambda do |&operation|
+          with_pinned_hardlink_source(source_path, source_root: source_root) do |source, parent, basename, parent_path, manifest|
+            validator = -> { validate_hardlink_source!(source, parent, basename, parent_path, manifest) }
+            operation.call(source, validator)
+            validator.call
+          end
+        end
+      elsif source_snapshot
+        ->(&operation) { with_pinned_source_snapshot(source_snapshot) { |source, *| operation.call(source, nil) } }
+      else
+        ->(&operation) { with_pinned_source(source_path, source_root: source_root) { |source, *| operation.call(source, nil) } }
+      end
+
+      source_operation.call do |source, source_validator|
+        with_pinned_destination_parent(destination_path, root: root) do |parent, basename, parent_path|
+          file_durable = false
+          manifest = nil
+          with_pinned_regular_child(parent, basename) do |destination|
+            source_stat = source.stat
+            destination_stat = destination.stat
+            next unless source_stat.size == destination_stat.size
+            if hardlink_mode &&
+                file_identity(source_stat) != file_identity(destination_stat) &&
+                !(destination_stat.mode & 0o7777).in?(HARDLINK_FALLBACK_FILE_MODES)
+              next
+            end
+
+            source.rewind
+            destination.rewind
+            next unless compare_io(source, destination)
+
+            unless hardlink_mode
+              apply_file_mode!(
+                destination,
+                LIBRARY_FILE_MODE,
+                accepted_modes: SAFE_LIBRARY_FILE_MODES
+              )
+            end
+            file_durable = sync_io(destination)
+            manifest = file_manifest_entry(destination.stat).freeze
+          end
+          next unless manifest
+
+          source_validator&.call
+          with_pinned_regular_child(parent, basename) do |current|
+            raise Errno::ESTALE, "library file changed after content validation" unless file_manifest_entry(current.stat) == manifest
+          end
+          validate_current_directory_identity!(parent_path, parent)
+          parent_durable = sync_io(parent)
+          if require_durable && !(file_durable && parent_durable)
+            raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
+          end
+
+          parent_stat = parent.stat
+          result = SourceFileSnapshot.new(
+            path: Pathname(destination_path).expand_path,
+            parent_path: Pathname(parent_path).expand_path,
+            canonical_parent_path: Pathname(parent_path).realpath,
+            parent_device: parent_stat.dev,
+            parent_inode: parent_stat.ino,
+            manifest: manifest
+          ).freeze
+        end
+      end
+      result
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
+      nil
+    rescue UnsafePathError => error
+      raise if error.is_a?(UnsafeFilePermissionsError)
+
+      nil
+    end
+
+    def file_snapshot_current?(snapshot, require_durable: false)
+      with_pinned_absolute_directory(snapshot.canonical_parent_path) do |parent|
+        return false unless file_identity(parent.stat) == [ snapshot.parent_device, snapshot.parent_inode ]
+
+        validate_current_directory_identity!(snapshot.parent_path, parent)
+        durable = false
+        with_pinned_regular_child(parent, snapshot.path.basename.to_s) do |file|
+          return false unless file_manifest_entry(file.stat) == snapshot.manifest
+
+          durable = sync_io(file)
+        end
+        with_pinned_regular_child(parent, snapshot.path.basename.to_s) do |current|
+          return false unless file_manifest_entry(current.stat) == snapshot.manifest
+        end
+        parent_durable = sync_io(parent)
+        return false if require_durable && !(durable && parent_durable)
+
+        true
+      end
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, Errno::ENOTDIR, Errno::ESTALE, UnsafePathError
+      false
+    end
+
+    def serialize_file_snapshot(snapshot)
+      manifest = snapshot.manifest
+      {
+        "path" => snapshot.path.to_s,
+        "parent_path" => snapshot.parent_path.to_s,
+        "canonical_parent_path" => snapshot.canonical_parent_path.to_s,
+        "parent_device" => snapshot.parent_device,
+        "parent_inode" => snapshot.parent_inode,
+        "manifest" => {
+          "device" => manifest.fetch(0),
+          "inode" => manifest.fetch(1),
+          "size" => manifest.fetch(3),
+          "mtime_numerator" => manifest.fetch(4).numerator,
+          "mtime_denominator" => manifest.fetch(4).denominator,
+          "ctime_numerator" => manifest.fetch(5).numerator,
+          "ctime_denominator" => manifest.fetch(5).denominator,
+          "mode" => manifest.fetch(6)
+        }
+      }
+    end
+
+    def deserialize_file_snapshot(attributes)
+      manifest = attributes.fetch("manifest")
+      SourceFileSnapshot.new(
+        path: Pathname(attributes.fetch("path")).expand_path,
+        parent_path: Pathname(attributes.fetch("parent_path")).expand_path,
+        canonical_parent_path: Pathname(attributes.fetch("canonical_parent_path")).expand_path,
+        parent_device: Integer(attributes.fetch("parent_device")),
+        parent_inode: Integer(attributes.fetch("parent_inode")),
+        manifest: [
+          Integer(manifest.fetch("device")),
+          Integer(manifest.fetch("inode")),
+          :file,
+          Integer(manifest.fetch("size")),
+          Rational(
+            Integer(manifest.fetch("mtime_numerator")),
+            Integer(manifest.fetch("mtime_denominator"))
+          ),
+          Rational(
+            Integer(manifest.fetch("ctime_numerator")),
+            Integer(manifest.fetch("ctime_denominator"))
+          ),
+          Integer(manifest.fetch("mode"))
+        ].freeze
+      ).freeze
     end
 
     # Reclaim private copy files left by a hard process exit. A unique lock
@@ -1020,12 +1343,60 @@ class FileCopyService
       relative
     end
 
+    def apply_file_mode!(file, requested_mode, accepted_modes:)
+      mode_error = nil
+      begin
+        native_fchmod(file.fileno, requested_mode)
+      rescue Errno::EACCES, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS => error
+        mode_error = error
+      end
+
+      effective_mode = file.stat.mode & 0o7777
+      unless effective_mode.in?(accepted_modes)
+        raise UnsafeFilePermissionsError,
+          "library filesystem did not preserve safe file permissions",
+          cause: mode_error
+      end
+      if mode_error || effective_mode != requested_mode
+        Rails.logger.warn(
+          "[FileCopyService] Library filesystem retained safe effective permissions instead of the requested mode"
+        )
+      end
+      effective_mode
+    end
+
+    def apply_directory_mode!(directory, requested_mode)
+      accepted_modes = requested_mode == DIRECTORY_MODE ? SAFE_LIBRARY_DIRECTORY_MODES : [ requested_mode ]
+      mode_error = nil
+      begin
+        native_fchmod(directory.fileno, requested_mode)
+      rescue Errno::EACCES, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS => error
+        mode_error = error
+      end
+
+      effective_mode = directory.stat.mode & 0o7777
+      unless effective_mode.in?(accepted_modes)
+        raise UnsafeFilePermissionsError,
+          "filesystem did not preserve safe directory permissions",
+          cause: mode_error
+      end
+      if mode_error || effective_mode != requested_mode
+        Rails.logger.warn(
+          "[FileCopyService] Filesystem retained safe effective directory permissions instead of the requested mode"
+        )
+      end
+      effective_mode
+    end
+
     def publish_source_io_noreplace(
       source,
       destination,
       root:,
       heartbeat: nil,
-      allow_compatibility_fallback: false
+      allow_compatibility_fallback: false,
+      source_validator: nil,
+      accepted_modes: SAFE_LIBRARY_FILE_MODES,
+      require_durable: false
     )
       raise Errno::EINVAL, "source is not a regular file" unless source.stat.file?
 
@@ -1037,6 +1408,8 @@ class FileCopyService
         temporary_identity = nil
         lock_identity = nil
         published_identity = nil
+        published_mode = LIBRARY_FILE_MODE
+        published_file_durable = false
 
         begin
           with_created_regular_child(parent, lock_basename, 0o600) do |lock|
@@ -1050,21 +1423,40 @@ class FileCopyService
               temporary_identity = file_identity(temporary.stat)
               persist_copy_lock_identity!(lock, token, temporary_identity)
               sync_io(parent)
+              apply_file_mode!(temporary, 0o600, accepted_modes: [ 0o600 ])
               if heartbeat
                 copy_source_io(source, temporary, heartbeat: heartbeat)
               else
                 copy_source_io(source, temporary)
               end
-              native_fchmod(temporary.fileno, LIBRARY_FILE_MODE)
-              flush_and_sync(temporary)
+              published_mode = apply_file_mode!(
+                temporary,
+                LIBRARY_FILE_MODE,
+                accepted_modes: accepted_modes
+              )
+              published_file_durable = flush_and_sync(temporary)
+              if require_durable && !published_file_durable
+                raise DurabilityUnsupportedError, "destination file fsync is unsupported"
+              end
+              source_validator&.call
 
               begin
-                publish_private_child_noreplace!(
-                  parent,
-                  temporary_basename,
-                  basename,
-                  temporary_identity
-                )
+                if published_mode == LIBRARY_FILE_MODE
+                  publish_private_child_noreplace!(
+                    parent,
+                    temporary_basename,
+                    basename,
+                    temporary_identity
+                  )
+                else
+                  publish_private_child_noreplace!(
+                    parent,
+                    temporary_basename,
+                    basename,
+                    temporary_identity,
+                    mode: published_mode
+                  )
+                end
                 published_identity = temporary_identity
               rescue AtomicPublicationUnsupportedError
                 raise unless allow_compatibility_fallback
@@ -1072,19 +1464,29 @@ class FileCopyService
                 Rails.logger.warn(
                   "[FileCopyService] Atomic publication unsupported; using exclusive-copy compatibility mode"
                 )
-                published_identity = publish_private_child_by_copy_noreplace!(
+                published_identity, published_mode, published_file_durable =
+                  publish_private_child_by_copy_noreplace!(
                   parent,
                   temporary_basename,
                   basename,
                   temporary_identity,
                   lock: lock,
                   token: token,
-                  heartbeat: heartbeat
-                )
+                  heartbeat: heartbeat,
+                  accepted_modes: accepted_modes
+                  )
               end
-              validate_published_child!(parent, basename, published_identity)
+              validate_published_child!(
+                parent,
+                basename,
+                published_identity,
+                expected_mode: published_mode
+              )
               validate_current_directory_identity!(parent_path, parent)
-              sync_io(parent)
+              parent_durable = sync_io(parent)
+              if require_durable && !(published_file_durable && parent_durable)
+                raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
+              end
             end
           end
         rescue
@@ -1113,7 +1515,8 @@ class FileCopyService
       source_parent_path,
       source_manifest,
       destination,
-      root:
+      root:,
+      require_durable: false
     )
       source_identity = source_manifest.first(2)
       expected_stable_manifest = stable_hardlink_snapshot_entry(source_manifest)
@@ -1157,14 +1560,19 @@ class FileCopyService
                 cause: error
             end
 
+            file_durable = false
             with_pinned_regular_child(parent, temporary_basename) do |temporary|
               temporary_stat = temporary.stat
               unless file_identity(temporary_stat) == temporary_identity &&
                   stable_hardlink_manifest_entry(temporary_stat) == expected_stable_manifest
                 raise Errno::ESTALE, "private hardlink does not match the pinned source"
               end
+              file_durable = sync_io(temporary)
             end
-            sync_io(parent)
+            private_parent_durable = sync_io(parent)
+            if require_durable && !(file_durable && private_parent_durable)
+              raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
+            end
 
             validate_hardlink_source!(
               source,
@@ -1197,7 +1605,10 @@ class FileCopyService
               source_manifest
             )
             validate_current_directory_identity!(parent_path, parent)
-            sync_io(parent)
+            parent_durable = sync_io(parent)
+            if require_durable && !(file_durable && parent_durable)
+              raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
+            end
           end
         ensure
           temporary_cleanup = remove_pinned_child_if_identity(
@@ -1288,9 +1699,12 @@ class FileCopyService
       lock:,
       token:,
       heartbeat:,
+      accepted_modes:,
       mode: LIBRARY_FILE_MODE
     )
       destination_identity = nil
+      destination_mode = nil
+      destination_durable = false
       source_size = nil
 
       begin
@@ -1310,6 +1724,7 @@ class FileCopyService
           )
           with_created_regular_child(parent, destination_basename, 0o600) do |destination|
             destination_identity = file_identity(destination.stat)
+            apply_file_mode!(destination, 0o600, accepted_modes: [ 0o600 ])
             persist_copy_lock_compatibility!(
               lock,
               token,
@@ -1325,8 +1740,8 @@ class FileCopyService
             else
               copy_source_io(source, destination)
             end
-            native_fchmod(destination.fileno, mode)
-            flush_and_sync(destination)
+            destination_mode = apply_file_mode!(destination, mode, accepted_modes: accepted_modes)
+            destination_durable = flush_and_sync(destination)
             unless file_identity(source.stat) == temporary_identity &&
                 source.stat.size == source_size && destination.stat.size == source_size
               raise Errno::ESTALE, "file changed during compatibility publication"
@@ -1343,7 +1758,7 @@ class FileCopyService
           parent,
           destination_basename,
           destination_identity,
-          expected_mode: mode
+          expected_mode: destination_mode
         )
         sync_io(parent)
         persist_copy_lock_compatibility!(
@@ -1354,7 +1769,7 @@ class FileCopyService
           destination_basename,
           destination_identity
         )
-        destination_identity
+        [ destination_identity, destination_mode, destination_durable ]
       rescue
         remove_pinned_child_if_identity(parent, destination_basename, destination_identity)
         sync_io(parent)
@@ -1382,25 +1797,6 @@ class FileCopyService
           raise Errno::ESTALE, "published hardlink changed during no-clobber publication"
         end
       end
-    end
-
-    def remove_pinned_source_after_publication!(source, parent, basename, parent_path, expected_identity)
-      unless file_identity(source.stat) == expected_identity
-        raise Errno::ESTALE, "source changed during no-clobber move"
-      end
-      validate_current_directory_identity!(parent_path, parent)
-
-      with_pinned_regular_child(parent, basename) do |current|
-        unless file_identity(current.stat) == expected_identity
-          raise Errno::ESTALE, "source changed during no-clobber move"
-        end
-      end
-
-      native_unlinkat(parent.fileno, basename)
-    rescue Errno::ENOENT
-      # A concurrent cleanup already removed the exact verified source. The
-      # destination remains a complete, fsynced publication.
-      nil
     end
 
     def cleanup_interrupted_copy(parent, token)
@@ -1659,11 +2055,63 @@ class FileCopyService
       with_pinned_absolute_directory(canonical_parent) do |parent|
         validate_current_directory_identity!(expanded.parent, parent)
         with_pinned_regular_child(parent, expanded.basename.to_s) do |source|
-          yield source, parent, expanded.basename.to_s, expanded.parent
+          manifest = file_manifest_entry(source.stat)
+          validator = lambda do
+            validate_pinned_source_manifest!(
+              source,
+              parent,
+              expanded.basename.to_s,
+              expanded.parent,
+              manifest
+            )
+          end
+          result = yield source, parent, expanded.basename.to_s, expanded.parent, validator
+          validator.call
+          result
         end
       end
     rescue Errno::ELOOP, Errno::ENOTDIR => error
       raise UnsafePathError, "source path contains a symbolic link or non-directory: #{error.message}"
+    end
+
+    def with_pinned_source_snapshot(source_snapshot)
+      expanded = source_snapshot.path
+      with_pinned_absolute_directory(source_snapshot.canonical_parent_path) do |parent|
+        unless file_identity(parent.stat) == [ source_snapshot.parent_device, source_snapshot.parent_inode ]
+          raise Errno::ESTALE, "source parent identity changed after it was snapshotted"
+        end
+        validate_current_directory_identity!(source_snapshot.parent_path, parent)
+        with_pinned_regular_child(parent, expanded.basename.to_s) do |source|
+          validator = lambda do
+            validate_pinned_source_manifest!(
+              source,
+              parent,
+              expanded.basename.to_s,
+              source_snapshot.parent_path,
+              source_snapshot.manifest
+            )
+          end
+          validator.call
+          result = yield source, parent, expanded.basename.to_s, source_snapshot.parent_path, validator
+          validator.call
+          result
+        end
+      end
+    rescue Errno::ELOOP, Errno::ENOTDIR => error
+      raise UnsafePathError, "source path contains a symbolic link or non-directory: #{error.message}"
+    end
+
+    def validate_pinned_source_manifest!(source, parent, basename, parent_path, expected_manifest)
+      unless file_manifest_entry(source.stat) == expected_manifest
+        raise Errno::ESTALE, "source file changed while it was being imported"
+      end
+      validate_current_directory_identity!(parent_path, parent)
+      with_pinned_regular_child(parent, basename) do |current|
+        unless file_manifest_entry(current.stat) == expected_manifest
+          raise Errno::ESTALE, "source path changed while it was being imported"
+        end
+      end
+      true
     end
 
     def with_pinned_hardlink_source(path, source_root:)
@@ -1760,10 +2208,17 @@ class FileCopyService
             unless expected_source == file_manifest_entry(source.stat)
               raise Errno::ESTALE, "source file changed after it was snapshotted"
             end
-            result = yield source, parent, relative.basename.to_s, parent_path
-            unless expected_source == file_manifest_entry(source.stat)
-              raise Errno::ESTALE, "source file changed while it was being imported"
+            validator = lambda do
+              validate_pinned_source_manifest!(
+                source,
+                parent,
+                relative.basename.to_s,
+                parent_path,
+                expected_source
+              )
             end
+            result = yield source, parent, relative.basename.to_s, parent_path, validator
+            validator.call
             result
           end
         end
@@ -1835,9 +2290,9 @@ class FileCopyService
           stat = child.stat
           if stat.directory?
             secure_pinned_library_tree!(child, heartbeat: heartbeat)
-            native_fchmod(child.fileno, DIRECTORY_MODE)
+            apply_directory_mode!(child, DIRECTORY_MODE)
           elsif stat.file?
-            native_fchmod(child.fileno, LIBRARY_FILE_MODE)
+            apply_file_mode!(child, LIBRARY_FILE_MODE, accepted_modes: SAFE_LIBRARY_FILE_MODES)
           else
             raise UnsafePathError, "source tree contains a symbolic link or non-regular path"
           end
@@ -1846,7 +2301,7 @@ class FileCopyService
           child.close unless child.closed?
         end
       end
-      native_fchmod(directory.fileno, DIRECTORY_MODE)
+      apply_directory_mode!(directory, DIRECTORY_MODE)
       sync_io(directory)
     end
 
@@ -2101,9 +2556,9 @@ class FileCopyService
             nil
           end
           child = open_pinned_directory_child(current, part)
-          native_fchmod(child.fileno, mode)
           sync_io(current)
         end
+        apply_directory_mode!(child, mode) if create
         handles << child
         current = child
       end
@@ -2171,12 +2626,20 @@ class FileCopyService
       raise Errno::ESTALE, "destination directory changed during publication"
     end
 
-    def remove_pinned_child_if_identity(parent, basename, expected_identity)
+    def remove_pinned_child_if_identity(
+      parent,
+      basename,
+      expected_identity,
+      expected_manifest: nil,
+      before_remove: nil,
+      quarantine_kind: :copy
+    )
       return :mismatch unless expected_identity
 
       begin
         with_pinned_regular_child(parent, basename) do |child|
           return :mismatch unless file_identity(child.stat) == expected_identity
+          return :mismatch if expected_manifest && file_manifest_entry(child.stat) != expected_manifest
         end
       rescue Errno::ENOENT
         return :missing
@@ -2186,7 +2649,8 @@ class FileCopyService
 
       quarantine, quarantine_basename, quarantine_identity = create_cleanup_quarantine(
         parent,
-        expected_identity
+        expected_identity,
+        kind: quarantine_kind
       )
       moved = false
       begin
@@ -2203,17 +2667,25 @@ class FileCopyService
         quarantined_identity = nil
         result = begin
           removal_result = with_pinned_regular_child(quarantine, COPY_QUARANTINE_ENTRY) do |child|
-            quarantined_identity = file_identity(child.stat)
-            if quarantined_identity == expected_identity
-              native_unlinkat(quarantine.fileno, COPY_QUARANTINE_ENTRY)
-              :removed
+            stat = child.stat
+            quarantined_identity = file_identity(stat)
+            manifest_matches = !expected_manifest ||
+              stable_hardlink_manifest_entry(stat) == stable_hardlink_snapshot_entry(expected_manifest)
+            if quarantined_identity == expected_identity && manifest_matches
+              if before_remove && !before_remove.call
+                restore_quarantined_child!(quarantine, parent, basename)
+                :mismatch
+              else
+                native_unlinkat(quarantine.fileno, COPY_QUARANTINE_ENTRY)
+                :removed
+              end
             end
           end
           removal_result || :retained
         rescue Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
           :retained
         end
-        if quarantined_identity && quarantined_identity != expected_identity
+        if quarantined_identity && result == :retained
           restore_quarantined_child!(quarantine, parent, basename)
           result = :mismatch
         end
@@ -2227,6 +2699,15 @@ class FileCopyService
         result
       rescue Errno::ENOENT
         moved ? :retained : :missing
+      rescue
+        restore_cleanup_entry_after_error!(quarantine, parent, basename, expected_identity) if moved
+        remove_empty_cleanup_quarantine!(
+          parent,
+          quarantine_basename,
+          quarantine,
+          quarantine_identity
+        ) if moved
+        raise
       ensure
         unless moved
           remove_empty_cleanup_quarantine!(
@@ -2254,9 +2735,10 @@ class FileCopyService
       :retained
     end
 
-    def create_cleanup_quarantine(parent, expected_identity)
+    def create_cleanup_quarantine(parent, expected_identity, kind: :copy)
+      prefix = kind == :source ? ".shelfarr-source-quarantine" : ".shelfarr-copy-quarantine"
       loop do
-        basename = ".shelfarr-copy-quarantine-#{expected_identity.first.to_s(16)}-" \
+        basename = "#{prefix}-#{expected_identity.first.to_s(16)}-" \
           "#{expected_identity.last.to_s(16)}-#{SecureRandom.hex(16)}"
         begin
           native_mkdirat(parent.fileno, basename, 0o700)
@@ -2271,11 +2753,17 @@ class FileCopyService
             raise UnsafePathError, "cleanup quarantine is owned by another user"
           end
 
-          native_fchmod(quarantine.fileno, 0o700)
+          apply_directory_mode!(quarantine, 0o700)
           sync_io(quarantine)
           sync_io(parent)
           return [ quarantine, basename, file_identity(stat) ]
         rescue
+          remove_empty_cleanup_quarantine!(
+            parent,
+            basename,
+            quarantine,
+            file_identity(quarantine.stat)
+          ) rescue nil
           quarantine.close unless quarantine.closed?
           raise
         end
@@ -2294,6 +2782,94 @@ class FileCopyService
       raise UnsafePathError, "mismatched cleanup entry was retained in quarantine"
     rescue Errno::EEXIST
       raise UnsafePathError, "mismatched cleanup entry was retained because its original path is occupied"
+    end
+
+    def restore_cleanup_entry_after_error!(quarantine, parent, basename, expected_identity)
+      with_pinned_regular_child(quarantine, COPY_QUARANTINE_ENTRY) do |entry|
+        return unless file_identity(entry.stat) == expected_identity
+
+        restore_quarantined_child!(quarantine, parent, basename)
+        sync_io(parent)
+      end
+    rescue Errno::ENOENT
+      nil
+    end
+
+    def remove_quarantined_source_snapshot(parent, original_basename, snapshot, before_remove: nil)
+      expected_identity = snapshot.manifest.first(2)
+      prefix = ".shelfarr-source-quarantine-#{expected_identity.first.to_s(16)}-" \
+        "#{expected_identity.last.to_s(16)}-"
+      candidates = pinned_directory_children(parent).select { |entry| entry.start_with?(prefix) }
+
+      candidates.each do |basename|
+        next unless SOURCE_QUARANTINE_PATTERN.match?(basename)
+
+        quarantine = open_pinned_directory_child(parent, basename)
+        begin
+          next unless quarantine.stat.uid == Process.euid
+          next unless pinned_directory_children(quarantine) == [ COPY_QUARANTINE_ENTRY ]
+
+          matches = false
+          with_pinned_regular_child(quarantine, COPY_QUARANTINE_ENTRY) do |entry|
+            matches = file_identity(entry.stat) == expected_identity &&
+              stable_hardlink_manifest_entry(entry.stat) == stable_hardlink_snapshot_entry(snapshot.manifest)
+          end
+          next unless matches
+
+          if before_remove && !before_remove.call
+            restore_quarantined_child!(quarantine, parent, original_basename)
+            remove_empty_cleanup_quarantine!(
+              parent,
+              basename,
+              quarantine,
+              file_identity(quarantine.stat)
+            )
+            return :mismatch
+          end
+
+          native_unlinkat(quarantine.fileno, COPY_QUARANTINE_ENTRY)
+          sync_io(quarantine)
+          remove_empty_cleanup_quarantine!(
+            parent,
+            basename,
+            quarantine,
+            file_identity(quarantine.stat)
+          )
+          return :removed
+        ensure
+          quarantine.close unless quarantine.closed?
+        end
+      rescue Errno::ENOENT, Errno::ELOOP, UnsafePathError
+        next
+      end
+
+      :missing
+    end
+
+    def quarantined_source_snapshot_present?(parent, snapshot)
+      expected_identity = snapshot.manifest.first(2)
+      prefix = ".shelfarr-source-quarantine-#{expected_identity.first.to_s(16)}-" \
+        "#{expected_identity.last.to_s(16)}-"
+      pinned_directory_children(parent).any? do |basename|
+        next false unless basename.start_with?(prefix) && SOURCE_QUARANTINE_PATTERN.match?(basename)
+
+        quarantine = open_pinned_directory_child(parent, basename)
+        begin
+          next false unless quarantine.stat.uid == Process.euid
+          next false unless pinned_directory_children(quarantine) == [ COPY_QUARANTINE_ENTRY ]
+
+          matches = false
+          with_pinned_regular_child(quarantine, COPY_QUARANTINE_ENTRY) do |entry|
+            matches = file_identity(entry.stat) == expected_identity &&
+              stable_hardlink_manifest_entry(entry.stat) == stable_hardlink_snapshot_entry(snapshot.manifest)
+          end
+          matches
+        ensure
+          quarantine.close unless quarantine.closed?
+        end
+      rescue Errno::ENOENT, Errno::ELOOP, UnsafePathError
+        false
+      end
     end
 
     def remove_empty_cleanup_quarantine!(parent, basename, quarantine, expected_identity)
@@ -2437,14 +3013,16 @@ class FileCopyService
     def flush_and_sync(io)
       io.flush
       io.fsync
+      true
     rescue Errno::EINVAL, Errno::EOPNOTSUPP
-      nil
+      false
     end
 
     def sync_io(io)
       io.fsync
+      true
     rescue Errno::EINVAL, Errno::EOPNOTSUPP
-      nil
+      false
     end
 
     def same_stat_identity?(left, right)

--- a/db/migrate/20260723120000_add_post_processing_cleanup_state_to_downloads.rb
+++ b/db/migrate/20260723120000_add_post_processing_cleanup_state_to_downloads.rb
@@ -1,0 +1,5 @@
+class AddPostProcessingCleanupStateToDownloads < ActiveRecord::Migration[8.1]
+  def change
+    add_column :downloads, :post_processing_cleanup_state, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -158,6 +158,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
     t.string "external_id"
     t.string "name"
     t.integer "not_found_count", default: 0, null: false
+    t.text "post_processing_cleanup_state"
     t.string "post_processing_job_id"
     t.integer "progress", default: 0
     t.integer "request_id", null: false

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -1121,6 +1121,181 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_not File.exist?(source_file), "Source file should no longer exist after move import"
   end
 
+  test "single-file move retains its source until database finalization" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
+    SettingsService.set(:completed_download_import_mode, "move")
+    first_job = PostProcessingJob.new(@download.id)
+
+    first_job.stub(:finalize_acquisition!, ->(*) { raise Interrupt, "simulated hard kill" }) do
+      assert_raises(Interrupt) { first_job.perform_now }
+    end
+
+    destination = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      "Test Author - Test Audiobook.m4b"
+    )
+    assert File.exist?(source_file)
+    assert_equal "single file audio content", File.binread(destination)
+    assert @request.reload.processing?
+
+    retry_job = PostProcessingJob.new(@download.id, 0, first_job.job_id)
+    retry_job.perform_now
+
+    assert @request.reload.completed?
+    assert_not File.exist?(source_file)
+    assert_equal [ "Test Author - Test Audiobook.m4b" ], Dir.children(File.dirname(destination))
+  end
+
+  test "single-file move removes its source after reusing an identical destination" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
+    SettingsService.set(:completed_download_import_mode, "move")
+    destination_directory = File.join(@temp_dest_base, @book.author, @book.title)
+    destination = File.join(destination_directory, "Test Author - Test Audiobook.m4b")
+    FileUtils.mkdir_p(destination_directory)
+    File.binwrite(destination, "single file audio content")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    assert @request.reload.completed?
+    assert_not File.exist?(source_file)
+    assert_equal [ "Test Author - Test Audiobook.m4b" ], Dir.children(destination_directory)
+  end
+
+  test "single-file move retains its source when a reused destination is replaced" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
+    SettingsService.set(:completed_download_import_mode, "move")
+    destination_directory = File.join(@temp_dest_base, @book.author, @book.title)
+    destination = File.join(destination_directory, "Test Author - Test Audiobook.m4b")
+    displaced = File.join(destination_directory, "displaced.m4b")
+    FileUtils.mkdir_p(destination_directory)
+    File.binwrite(destination, "single file audio content")
+    real_comparison = FileCopyService.method(:same_file_content?)
+    replaced = false
+
+    comparison = lambda do |*args, **kwargs|
+      identical = real_comparison.call(*args, **kwargs)
+      if identical && !replaced
+        replaced = true
+        File.rename(destination, displaced)
+        File.binwrite(destination, "unrelated replacement")
+      end
+      identical
+    end
+
+    FileCopyService.stub(:same_file_content?, comparison) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert replaced
+    assert @request.reload.attention_needed?
+    assert_equal "single file audio content", File.binread(source_file)
+    assert_equal "unrelated replacement", File.binread(destination)
+  end
+
+  test "single-file move recovery completes cleanup after a post-commit interruption" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "move")
+    job = PostProcessingJob.new(@download.id)
+
+    job.stub(:remove_import_source, ->(*) { raise Interrupt, "simulated post-commit interruption" }) do
+      assert_raises(Interrupt) { job.perform_now }
+    end
+
+    assert @request.reload.completed?
+    assert File.exist?(source_file)
+    assert @download.reload.post_processing_cleanup_state.present?
+
+    PostProcessingRecoveryJob.perform_now
+
+    assert_not File.exist?(source_file)
+    assert_nil @download.reload.post_processing_cleanup_state
+  end
+
+  test "single-file move retains its source when the destination changes after finalization" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
+    SettingsService.set(:completed_download_import_mode, "move")
+    destination = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      "Test Author - Test Audiobook.m4b"
+    )
+    job = PostProcessingJob.new(@download.id)
+    real_finalize = job.method(:finalize_acquisition!)
+
+    finalizing = lambda do |*args|
+      finalized = real_finalize.call(*args)
+      File.binwrite(destination, "replacement after finalization") if finalized
+      finalized
+    end
+
+    job.stub(:finalize_acquisition!, finalizing) { job.perform_now }
+
+    assert @request.reload.completed?
+    assert_equal "single file audio content", File.binread(source_file)
+    assert_equal "replacement after finalization", File.binread(destination)
+    assert_nil @download.reload.post_processing_cleanup_state
+  end
+
+  test "single-file move retains its source when destination fsync is unsupported" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "move")
+
+    FileCopyService.stub(:sync_io, false) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert @request.reload.attention_needed?
+    assert_match(/fsync is unsupported/i, @request.issue_description)
+    assert File.exist?(source_file)
+  end
+
+  test "single-file copy accepts safe mode when chmod is ignored" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @download.update!(download_path: source_file)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    FileCopyService.stub(:native_fchmod, ->(*) { }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    destination = Dir.glob(File.join(@temp_dest_base, @book.author, @book.title, "*.m4b")).sole
+    assert @request.reload.completed?
+    assert_equal 0o600, File.stat(destination).mode & 0o777
+  end
+
   test "falls back to buffered move when NFS copy_file_range fails for single files" do
     source_file = File.join(@temp_source, "Original Name.m4b")
     File.write(source_file, "single file audio content")
@@ -1131,7 +1306,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     SettingsService.set(:audiobook_filename_template, "{author} - {title}")
     SettingsService.set(:completed_download_import_mode, "move")
 
-    FileUtils.stub(:mv, ->(*) { raise Errno::EACCES, "copy_file_range" }) do
+    IO.stub(:copy_stream, ->(*) { raise Errno::EACCES, "copy_file_range" }) do
       PostProcessingJob.perform_now(@download.id)
     end
 
@@ -1149,7 +1324,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:completed_download_import_mode, "move")
 
-    FileCopyService.stub(:mv_noreplace, ->(*) { raise Errno::EACCES, "permission denied" }) do
+    FileCopyService.stub(:cp_noreplace, ->(*) { raise Errno::EACCES, "permission denied" }) do
       PostProcessingJob.perform_now(@download.id)
     end
 
@@ -1222,15 +1397,17 @@ class PostProcessingJobTest < ActiveJob::TestCase
     original_file = File.join(@temp_source, "audiobook.mp3")
 
     real_copy = FileCopyService.method(:cp_noreplace)
-    FileCopyService.stub(:cp_noreplace, ->(source, destination) {
+    FileCopyService.stub(:cp_noreplace, ->(source, destination, **options) {
       raise "import failed" if File.basename(source) == "second.mp3"
 
-      real_copy.call(source, destination)
+      real_copy.call(source, destination, **options)
     }) do
       PostProcessingJob.perform_now(@download.id)
     end
 
     assert @request.reload.attention_needed?
+    imported_file = File.join(@temp_dest_base, @book.author, @book.title, "audiobook.mp3")
+    assert_equal "test audio content", File.binread(imported_file)
     assert File.exist?(original_file), "First source file should remain when a later import fails"
     assert File.exist?(File.join(@temp_source, "second.mp3")), "Failing source file should remain after partial import"
     assert File.exist?(@temp_source), "Source download folder should remain after failed import"
@@ -1315,6 +1492,40 @@ class PostProcessingJobTest < ActiveJob::TestCase
     FileUtils.rm_rf(outside) if outside
   end
 
+  test "rejects a source swapped outside its authorized root before snapshot" do
+    SettingsService.set(:audiobookshelf_url, "")
+    displaced_source = "#{@temp_source}-authorized"
+    outside = Dir.mktmpdir("outside-authorized-source")
+    File.binwrite(File.join(outside, "audiobook.mp3"), "outside audiobook bytes")
+    real_snapshot = FileCopyService.method(:snapshot_source_root)
+    swapped = false
+
+    snapshotting = lambda do |path, **options|
+      unless swapped
+        swapped = true
+        File.rename(@temp_source, displaced_source)
+        File.symlink(outside, @temp_source)
+      end
+      real_snapshot.call(path, **options)
+    end
+
+    FileCopyService.stub(:snapshot_source_root, snapshotting) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert swapped
+    assert @request.reload.attention_needed?
+    assert_match(/outside configured download roots/i, @request.issue_description)
+    imported = Dir.glob(File.join(@temp_dest_base, "**", "*"))
+      .select { |path| File.file?(path) }
+    assert_empty imported
+    assert_equal "outside audiobook bytes", File.binread(File.join(outside, "audiobook.mp3"))
+  ensure
+    FileUtils.rm_f(@temp_source) if @temp_source && File.symlink?(@temp_source)
+    FileUtils.rm_rf(displaced_source) if displaced_source
+    FileUtils.rm_rf(outside) if outside
+  end
+
   test "preserves both files and asks for review when another acquisition wins the book claim" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:completed_download_import_mode, "move")
@@ -1325,9 +1536,9 @@ class PostProcessingJobTest < ActiveJob::TestCase
     job = PostProcessingJob.new(@download.id)
     real_finalize = job.method(:finalize_acquisition!)
 
-    job.stub(:finalize_acquisition!, ->(download, request, book, path) {
+    job.stub(:finalize_acquisition!, ->(download, request, book, path, cleanup_state = nil) {
       Book.where(id: book.id).update_all(file_path: existing_path, updated_at: Time.current)
-      real_finalize.call(download, request, book, path)
+      real_finalize.call(download, request, book, path, cleanup_state)
     }) do
       job.perform_now
     end
@@ -1532,6 +1743,80 @@ class PostProcessingJobTest < ActiveJob::TestCase
       assert_requested remove_stub
       assert @request.reload.completed?
     end
+  end
+
+  test "retains a usenet download when destination fsync is unsupported" do
+    client = DownloadClient.create!(
+      name: "SABnzbd durability test",
+      client_type: :sabnzbd,
+      url: "http://localhost:8080",
+      api_key: "test-api-key"
+    )
+    @download.update!(download_client: client, external_id: "SABnzbd_nzo_durable")
+    SettingsService.set(:audiobookshelf_url, "")
+
+    VCR.turned_off do
+      remove_stub = stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "queue", "name" => "delete"))
+        .to_return(status: 200, body: { "status" => true }.to_json)
+
+      FileCopyService.stub(:sync_io, false) do
+        PostProcessingJob.perform_now(@download.id)
+      end
+
+      assert_not_requested remove_stub
+    end
+
+    assert @request.reload.attention_needed?
+    assert_match(/fsync is unsupported/i, @request.issue_description)
+    assert File.exist?(File.join(@temp_source, "audiobook.mp3"))
+  end
+
+  test "retains a usenet download when its destination changes after finalization" do
+    source_file = File.join(@temp_source, "Original Name.m4b")
+    File.binwrite(source_file, "single file audio content")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    client = DownloadClient.create!(
+      name: "SABnzbd destination validation",
+      client_type: :sabnzbd,
+      url: "http://localhost:8080",
+      api_key: "test-api-key"
+    )
+    @download.update!(
+      download_path: source_file,
+      download_client: client,
+      external_id: "SABnzbd_nzo_replaced"
+    )
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobook_filename_template, "{author} - {title}")
+    destination = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      "Test Author - Test Audiobook.m4b"
+    )
+    job = PostProcessingJob.new(@download.id)
+    real_finalize = job.method(:finalize_acquisition!)
+
+    finalizing = lambda do |*args|
+      finalized = real_finalize.call(*args)
+      File.binwrite(destination, "replacement after finalization") if finalized
+      finalized
+    end
+
+    VCR.turned_off do
+      remove_stub = stub_request(:get, "http://localhost:8080/api")
+        .with(query: hash_including("mode" => "queue", "name" => "delete"))
+        .to_return(status: 200, body: { "status" => true }.to_json)
+
+      job.stub(:finalize_acquisition!, finalizing) { job.perform_now }
+
+      assert_not_requested remove_stub
+    end
+
+    assert @request.reload.completed?
+    assert_equal "single file audio content", File.binread(source_file)
+    assert_equal "replacement after finalization", File.binread(destination)
   end
 
   test "does not remove torrent download after import" do

--- a/test/jobs/post_processing_recovery_job_test.rb
+++ b/test/jobs/post_processing_recovery_job_test.rb
@@ -47,6 +47,7 @@ class PostProcessingRecoveryJobTest < ActiveJob::TestCase
   end
 
   test "does not supersede a live or scheduled post-processing job" do
+    previous_updated_at = @download.updated_at
     PostProcessingRecoveryJob.stub(:processing_job_pending?, true) do
       assert_no_enqueued_jobs only: PostProcessingJob do
         PostProcessingRecoveryJob.perform_now
@@ -54,6 +55,7 @@ class PostProcessingRecoveryJobTest < ActiveJob::TestCase
     end
 
     assert_equal "stale-owner", @download.reload.post_processing_job_id
+    assert @download.updated_at > previous_updated_at
   end
 
   test "queue inspection recognizes a scheduled Solid Queue delivery" do

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -69,6 +69,25 @@ class BookTest < ActiveSupport::TestCase
     assert Request.exists?(request.id)
   end
 
+  test "model destruction preserves completed source cleanup state" do
+    book = Book.create!(title: "Completed cleanup book", book_type: :ebook)
+    request = Request.create!(
+      book: book,
+      user: users(:one),
+      status: :completed
+    )
+    request.downloads.create!(
+      name: book.title,
+      status: :completed,
+      post_processing_cleanup_state: '{"version":1}'
+    )
+
+    assert book.post_processing_recovery_pending?
+    assert_raises(ActiveRecord::RecordNotDestroyed) { book.destroy! }
+    assert Book.exists?(book.id)
+    assert Request.exists?(request.id)
+  end
+
   test "uses consolidated content kind values" do
     assert_equal({ "book" => 0, "graphic" => 1 }, Book.content_kinds)
 

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -338,6 +338,24 @@ class RequestTest < ActiveSupport::TestCase
     assert_nothing_raised { request.destroy! }
   end
 
+  test "completed source cleanup state blocks request destruction" do
+    request = Request.create!(
+      book: Book.create!(title: "Completed cleanup", book_type: :ebook),
+      user: users(:one),
+      status: :completed
+    )
+    download = request.downloads.create!(
+      name: "Completed cleanup",
+      status: :completed,
+      post_processing_cleanup_state: '{"version":1}'
+    )
+
+    assert request.post_processing_recovery_pending?
+    assert_raises(ActiveRecord::RecordNotDestroyed) { request.destroy! }
+    assert Request.exists?(request.id)
+    assert Download.exists?(download.id)
+  end
+
   test "cancel rechecks upload blockers after taking the transition lock" do
     request = Request.create!(
       book: Book.create!(title: "Cancel interleaving", book_type: :ebook),

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -77,6 +77,98 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal 0o777, File.stat(@src_file).mode & 0o777
   end
 
+  test "cp_noreplace accepts safe effective mode when chmod is ignored" do
+    destination = File.join(@dest_dir, "safe-mode.txt")
+
+    FileCopyService.stub(:native_fchmod, ->(*) { }) do
+      FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_equal 0o600, File.stat(destination).mode & 0o777
+  end
+
+  test "cp_noreplace accepts safe effective modes when fchmod is unsupported" do
+    destination = File.join(@dest_dir, "unsupported-fchmod.txt")
+
+    FileCopyService.stub(:native_fchmod, ->(*) { raise Errno::EOPNOTSUPP }) do
+      FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_equal 0o600, File.stat(destination).mode & 0o777
+    assert_empty Dir.children(@dest_dir) - [ "unsupported-fchmod.txt" ]
+  end
+
+  test "hardlink fallback copy accepts owner-only mode when fchmod is unsupported" do
+    destination = File.join(@dest_dir, "hardlink-fallback-mode.txt")
+
+    FileCopyService.stub(:native_fchmod, ->(*) { raise Errno::EOPNOTSUPP }) do
+      FileCopyService.cp_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        hardlink_mode: true
+      )
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_equal 0o600, File.stat(destination).mode & 0o777
+    assert FileCopyService.secure_library_file_mode?(destination, root: @dest_dir)
+  end
+
+  test "ensure_directory accepts a safe effective mode when fchmod is unsupported" do
+    directory = File.join(@dest_dir, "safe-directory")
+
+    FileCopyService.stub(:native_fchmod, ->(*) { raise Errno::EOPNOTSUPP }) do
+      FileCopyService.ensure_directory(directory, root: @dest_dir)
+    end
+
+    assert File.directory?(directory)
+    assert_includes FileCopyService::SAFE_LIBRARY_DIRECTORY_MODES,
+      File.stat(directory).mode & 0o777
+  end
+
+  test "cp_noreplace rejects unsafe effective mode when chmod is ignored" do
+    destination = File.join(@dest_dir, "unsafe-mode.txt")
+    real_fchmod = FileCopyService.method(:native_fchmod)
+    unsafe_fchmod = lambda do |descriptor, mode|
+      handle = File.for_fd(descriptor, "rb", autoclose: false)
+      if handle.stat.file? && mode == FileCopyService::LIBRARY_FILE_MODE
+        handle.chmod(0o644)
+      else
+        real_fchmod.call(descriptor, mode)
+      end
+    end
+
+    FileCopyService.stub(:native_fchmod, unsafe_fchmod) do
+      assert_raises(FileCopyService::UnsafeFilePermissionsError) do
+        FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert_not File.exist?(destination)
+    assert_equal "test content", File.binread(@src_file)
+  end
+
+  test "cp_noreplace rejects a source modified while its private copy is written" do
+    destination = File.join(@dest_dir, "changed-source.txt")
+    real_copy = FileCopyService.method(:copy_source_io)
+    mutating_copy = lambda do |source, target, heartbeat: nil|
+      real_copy.call(source, target, heartbeat: heartbeat)
+      File.binwrite(@src_file, "other bytes!")
+    end
+
+    FileCopyService.stub(:copy_source_io, mutating_copy) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert_not File.exist?(destination)
+    assert_equal "other bytes!", File.binread(@src_file)
+  end
+
   test "cp_noreplace uses exclusive copy when atomic publication is unsupported" do
     destination = File.join(@dest_dir, "compatible.txt")
 
@@ -187,6 +279,57 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(@src_file)
     assert_equal "test content", File.binread(destination)
     assert_empty Dir.children(@dest_dir) - [ "moved-compatible.txt" ]
+  end
+
+  test "mv_noreplace retains its source when file fsync is unsupported" do
+    destination = File.join(@dest_dir, "unsynced-file.txt")
+
+    FileCopyService.stub(:flush_and_sync, false) do
+      assert_raises(FileCopyService::DurabilityUnsupportedError) do
+        FileCopyService.mv_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert File.exist?(@src_file)
+    assert_not File.exist?(destination)
+  end
+
+  test "mv_noreplace retains its source when parent fsync is unsupported" do
+    destination = File.join(@dest_dir, "unsynced-parent.txt")
+
+    FileCopyService.stub(:sync_io, false) do
+      assert_raises(FileCopyService::DurabilityUnsupportedError) do
+        FileCopyService.mv_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert_equal "test content", File.binread(@src_file)
+    assert_equal "test content", File.binread(destination)
+  end
+
+  test "mv_noreplace honors a supplied source root snapshot" do
+    source_root_path = File.join(@tmp_dir, "authorized-source")
+    FileUtils.mkdir_p(source_root_path)
+    source = File.join(source_root_path, "book.epub")
+    File.binwrite(source, "authorized bytes")
+    source_root = FileCopyService.snapshot_source_root(source_root_path)
+    displaced = File.join(@tmp_dir, "displaced-source")
+    File.rename(source_root_path, displaced)
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "replacement bytes")
+    destination = File.join(@dest_dir, "book.epub")
+
+    assert_raises(Errno::ESTALE) do
+      FileCopyService.mv_noreplace(
+        source,
+        destination,
+        root: @dest_dir,
+        source_root: source_root
+      )
+    end
+
+    assert_equal "replacement bytes", File.binread(source)
+    assert_not File.exist?(destination)
   end
 
   test "hardlink_noreplace publishes the source inode without removing or chmodding it" do
@@ -1728,6 +1871,217 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(destination)
   end
 
+  test "remove_source_file retains an in-place mutation after snapshot" do
+    snapshot = FileCopyService.snapshot_source_file(@src_file)
+    File.binwrite(@src_file, "other bytes!")
+
+    assert_not FileCopyService.remove_source_file(snapshot)
+    assert_equal "other bytes!", File.binread(@src_file)
+  end
+
+  test "remove_source_file restores a replacement that wins before quarantine" do
+    snapshot = FileCopyService.snapshot_source_file(@src_file)
+    displaced = File.join(@tmp_dir, "original-source")
+    real_rename = FileCopyService.method(:native_renameat)
+    swapped = false
+
+    racing_rename = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if !swapped && source_name == File.basename(@src_file) &&
+          destination_name == FileCopyService::COPY_QUARANTINE_ENTRY
+        swapped = true
+        File.rename(@src_file, displaced)
+        File.binwrite(@src_file, "replacement bytes")
+      end
+      real_rename.call(source_fd, source_name, destination_fd, destination_name)
+    end
+
+    FileCopyService.stub(:native_renameat, racing_rename) do
+      assert_not FileCopyService.remove_source_file(snapshot)
+    end
+
+    assert_equal "replacement bytes", File.binread(@src_file)
+    assert_equal "test content", File.binread(displaced)
+  end
+
+  test "remove_source_file restores its source when quarantine unlink fails" do
+    snapshot = FileCopyService.snapshot_source_file(@src_file)
+    real_unlink = FileCopyService.method(:native_unlinkat)
+
+    unlinking = lambda do |directory_fd, basename, flags = 0|
+      raise Errno::EIO if basename == FileCopyService::COPY_QUARANTINE_ENTRY
+
+      real_unlink.call(directory_fd, basename, flags)
+    end
+
+    FileCopyService.stub(:native_unlinkat, unlinking) do
+      assert_raises(Errno::EIO) { FileCopyService.remove_source_file(snapshot) }
+    end
+
+    assert_equal "test content", File.binread(@src_file)
+    assert_empty Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*"))
+  end
+
+  test "remove_source_file recovers a source quarantined by a hard interruption" do
+    snapshot = FileCopyService.snapshot_source_file(@src_file)
+    real_unlink = FileCopyService.method(:native_unlinkat)
+    interrupted = false
+
+    unlinking = lambda do |directory_fd, basename, flags = 0|
+      if !interrupted && basename == FileCopyService::COPY_QUARANTINE_ENTRY
+        interrupted = true
+        raise Interrupt, "simulated hard interruption"
+      end
+
+      real_unlink.call(directory_fd, basename, flags)
+    end
+
+    FileCopyService.stub(:native_unlinkat, unlinking) do
+      assert_raises(Interrupt) { FileCopyService.remove_source_file(snapshot) }
+    end
+    assert_not File.exist?(@src_file)
+    assert_equal 1, Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*")).size
+
+    assert FileCopyService.remove_source_file(snapshot)
+    assert_empty Dir.glob(File.join(@tmp_dir, ".shelfarr-source-quarantine-*"))
+  end
+
+  test "remove_source_file reports a source retained in quarantine behind a replacement" do
+    destination = File.join(@dest_dir, "verified-quarantine.txt")
+    FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    destination_snapshot = FileCopyService.verified_library_file_snapshot(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      require_durable: true
+    )
+    source_snapshot = FileCopyService.snapshot_source_file(@src_file)
+    real_unlink = FileCopyService.method(:native_unlinkat)
+    interrupted = false
+
+    unlinking = lambda do |directory_fd, basename, flags = 0|
+      if !interrupted && basename == FileCopyService::COPY_QUARANTINE_ENTRY
+        interrupted = true
+        raise Interrupt, "simulated hard interruption"
+      end
+
+      real_unlink.call(directory_fd, basename, flags)
+    end
+    FileCopyService.stub(:native_unlinkat, unlinking) do
+      assert_raises(Interrupt) do
+        FileCopyService.remove_source_file(
+          source_snapshot,
+          destination_snapshot: destination_snapshot
+        )
+      end
+    end
+
+    replacement = File.join(@tmp_dir, "replacement.txt")
+    File.binwrite(replacement, "replacement source")
+    File.symlink(replacement, @src_file)
+    File.binwrite(destination, "changed destination")
+
+    assert_not FileCopyService.remove_source_file(
+      source_snapshot,
+      destination_snapshot: destination_snapshot
+    )
+    assert FileCopyService.source_file_quarantined?(source_snapshot)
+    assert_equal "replacement source", File.binread(@src_file)
+  end
+
+  test "remove_source_file does not report success when its snapshotted parent moved" do
+    parent = File.join(@tmp_dir, "source-parent")
+    displaced = File.join(@tmp_dir, "displaced-source-parent")
+    FileUtils.mkdir_p(parent)
+    source = File.join(parent, "book.epub")
+    File.binwrite(source, "source bytes")
+    snapshot = FileCopyService.snapshot_source_file(source)
+    File.rename(parent, displaced)
+
+    assert_not FileCopyService.remove_source_file(snapshot)
+    assert_equal "source bytes", File.binread(File.join(displaced, "book.epub"))
+  end
+
+  test "remove_source_file restores a quarantined source when its destination changed" do
+    destination = File.join(@dest_dir, "verified.txt")
+    FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    destination_snapshot = FileCopyService.verified_library_file_snapshot(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      require_durable: true
+    )
+    source_snapshot = FileCopyService.snapshot_source_file(@src_file)
+    File.binwrite(destination, "changed bytes")
+
+    assert_not FileCopyService.remove_source_file(
+      source_snapshot,
+      destination_snapshot: destination_snapshot
+    )
+
+    assert_equal "test content", File.binread(@src_file)
+    assert_equal "changed bytes", File.binread(destination)
+  end
+
+  test "remove_source_file validates the destination when the source is already missing" do
+    destination = File.join(@dest_dir, "missing-source-destination.txt")
+    FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    destination_snapshot = FileCopyService.verified_library_file_snapshot(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      require_durable: true
+    )
+    source_snapshot = FileCopyService.snapshot_source_file(@src_file)
+    File.unlink(@src_file)
+    File.binwrite(destination, "changed destination")
+
+    assert_not FileCopyService.remove_source_file(
+      source_snapshot,
+      destination_snapshot: destination_snapshot
+    )
+  end
+
+  test "file snapshot validation rejects a destination replaced during fsync" do
+    destination = File.join(@dest_dir, "sync-replaced-destination.txt")
+    displaced = File.join(@dest_dir, "sync-displaced-destination.txt")
+    FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    snapshot = FileCopyService.verified_library_file_snapshot(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      require_durable: true
+    )
+    destination_identity = [ File.stat(destination).dev, File.stat(destination).ino ]
+    real_sync = FileCopyService.method(:sync_io)
+    replaced = false
+
+    syncing = lambda do |io|
+      result = real_sync.call(io)
+      if !replaced && io.stat.file? && [ io.stat.dev, io.stat.ino ] == destination_identity
+        replaced = true
+        File.rename(destination, displaced)
+        File.binwrite(destination, "replacement during fsync")
+      end
+      result
+    end
+
+    result = FileCopyService.stub(:sync_io, syncing) do
+      FileCopyService.file_snapshot_current?(snapshot, require_durable: true)
+    end
+
+    assert replaced
+    assert_not result
+    assert_equal "replacement during fsync", File.binread(destination)
+    assert_equal "test content", File.binread(displaced)
+  end
+
+  test "remove_source_file is idempotent when the source is already missing" do
+    snapshot = FileCopyService.snapshot_source_file(@src_file)
+    File.unlink(@src_file)
+
+    assert FileCopyService.remove_source_file(snapshot)
+  end
+
   test "remove_source_tree only deletes the exact snapshotted directory" do
     source_root_path = File.join(@tmp_dir, "download")
     FileUtils.mkdir_p(source_root_path)
@@ -1986,14 +2340,14 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal "test content", File.read(@src_file)
   end
 
-  test "mv_noreplace preserves a destination replacement before source removal" do
+  test "mv_noreplace preserves a source replacement before source removal" do
     dest_file = File.join(@dest_dir, "output.txt")
-    real_remove = FileCopyService.method(:remove_pinned_source_after_publication!)
+    real_remove = FileCopyService.method(:remove_source_file)
 
-    FileCopyService.stub(:remove_pinned_source_after_publication!, ->(source, parent, basename, parent_path, identity) {
+    FileCopyService.stub(:remove_source_file, ->(source_snapshot, destination_snapshot:) {
       File.unlink(@src_file)
       File.binwrite(@src_file, "concurrent source replacement")
-      real_remove.call(source, parent, basename, parent_path, identity)
+      real_remove.call(source_snapshot, destination_snapshot: destination_snapshot)
     }) do
       assert_raises(Errno::ESTALE) do
         FileCopyService.mv_noreplace(@src_file, dest_file)
@@ -2002,6 +2356,26 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     assert_equal "test content", File.binread(dest_file)
     assert_equal "concurrent source replacement", File.binread(@src_file)
+  end
+
+  test "mv_noreplace retains its source when the destination changes before removal" do
+    destination = File.join(@dest_dir, "replaced-output.txt")
+    displaced = File.join(@dest_dir, "original-output.txt")
+    real_remove = FileCopyService.method(:remove_source_file)
+
+    FileCopyService.stub(:remove_source_file, ->(source_snapshot, destination_snapshot:) {
+      File.rename(destination, displaced)
+      File.binwrite(destination, "concurrent destination replacement")
+      real_remove.call(source_snapshot, destination_snapshot: destination_snapshot)
+    }) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.mv_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert_equal "test content", File.binread(@src_file)
+    assert_equal "concurrent destination replacement", File.binread(destination)
+    assert_equal "test content", File.binread(displaced)
   end
 
   test "mv_noreplace uses private copy publication before removing the source" do

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -129,6 +129,16 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       File.stat(directory).mode & 0o777
   end
 
+  test "ensure_directory does not chmod the caller-provided root" do
+    File.chmod(0o1777, @dest_dir)
+
+    FileCopyService.stub(:native_fchmod, ->(*) { raise Errno::EPERM }) do
+      FileCopyService.ensure_directory(@dest_dir, root: @dest_dir)
+    end
+
+    assert_equal 0o1777, File.stat(@dest_dir).mode & 0o7777
+  end
+
   test "cp_noreplace rejects unsafe effective mode when chmod is ignored" do
     destination = File.join(@dest_dir, "unsafe-mode.txt")
     real_fchmod = FileCopyService.method(:native_fchmod)


### PR DESCRIPTION
## Summary
- bind post-processing imports to immutable source and destination snapshots, including duplicate reuse and destructive cleanup validation
- persist single-file move cleanup state across post-finalization crashes and recover it without deleting replacements
- require durable publication before move or Usenet deletion, accept verified safe effective modes on limited filesystems, and reject destructive source/destination overlap
- protect requests and books while cleanup recovery remains pending and rotate stalled recovery rows fairly

Follow-up to #378 and #379.

## Test plan
- `bin/quality commit --staged`
- pre-push `bin/quality push`
- full Rails suite: 2,796 tests, 10,486 assertions
- system suite: 21 tests, 162 assertions
- coverage: 91.33% line, 73.06% branch