### PR TITLE
fix: refresh expired BookOrbit access tokens

### DIFF
--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -28,7 +28,7 @@ class BookOrbitClient
     def libraries
       ensure_configured!
 
-      response = request { connection.get("/api/v1/libraries") }
+      response = authenticated_request { |client| client.get("/api/v1/libraries") }
       handle_response(response) do |data|
         Array(data).map { |library| parse_library(library) }
       end
@@ -37,14 +37,14 @@ class BookOrbitClient
     def library(id)
       ensure_configured!
 
-      response = request { connection.get("/api/v1/libraries/#{id}") }
+      response = authenticated_request { |client| client.get("/api/v1/libraries/#{id}") }
       handle_response(response) { |data| parse_library(data) }
     end
 
     def scan_library(id)
       ensure_configured!
 
-      response = request { connection.post("/api/v1/scanner/libraries/#{id}/scan") }
+      response = authenticated_request { |client| client.post("/api/v1/scanner/libraries/#{id}/scan") }
       response.status.in?([ 200, 201, 202, 204 ])
     end
 
@@ -57,8 +57,8 @@ class BookOrbitClient
       query_page_size = 200 if query_page_size <= 0
 
       loop do
-        response = request do
-          connection.post("/api/v1/libraries/#{id}/books", {
+        response = authenticated_request do |client|
+          client.post("/api/v1/libraries/#{id}/books", {
             sort: [],
             pagination: { page: page, size: query_page_size },
             collapseSeries: false
@@ -107,6 +107,17 @@ class BookOrbitClient
       yield
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError, URI::Error => e
       raise ConnectionError, "Failed to connect to BookOrbit: #{e.message}"
+    end
+
+    def authenticated_request
+      request_connection = connection
+      response = request { yield(request_connection) }
+      return response unless response.status.in?([ 401, 403 ])
+
+      CONNECTION_MUTEX.synchronize do
+        clear_connection_cache! if @connection.equal?(request_connection)
+      end
+      request { yield(connection) }
     end
 
     def connection

--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -110,7 +110,7 @@ class BookOrbitClient
     end
 
     def authenticated_request
-      request_connection = connection
+      request_connection = request { connection }
       response = request { yield(request_connection) }
       return response unless response.status.in?([ 401, 403 ])
 

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -252,6 +252,14 @@ class BookOrbitClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "malformed BookOrbit URLs raise a connection error" do
+    SettingsService.set(:bookorbit_url, "not a url")
+
+    assert_raises BookOrbitClient::ConnectionError do
+      BookOrbitClient.libraries
+    end
+  end
+
   test "relogs in once when cached BookOrbit token is rejected" do
     VCR.turned_off do
       login = stub_request(:post, "http://localhost:3000/api/v1/auth/login")

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -252,6 +252,134 @@ class BookOrbitClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "relogs in once when cached BookOrbit token is rejected" do
+    VCR.turned_off do
+      login = stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "expired-token" }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "fresh-token" }.to_json
+          }
+        )
+      expired_request = stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer expired-token" })
+        .to_return(status: 401, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+      fresh_request = stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer fresh-token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { id: 42, name: "Kobo Books", folders: [] } ].to_json
+        )
+
+      libraries = BookOrbitClient.libraries
+
+      assert_equal [ "42" ], libraries.map(&:id)
+      assert_requested login, times: 2
+      assert_requested expired_request, times: 1
+      assert_requested fresh_request, times: 1
+    end
+  end
+
+  test "raises after a refreshed BookOrbit token is also rejected" do
+    VCR.turned_off do
+      login = stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "expired-token" }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "fresh-token" }.to_json
+          }
+        )
+      libraries_request = stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .to_return(status: 401, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+
+      assert_raises BookOrbitClient::AuthenticationError do
+        BookOrbitClient.libraries
+      end
+      assert_requested login, times: 2
+      assert_requested libraries_request, times: 2
+    end
+  end
+
+  test "concurrent rejections share one BookOrbit token refresh" do
+    VCR.turned_off do
+      old_requests = Queue.new
+      release_old_requests = Queue.new
+      fresh_requests = Queue.new
+      requests = []
+
+      login = stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .with(body: { username: "admin", password: "secret" }.to_json)
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "expired-token" }.to_json
+          },
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { accessToken: "fresh-token" }.to_json
+          }
+        )
+      expired_request = stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer expired-token" })
+        .to_return do
+          old_requests << true
+          release_old_requests.pop
+          { status: 401, headers: { "Content-Type" => "application/json" }, body: {}.to_json }
+        end
+      fresh_request = stub_request(:get, "http://localhost:3000/api/v1/libraries")
+        .with(headers: { "Authorization" => "Bearer fresh-token" })
+        .to_return do
+          fresh_requests << true
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: [ { id: 42, name: "Kobo Books", folders: [] } ].to_json
+          }
+        end
+
+      begin
+        requests = 2.times.map { Thread.new { BookOrbitClient.libraries } }
+        2.times { Timeout.timeout(2) { old_requests.pop } }
+
+        release_old_requests << true
+        Timeout.timeout(2) { fresh_requests.pop }
+        release_old_requests << true
+
+        results = requests.map { |thread| Timeout.timeout(2) { thread.value } }
+        assert results.all? { |libraries| libraries.map(&:id) == [ "42" ] }
+      ensure
+        2.times { release_old_requests << true }
+        requests.each do |thread|
+          next if thread.join(2)
+
+          thread.kill
+          thread.join
+        end
+      end
+
+      assert_requested login, times: 2
+      assert_requested expired_request, times: 2
+      assert_requested fresh_request, times: 2
+    end
+  end
+
   test "library_items returns empty array on page 0 404 or 410 response" do
     VCR.turned_off do
       stub_login


### PR DESCRIPTION
## Summary
- retry authenticated BookOrbit requests once after a 401 or 403 response
- clear only the rejected cached connection so concurrent requests share one token refresh
- preserve malformed URL error translation and cover success, bounded retry, and concurrency behavior

## Test plan
- `bin/quality commit --staged`
- `bin/quality push`
- `bundle exec rails test test/services/bookorbit_client_test.rb test/services/grimmory_client_test.rb`

Closes #390