### PR TITLE
fix: accept BookOrbit inventory responses

### DIFF
--- a/app/services/book_orbit_client.rb
+++ b/app/services/book_orbit_client.rb
@@ -45,37 +45,23 @@ class BookOrbitClient
       ensure_configured!
 
       response = authenticated_request { |client| client.post("/api/v1/scanner/libraries/#{id}/scan") }
-      response.status.in?([ 200, 201, 202, 204 ])
+      handle_response(response, success_statuses: [ 202 ]) { true }
     end
 
     def library_items(id, page_size: 200)
       ensure_configured!
 
-      items = []
-      page = 0
       query_page_size = [ page_size.to_i, 200 ].min
       query_page_size = 200 if query_page_size <= 0
+      items = fetch_library_items(id, query_page_size)
+      return items if items.size <= query_page_size
 
-      loop do
-        response = authenticated_request do |client|
-          client.post("/api/v1/libraries/#{id}/books", {
-            sort: [],
-            pagination: { page: page, size: query_page_size },
-            collapseSeries: false
-          })
-        end
-        if (response.status == 404 || response.status == 410) && page == 0
-          return []
-        end
-        raise Error, "BookOrbit library #{id} returned status #{response.status}" unless response.status == 200
-
-        page_items = extract_library_items(response.body)
-        items.concat(page_items)
-        break if end_of_items?(page_items, response.body, query_page_size, page)
-        page += 1
+      verified_items = fetch_library_items(id, query_page_size)
+      if items.pluck("audiobookshelf_id").sort != verified_items.pluck("audiobookshelf_id").sort
+        raise Error, "BookOrbit library inventory changed during synchronization"
       end
 
-      items
+      verified_items
     end
 
     def delete_item_by_path(_path)
@@ -99,12 +85,56 @@ class BookOrbitClient
 
     private
 
+    def fetch_library_items(id, page_size)
+      items = []
+      item_ids = {}
+      expected_total = nil
+      page = 0
+
+      loop do
+        response = authenticated_request do |client|
+          client.post("/api/v1/libraries/#{id}/books", {
+            sort: [],
+            pagination: { page: page, size: page_size },
+            collapseSeries: false
+          })
+        end
+        if (response.status == 404 || response.status == 410) && page == 0
+          return []
+        end
+
+        data = handle_response(response, success_statuses: [ 200, 201 ]) { |body| body }
+        page_items, total = extract_library_items(data, page: page, page_size: page_size)
+        expected_total ||= total
+        if total != expected_total
+          raise Error, "BookOrbit library inventory changed during synchronization"
+        end
+
+        page_items.each do |item|
+          item_id = item["audiobookshelf_id"]
+          raise Error, "BookOrbit library inventory changed during synchronization" if item_ids.key?(item_id)
+
+          item_ids[item_id] = true
+        end
+        items.concat(page_items)
+        break if items.size >= expected_total
+        if page_items.size < page_size
+          raise Error, "BookOrbit returned an incomplete library inventory"
+        end
+        page += 1
+      end
+
+      items
+    end
+
     def ensure_configured!
       raise NotConfiguredError, "BookOrbit is not configured" unless configured?
     end
 
     def request
       yield
+    rescue Faraday::ParsingError
+      raise Error, "BookOrbit returned invalid JSON"
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError, URI::Error => e
       raise ConnectionError, "Failed to connect to BookOrbit: #{e.message}"
     end
@@ -200,10 +230,10 @@ class BookOrbitClient
       url
     end
 
-    def handle_response(response)
+    def handle_response(response, success_statuses: [ 200 ])
+      return yield(response.body.presence || {}) if response.status.in?(success_statuses)
+
       case response.status
-      when 200, 201, 202, 204
-        yield(response.body.presence || {})
       when 401, 403
         raise AuthenticationError, "Invalid BookOrbit credentials or permissions"
       when 404
@@ -222,10 +252,12 @@ class BookOrbitClient
       )
     end
 
-    def extract_library_items(data)
-      Array(data["items"]).filter_map do |raw_item|
-        next unless raw_item.is_a?(Hash)
+    def extract_library_items(data, page:, page_size:)
+      unless valid_library_items_page?(data, page: page, page_size: page_size)
+        raise Error, "BookOrbit returned an invalid library inventory response"
+      end
 
+      items = data["items"].map do |raw_item|
         {
           "audiobookshelf_id" => raw_item["id"].to_s,
           "title" => raw_item["title"],
@@ -243,14 +275,21 @@ class BookOrbitClient
           "missing" => raw_item["status"] == "missing"
         }
       end
+
+      [ items, data["total"] ]
     end
 
-    def end_of_items?(page_items, data, page_size, page)
-      return true if page_items.empty?
-      return true if page_items.length < page_size
+    def valid_library_items_page?(data, page:, page_size:)
+      return false unless data.is_a?(Hash)
 
+      items = data["items"]
       total = data["total"]
-      total.present? && total <= ((page + 1) * page_size)
+      items.is_a?(Array) &&
+        items.size <= page_size &&
+        items.all? { |item| item.is_a?(Hash) && item["id"].present? } &&
+        total.is_a?(Integer) && total >= (page * page_size) + items.size &&
+        data["page"] == page &&
+        data["size"] == page_size
     end
   end
 end

--- a/test/services/audiobookshelf_library_sync_service_test.rb
+++ b/test/services/audiobookshelf_library_sync_service_test.rb
@@ -229,13 +229,15 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
         .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: { accessToken: "bookorbit-token" }.to_json)
       stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
         .to_return(
-          status: 200,
+          status: 201,
           headers: { "Content-Type" => "application/json" },
           body: {
             items: [
               { id: 101, status: "present", title: "BookOrbit Copy", authors: [ "New Author" ] }
             ],
-            total: 1
+            total: 1,
+            page: 0,
+            size: 200
           }.to_json
         )
 
@@ -246,6 +248,42 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
       assert_equal "Audiobookshelf Copy", LibraryItem.find_by!(library_platform: "audiobookshelf", library_id: "42", audiobookshelf_id: "101").title
       assert_equal "BookOrbit Copy", LibraryItem.find_by!(library_platform: "bookorbit", library_id: "42", audiobookshelf_id: "101").title
       assert_equal [ "BookOrbit Copy" ], LibraryItem.available_for_matching.pluck(:title)
+    end
+  ensure
+    LibraryPlatformClient.reset_connections!
+  end
+
+  test "keeps cached BookOrbit items when a successful response is malformed" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:bookorbit_url, "http://localhost:3000")
+    SettingsService.set(:bookorbit_username, "admin")
+    SettingsService.set(:bookorbit_password, "secret")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "42")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    LibraryPlatformClient.reset_connections!
+    existing = LibraryItem.create!(
+      library_platform: "bookorbit",
+      library_id: "42",
+      audiobookshelf_id: "101",
+      title: "Existing BookOrbit Item",
+      synced_at: 1.day.ago
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:3000/api/v1/auth/login")
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: { accessToken: "bookorbit-token" }.to_json)
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: { total: 0, page: 0, size: 200 }.to_json
+        )
+
+      result = AudiobookshelfLibrarySyncService.new.sync!
+
+      assert_not result.success?
+      assert_includes result.errors.first, "invalid library inventory response"
+      assert_equal "Existing BookOrbit Item", existing.reload.title
     end
   ensure
     LibraryPlatformClient.reset_connections!

--- a/test/services/bookorbit_client_test.rb
+++ b/test/services/bookorbit_client_test.rb
@@ -169,7 +169,7 @@ class BookOrbitClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "library_items maps BookOrbit book cards into Shelfarr library item attributes" do
+  test "library_items maps BookOrbit 201 BooksPage responses into Shelfarr attributes" do
     VCR.turned_off do
       stub_login
       stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
@@ -182,7 +182,7 @@ class BookOrbitClientTest < ActiveSupport::TestCase
           )
         )
         .to_return(
-          status: 200,
+          status: 201,
           headers: { "Content-Type" => "application/json" },
           body: {
             "items" => [
@@ -230,6 +230,193 @@ class BookOrbitClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "library_items accepts 200 BooksPage responses for compatibility" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { items: [], total: 0, page: 0, size: 200 }.to_json
+        )
+
+      assert_empty BookOrbitClient.library_items("42")
+    end
+  end
+
+  test "library_items follows BookOrbit pagination and stops at total" do
+    VCR.turned_off do
+      stub_login
+      first_page = stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 0, "size" => 2 }))
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            items: [ { id: 101, title: "First" }, { id: 102, title: "Second" } ],
+            total: 3,
+            page: 0,
+            size: 2
+          }.to_json
+        )
+      second_page = stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 1, "size" => 2 }))
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            items: [ { id: 103, title: "Third" } ],
+            total: 3,
+            page: 1,
+            size: 2
+          }.to_json
+        )
+
+      items = BookOrbitClient.library_items("42", page_size: 2)
+
+      assert_equal %w[101 102 103], items.pluck("audiobookshelf_id")
+      assert_requested first_page, times: 2
+      assert_requested second_page, times: 2
+      assert_not_requested :post, "http://localhost:3000/api/v1/libraries/42/books",
+        body: hash_including("pagination" => { "page" => 2, "size" => 2 })
+    end
+  end
+
+  test "library_items rejects malformed successful inventory responses" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: { total: 0, page: 0, size: 200 }.to_json
+        )
+
+      error = assert_raises(BookOrbitClient::Error) { BookOrbitClient.library_items("42") }
+      assert_equal "BookOrbit returned an invalid library inventory response", error.message
+    end
+  end
+
+  test "library_items rejects incomplete inventory pages" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: { items: [ { id: 101 } ], total: 2, page: 0, size: 200 }.to_json
+        )
+
+      error = assert_raises(BookOrbitClient::Error) { BookOrbitClient.library_items("42") }
+      assert_equal "BookOrbit returned an incomplete library inventory", error.message
+    end
+  end
+
+  test "library_items rejects totals that change during pagination" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 0, "size" => 2 }))
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: { items: [ { id: 101 }, { id: 102 } ], total: 3, page: 0, size: 2 }.to_json
+        )
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 1, "size" => 2 }))
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: { items: [ { id: 103 }, { id: 104 } ], total: 4, page: 1, size: 2 }.to_json
+        )
+
+      error = assert_raises(BookOrbitClient::Error) { BookOrbitClient.library_items("42", page_size: 2) }
+      assert_equal "BookOrbit library inventory changed during synchronization", error.message
+    end
+  end
+
+  test "library_items rejects duplicate IDs across pages" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 0, "size" => 2 }))
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: { items: [ { id: 101 }, { id: 102 } ], total: 4, page: 0, size: 2 }.to_json
+        )
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 1, "size" => 2 }))
+        .to_return(
+          status: 201,
+          headers: { "Content-Type" => "application/json" },
+          body: { items: [ { id: 102 }, { id: 103 } ], total: 4, page: 1, size: 2 }.to_json
+        )
+
+      error = assert_raises(BookOrbitClient::Error) { BookOrbitClient.library_items("42", page_size: 2) }
+      assert_equal "BookOrbit library inventory changed during synchronization", error.message
+    end
+  end
+
+  test "library_items rejects different ID sets across verification passes" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 0, "size" => 2 }))
+        .to_return(
+          {
+            status: 201,
+            headers: { "Content-Type" => "application/json" },
+            body: { items: [ { id: 101 }, { id: 102 } ], total: 4, page: 0, size: 2 }.to_json
+          },
+          {
+            status: 201,
+            headers: { "Content-Type" => "application/json" },
+            body: { items: [ { id: 102 }, { id: 103 } ], total: 4, page: 0, size: 2 }.to_json
+          }
+        )
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .with(body: hash_including("pagination" => { "page" => 1, "size" => 2 }))
+        .to_return(
+          {
+            status: 201,
+            headers: { "Content-Type" => "application/json" },
+            body: { items: [ { id: 103 }, { id: 104 } ], total: 4, page: 1, size: 2 }.to_json
+          },
+          {
+            status: 201,
+            headers: { "Content-Type" => "application/json" },
+            body: { items: [ { id: 104 }, { id: 105 } ], total: 4, page: 1, size: 2 }.to_json
+          }
+        )
+
+      error = assert_raises(BookOrbitClient::Error) { BookOrbitClient.library_items("42", page_size: 2) }
+      assert_equal "BookOrbit library inventory changed during synchronization", error.message
+    end
+  end
+
+  test "library_items translates invalid JSON responses" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .to_return(status: 201, headers: { "Content-Type" => "application/json" }, body: "{")
+
+      error = assert_raises(LibraryPlatformClient::Error) { LibraryPlatformClient.library_items("42") }
+      assert_equal "BookOrbit returned invalid JSON", error.message
+    end
+  end
+
+  test "library_items rejects unrelated successful statuses" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+        .to_return(status: 202, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+
+      error = assert_raises(BookOrbitClient::Error) { BookOrbitClient.library_items("42") }
+      assert_equal "BookOrbit API error: 202", error.message
+    end
+  end
+
   test "scan_library calls BookOrbit scanner endpoint" do
     VCR.turned_off do
       stub_login
@@ -238,6 +425,17 @@ class BookOrbitClientTest < ActiveSupport::TestCase
         .to_return(status: 202, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
 
       assert LibraryPlatformClient.scan_library("42")
+    end
+  end
+
+  test "scan_library raises when BookOrbit does not accept the scan" do
+    VCR.turned_off do
+      stub_login
+      stub_request(:post, "http://localhost:3000/api/v1/scanner/libraries/42/scan")
+        .to_return(status: 409, headers: { "Content-Type" => "application/json" }, body: {}.to_json)
+
+      error = assert_raises(LibraryPlatformClient::Error) { LibraryPlatformClient.scan_library("42") }
+      assert_equal "BookOrbit API error: 409", error.message
     end
   end
 
@@ -407,22 +605,24 @@ class BookOrbitClientTest < ActiveSupport::TestCase
       stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
         .with(body: hash_including("pagination" => { "page" => 0, "size" => 200 }))
         .to_return(
-          status: 200,
+          status: 201,
           headers: { "Content-Type" => "application/json" },
           body: {
-            "items" => Array.new(200) { { "id" => 101, "title" => "a" } },
+            "items" => Array.new(200) { |index| { "id" => index + 1, "title" => "a" } },
             "total" => 400,
             "page" => 0,
             "size" => 200
           }.to_json
         )
-      stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
+      second_page = stub_request(:post, "http://localhost:3000/api/v1/libraries/42/books")
         .with(body: hash_including("pagination" => { "page" => 1, "size" => 200 }))
         .to_return(status: 404)
 
-      assert_raises BookOrbitClient::Error do
+      error = assert_raises BookOrbitClient::Error do
         BookOrbitClient.library_items("42")
       end
+      assert_equal "BookOrbit resource not found", error.message
+      assert_requested second_page, times: 1
     end
   end
 


### PR DESCRIPTION
## Summary

- align BookOrbit inventory synchronization with its `201 Created` BooksPage contract and `202 Accepted` scan contract
- validate pagination envelopes and fail safely on malformed, incomplete, or changing inventories so cached items are not pruned from a partial response
- verify multi-page inventory ID sets before reconciliation and add regression coverage for the upstream response shape

Fixes #384

## Test plan

- `bundle exec rails test test/services/bookorbit_client_test.rb test/services/audiobookshelf_library_sync_service_test.rb`
- `bin/quality commit --staged`
- `bin/quality push`
