### PR TITLE
fix: start BookOrbit library sync on boot

### DIFF
--- a/config/initializers/audiobookshelf_library_sync.rb
+++ b/config/initializers/audiobookshelf_library_sync.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Start the periodic Audiobookshelf library sync job when the server boots
+# Start the periodic library platform sync job when the server boots
 Rails.application.config.after_initialize do
-  if defined?(Rails::Server) && AudiobookshelfClient.configured?
+  if defined?(Rails::Server) && LibraryPlatformClient.configured?
     Rails.logger.info "[Shelfarr] Starting AudiobookshelfLibrarySyncJob"
     AudiobookshelfLibrarySyncJob.perform_later
   end

--- a/test/config/initializers/audiobookshelf_library_sync_test.rb
+++ b/test/config/initializers/audiobookshelf_library_sync_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AudiobookshelfLibrarySyncInitializerTest < ActiveJob::TestCase
+  INITIALIZER_PATH = Rails.root.join("config/initializers/audiobookshelf_library_sync.rb").to_s
+  LIBRARY_SETTING_KEYS = %w[
+    library_platform audiobookshelf_url audiobookshelf_api_key
+    bookorbit_url bookorbit_username bookorbit_password
+    grimmory_url grimmory_username grimmory_password
+  ].freeze
+
+  setup do
+    Setting.where(key: LIBRARY_SETTING_KEYS).delete_all
+    @callback = capture_after_initialize_callback
+  end
+
+  test "keeps starting sync for configured Audiobookshelf in server mode" do
+    SettingsService.set(:library_platform, "audiobookshelf")
+    SettingsService.set(:audiobookshelf_url, "http://audiobookshelf.test")
+    SettingsService.set(:audiobookshelf_api_key, "api-key")
+
+    with_rails_server do
+      assert_enqueued_with(job: AudiobookshelfLibrarySyncJob) { @callback.call }
+    end
+  end
+
+  test "starts sync for configured BookOrbit in server mode" do
+    configure_bookorbit
+
+    with_rails_server do
+      assert_enqueued_with(job: AudiobookshelfLibrarySyncJob) { @callback.call }
+    end
+  end
+
+  test "starts sync for configured Grimmory in server mode" do
+    configure_grimmory
+
+    with_rails_server do
+      assert_enqueued_with(job: AudiobookshelfLibrarySyncJob) { @callback.call }
+    end
+  end
+
+  test "does not start sync when the active library platform is not configured" do
+    SettingsService.set(:library_platform, "bookorbit")
+
+    with_rails_server do
+      assert_no_enqueued_jobs(only: AudiobookshelfLibrarySyncJob) { @callback.call }
+    end
+  end
+
+  test "does not start sync outside server mode" do
+    configure_bookorbit
+
+    without_rails_server do
+      assert_no_enqueued_jobs(only: AudiobookshelfLibrarySyncJob) { @callback.call }
+    end
+  end
+
+  private
+
+  def capture_after_initialize_callback
+    callback = nil
+    capture = ->(&block) { callback = block }
+
+    Rails.application.config.stub(:after_initialize, capture) do
+      load INITIALIZER_PATH
+    end
+
+    callback || raise("Initializer did not register an after_initialize callback")
+  end
+
+  def with_rails_server
+    server_defined = Rails.const_defined?(:Server, false)
+    Rails.const_set(:Server, Class.new) unless server_defined
+    yield
+  ensure
+    Rails.send(:remove_const, :Server) unless server_defined
+  end
+
+  def without_rails_server
+    server = Rails.const_get(:Server, false) if Rails.const_defined?(:Server, false)
+    Rails.send(:remove_const, :Server) if server
+    yield
+  ensure
+    Rails.const_set(:Server, server) if server
+  end
+
+  def configure_bookorbit
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:bookorbit_url, "http://bookorbit.test")
+    SettingsService.set(:bookorbit_username, "admin")
+    SettingsService.set(:bookorbit_password, "secret")
+  end
+
+  def configure_grimmory
+    SettingsService.set(:library_platform, "grimmory")
+    SettingsService.set(:grimmory_url, "http://grimmory.test")
+    SettingsService.set(:grimmory_username, "admin")
+    SettingsService.set(:grimmory_password, "secret")
+  end
+end

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -3,6 +3,12 @@
 require "test_helper"
 
 class DownloadMonitorJobTest < ActiveJob::TestCase
+  CLIENT_THREAD_LOCALS = %i[qbittorrent_sessions transmission_sessions transmission_protocols].freeze
+
+  def run
+    Request.suppressing_turbo_broadcasts { super }
+  end
+
   setup do
     @original_cache = Rails.cache
     Rails.cache = ActiveSupport::Cache::MemoryStore.new
@@ -22,9 +28,10 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     )
 
     # Clear qBittorrent sessions
-    Thread.current[:qbittorrent_sessions] = {}
-    Thread.current[:transmission_sessions] = {}
-    Thread.current[:transmission_protocols] = {}
+    @original_client_thread_locals = CLIENT_THREAD_LOCALS.to_h do |key|
+      [ key, Thread.current.key?(key) ? Thread.current[key] : :unset ]
+    end
+    CLIENT_THREAD_LOCALS.each { |key| Thread.current[key] = {} }
 
     # Create an active download associated with the client
     @download = @request.downloads.create!(
@@ -41,10 +48,15 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
   teardown do
     DownloadMonitorJob.clear_schedule!
     Rails.cache = @original_cache
+    @original_client_thread_locals&.each do |key, value|
+      value == :unset ? Thread.current[key] = nil : Thread.current[key] = value
+    end
   end
 
-  test "does nothing when no download client configured" do
+  test "does not reschedule when monitoring is not required" do
     DownloadClient.destroy_all
+
+    assert_not DownloadMonitorJob.monitoring_required?
 
     assert_no_enqueued_jobs do
       DownloadMonitorJob.perform_now


### PR DESCRIPTION
## Summary

- start the periodic library sync for whichever library platform is active, including BookOrbit and Grimmory
- cover server startup behavior for all supported platforms and preserve the non-server guard
- isolate delayed Turbo broadcasts and client thread-local state in download monitor tests so the release gate cannot fail from unrelated queued jobs

The BookOrbit `201 Created` response fix was merged in #396, but its release workflow failed on the polluted download monitor assertion, leaving `latest` on v0.39.1 without that fix. This change removes the release blocker and fixes BookOrbit-only startup scheduling.

Closes #397

## Test plan

- `bin/rails test test/config/initializers/audiobookshelf_library_sync_test.rb test/jobs/download_monitor_job_test.rb`
- `PARALLEL_WORKERS=4 bin/rails test --seed 17693`
- `bin/quality commit --staged`
- `bin/quality push`
- two rounds of three independent adversarial reviews, with no remaining findings