### PR TITLE
fix: support WSL post-processing permissions

### DIFF
--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -10,6 +10,8 @@ class PostProcessingJob < ApplicationJob
   EBOOK_FILE_EXTENSIONS = %w[epub pdf mobi azw azw3 cbz cbr djvu].freeze
   EBOOK_SIDECAR_EXTENSIONS = %w[jpg jpeg png webp opf nfo txt].freeze
   EBOOK_ALLOWED_EXTENSIONS = (EBOOK_FILE_EXTENSIONS + EBOOK_SIDECAR_EXTENSIONS).freeze
+  ERROR_DETAIL_CHARACTER_LIMIT = 500
+  ERROR_DETAIL_INPUT_BYTE_LIMIT = ERROR_DETAIL_CHARACTER_LIMIT * 4
   MAX_FILENAME_BYTES = 255
   POST_PROCESSING_LOCK_SLOTS = 256
   class BookAcquisitionConflictError < StandardError; end
@@ -20,8 +22,8 @@ class PostProcessingJob < ApplicationJob
   def perform(download_id, source_path_retry_count = 0, expected_owner_job_id = nil)
     if Rails.logger.respond_to?(:silence)
       # Active Record DEBUG binds can contain Book titles and library paths.
-      # Post-processing logs only opaque record IDs and error classes, so keep
-      # the entire acquisition below INFO even in verbose development mode.
+      # Keep those below INFO; explicit error diagnostics are scrubbed and
+      # bounded before they reach the logger.
       Rails.logger.silence(Logger::INFO) do
         perform_privately(download_id, source_path_retry_count, expected_owner_job_id)
       end
@@ -125,9 +127,10 @@ class PostProcessingJob < ApplicationJob
 
       run_completion_side_effects(request, download, book, book_path)
     rescue => e
-      error_detail = "#{e.class}: #{e.message.to_s.squish.first(500)}"
-      if e.cause && !e.cause.equal?(e)
-        error_detail << " (caused by #{e.cause.class}: #{e.cause.message.to_s.squish.first(500)})"
+      error_detail = "#{e.class}: #{bounded_exception_message(e)}"
+      cause = e.cause
+      if cause && !cause.equal?(e)
+        error_detail << " (caused by #{cause.class}: #{bounded_exception_message(cause)})"
       end
       Rails.logger.error "[PostProcessingJob] Download ##{download.id} failed: #{error_detail}"
       mark_post_processing_failure!(download, request, e) unless acquisition_finalized
@@ -259,7 +262,7 @@ class PostProcessingJob < ApplicationJob
   def safe_attention_message(error)
     detail = case error
     when BookAcquisitionConflictError
-      error.message
+      bounded_exception_message(error)
     when FileCopyService::UnsafeFilePermissionsError
       "The library filesystem reported unsupported file or directory permissions"
     when FileCopyService::DurabilityUnsupportedError
@@ -281,8 +284,23 @@ class PostProcessingJob < ApplicationJob
     "Post-processing failed: #{detail.to_s.first(500)}"
   end
 
+  def bounded_exception_message(error)
+    raw = error.message.to_s.dup
+    raw = raw.byteslice(0, ERROR_DETAIL_INPUT_BYTE_LIMIT).to_s
+    raw.force_encoding(Encoding::UTF_8) if raw.encoding == Encoding::BINARY
+    normalized = raw.encode(
+      Encoding::UTF_8,
+      invalid: :replace,
+      undef: :replace,
+      replace: "\uFFFD"
+    )
+    normalized.squish.first(ERROR_DETAIL_CHARACTER_LIMIT)
+  rescue StandardError
+    "[unavailable error detail]"
+  end
+
   def safe_attention_detail(error)
-    case error.message.to_s
+    case bounded_exception_message(error)
     when /source path is blank/i
       "Source path is blank because the download client did not report one"
     when /source path not found/i

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -125,7 +125,11 @@ class PostProcessingJob < ApplicationJob
 
       run_completion_side_effects(request, download, book, book_path)
     rescue => e
-      Rails.logger.error "[PostProcessingJob] Download ##{download.id} failed: #{e.class}"
+      error_detail = "#{e.class}: #{e.message.to_s.squish.first(500)}"
+      if e.cause && !e.cause.equal?(e)
+        error_detail << " (caused by #{e.cause.class}: #{e.cause.message.to_s.squish.first(500)})"
+      end
+      Rails.logger.error "[PostProcessingJob] Download ##{download.id} failed: #{error_detail}"
       mark_post_processing_failure!(download, request, e) unless acquisition_finalized
     end
   end
@@ -257,7 +261,7 @@ class PostProcessingJob < ApplicationJob
     when BookAcquisitionConflictError
       error.message
     when FileCopyService::UnsafeFilePermissionsError
-      "The library filesystem cannot enforce safe file permissions; it must support mode 0600 or 0640"
+      "The library filesystem reported unsupported file or directory permissions"
     when FileCopyService::DurabilityUnsupportedError
       "The library filesystem cannot safely complete destructive imports because fsync is unsupported; use another filesystem or retain the download source"
     when FileCopyService::UnsafePathError
@@ -951,14 +955,10 @@ class PostProcessingJob < ApplicationJob
     else
       raise "Refusing to import non-regular path: #{source}"
     end
-  rescue Errno::ENOENT, Errno::EACCES => e
-    raise "Could not safely import #{source}: #{e.message}"
   end
 
   def ensure_real_import_directory!(path)
     FileCopyService.ensure_directory(path, root: @import_base_path, mode: 0o750)
-  rescue FileCopyService::UnsafePathError, SystemCallError => error
-    raise "Refusing to import into an unsafe directory: #{path}: #{error.message}"
   end
 
   def move_completed_downloads?

--- a/app/services/audiobook_image_probe_service.rb
+++ b/app/services/audiobook_image_probe_service.rb
@@ -13,6 +13,14 @@ class AudiobookImageProbeService
   MAX_DURATION = 10.seconds
   MAX_ADDRESS_SPACE_BYTES = 1_536.megabytes
   SUPPORTED_FORMATS = %w[jpeg png webp].freeze
+  SPAWN_RESOURCE_LIMITS = {
+    rlimit_cpu: 5,
+    rlimit_fsize: MAX_FILE_BYTES,
+    rlimit_core: 0
+  }.tap do |limits|
+    # Darwin exposes RLIMIT_AS but rejects attempts to set it with EINVAL.
+    limits[:rlimit_as] = MAX_ADDRESS_SPACE_BYTES unless RUBY_PLATFORM.include?("darwin")
+  end.freeze
   PROBE_SCRIPT = <<~'RUBY'.freeze
     Vips.concurrency_set(1)
     Vips.cache_set_max(0)
@@ -100,10 +108,7 @@ class AudiobookImageProbeService
             out: metadata_output.path,
             err: File::NULL,
             pgroup: true,
-            rlimit_cpu: 5,
-            rlimit_as: MAX_ADDRESS_SPACE_BYTES,
-            rlimit_fsize: MAX_FILE_BYTES,
-            rlimit_core: 0
+            **SPAWN_RESOURCE_LIMITS
           )
           status = wait_for_probe(pid, max_duration)
           return false unless status&.success?

--- a/app/services/audiobook_probe_service.rb
+++ b/app/services/audiobook_probe_service.rb
@@ -10,6 +10,14 @@ class AudiobookProbeService
   MAX_ANALYZE_MICROSECONDS = 5_000_000
   MAX_DURATION = 15.seconds
   MAX_ADDRESS_SPACE_BYTES = 512.megabytes
+  SPAWN_RESOURCE_LIMITS = {
+    rlimit_cpu: 10,
+    rlimit_fsize: MAX_OUTPUT_BYTES,
+    rlimit_core: 0
+  }.tap do |limits|
+    # Darwin exposes RLIMIT_AS but rejects attempts to set it with EINVAL.
+    limits[:rlimit_as] = MAX_ADDRESS_SPACE_BYTES unless RUBY_PLATFORM.include?("darwin")
+  end.freeze
 
   class << self
     attr_writer :probe
@@ -42,10 +50,7 @@ class AudiobookProbeService
           out: output.path,
           err: File::NULL,
           pgroup: true,
-          rlimit_cpu: 10,
-          rlimit_as: MAX_ADDRESS_SPACE_BYTES,
-          rlimit_fsize: MAX_OUTPUT_BYTES,
-          rlimit_core: 0
+          **SPAWN_RESOURCE_LIMITS
         )
         status = wait_for_probe(pid)
         return false unless status&.success?

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -16,10 +16,14 @@ require "digest"
 class FileCopyService
   BUFFER_SIZE = 1024 * 1024 # 1 MB
   LIBRARY_FILE_MODE = 0o640
-  SAFE_LIBRARY_FILE_MODES = [ 0o600, LIBRARY_FILE_MODE ].freeze
-  HARDLINK_FALLBACK_FILE_MODES = SAFE_LIBRARY_FILE_MODES
   DIRECTORY_MODE = 0o750
-  SAFE_LIBRARY_DIRECTORY_MODES = [ 0o700, DIRECTORY_MODE ].freeze
+  # Windows ACL-backed mounts can ignore chmod and synthesize broad Unix mode
+  # bits. Ordinary media and descriptor-pinned recovery artifacts remain usable
+  # when the process retains owner control and no special bits are present;
+  # application-private state still requires exact modes.
+  LIBRARY_FILE_MODES = (0o600..0o777).select { |mode| (mode & 0o600) == 0o600 }.freeze
+  LIBRARY_DIRECTORY_MODES = (0o700..0o777).freeze
+  HARDLINK_FALLBACK_FILE_MODES = [ 0o600, LIBRARY_FILE_MODE ].freeze
   COPY_LOCK_LEGACY_MAGIC = "shelfarr-copy-v1"
   COPY_LOCK_MAGIC = "shelfarr-copy-v2"
   COPY_LOCK_PATTERN = /\A\.shelfarr-copy-([0-9a-f]{32})\.lock\z/
@@ -114,7 +118,7 @@ class FileCopyService
             heartbeat: heartbeat,
             allow_compatibility_fallback: allow_compatibility_fallback,
             source_validator: validator,
-            accepted_modes: HARDLINK_FALLBACK_FILE_MODES,
+            accepted_modes: LIBRARY_FILE_MODES,
             require_durable: require_durable
           )
         end
@@ -132,7 +136,7 @@ class FileCopyService
             heartbeat: heartbeat,
             allow_compatibility_fallback: allow_compatibility_fallback,
             source_validator: validator,
-            accepted_modes: SAFE_LIBRARY_FILE_MODES,
+            accepted_modes: LIBRARY_FILE_MODES,
             require_durable: require_durable
           )
         end
@@ -852,7 +856,8 @@ class FileCopyService
           stat = file.stat
           expected_identity = file_identity(stat)
           expected_mode = stat.mode & 0o7777
-          result = expected_mode.in?(HARDLINK_FALLBACK_FILE_MODES)
+          result = expected_mode.in?(HARDLINK_FALLBACK_FILE_MODES) ||
+            (expected_mode.in?(LIBRARY_FILE_MODES) && synthetic_library_file_mode?(parent, expected_mode))
         end
         with_pinned_regular_child(parent, basename) do |current|
           stat = current.stat
@@ -1092,7 +1097,7 @@ class FileCopyService
           expected_mode = apply_file_mode!(
             file,
             LIBRARY_FILE_MODE,
-            accepted_modes: SAFE_LIBRARY_FILE_MODES
+            accepted_modes: LIBRARY_FILE_MODES
           )
           file_durable = sync_io(file)
           expected_identity = file_identity(file.stat)
@@ -1147,10 +1152,12 @@ class FileCopyService
             source_stat = source.stat
             destination_stat = destination.stat
             next unless source_stat.size == destination_stat.size
-            if hardlink_mode &&
-                file_identity(source_stat) != file_identity(destination_stat) &&
-                !(destination_stat.mode & 0o7777).in?(HARDLINK_FALLBACK_FILE_MODES)
-              next
+            if hardlink_mode && file_identity(source_stat) != file_identity(destination_stat)
+              destination_mode = destination_stat.mode & 0o7777
+              retry_safe_mode = destination_mode.in?(HARDLINK_FALLBACK_FILE_MODES) ||
+                (destination_mode.in?(LIBRARY_FILE_MODES) &&
+                  synthetic_library_file_mode?(parent, destination_mode))
+              next unless retry_safe_mode
             end
 
             source.rewind
@@ -1161,7 +1168,7 @@ class FileCopyService
               apply_file_mode!(
                 destination,
                 LIBRARY_FILE_MODE,
-                accepted_modes: SAFE_LIBRARY_FILE_MODES
+                accepted_modes: LIBRARY_FILE_MODES
               )
             end
             file_durable = sync_io(destination)
@@ -1373,6 +1380,43 @@ class FileCopyService
       trusted
     end
 
+    # Probe a newly created sibling rather than chmodding retained download
+    # data. A broad fallback mode is retry-safe only when this filesystem
+    # demonstrably ignores the requested library mode.
+    def synthetic_library_file_mode?(parent, expected_mode)
+      probe_basename = ".shelfarr-owner-probe-#{SecureRandom.hex(16)}.tmp"
+      probe_identity = nil
+      probe_uid = nil
+      synthetic = false
+      begin
+        with_created_regular_child(parent, probe_basename, 0o600) do |probe|
+          probe_stat = probe.stat
+          probe_identity = file_identity(probe_stat)
+          probe_uid = probe_stat.uid
+          effective_mode = apply_file_mode!(
+            probe,
+            LIBRARY_FILE_MODE,
+            accepted_modes: LIBRARY_FILE_MODES
+          )
+          synthetic = effective_mode == expected_mode && effective_mode != LIBRARY_FILE_MODE
+        end
+      ensure
+        if probe_identity
+          cleanup = remove_pinned_child_if_identity(
+            parent,
+            probe_basename,
+            probe_identity,
+            expected_owner_uid: probe_uid
+          )
+          synthetic = false unless cleanup.in?([ :removed, :missing ])
+          cleanup_interrupted_owner_probes(parent, probe_uid)
+        end
+      end
+      synthetic
+    rescue UnsafePathError, SystemCallError
+      false
+    end
+
     def safe_relative_path(path)
       relative = Pathname(path.to_s)
       if relative.absolute? || relative.each_filename.any? { |part| part.in?([ ".", ".." ]) }
@@ -1403,8 +1447,8 @@ class FileCopyService
       effective_mode
     end
 
-    def apply_directory_mode!(directory, requested_mode)
-      accepted_modes = requested_mode == DIRECTORY_MODE ? SAFE_LIBRARY_DIRECTORY_MODES : [ requested_mode ]
+    def apply_directory_mode!(directory, requested_mode, accepted_modes: nil)
+      accepted_modes ||= requested_mode == DIRECTORY_MODE ? LIBRARY_DIRECTORY_MODES : [ requested_mode ]
       mode_error = nil
       begin
         native_fchmod(directory.fileno, requested_mode)
@@ -1433,7 +1477,7 @@ class FileCopyService
       heartbeat: nil,
       allow_compatibility_fallback: false,
       source_validator: nil,
-      accepted_modes: SAFE_LIBRARY_FILE_MODES,
+      accepted_modes: LIBRARY_FILE_MODES,
       require_durable: false
     )
       raise Errno::EINVAL, "source is not a regular file" unless source.stat.file?
@@ -1454,6 +1498,7 @@ class FileCopyService
             lock_identity = file_identity(lock.stat)
             raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
 
+            apply_file_mode!(lock, 0o600, accepted_modes: LIBRARY_FILE_MODES)
             sync_io(parent)
             persist_copy_lock_pending!(lock, token)
 
@@ -1461,7 +1506,7 @@ class FileCopyService
               temporary_identity = file_identity(temporary.stat)
               persist_copy_lock_identity!(lock, token, temporary_identity)
               sync_io(parent)
-              apply_file_mode!(temporary, 0o600, accepted_modes: [ 0o600 ])
+              apply_file_mode!(temporary, 0o600, accepted_modes: accepted_modes)
               if heartbeat
                 copy_source_io(source, temporary, heartbeat: heartbeat)
               else
@@ -1573,6 +1618,7 @@ class FileCopyService
             lock_identity = file_identity(lock.stat)
             raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
 
+            apply_file_mode!(lock, 0o600, accepted_modes: LIBRARY_FILE_MODES)
             sync_io(parent)
 
             validate_hardlink_source!(
@@ -1762,7 +1808,7 @@ class FileCopyService
           )
           with_created_regular_child(parent, destination_basename, 0o600) do |destination|
             destination_identity = file_identity(destination.stat)
-            apply_file_mode!(destination, 0o600, accepted_modes: [ 0o600 ])
+            apply_file_mode!(destination, 0o600, accepted_modes: accepted_modes)
             persist_copy_lock_compatibility!(
               lock,
               token,
@@ -1843,7 +1889,7 @@ class FileCopyService
 
       with_pinned_regular_child(parent, lock_basename) do |lock|
         return unless lock.flock(File::LOCK_EX | File::LOCK_NB)
-        return unless private_entry_owned_by_process?(lock.stat, parent)
+        return unless secure_copy_lock?(lock, parent)
 
         lock_identity = file_identity(lock.stat)
         lock.rewind
@@ -1952,7 +1998,7 @@ class FileCopyService
       quarantine = open_pinned_directory_child(parent, basename)
       begin
         stat = quarantine.stat
-        return unless private_entry_owned_by_process?(stat, parent) && (stat.mode & 0o777) == 0o700
+        return unless secure_cleanup_quarantine?(quarantine, parent)
 
         quarantine_identity = file_identity(stat)
         children = pinned_directory_children(quarantine)
@@ -1987,6 +2033,24 @@ class FileCopyService
       end
     rescue Errno::ENOENT, Errno::ELOOP, UnsafePathError
       nil
+    end
+
+    def secure_copy_lock?(lock, parent)
+      stat = lock.stat
+      return false unless private_entry_owned_by_process?(stat, parent)
+      return false unless (stat.mode & 0o7777).in?(LIBRARY_FILE_MODES)
+
+      apply_file_mode!(lock, 0o600, accepted_modes: LIBRARY_FILE_MODES)
+      true
+    end
+
+    def secure_cleanup_quarantine?(quarantine, parent)
+      stat = quarantine.stat
+      return false unless private_entry_owned_by_process?(stat, parent)
+      return false unless (stat.mode & 0o7777).in?(LIBRARY_DIRECTORY_MODES)
+
+      apply_directory_mode!(quarantine, 0o700, accepted_modes: LIBRARY_DIRECTORY_MODES)
+      true
     end
 
     def persist_copy_lock_pending!(lock, token)
@@ -2363,7 +2427,7 @@ class FileCopyService
             secure_pinned_library_tree!(child, heartbeat: heartbeat)
             apply_directory_mode!(child, DIRECTORY_MODE)
           elsif stat.file?
-            apply_file_mode!(child, LIBRARY_FILE_MODE, accepted_modes: SAFE_LIBRARY_FILE_MODES)
+            apply_file_mode!(child, LIBRARY_FILE_MODE, accepted_modes: LIBRARY_FILE_MODES)
           else
             raise UnsafePathError, "source tree contains a symbolic link or non-regular path"
           end
@@ -2831,7 +2895,11 @@ class FileCopyService
             raise UnsafePathError, "cleanup quarantine is owned by another user"
           end
 
-          apply_directory_mode!(quarantine, 0o700)
+          apply_directory_mode!(
+            quarantine,
+            0o700,
+            accepted_modes: LIBRARY_DIRECTORY_MODES
+          )
           sync_io(quarantine)
           sync_io(parent)
           return [ quarantine, basename, file_identity(stat) ]
@@ -2884,7 +2952,7 @@ class FileCopyService
 
         quarantine = open_pinned_directory_child(parent, basename)
         begin
-          next unless private_entry_owned_by_process?(quarantine.stat, parent)
+          next unless secure_cleanup_quarantine?(quarantine, parent)
           next unless pinned_directory_children(quarantine) == [ COPY_QUARANTINE_ENTRY ]
 
           matches = false

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 require "stringio"
 
 class PostProcessingJobTest < ActiveJob::TestCase
+  include SyntheticLibraryModesTestHelper
+
   setup do
     LibraryPlatformClient.reset_connections!
 
@@ -1405,6 +1407,48 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_match(/does not have permission .*write the library/i, @request.reload.issue_description)
   end
 
+  test "invalid filesystem diagnostic bytes do not strand post-processing" do
+    SettingsService.set(:audiobookshelf_url, "")
+    invalid_message = "permission denied for bad-\xFF".dup.force_encoding(Encoding::UTF_8)
+    failure = lambda do |*|
+      raise FileCopyService::UnsafeFilePermissionsError,
+        invalid_message,
+        cause: Errno::EACCES.new(invalid_message)
+    end
+
+    output = FileCopyService.stub(:cp_noreplace, failure) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert output.valid_encoding?
+    assert_includes output,
+      "Download ##{@download.id} failed: FileCopyService::UnsafeFilePermissionsError"
+    assert_includes output, "caused by Errno::EACCES"
+    assert_includes output, "\uFFFD"
+    assert @request.reload.attention_needed?
+    assert_match(/unsupported file or directory permissions/i, @request.issue_description)
+  end
+
+  test "invalid generic error bytes still mark post-processing for attention" do
+    SettingsService.set(:audiobookshelf_url, "")
+    invalid_message = "unexpected failure for bad-\xFF".dup.force_encoding(Encoding::UTF_8)
+    failure = ->(*) { raise RuntimeError, invalid_message }
+
+    output = FileCopyService.stub(:cp_noreplace, failure) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert output.valid_encoding?
+    assert_includes output, "Download ##{@download.id} failed: RuntimeError"
+    assert_includes output, "\uFFFD"
+    assert @request.reload.attention_needed?
+    assert_match(/safe filesystem operation failed/i, @request.issue_description)
+  end
+
   test "falls back to buffered move when NFS copy_file_range fails for single files" do
     source_file = File.join(@temp_source, "Original Name.m4b")
     File.write(source_file, "single file audio content")
@@ -2665,22 +2709,6 @@ class PostProcessingJobTest < ActiveJob::TestCase
     FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EOPNOTSUPP }) do
       FileCopyService.stub(:native_rename_noreplace, false, &operation)
     end
-  end
-
-  def with_synthetic_library_modes(root:, file_mode:, directory_mode:, &operation)
-    root = File.expand_path(root)
-    real_fchmod = FileCopyService.method(:native_fchmod)
-    synthetic_fchmod = lambda do |descriptor, requested_mode|
-      descriptor_path = File.readlink("/proc/self/fd/#{descriptor}") rescue nil
-      unless descriptor_path == root || descriptor_path&.start_with?("#{root}/")
-        next real_fchmod.call(descriptor, requested_mode)
-      end
-
-      handle = File.for_fd(descriptor, "rb", autoclose: false)
-      handle.chmod(handle.stat.directory? ? directory_mode : file_mode)
-    end
-
-    FileCopyService.stub(:native_fchmod, synthetic_fchmod, &operation)
   end
 
   def capture_private_post_processing_logs

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -676,6 +676,45 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_includes output, "0 hardlinked, 0 copied after unsupported fallback, 1 reused"
   end
 
+  test "hardlink retry reuses a synthetic-mode fallback copy after interruption" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "hardlink")
+    source_file = File.join(@temp_source, "audiobook.mp3")
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    destination_file = File.join(destination, "audiobook.mp3")
+    hardlink_attempts = 0
+    first_job = PostProcessingJob.new(@download.id)
+
+    output = with_synthetic_library_modes(
+      root: @temp_dest_base,
+      file_mode: 0o666,
+      directory_mode: 0o777
+    ) do
+      FileCopyService.stub(:hardlink_noreplace, ->(*) {
+        hardlink_attempts += 1
+        raise FileCopyService::HardlinkUnsupportedError, "simulated unsupported hardlink"
+      }) do
+        first_job.stub(:finalize_acquisition!, ->(*) { raise Interrupt, "simulated interruption" }) do
+          assert_raises(Interrupt) { first_job.perform_now }
+        end
+
+        assert_equal 0o666, File.stat(destination_file).mode & 0o7777
+
+        retry_job = PostProcessingJob.new(@download.id, 0, first_job.job_id)
+        capture_private_post_processing_logs do
+          retry_job.perform_now
+        end
+      end
+    end
+
+    assert_equal 1, hardlink_attempts
+    assert @request.reload.completed?
+    assert File.exist?(source_file)
+    assert_equal "test audio content", File.binread(destination_file)
+    assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
+    assert_includes output, "0 hardlinked, 0 copied after unsupported fallback, 1 reused"
+  end
+
   test "hardlinks a shared sidecar into each split bundle destination" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
@@ -1294,6 +1333,76 @@ class PostProcessingJobTest < ActiveJob::TestCase
     destination = Dir.glob(File.join(@temp_dest_base, @book.author, @book.title, "*.m4b")).sole
     assert @request.reload.completed?
     assert_equal 0o600, File.stat(destination).mode & 0o777
+  end
+
+  test "single-file ebook copy supports synthetic Windows ACL modes and compatibility publication" do
+    source_file = File.join(@temp_source, "Original.epub")
+    write_valid_ebook_file(source_file)
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    @book.update!(book_type: :ebook)
+    @download.update!(download_path: source_file)
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:audiobookshelf_url, "")
+
+    with_synthetic_library_modes(root: @temp_dest_base, file_mode: 0o666, directory_mode: 0o777) do
+      without_atomic_file_publication do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    destination = Dir.glob(File.join(@temp_dest_base, @book.author, @book.title, "*.epub")).sole
+    assert @request.reload.completed?
+    assert_equal "PK\x03\x04valid ebook content", File.binread(destination)
+    assert_equal 0o666, File.stat(destination).mode & 0o7777
+    assert_equal 0o777, File.stat(File.dirname(destination)).mode & 0o7777
+  end
+
+  test "recursive audiobook copy supports synthetic Windows ACL modes and compatibility publication" do
+    nested_source = File.join(@temp_source, "Disc One")
+    FileUtils.mkdir_p(nested_source)
+    FileUtils.mv(File.join(@temp_source, "audiobook.mp3"), File.join(nested_source, "chapter.mp3"))
+    SettingsService.set(:audiobookshelf_url, "")
+
+    with_synthetic_library_modes(root: @temp_dest_base, file_mode: 0o644, directory_mode: 0o755) do
+      without_atomic_file_publication do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    destination = File.join(@temp_dest_base, @book.author, @book.title, "Disc One", "chapter.mp3")
+    assert @request.reload.completed?
+    assert_equal "test audio content", File.binread(destination)
+    assert_equal 0o644, File.stat(destination).mode & 0o7777
+    assert_equal 0o755, File.stat(File.dirname(destination)).mode & 0o7777
+  end
+
+  test "unsafe synthetic directory modes preserve typed permission diagnostics" do
+    SettingsService.set(:audiobookshelf_url, "")
+
+    output = capture_private_post_processing_logs do
+      with_synthetic_library_modes(root: @temp_dest_base, file_mode: 0o4777, directory_mode: 0o1777) do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert_includes output, "Download ##{@download.id} failed: FileCopyService::UnsafeFilePermissionsError"
+    refute_includes output, "Download ##{@download.id} failed: RuntimeError"
+    assert_match(/unsupported file or directory permissions/i, @request.reload.issue_description)
+  end
+
+  test "nested import permission failures preserve typed diagnostics" do
+    SettingsService.set(:audiobookshelf_url, "")
+
+    output = FileCopyService.stub(:cp_noreplace, ->(*) { raise Errno::EACCES, "permission denied" }) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert_includes output, "Download ##{@download.id} failed: Errno::EACCES"
+    assert_includes output, "permission denied"
+    refute_includes output, "Download ##{@download.id} failed: RuntimeError"
+    assert_match(/does not have permission .*write the library/i, @request.reload.issue_description)
   end
 
   test "falls back to buffered move when NFS copy_file_range fails for single files" do
@@ -2551,6 +2660,28 @@ class PostProcessingJobTest < ActiveJob::TestCase
   end
 
   private
+
+  def without_atomic_file_publication(&operation)
+    FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EOPNOTSUPP }) do
+      FileCopyService.stub(:native_rename_noreplace, false, &operation)
+    end
+  end
+
+  def with_synthetic_library_modes(root:, file_mode:, directory_mode:, &operation)
+    root = File.expand_path(root)
+    real_fchmod = FileCopyService.method(:native_fchmod)
+    synthetic_fchmod = lambda do |descriptor, requested_mode|
+      descriptor_path = File.readlink("/proc/self/fd/#{descriptor}") rescue nil
+      unless descriptor_path == root || descriptor_path&.start_with?("#{root}/")
+        next real_fchmod.call(descriptor, requested_mode)
+      end
+
+      handle = File.for_fd(descriptor, "rb", autoclose: false)
+      handle.chmod(handle.stat.directory? ? directory_mode : file_mode)
+    end
+
+    FileCopyService.stub(:native_fchmod, synthetic_fchmod, &operation)
+  end
 
   def capture_private_post_processing_logs
     output = StringIO.new

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -125,8 +125,66 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     end
 
     assert File.directory?(directory)
-    assert_includes FileCopyService::SAFE_LIBRARY_DIRECTORY_MODES,
+    assert_includes FileCopyService::LIBRARY_DIRECTORY_MODES,
       File.stat(directory).mode & 0o777
+  end
+
+  test "ensure_directory accepts a synthetic Windows ACL mode" do
+    directory = File.join(@dest_dir, "windows-mode-directory")
+
+    with_synthetic_library_modes(root: @dest_dir, file_mode: 0o666, directory_mode: 0o777) do
+      FileCopyService.ensure_directory(directory, root: @dest_dir)
+    end
+
+    assert File.directory?(directory)
+    assert_equal 0o777, File.stat(directory).mode & 0o7777
+  end
+
+  test "cp_noreplace supports synthetic Windows ACL modes and compatibility publication" do
+    destination = File.join(@dest_dir, "windows-mode.txt")
+
+    with_synthetic_library_modes(
+      root: @dest_dir,
+      file_mode: 0o666,
+      directory_mode: 0o777,
+      fchmod_error: Errno::EOPNOTSUPP
+    ) do
+      without_atomic_file_publication do
+        FileCopyService.cp_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          allow_compatibility_fallback: true
+        )
+      end
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_equal 0o666, File.stat(destination).mode & 0o7777
+    assert_empty Dir.children(@dest_dir) - [ "windows-mode.txt" ]
+  end
+
+  test "private directories still reject synthetic broad modes" do
+    directory = File.join(@dest_dir, "private-directory")
+
+    with_synthetic_library_modes(root: @dest_dir, file_mode: 0o666, directory_mode: 0o777) do
+      assert_raises(FileCopyService::UnsafeFilePermissionsError) do
+        FileCopyService.secure_private_directory!(directory, root: @dest_dir)
+      end
+    end
+  end
+
+  test "library publication rejects synthetic modes with special bits" do
+    destination = File.join(@dest_dir, "special-mode.txt")
+
+    with_synthetic_library_modes(root: @dest_dir, file_mode: 0o4777, directory_mode: 0o1777) do
+      assert_raises(FileCopyService::UnsafeFilePermissionsError) do
+        FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert_not File.exist?(destination)
+    assert_equal "test content", File.binread(@src_file)
   end
 
   test "ensure_directory does not chmod the caller-provided root" do
@@ -145,7 +203,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     unsafe_fchmod = lambda do |descriptor, mode|
       handle = File.for_fd(descriptor, "rb", autoclose: false)
       if handle.stat.file? && mode == FileCopyService::LIBRARY_FILE_MODE
-        handle.chmod(0o644)
+        handle.chmod(0o444)
       else
         real_fchmod.call(descriptor, mode)
       end
@@ -757,7 +815,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     mode_quarantine = copy_quarantine_path(expected_stat, "8" * 32)
     Dir.mkdir(owner_quarantine, 0o700)
     Dir.mkdir(mode_quarantine, 0o700)
-    File.chmod(0o750, mode_quarantine)
+    File.chmod(0o1777, mode_quarantine)
     stale_time = Time.now - FileCopyService::COPY_QUARANTINE_STALE_AGE - 60
     File.utime(stale_time, stale_time, owner_quarantine)
     File.utime(stale_time, stale_time, mode_quarantine)
@@ -1673,6 +1731,38 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not FileCopyService.secure_library_file_mode?(symlink, root: @dest_dir)
     File.chmod(0o644, destination)
     assert_not FileCopyService.secure_library_file_mode?(destination, root: @dest_dir)
+  end
+
+  test "secure_library_file_mode rejects a broad collision when a mode probe remains private" do
+    destination = File.join(@dest_dir, "independent-copy.txt")
+    File.binwrite(destination, "independent bytes")
+    File.chmod(0o644, destination)
+
+    FileCopyService.stub(:native_fchmod, ->(*) { raise Errno::EOPNOTSUPP }) do
+      assert_not FileCopyService.secure_library_file_mode?(destination, root: @dest_dir)
+    end
+
+    assert_equal 0o644, File.stat(destination).mode & 0o7777
+    assert_empty Dir.children(@dest_dir) - [ "independent-copy.txt" ]
+  end
+
+  test "hardlink verification rejects a broad collision when a mode probe remains private" do
+    destination = File.join(@dest_dir, "independent-copy.txt")
+    FileUtils.cp(@src_file, destination)
+    File.chmod(0o644, destination)
+
+    snapshot = FileCopyService.stub(:native_fchmod, ->(*) { raise Errno::EOPNOTSUPP }) do
+      FileCopyService.verified_library_file_snapshot(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        hardlink_mode: true
+      )
+    end
+
+    assert_nil snapshot
+    assert_equal 0o644, File.stat(destination).mode & 0o7777
+    assert_empty Dir.children(@dest_dir) - [ "independent-copy.txt" ]
   end
 
   test "secure_library_file_mode rejects a destination swap during revalidation" do
@@ -2727,6 +2817,23 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EOPNOTSUPP }) do
       FileCopyService.stub(:native_rename_noreplace, false, &operation)
     end
+  end
+
+  def with_synthetic_library_modes(root:, file_mode:, directory_mode:, fchmod_error: nil, &operation)
+    root = File.expand_path(root)
+    real_fchmod = FileCopyService.method(:native_fchmod)
+    synthetic_fchmod = lambda do |descriptor, requested_mode|
+      descriptor_path = File.readlink("/proc/self/fd/#{descriptor}") rescue nil
+      unless descriptor_path == root || descriptor_path&.start_with?("#{root}/")
+        next real_fchmod.call(descriptor, requested_mode)
+      end
+
+      handle = File.for_fd(descriptor, "rb", autoclose: false)
+      handle.chmod(handle.stat.directory? ? directory_mode : file_mode)
+      raise fchmod_error if fchmod_error
+    end
+
+    FileCopyService.stub(:native_fchmod, synthetic_fchmod, &operation)
   end
 
   def copy_quarantine_path(expected_stat, token)

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 require "fiddle"
 
 class FileCopyServiceTest < ActiveSupport::TestCase
+  include SyntheticLibraryModesTestHelper
+
   setup do
     @tmp_dir = Dir.mktmpdir
     @src_file = File.join(@tmp_dir, "source.txt")
@@ -769,6 +771,28 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_empty Dir.children(@dest_dir)
   end
 
+  test "cleanup_interrupted_copies recovers a synthetic-mode copy lock" do
+    token = "f" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    File.binwrite(temporary, "interrupted bytes")
+    temporary_stat = File.stat(temporary)
+    lock = write_copy_lock(token, temporary_stat)
+    File.chmod(0o666, temporary)
+    File.chmod(0o666, lock)
+
+    with_synthetic_library_modes(
+      root: @dest_dir,
+      file_mode: 0o666,
+      directory_mode: 0o777
+    ) do
+      FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+    end
+
+    assert_not File.exist?(temporary)
+    assert_not File.exist?(lock)
+    assert_empty Dir.children(@dest_dir)
+  end
+
   test "cleanup_interrupted_copies recovers a crash-left private quarantine" do
     token = "a" * 32
     temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
@@ -784,6 +808,31 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(temporary)
     assert_not File.exist?(lock)
     assert_not File.exist?(quarantine)
+  end
+
+  test "cleanup_interrupted_copies recovers a synthetic-mode quarantine" do
+    token = "d" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    File.binwrite(temporary, "interrupted bytes")
+    temporary_stat = File.stat(temporary)
+    quarantine = copy_quarantine_path(temporary_stat, "e" * 32)
+    Dir.mkdir(quarantine, 0o700)
+    entry = File.join(quarantine, FileCopyService::COPY_QUARANTINE_ENTRY)
+    File.rename(temporary, entry)
+    File.chmod(0o666, entry)
+    File.chmod(0o777, quarantine)
+
+    with_synthetic_library_modes(
+      root: @dest_dir,
+      file_mode: 0o666,
+      directory_mode: 0o777
+    ) do
+      FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+    end
+
+    assert_not File.exist?(entry)
+    assert_not File.exist?(quarantine)
+    assert_empty Dir.children(@dest_dir)
   end
 
   test "cleanup_interrupted_copies retains a fresh empty quarantine" do
@@ -1976,7 +2025,11 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     nested = File.join(source_root_path, "nested")
     invalid_filename = "chapter-\xFF.mp3".b
     FileUtils.mkdir_p(nested)
-    File.binwrite(File.join(nested, invalid_filename), "chapter")
+    begin
+      File.binwrite(File.join(nested, invalid_filename), "chapter")
+    rescue Errno::EILSEQ
+      skip "host filesystem rejects invalid UTF-8 filenames"
+    end
 
     error = assert_raises(FileCopyService::UnsafePathError) do
       FileCopyService.snapshot_source_root(source_root_path)
@@ -2817,23 +2870,6 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EOPNOTSUPP }) do
       FileCopyService.stub(:native_rename_noreplace, false, &operation)
     end
-  end
-
-  def with_synthetic_library_modes(root:, file_mode:, directory_mode:, fchmod_error: nil, &operation)
-    root = File.expand_path(root)
-    real_fchmod = FileCopyService.method(:native_fchmod)
-    synthetic_fchmod = lambda do |descriptor, requested_mode|
-      descriptor_path = File.readlink("/proc/self/fd/#{descriptor}") rescue nil
-      unless descriptor_path == root || descriptor_path&.start_with?("#{root}/")
-        next real_fchmod.call(descriptor, requested_mode)
-      end
-
-      handle = File.for_fd(descriptor, "rb", autoclose: false)
-      handle.chmod(handle.stat.directory? ? directory_mode : file_mode)
-      raise fchmod_error if fchmod_error
-    end
-
-    FileCopyService.stub(:native_fchmod, synthetic_fchmod, &operation)
   end
 
   def copy_quarantine_path(expected_stat, token)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "rails/test_help"
 require "minitest/mock"
 require "mutant/minitest/coverage"
 require_relative "test_helpers/session_test_helper"
+require_relative "test_helpers/synthetic_library_modes_test_helper"
 require_relative "support/vcr_setup"
 
 # Resolve hostnames to a fixed public test address instead of doing real DNS

--- a/test/test_helpers/synthetic_library_modes_test_helper.rb
+++ b/test/test_helpers/synthetic_library_modes_test_helper.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module SyntheticLibraryModesTestHelper
+  # Ruby's Fcntl module does not expose Darwin's F_GETPATH.
+  DARWIN_F_GETPATH = 50
+  DARWIN_PATH_BUFFER_SIZE = 1024
+
+  def with_synthetic_library_modes(
+    root:,
+    file_mode:,
+    directory_mode:,
+    fchmod_error: nil,
+    &operation
+  )
+    root = File.realpath(root)
+    real_fchmod = FileCopyService.method(:native_fchmod)
+    synthetic_fchmod = lambda do |descriptor, requested_mode|
+      descriptor_path = synthetic_mode_descriptor_path(descriptor)
+      unless descriptor_path == root || descriptor_path.start_with?("#{root}/")
+        next real_fchmod.call(descriptor, requested_mode)
+      end
+
+      handle = File.for_fd(descriptor, "rb", autoclose: false)
+      handle.chmod(handle.stat.directory? ? directory_mode : file_mode)
+      raise fchmod_error if fchmod_error
+    end
+
+    FileCopyService.stub(:native_fchmod, synthetic_fchmod, &operation)
+  end
+
+  private
+
+  def synthetic_mode_descriptor_path(descriptor)
+    if File.directory?("/proc/self/fd")
+      return File.readlink("/proc/self/fd/#{descriptor}")
+    end
+
+    if RUBY_PLATFORM.include?("darwin")
+      handle = File.for_fd(descriptor, "rb", autoclose: false)
+      buffer = "\0" * DARWIN_PATH_BUFFER_SIZE
+      handle.fcntl(DARWIN_F_GETPATH, buffer)
+      return buffer.split("\0", 2).first
+    end
+
+    raise "Cannot resolve file descriptor paths on #{RUBY_PLATFORM}"
+  end
+end


### PR DESCRIPTION
## Summary
- accept synthetic Windows ACL file and directory modes for ordinary library publication while continuing to reject missing owner control and special bits
- preserve hardlink retry and collision safety with descriptor-pinned exact-mode filesystem probes, and revalidate recovery locks and quarantines
- keep filesystem exceptions typed and include bounded diagnostic details in private post-processing logs
- cover single-file ebooks, recursive audiobooks, compatibility publication, crash retries, and unsafe modes

## Test plan
- `bin/quality push`
- `bin/quality commit --staged`
- `bin/rails test test/services/file_copy_service_test.rb test/jobs/post_processing_job_test.rb`

Closes #401