### PR TITLE
fix: send the author to Prowlarr indexers that only accept free text

### DIFF
--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -19,8 +19,12 @@ module IndexerClients
           return items.map { |item| parse_result(item) }
         end
 
-        scoped = scoped_indexers
-        plans = book_search_plans(query, title: title, author: author, indexers: scoped)
+        # Resolve the configured tag scope once and carry it through. Reading it
+        # a second time while planning lets a transient /api/v1/tag failure read
+        # as "no tags configured" and widen the search past the user's scope.
+        tags = indexer_filter_tags
+        scoped = scoped_indexers(tags: tags)
+        plans = book_search_plans(query, title: title, author: author, tags: tags, indexers: scoped)
         items = execute_book_search_plans(plans, categories: cats, limit: limit)
 
         deduplicate_by_guid(items, indexer_priorities(scoped)).map { |item| parse_result(item) }
@@ -292,7 +296,7 @@ module IndexerClients
       # accept and give each group the richest query it supports. A token is
       # only ever emitted when the indexer is known to support it; everything
       # else falls back to free text, which every indexer accepts.
-      def book_search_plans(query, title:, author:, indexers: scoped_indexers)
+      def book_search_plans(query, title:, author:, tags: indexer_filter_tags, indexers: scoped_indexers(tags: tags))
         free_text_query = build_free_text_query(query, title: title, author: author)
 
         # Indexer list unavailable, or nothing matched the configured tags: keep
@@ -317,8 +321,9 @@ module IndexerClients
         # One plan covers every indexer Prowlarr would have searched anyway, so
         # drop the selection and leave the choice to Prowlarr exactly as before
         # this split existed. An indexer blocked since the list was read then
-        # costs nothing.
-        plans.first[:indexer_ids] = nil if plans.one? && indexer_filter_tags.empty?
+        # costs nothing. Only safe without a tag scope: with one, "every indexer
+        # Prowlarr would search" is the whole enabled set, not the tagged subset.
+        plans.first[:indexer_ids] = nil if plans.one? && tags.empty?
 
         plans
       end

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -8,22 +8,14 @@ module IndexerClients
       def search(query, categories: nil, book_type: nil, limit: 100, title: nil, author: nil)
         ensure_configured!
 
-        params = {
-          query: build_query(query, title: title, author: author),
-          type: search_type_for(title: title, author: author),
-          limit: limit
-        }
-
         cats = categories || categories_for_type(book_type)
-        params[:categories] = Array(cats) if cats.present?
 
-        indexer_ids = filtered_indexer_ids
-        params[:indexerIds] = indexer_ids if indexer_ids.present?
+        if search_type_for(title: title, author: author) == "search"
+          return execute_search(query, type: "search", categories: cats, limit: limit, indexer_ids: filtered_indexer_ids)
+        end
 
-        response = request { connection.get("api/v1/search", params) }
-
-        handle_response(response) do |data|
-          Array(data).map { |item| parse_result(item) }
+        book_search_plans(query, title: title, author: author).flat_map do |plan|
+          execute_search(plan[:query], type: "book", categories: cats, limit: limit, indexer_ids: plan[:indexer_ids])
         end
       end
 
@@ -34,16 +26,25 @@ module IndexerClients
         handle_response(response) { |data| Array(data) }
       end
 
+      # Indexers Prowlarr would search on our behalf: every configured indexer,
+      # or only the tagged subset when prowlarr_tags is set. Returns nil when
+      # Prowlarr's indexer list cannot be read.
+      def scoped_indexers(tags: indexer_filter_tags)
+        normalized_tags = tags.map(&:to_s).map(&:downcase)
+        all = indexers
+        return all if normalized_tags.empty?
+
+        all.select { |indexer| (normalized_indexer_tags(indexer["tags"]) & normalized_tags).any? }
+      rescue IndexerClients::Base::Error => e
+        Rails.logger.warn "[IndexerClients::Prowlarr] Failed to fetch indexers: #{e.message}"
+        nil
+      end
+
       def filtered_indexer_ids
-        tags = indexer_filter_tags.map(&:to_s).map(&:downcase)
+        tags = indexer_filter_tags
         return nil if tags.empty?
 
-        indexers
-          .select { |indexer| (normalized_indexer_tags(indexer["tags"]) & tags).any? }
-          .map { |indexer| indexer["id"] }
-      rescue IndexerClients::Base::Error => e
-        Rails.logger.warn "[IndexerClients::Prowlarr] Failed to fetch indexers for tag filtering: #{e.message}"
-        nil
+        scoped_indexers(tags: tags)&.map { |indexer| indexer["id"] }
       end
 
       def configured_tags
@@ -202,6 +203,71 @@ module IndexerClients
         nil
       end
 
+      def execute_search(query, type:, categories:, limit:, indexer_ids:)
+        params = { query: query, type: type, limit: limit }
+        params[:categories] = Array(categories) if categories.present?
+        params[:indexerIds] = indexer_ids if indexer_ids.present?
+
+        response = request { connection.get("api/v1/search", params) }
+
+        handle_response(response) do |data|
+          Array(data).map { |item| parse_result(item) }
+        end
+      end
+
+      # Prowlarr does not degrade a book search gracefully: when the query
+      # carries a {title:} or {author:} token that an indexer does not
+      # advertise in its bookSearchParams, that indexer is skipped outright
+      # ("Book search skipped due to unsupported capabilities used") and
+      # contributes nothing, rather than being queried on the free text.
+      # Most torrent trackers advertise `q` only, so a structured query
+      # retrieves literally zero results there while looking healthy.
+      #
+      # Group the indexers we are about to search by what they can actually
+      # accept and give each group the richest query it supports. A token is
+      # only ever emitted when the indexer is known to support it; everything
+      # else falls back to free text, which every indexer accepts.
+      def book_search_plans(query, title:, author:)
+        structured, free_text = Array(scoped_indexers).partition do |indexer|
+          supports_structured_book_search?(indexer, title: title, author: author)
+        end
+
+        plans = []
+        plans << search_plan(build_query(query, title: title, author: author), structured) if structured.any?
+        plans << search_plan(build_free_text_query(query, title: title, author: author), free_text) if free_text.any?
+
+        return plans if plans.any?
+
+        # Indexer list unavailable (or nothing matched the configured tags):
+        # search everything with the query shape no indexer can reject.
+        [ search_plan(build_free_text_query(query, title: title, author: author), []) ]
+      end
+
+      def search_plan(query, indexers)
+        { query: query, indexer_ids: indexers.map { |indexer| indexer["id"] }.presence }
+      end
+
+      def supports_structured_book_search?(indexer, title:, author:)
+        params = book_search_params(indexer)
+        return false if params.nil?
+        return false if sanitized_book_value(title).present? && !params.include?("title")
+        return false if sanitized_book_value(author).present? && !params.include?("author")
+
+        true
+      end
+
+      def book_search_params(indexer)
+        return nil unless indexer.is_a?(Hash)
+
+        capabilities = indexer["capabilities"]
+        return nil unless capabilities.is_a?(Hash)
+
+        params = capabilities["bookSearchParams"]
+        return nil unless params.is_a?(Array)
+
+        params.map { |param| param.to_s.downcase }
+      end
+
       def search_type_for(title:, author:)
         sanitized_book_value(title).present? || sanitized_book_value(author).present? ? "book" : "search"
       end
@@ -217,6 +283,13 @@ module IndexerClients
         parts << "{author:#{sanitized_author}}" if sanitized_author.present?
         parts << query if query.present?
         parts.join(" ")
+      end
+
+      def build_free_text_query(query, title:, author:)
+        [ sanitized_book_value(title), sanitized_book_value(author), query ]
+          .compact_blank
+          .join(" ")
+          .squish
       end
 
       def sanitized_book_value(value)

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -4,6 +4,10 @@ module IndexerClients
   class Prowlarr < Base
     Result = IndexerClients::Result
 
+    # Prowlarr's own default when a definition carries no priority, so
+    # de-duplication always has something to order by.
+    DEFAULT_INDEXER_PRIORITY = 25
+
     class << self
       def search(query, categories: nil, book_type: nil, limit: 100, title: nil, author: nil)
         ensure_configured!
@@ -11,12 +15,15 @@ module IndexerClients
         cats = categories || categories_for_type(book_type)
 
         if search_type_for(title: title, author: author) == "search"
-          return execute_search(query, type: "search", categories: cats, limit: limit, indexer_ids: filtered_indexer_ids)
+          items = execute_search(query, type: "search", categories: cats, limit: limit, indexer_ids: filtered_indexer_ids)
+          return items.map { |item| parse_result(item) }
         end
 
-        book_search_plans(query, title: title, author: author).flat_map do |plan|
-          execute_search(plan[:query], type: "book", categories: cats, limit: limit, indexer_ids: plan[:indexer_ids])
-        end
+        scoped = scoped_indexers
+        plans = book_search_plans(query, title: title, author: author, indexers: scoped)
+        items = execute_book_search_plans(plans, categories: cats, limit: limit)
+
+        deduplicate_by_guid(items, indexer_priorities(scoped)).map { |item| parse_result(item) }
       end
 
       def indexers
@@ -210,9 +217,67 @@ module IndexerClients
 
         response = request { connection.get("api/v1/search", params) }
 
-        handle_response(response) do |data|
-          Array(data).map { |item| parse_result(item) }
+        handle_response(response) { |data| Array(data) }
+      end
+
+      # A plan can name indexers Prowlarr will not search: it drops disabled
+      # definitions and indexers it has temporarily blocked after repeated
+      # failures from an explicit indexerIds selection, then fails the whole
+      # search ("Search failed due to all selected indexers being unavailable",
+      # HTTP 400) when nothing is left. That must not throw away what the other
+      # plan already returned, so an error is only propagated when every plan
+      # fails.
+      def execute_book_search_plans(plans, categories:, limit:)
+        items = []
+        errors = []
+
+        plans.each do |plan|
+          items.concat(
+            execute_search(plan[:query], type: "book", categories: categories, limit: limit, indexer_ids: plan[:indexer_ids])
+          )
+        rescue IndexerClients::Base::Error => e
+          selection = plan[:indexer_ids] ? plan[:indexer_ids].join(", ") : "all indexers"
+          Rails.logger.warn "[IndexerClients::Prowlarr] Book search plan failed (#{selection}): #{e.message}"
+          errors << e
         end
+
+        raise errors.first if errors.any? && errors.size == plans.size
+
+        items
+      end
+
+      # Prowlarr de-duplicates by GUID within a single search and keeps the copy
+      # from the highest-priority indexer (DeDupeReleases orders by ascending
+      # IndexerPriority). Splitting the search across plans moves that job here,
+      # since the same release can legitimately come back from both plans.
+      def deduplicate_by_guid(items, priorities)
+        best = {}
+
+        items.each do |item|
+          # Nothing to de-duplicate a GUID-less result against; key it on
+          # identity so it is kept rather than merged with another.
+          key = item["guid"].presence || item.object_id
+          incumbent = best[key]
+          next if incumbent && indexer_priority(incumbent, priorities) <= indexer_priority(item, priorities)
+
+          best[key] = item
+        end
+
+        best.values
+      end
+
+      def indexer_priorities(indexers)
+        Array(indexers).each_with_object({}) do |indexer, priorities|
+          next unless indexer.is_a?(Hash)
+
+          id = indexer["id"]
+          priority = Integer(indexer["priority"], exception: false)
+          priorities[id] = priority if id.present? && priority
+        end
+      end
+
+      def indexer_priority(item, priorities)
+        priorities.fetch(item["indexerId"], DEFAULT_INDEXER_PRIORITY)
       end
 
       # Prowlarr does not degrade a book search gracefully: when the query
@@ -227,24 +292,58 @@ module IndexerClients
       # accept and give each group the richest query it supports. A token is
       # only ever emitted when the indexer is known to support it; everything
       # else falls back to free text, which every indexer accepts.
-      def book_search_plans(query, title:, author:)
-        structured, free_text = Array(scoped_indexers).partition do |indexer|
+      def book_search_plans(query, title:, author:, indexers: scoped_indexers)
+        free_text_query = build_free_text_query(query, title: title, author: author)
+
+        # Indexer list unavailable, or nothing matched the configured tags: keep
+        # letting Prowlarr pick the indexers, with the query shape none of them
+        # can reject.
+        return [ search_plan(free_text_query, nil) ] if indexers.blank?
+
+        available = indexers.select { |indexer| searchable?(indexer) }
+
+        # Every indexer in scope is disabled or blocked. Prowlarr would fail any
+        # explicit selection built from them, and there is nothing else to ask.
+        return [] if available.empty?
+
+        structured, free_text = available.partition do |indexer|
           supports_structured_book_search?(indexer, title: title, author: author)
         end
 
         plans = []
-        plans << search_plan(build_query(query, title: title, author: author), structured) if structured.any?
-        plans << search_plan(build_free_text_query(query, title: title, author: author), free_text) if free_text.any?
+        plans << search_plan(build_query(query, title: title, author: author), indexer_ids(structured)) if structured.any?
+        plans << search_plan(free_text_query, indexer_ids(free_text)) if free_text.any?
 
-        return plans if plans.any?
+        # One plan covers every indexer Prowlarr would have searched anyway, so
+        # drop the selection and leave the choice to Prowlarr exactly as before
+        # this split existed. An indexer blocked since the list was read then
+        # costs nothing.
+        plans.first[:indexer_ids] = nil if plans.one? && indexer_filter_tags.empty?
 
-        # Indexer list unavailable (or nothing matched the configured tags):
-        # search everything with the query shape no indexer can reject.
-        [ search_plan(build_free_text_query(query, title: title, author: author), []) ]
+        plans
       end
 
-      def search_plan(query, indexers)
-        { query: query, indexer_ids: indexers.map { |indexer| indexer["id"] }.presence }
+      # Prowlarr searches neither a disabled indexer nor one it has temporarily
+      # blocked after repeated failures, and rejects a selection containing only
+      # those, so they must not shape a plan.
+      def searchable?(indexer)
+        return false unless indexer.is_a?(Hash)
+        return false if indexer["enable"] == false
+
+        disabled_till = indexer.dig("status", "disabledTill")
+        return true if disabled_till.blank?
+
+        Time.parse(disabled_till.to_s) <= Time.current
+      rescue ArgumentError
+        true
+      end
+
+      def indexer_ids(indexers)
+        indexers.filter_map { |indexer| indexer["id"] }.presence
+      end
+
+      def search_plan(query, indexer_ids)
+        { query: query, indexer_ids: indexer_ids }
       end
 
       def supports_structured_book_search?(indexer, title:, author:)

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -3,9 +3,30 @@
 require "test_helper"
 
 class SearchJobTest < ActiveJob::TestCase
+  # Prowlarr book searches are now shaped by what each indexer advertises, so
+  # the client reads /api/v1/indexer before searching. Default to an indexer
+  # that accepts the structured {title:}/{author:} query; the tests that care
+  # about the free-text path stub their own capabilities.
+  STRUCTURED_INDEXERS = [
+    {
+      "id" => 1,
+      "name" => "StructuredIndexer",
+      "capabilities" => { "bookSearchParams" => [ "q", "author", "title" ] }
+    }
+  ].freeze
+
+  FREE_TEXT_INDEXERS = [
+    {
+      "id" => 2,
+      "name" => "FreeTextIndexer",
+      "capabilities" => { "bookSearchParams" => [ "q" ] }
+    }
+  ].freeze
+
   setup do
     @request = requests(:pending_request)
     @request.search_results.blocklisted.destroy_all
+    stub_prowlarr_indexers
     SettingsService.set(:prowlarr_url, "http://localhost:9696")
     SettingsService.set(:prowlarr_api_key, "test-key")
     SettingsService.set(:zlibrary_enabled, false)
@@ -891,6 +912,33 @@ class SearchJobTest < ActiveJob::TestCase
       assert_nothing_raised do
         SearchJob.perform_now(@request.id)
       end
+    end
+  end
+
+  test "sends the author to Prowlarr indexers that only accept free text" do
+    VCR.turned_off do
+      stub_prowlarr_indexers(FREE_TEXT_INDEXERS)
+
+      book_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values["query"]
+
+          req.uri.query_values["type"] == "book" &&
+            query.include?(@request.book.title) &&
+            query.include?(@request.book.author) &&
+            query.exclude?("{title:") &&
+            query.exclude?("{author:")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ prowlarr_result_payload ].to_json
+        )
+      stub_prowlarr_generic_search_empty
+
+      SearchJob.perform_now(@request.id)
+
+      assert_requested book_stub
     end
   end
 
@@ -2532,6 +2580,15 @@ class SearchJobTest < ActiveJob::TestCase
         published_at: Time.current
       )
     }
+  end
+
+  def stub_prowlarr_indexers(indexers = STRUCTURED_INDEXERS)
+    stub_request(:get, %r{localhost:9696/api/v1/indexer})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: indexers.to_json
+      )
   end
 
   def stub_prowlarr_search_with_results

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -161,7 +161,9 @@ class ProwlarrClientTest < ActiveSupport::TestCase
 
           query["type"] == "book" &&
             query["query"] == "Inferno Dan Brown" &&
-            query["indexerIds"] == "2"
+            # A single plan covers every indexer Prowlarr would search anyway,
+            # so it is left unrestricted rather than pinned to a selection.
+            query["indexerIds"].nil?
         end
         .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
 
@@ -223,6 +225,133 @@ class ProwlarrClientTest < ActiveSupport::TestCase
 
       assert_equal [], ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
       assert_requested search_stub
+    end
+  end
+
+  test "search does not plan around a disabled indexer" do
+    VCR.turned_off do
+      # /api/v1/indexer returns every configured definition, disabled ones
+      # included, but Prowlarr will not search them: a selection naming only
+      # disabled indexers fails the search outright.
+      stub_indexers(STRUCTURED_INDEXER, FREE_TEXT_INDEXER.merge("enable" => false))
+
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values
+
+          query["query"] == "{title:Inferno} {author:Dan Brown}" && query["indexerIds"].nil?
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "guid" => "structured-1", "title" => "Inferno", "indexer" => "StructuredIndexer" } ].to_json
+        )
+
+      results = ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+
+      assert_equal [ "structured-1" ], results.map(&:guid)
+      assert_requested structured_stub
+      assert_not_requested :get, %r{localhost:9696/api/v1/search}, query: hash_including("indexerIds" => "2")
+    end
+  end
+
+  test "search does not plan around an indexer Prowlarr has temporarily blocked" do
+    VCR.turned_off do
+      blocked = FREE_TEXT_INDEXER.merge("status" => { "disabledTill" => 1.hour.from_now.utc.iso8601 })
+      stub_indexers(STRUCTURED_INDEXER, blocked)
+
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["query"] == "{title:Inferno} {author:Dan Brown}" }
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      assert_equal [], ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+      assert_requested structured_stub
+      assert_not_requested :get, %r{localhost:9696/api/v1/search}, query: hash_including("query" => "Inferno Dan Brown")
+    end
+  end
+
+  test "search returns nothing when every indexer in scope is unavailable" do
+    VCR.turned_off do
+      stub_indexers(
+        STRUCTURED_INDEXER.merge("enable" => false),
+        FREE_TEXT_INDEXER.merge("enable" => false)
+      )
+
+      assert_equal [], ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+      assert_not_requested :get, %r{localhost:9696/api/v1/search}
+    end
+  end
+
+  test "search keeps the results of a plan that succeeded when another plan fails" do
+    VCR.turned_off do
+      # An indexer can be disabled or blocked between reading the list and
+      # running the search; Prowlarr then answers 400 for that selection.
+      stub_indexers(STRUCTURED_INDEXER, FREE_TEXT_INDEXER)
+
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["indexerIds"] == "1" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "guid" => "structured-1", "title" => "Inferno", "indexer" => "StructuredIndexer" } ].to_json
+        )
+
+      free_text_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["indexerIds"] == "2" }
+        .to_return(status: 400, body: "")
+
+      results = ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+
+      assert_equal [ "structured-1" ], results.map(&:guid)
+      assert_requested structured_stub
+      assert_requested free_text_stub
+    end
+  end
+
+  test "search raises when every book search plan fails" do
+    VCR.turned_off do
+      stub_indexers(STRUCTURED_INDEXER, FREE_TEXT_INDEXER)
+      stub_request(:get, %r{localhost:9696/api/v1/search}).to_return(status: 400, body: "")
+
+      assert_raises IndexerClients::Base::Error do
+        ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+      end
+    end
+  end
+
+  test "search de-duplicates plan results by guid, keeping the higher-priority indexer" do
+    VCR.turned_off do
+      # Prowlarr de-duplicates by GUID within one search and keeps the copy from
+      # the indexer with the lowest priority number. Splitting the search across
+      # plans makes that this client's job.
+      stub_indexers(
+        STRUCTURED_INDEXER.merge("priority" => 50),
+        FREE_TEXT_INDEXER.merge("priority" => 1)
+      )
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["indexerIds"] == "1" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "guid" => "shared", "title" => "Inferno", "indexer" => "StructuredIndexer", "indexerId" => 1 } ].to_json
+        )
+
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["indexerIds"] == "2" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [
+            { "guid" => "shared", "title" => "Inferno", "indexer" => "FreeTextIndexer", "indexerId" => 2 },
+            { "guid" => "free-text-only", "title" => "Inferno", "indexer" => "FreeTextIndexer", "indexerId" => 2 }
+          ].to_json
+        )
+
+      results = ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+
+      assert_equal [ "shared", "free-text-only" ], results.map(&:guid)
+      assert_equal "FreeTextIndexer", results.first.indexer
     end
   end
 

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -3,6 +3,21 @@
 require "test_helper"
 
 class ProwlarrClientTest < ActiveSupport::TestCase
+  # Indexer advertising the structured book search params Prowlarr needs before
+  # it will accept a {title:}/{author:} query.
+  STRUCTURED_INDEXER = {
+    "id" => 1,
+    "name" => "StructuredIndexer",
+    "capabilities" => { "bookSearchParams" => [ "q", "author", "title" ] }
+  }.freeze
+
+  # The common case: a tracker that only accepts free text.
+  FREE_TEXT_INDEXER = {
+    "id" => 2,
+    "name" => "FreeTextIndexer",
+    "capabilities" => { "bookSearchParams" => [ "q" ] }
+  }.freeze
+
   setup do
     # Configure Prowlarr settings for tests
     SettingsService.set(:prowlarr_url, "http://localhost:9696")
@@ -77,6 +92,8 @@ class ProwlarrClientTest < ActiveSupport::TestCase
 
   test "search uses Prowlarr book search when title or author are provided" do
     VCR.turned_off do
+      stub_indexers(STRUCTURED_INDEXER)
+
       search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           query = req.uri.query_values
@@ -105,6 +122,8 @@ class ProwlarrClientTest < ActiveSupport::TestCase
 
   test "search sanitizes braces in structured book query values" do
     VCR.turned_off do
+      stub_indexers(STRUCTURED_INDEXER)
+
       search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           query = req.uri.query_values
@@ -128,6 +147,81 @@ class ProwlarrClientTest < ActiveSupport::TestCase
       )
 
       assert_equal [], results
+      assert_requested search_stub
+    end
+  end
+
+  test "search sends a free-text book query to indexers that only support q" do
+    VCR.turned_off do
+      stub_indexers(FREE_TEXT_INDEXER)
+
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values
+
+          query["type"] == "book" &&
+            query["query"] == "Inferno Dan Brown" &&
+            query["indexerIds"] == "2"
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      assert_equal [], ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+      assert_requested search_stub
+    end
+  end
+
+  test "search splits a book search by what each indexer can accept" do
+    VCR.turned_off do
+      stub_indexers(STRUCTURED_INDEXER, FREE_TEXT_INDEXER)
+
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values
+
+          query["indexerIds"] == "1" &&
+            query["query"] == "{title:Inferno} {author:Dan Brown}"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "guid" => "structured-1", "title" => "Inferno", "indexer" => "StructuredIndexer" } ].to_json
+        )
+
+      free_text_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values
+
+          query["indexerIds"] == "2" && query["query"] == "Inferno Dan Brown"
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "guid" => "free-text-1", "title" => "Inferno", "indexer" => "FreeTextIndexer" } ].to_json
+        )
+
+      results = ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
+
+      assert_equal [ "structured-1", "free-text-1" ], results.map(&:guid)
+      assert_requested structured_stub
+      assert_requested free_text_stub
+    end
+  end
+
+  test "search falls back to a free-text book query when indexer capabilities are unavailable" do
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/indexer}).to_return(status: 500, body: "")
+
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          query = req.uri.query_values
+
+          query["type"] == "book" &&
+            query["query"] == "Inferno Dan Brown" &&
+            query["indexerIds"].nil?
+        end
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: [].to_json)
+
+      assert_equal [], ProwlarrClient.search("", book_type: :ebook, title: "Inferno", author: "Dan Brown")
       assert_requested search_stub
     end
   end
@@ -405,5 +499,16 @@ class ProwlarrClientTest < ActiveSupport::TestCase
         ProwlarrClient.search("test query")
       end
     end
+  end
+
+  private
+
+  def stub_indexers(*indexers)
+    stub_request(:get, %r{localhost:9696/api/v1/indexer})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: indexers.to_json
+      )
   end
 end

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -609,6 +609,49 @@ class ProwlarrClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "book search keeps a name-resolved tag scope when the tag endpoint fails again" do
+    SettingsService.set(:prowlarr_tags, "books")
+    ProwlarrClient.instance_variable_set(:@connection, nil)
+
+    VCR.turned_off do
+      # The tag names resolve once, then the endpoint starts failing. The scope
+      # was already resolved, so the book search must still be restricted to it.
+      stub_request(:get, %r{localhost:9696/api/v1/tag})
+        .to_return(
+          {
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: [ { "id" => 42, "label" => "books" } ].to_json
+          },
+          {
+            status: 500,
+            headers: { "Content-Type" => "application/json" },
+            body: { "error" => "boom" }.to_json
+          }
+        )
+
+      # Both are free-text only, so the split leaves a single plan — the path
+      # that drops indexerIds when nothing is scoping the search.
+      stub_indexers(
+        { "id" => 1, "name" => "Untagged", "tags" => [ 7 ],
+          "capabilities" => { "bookSearchParams" => [ "q" ] } },
+        { "id" => 2, "name" => "Tagged", "tags" => [ 42 ],
+          "capabilities" => { "bookSearchParams" => [ "q" ] } }
+      )
+
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with(query: hash_including("type" => "book", "indexerIds" => "2"))
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      ProwlarrClient.search("", title: "Frankenstein", author: "Mary Shelley")
+      assert_requested search_stub
+    end
+  end
+
   # SSL error handling tests
   test "test_connection returns false on SSL error" do
     VCR.turned_off do


### PR DESCRIPTION
**If you'd rather implement this yourself, please do — everything needed to reproduce, diagnose and re-derive the fix is written out below, and the patch can be discarded without losing anything.**

## The problem

For anyone whose indexers are free-text only — which is most torrent trackers — **the structured book search retrieves nothing at all**, and the author never reaches any indexer.

`IndexerClients::Prowlarr.build_query` builds a correct structured query and `search` issues it as `type=book`:

```ruby
parts << "{title:#{sanitized_title}}"   if sanitized_title.present?
parts << "{author:#{sanitized_author}}" if sanitized_author.present?
```

Prowlarr parses those tokens into `BookSearchCriteria.Title` / `.Author` (`NewznabRequest.QueryToParams()`), and then, in `src/NzbDrone.Core/Indexers/HttpIndexerBase.cs`:

```csharp
public override Task<IndexerPageableQueryResult> Fetch(BookSearchCriteria searchCriteria)
{
    ...
    if ((searchCriteria.Title.IsNotNullOrWhiteSpace() && !caps.BookSearchTitleAvailable) ||
        (searchCriteria.Author.IsNotNullOrWhiteSpace() && !caps.BookSearchAuthorAvailable) ||
        (searchCriteria.Publisher.IsNotNullOrWhiteSpace() && !caps.BookSearchPublisherAvailable) ||
        (searchCriteria.Genre.IsNotNullOrWhiteSpace() && !caps.BookSearchGenreAvailable) ||
        (searchCriteria.Year.HasValue && !caps.BookSearchYearAvailable))
    {
        _logger.Debug("Book search skipped due to unsupported capabilities used: {0}", Definition.Name);
```

It **skips the indexer entirely** rather than falling back to the free text. On a `bookSearchParams: ['q']` indexer the search returns zero, in under 10 ms, having made no HTTP request and left no row in Prowlarr's history.

## Reproduce it in one command

Any Prowlarr with a `q`-only book indexer (check `GET /api/v1/indexer` → `capabilities.bookSearchParams`). This is the exact query Shelfarr sends:

```bash
# what Shelfarr sends today -> 0 results, indexer never contacted
curl -s -G -H "X-Api-Key: $KEY" http://prowlarr:9696/api/v1/search \
  --data-urlencode 'query={title:Frankenstein} {author:Mary Shelley}' \
  --data-urlencode 'type=book' | jq length

# same indexer, free text -> the real results
curl -s -G -H "X-Api-Key: $KEY" http://prowlarr:9696/api/v1/search \
  --data-urlencode 'query=Frankenstein Mary Shelley' \
  --data-urlencode 'type=book' | jq length
```

Measured against a live Prowlarr 2.4.0.5397 / Shelfarr 0.39.2, one `q`-only indexer:

| query | type | result |
|---|---|---|
| `{title:Frankenstein} {author:Mary Shelley}` | book | **0 results, <10 ms, indexer never contacted** |
| the same tokens **+** free text appended | book | **0** — the token's mere presence triggers the skip |
| `Frankenstein Mary Shelley` | book | **20 results** |
| `Frankenstein Mary Shelley` | search | 20 results |

★ **The diagnostic tell is that a `type=book` search leaves NO ROW in Prowlarr's history** (`GET /api/v1/history?sortKey=date&sortDirection=descending`). A skipped indexer and a genuinely-empty search are indistinguishable from Shelfarr's side, since Shelfarr doesn't log its outbound query — Prowlarr's history is the only honest witness. That is also how to verify any fix: **pass = the recorded query contains the author.**

## Why it stays invisible

Because the structured search comes back empty, `search_prowlarr` falls through to `search_generic_indexer_attempts`, whose first attempt is `exact_title` — **title only**. `strong_indexer_match?` then breaks the attempt loop as soon as anything clears `min_match_confidence`, so the `title_author` and `author_title` attempts a few lines below **never run**.

So **the author drives ranking but never retrieval.** The scorer is author-aware and does its job — it just can only rank what the query dragged in. What a title-only query actually drags in, across four indexers in the ebook categories:

```
"Frankenstein"  ->  126 candidates, 12 of which name Shelley

  Frankenstein by Mary Shelley EPUB
  Cleopatra and Frankenstein by Coco Mellors EPUB
  Frankenstein in Baghdad by Ahmed Saadawi EPUB
  Criminal Macabre - The Eyes of Frankenstein 04 (of 04) (2013)
  Frankenstein and Philosophy by Nicolas Michaud
  Frankenstein Agent of S.H.A.D.E. v1 (000 - 016) (2011 - 2013)
  Tales of Terror (Dracula, Frankenstein, The Legend of Sleepy Hollow)
  Dean Koontz's Frankenstein - Prodigal Son v2 (01 - 05) (2010)
  Young Frankenstein_ The Story of the Making of the Film by Mel Brooks
  Young.Frankenstein.1974.480p.BRRip.XviD-SHiRK
  ...
```

Nine in ten candidates are a different book, a comic, a making-of, or a 1974 film. A good scorer on a pool like that produces a confident-looking wrong answer: in the request that surfaced this for me, the top-ranked result sat at **confidence 96** and was a **1-seeder** public-tracker torrent, ranked above four unrelated books with similar titles, while a several-hundred-seeder copy of the right book on another indexer was never asked for.

It applies to every request and every `q`-only indexer, always. Merely survivable for a distinctive title; severe for a one-word one.

## If you'd rather write it yourself

The whole fix fits in `app/services/indexer_clients/prowlarr.rb`. The shape I'd suggest, and the decisions any implementation has to make:

1. **Capabilities are already one call away.** `GET /api/v1/indexer` returns `capabilities.bookSearchParams` per indexer, and `Prowlarr.indexers` already fetches it for tag filtering — so a capability-aware query costs no new endpoint, and no extra request at all when `prowlarr_tags` is set.
2. **Partition, don't pick one shape.** A mixed setup (a Newznab book indexer alongside torrent trackers) needs the structured query for the former and free text for the latter, i.e. one `api/v1/search` call per group with explicit `indexerIds`. Choosing a single shape for everyone regresses one half or the other.
3. **Only emit a token you can prove is supported.** An indexer qualifies for the structured query only if it advertises *every* field being sent — sending `{title:}` to something that supports `author` but not `title` re-triggers the same skip.
4. **Keep `type=book`.** Free text works fine under `type=book` (see the table above), and it preserves category mapping. Downgrading to `type=search` would lose that.
5. **Degrade toward free text, never toward tokens.** If the indexer list can't be read, or an indexer reports no capabilities, free text is the shape no indexer can reject.
6. **Appending free text to the tokens does not work** — worth knowing before trying it, since it looks like the cheapest fix. The token's presence triggers the skip regardless of what else is in `q` (row 2 of the table).

An alternative worth naming and rejecting: always sending free text and dropping the structured query entirely. It fixes the reported symptom in one line, but throws away real precision on Newznab/usenet indexers that *do* advertise `author`/`title`.

## What this PR does

Exactly the above:

- advertises `author`/`title` → the structured `{title:}{author:}` query, unchanged
- otherwise → `"<title> <author>"` as free text, still `type=book`
- indexer list unreadable → free text

Common all-`q`-only and all-structured setups stay a single request; only genuinely mixed setups issue two.

## Verification

Same environment, same book, through the patched client: **31 candidates, 29 of which name Shelley**, topped by a 319-seeder EPUB — against **0** before, and against 126-candidates-12-of-which-are-the-book from the title-only fallback that was doing all the real work. Prowlarr history for that run:

```
idx=12 | query='Frankenstein Mary Shelley' | type=book | results=40
idx=10 | query='Frankenstein Mary Shelley' | type=book | results=20
idx=11 | query='Frankenstein Mary Shelley' | type=book | results=5
idx=7  | query='Frankenstein Mary Shelley' | type=book | results=4
```

Audiobooks share this path, so they were checked separately (categories 3030):

| query | results | actually the right book |
|---|---|---|
| tokens (today) | **0** | 0 |
| free text (this PR) | 20 | **20** |
| title-only fallback | 20 | 8 |

The new primary query is narrower than a bare title, so a release whose name omits the author can be missed by it — but the title-only generic attempts still fire whenever no strong match is found, so that safety net is unchanged.

Running in production on my own stack since 2026-07-27, verified end to end in the app as well: a newly filed request now puts `query='<title> <author>'` `type=book` on the wire to all four indexers, where the book search previously produced no history row at all.

## Tests

- `test/services/prowlarr_client_test.rb`: free-text query for a `q`-only indexer; the split across a mixed indexer set; the fallback when capabilities are unavailable. The two existing structured-query tests now stub an indexer advertising `author`/`title`.
- `test/jobs/search_job_test.rb`: a job-level regression test asserting the author reaches a `q`-only indexer with no `{title:}`/`{author:}` tokens, plus a default capability stub in `setup` (the client now reads `/api/v1/indexer` on the book path, which most existing tests didn't stub).

Full suite green, `rubocop` clean. One pre-existing unrelated failure (`FileCopyServiceTest#test_remove_source_file_retains_an_in-place_mutation_after_snapshot`) fails identically on a clean `main`.

## Unrelated observation

`generic_indexer_query` looks like dead code on `main` — defined at `app/jobs/search_job.rb:343`, never called. Not touched here.
