### PR TITLE
feat: attended watched-folder import

### DIFF
--- a/app/controllers/admin/detected_imports_controller.rb
+++ b/app/controllers/admin/detected_imports_controller.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+module Admin
+  class DetectedImportsController < BaseController
+    # Raised when the admin picked a specific candidate that can no longer be
+    # resolved to a book, so import fails loudly instead of silently importing a
+    # different target.
+    class SelectionError < StandardError; end
+
+    # How many imported items the history section shows before the admin expands
+    # it. The full history is only queried when expanded, so the common (collapsed)
+    # render stays cheap and the dismissed section below remains within reach.
+    IMPORTED_PREVIEW_COUNT = 10
+
+    before_action :set_detected_import, only: [ :show, :destroy, :import, :dismiss, :restore, :rematch, :search, :undo ]
+
+    def index
+      @pending = DetectedImport.pending_review.includes(:suggested_book).recent
+      @dismissed = DetectedImport.where(status: "dismissed").recent.limit(20)
+      @scan_status = WatchedFolderScanJob.scan_status
+
+      imported = DetectedImport.where(status: "imported").order(updated_at: :desc)
+      @imported_total = imported.count
+      @imported_expanded = params[:imported] == "all"
+      @imported_has_more = @imported_total > IMPORTED_PREVIEW_COUNT
+      @imported = (@imported_expanded ? imported : imported.limit(IMPORTED_PREVIEW_COUNT))
+        .includes(:imported_book).to_a
+    end
+
+    def show
+    end
+
+    # Manually trigger a watched-folder scan (in addition to the recurring one).
+    def scan
+      if WatchedFolderScanJob.scanning_enabled?
+        WatchedFolderScanJob.perform_later(manual: true)
+        redirect_to admin_detected_imports_path, notice: "Watched-folder scan started."
+      else
+        redirect_to admin_detected_imports_path,
+          alert: "Enable watched-folder import and set a path in Settings first."
+      end
+    end
+
+    # Approve an item: apply any edited book selection, then queue the import.
+    def import
+      unless @detected_import.actionable?
+        redirect_to admin_detected_imports_path, alert: "This item can no longer be imported."
+        return
+      end
+
+      apply_selection!(@detected_import)
+      DetectedImportJob.perform_later(@detected_import.id)
+      redirect_to admin_detected_imports_path,
+        notice: "Import queued for \"#{@detected_import.display_title}\"."
+    rescue SelectionError => e
+      redirect_to admin_detected_import_path(@detected_import), alert: e.message
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Import approval failed (#{e.class})"
+      redirect_to admin_detected_import_path(@detected_import),
+        alert: "Could not queue import for \"#{@detected_import.display_title}\"."
+    end
+
+    def dismiss
+      @detected_import.update!(status: "dismissed") if @detected_import.actionable?
+      redirect_to admin_detected_imports_path, notice: "Dismissed \"#{@detected_import.display_title}\"."
+    end
+
+    # Bring a dismissed detection back into the review queue.
+    def restore
+      @detected_import.update!(status: "detected") if @detected_import.status == "dismissed"
+      redirect_to admin_detected_imports_path, notice: "Restored \"#{@detected_import.display_title}\" to the review queue."
+    end
+
+    # Reverse a completed import so it can be re-imported against a different
+    # match (e.g. approved as a new book by mistake). Removes the published
+    # library file (returning it to the watched folder when it was moved) and
+    # returns the detection to the queue.
+    def undo
+      unless @detected_import.imported?
+        redirect_to admin_detected_imports_path, alert: "This item hasn't been imported, so there's nothing to undo."
+        return
+      end
+
+      LibraryAcquisitionService.undo_import!(@detected_import)
+      redirect_to admin_detected_import_path(@detected_import),
+        notice: "Undid the import for \"#{@detected_import.display_title}\". Pick the correct match and import again."
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Undo failed for ##{@detected_import.id} (#{e.class})"
+      redirect_to admin_detected_imports_path,
+        alert: "Could not undo the import for \"#{@detected_import.display_title}\"."
+    end
+
+    # Manual free-text metadata search from the review page, for when neither the
+    # suggestion nor the auto-detected alternates are right. Matches are merged
+    # into the detection's candidate list so they become selectable radios in the
+    # existing import form.
+    def search
+      query = params[:query].to_s.strip
+      if query.blank?
+        redirect_to admin_detected_import_path(@detected_import), alert: "Enter a title or author to search."
+        return
+      end
+
+      results = LibraryAcquisitionService.search_candidates(
+        query: query,
+        book_type: @detected_import.book_type
+      )
+
+      if results.empty?
+        redirect_to admin_detected_import_path(@detected_import, query: query),
+          alert: "No matches found for \"#{query}\"."
+        return
+      end
+
+      @detected_import.update!(candidate_books: merge_candidates(@detected_import.candidate_books, results))
+      redirect_to admin_detected_import_path(@detected_import, query: query),
+        notice: "Found #{results.size} #{'match'.pluralize(results.size)} for \"#{query}\". Pick one, then import."
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Manual search failed (#{e.class})"
+      redirect_to admin_detected_import_path(@detected_import), alert: "Search failed. Please try again."
+    end
+
+    # Re-run identification against the source, refreshing the suggestion and
+    # alternates (useful after adding a metadata provider or API key).
+    def rematch
+      identification = LibraryAcquisitionService.identify(
+        source_path: @detected_import.source_path,
+        book_type: @detected_import.book_type
+      )
+      @detected_import.update!(
+        parsed_title: identification.parsed_title,
+        parsed_author: identification.parsed_author,
+        match_confidence: identification.match_confidence,
+        suggested_book: identification.suggested_book,
+        candidate_books: identification.candidate_books
+      )
+      redirect_to admin_detected_import_path(@detected_import), notice: "Re-matched \"#{@detected_import.display_title}\"."
+    rescue => e
+      Rails.logger.error "[DetectedImportsController] Rematch failed (#{e.class})"
+      redirect_to admin_detected_import_path(@detected_import), alert: "Could not re-match this item."
+    end
+
+    def destroy
+      @detected_import.destroy
+      redirect_to admin_detected_imports_path, notice: "Removed detection."
+    end
+
+    private
+
+    def set_detected_import
+      @detected_import = DetectedImport.find(params[:id])
+    end
+
+    # Prepend fresh manual-search hits ahead of the existing candidates, dropping
+    # any prior online entry for the same work so repeated searches don't stack
+    # duplicates. Library candidates (no work_id) are always preserved.
+    def merge_candidates(existing, incoming)
+      incoming_work_ids = incoming.filter_map { |candidate| candidate["work_id"] }.to_set
+      retained = existing.reject do |candidate|
+        candidate["work_id"].present? && incoming_work_ids.include?(candidate["work_id"])
+      end
+      incoming + retained
+    end
+
+    # Resolve the user's decision from the approve form into the detection's
+    # target book. Defaults to the existing suggestion when no selection is made.
+    def apply_selection!(detected_import)
+      selection = params[:selection].to_s
+
+      if (match = selection.match(/\Abook:(\d+)\z/))
+        book = Book.find_by(id: match[1])
+        raise SelectionError, "The selected library book no longer exists. Please choose another match." unless book
+        detected_import.update!(suggested_book: book)
+      elsif (match = selection.match(/\Awork:(.+)\z/))
+        book = resolve_work_candidate(detected_import, match[1])
+        raise SelectionError, "The selected match could not be resolved. Try Re-match, then choose again." unless book
+        detected_import.update!(suggested_book: book)
+      elsif selection == "new"
+        apply_metadata_edits!(detected_import)
+      end
+    end
+
+    def apply_metadata_edits!(detected_import)
+      attrs = { suggested_book_id: nil }
+      attrs[:parsed_title] = params[:title].to_s.strip if params[:title].present?
+      attrs[:parsed_author] = params[:author].to_s.strip if params.key?(:author)
+      if DetectedImport::BOOK_TYPES.include?(params[:book_type])
+        attrs[:book_type] = params[:book_type]
+      end
+      detected_import.update!(attrs)
+    end
+
+    # Resolve an online candidate (by work_id) to a Book, reusing an existing
+    # record when one already carries that work_id, otherwise creating one from
+    # the candidate metadata already captured at detection time (no network).
+    def resolve_work_candidate(detected_import, work_id)
+      book_type = detected_import.book_type.presence || "ebook"
+      existing = Book.find_by_work_id(work_id, book_type: book_type)
+      return existing if existing
+
+      candidate = detected_import.candidate_books.find { |c| c["work_id"] == work_id }
+      return nil unless candidate
+
+      source, = Book.parse_work_id(work_id)
+      book = Book.new(
+        title: candidate["title"].presence || detected_import.parsed_title,
+        author: candidate["author"],
+        book_type: book_type,
+        cover_url: candidate["cover_url"],
+        year: candidate["year"],
+        metadata_source: source
+      )
+      book.assign_work_id(work_id)
+      book.save!
+      book
+    end
+  end
+end

--- a/app/controllers/admin/detected_imports_controller.rb
+++ b/app/controllers/admin/detected_imports_controller.rb
@@ -48,6 +48,12 @@ module Admin
         return
       end
 
+      unless reclaim_stuck_import!(@detected_import)
+        redirect_to admin_detected_imports_path,
+          alert: "This item is being imported right now. Try again once that attempt finishes."
+        return
+      end
+
       apply_selection!(@detected_import)
       DetectedImportJob.perform_later(@detected_import.id)
       redirect_to admin_detected_imports_path,
@@ -122,10 +128,17 @@ module Admin
 
     # Re-run identification against the source, refreshing the suggestion and
     # alternates (useful after adding a metadata provider or API key).
+    #
+    # Reads the source exactly the way the scanner did: embedded metadata comes
+    # from the release's own audio file (the detection itself is the containing
+    # folder for an audiobook), while the filename parse falls back to the
+    # release name. Re-matching on the folder alone would discard the embedded
+    # tags and could replace a good suggestion with a filename-only guess.
     def rematch
       identification = LibraryAcquisitionService.identify(
-        source_path: @detected_import.source_path,
-        book_type: @detected_import.book_type
+        source_path: WatchedFolderScanService.metadata_path_for(@detected_import.source_path),
+        book_type: @detected_import.book_type,
+        filename_hint: File.basename(@detected_import.source_path.to_s)
       )
       @detected_import.update!(
         parsed_title: identification.parsed_title,
@@ -160,6 +173,32 @@ module Admin
         candidate["work_id"].present? && incoming_work_ids.include?(candidate["work_id"])
       end
       incoming + retained
+    end
+
+    # A row wedged in "importing" is actionable only because its lease expired,
+    # and DetectedImportJob#claim recognises that by the row's age. Everything
+    # below — applying a selection, the job's own claim — touches updated_at,
+    # which would push the row back inside the lease window and make the claim
+    # fail silently. Retire the dead lease first: "failed" is claimable outright
+    # and keeps the record of the interrupted attempt visible in the queue.
+    #
+    # Returns false when the row could not be retired because a worker really is
+    # importing it, so the caller can say so instead of flashing "Import queued".
+    def reclaim_stuck_import!(detected_import)
+      return true unless detected_import.stuck_importing?
+
+      reclaimed = DetectedImport
+        .where(id: detected_import.id, status: "importing")
+        .where("updated_at < ?", DetectedImport::STUCK_IMPORTING_AFTER.ago)
+        .update_all(
+          status: "failed",
+          error_message: "The previous import was interrupted before it finished.",
+          updated_at: Time.current
+        )
+      return false unless reclaimed == 1
+
+      detected_import.reload
+      true
     end
 
     # Resolve the user's decision from the approve form into the detection's

--- a/app/controllers/admin/detected_imports_controller.rb
+++ b/app/controllers/admin/detected_imports_controller.rb
@@ -2,14 +2,13 @@
 
 module Admin
   class DetectedImportsController < BaseController
-    # Raised when the admin picked a specific candidate that can no longer be
-    # resolved to a book, so import fails loudly instead of silently importing a
-    # different target.
+    # Raised when a picked candidate can no longer be resolved to a book, so the
+    # import fails loudly instead of silently importing a different target.
     class SelectionError < StandardError; end
 
-    # How many imported items the history section shows before the admin expands
-    # it. The full history is only queried when expanded, so the common (collapsed)
-    # render stays cheap and the dismissed section below remains within reach.
+    # How many imported items the history shows before the admin expands it. The
+    # full history is only queried when expanded, so the collapsed render stays
+    # cheap and the dismissed section stays within reach.
     IMPORTED_PREVIEW_COUNT = 10
 
     before_action :set_detected_import, only: [ :show, :destroy, :import, :dismiss, :restore, :rematch, :search, :undo ]
@@ -30,14 +29,22 @@ module Admin
     def show
     end
 
-    # Manually trigger a watched-folder scan (in addition to the recurring one).
+    # Manually trigger a watched-folder scan, in addition to the recurring one.
+    #
+    # A scan in flight holds the job's concurrency key, declared
+    # on_conflict: :discard, so a manual scan enqueued now would be thrown away.
+    # Say so rather than claiming a scan started — the running one is about to
+    # report what it found anyway.
     def scan
-      if WatchedFolderScanJob.scanning_enabled?
-        WatchedFolderScanJob.perform_later(manual: true)
-        redirect_to admin_detected_imports_path, notice: "Watched-folder scan started."
-      else
+      if !WatchedFolderScanJob.scanning_enabled?
         redirect_to admin_detected_imports_path,
           alert: "Enable watched-folder import and set a path in Settings first."
+      elsif WatchedFolderScanJob.scanning_now?
+        redirect_to admin_detected_imports_path,
+          notice: "A watched-folder scan is already running. Its results will appear here when it finishes."
+      else
+        WatchedFolderScanJob.perform_later(manual: true)
+        redirect_to admin_detected_imports_path, notice: "Watched-folder scan started."
       end
     end
 
@@ -78,9 +85,8 @@ module Admin
     end
 
     # Reverse a completed import so it can be re-imported against a different
-    # match (e.g. approved as a new book by mistake). Removes the published
-    # library file (returning it to the watched folder when it was moved) and
-    # returns the detection to the queue.
+    # match. Removes the published library file — returning it to the watched
+    # folder if it was moved — and puts the detection back in the queue.
     def undo
       unless @detected_import.imported?
         redirect_to admin_detected_imports_path, alert: "This item hasn't been imported, so there's nothing to undo."
@@ -96,10 +102,9 @@ module Admin
         alert: "Could not undo the import for \"#{@detected_import.display_title}\"."
     end
 
-    # Manual free-text metadata search from the review page, for when neither the
-    # suggestion nor the auto-detected alternates are right. Matches are merged
-    # into the detection's candidate list so they become selectable radios in the
-    # existing import form.
+    # Manual free-text search, for when neither the suggestion nor the alternates
+    # are right. Matches merge into the detection's candidate list so they become
+    # selectable radios in the existing import form.
     def search
       query = params[:query].to_s.strip
       if query.blank?
@@ -129,11 +134,10 @@ module Admin
     # Re-run identification against the source, refreshing the suggestion and
     # alternates (useful after adding a metadata provider or API key).
     #
-    # Reads the source exactly the way the scanner did: embedded metadata comes
-    # from the release's own audio file (the detection itself is the containing
-    # folder for an audiobook), while the filename parse falls back to the
-    # release name. Re-matching on the folder alone would discard the embedded
-    # tags and could replace a good suggestion with a filename-only guess.
+    # Reads the source exactly as the scanner did: embedded metadata from the
+    # release's own audio file, filename parse from the release name. Re-matching
+    # on the folder alone would discard the tags and could replace a good
+    # suggestion with a filename-only guess.
     def rematch
       identification = LibraryAcquisitionService.identify(
         source_path: WatchedFolderScanService.metadata_path_for(@detected_import.source_path),
@@ -153,20 +157,40 @@ module Admin
       redirect_to admin_detected_import_path(@detected_import), alert: "Could not re-match this item."
     end
 
+    # The row is the only thing suppressing re-detection of its source: the
+    # scanner recognises a file by the (device, inode) or path on a
+    # DetectedImport, so removing one whose file is still in the watched folder
+    # puts it back at the top of the queue — with a fresh notification — on the
+    # next scan. Removal is for pruning entries whose source is gone; while it is
+    # still there, the dismissal is what keeps it out.
     def destroy
+      if source_present?(@detected_import)
+        redirect_to admin_detected_imports_path,
+          alert: "\"#{@detected_import.display_title}\" is still in your watched folder, so the next scan would " \
+                 "detect it again. It stays dismissed and out of the review queue for as long as this entry exists."
+        return
+      end
+
       @detected_import.destroy
       redirect_to admin_detected_imports_path, notice: "Removed detection."
     end
 
     private
 
+    # Whether the file is still where the scanner found it. Only presence
+    # matters, so no identity is passed and an unreadable path counts as present
+    # — refusing to remove an entry is recoverable, resurrecting one is not.
+    def source_present?(detected_import)
+      FileCopyService.path_identity_state(detected_import.source_path.to_s) != :absent
+    end
+
     def set_detected_import
       @detected_import = DetectedImport.find(params[:id])
     end
 
-    # Prepend fresh manual-search hits ahead of the existing candidates, dropping
-    # any prior online entry for the same work so repeated searches don't stack
-    # duplicates. Library candidates (no work_id) are always preserved.
+    # Prepend fresh search hits, dropping any prior online entry for the same
+    # work so repeated searches don't stack duplicates. Library candidates (no
+    # work_id) are always preserved.
     def merge_candidates(existing, incoming)
       incoming_work_ids = incoming.filter_map { |candidate| candidate["work_id"] }.to_set
       retained = existing.reject do |candidate|
@@ -175,21 +199,20 @@ module Admin
       incoming + retained
     end
 
-    # A row wedged in "importing" is actionable only because its lease expired,
-    # and DetectedImportJob#claim recognises that by the row's age. Everything
-    # below — applying a selection, the job's own claim — touches updated_at,
-    # which would push the row back inside the lease window and make the claim
-    # fail silently. Retire the dead lease first: "failed" is claimable outright
-    # and keeps the record of the interrupted attempt visible in the queue.
+    # A wedged "importing" row is actionable only because its lease expired, which
+    # DetectedImportJob#claim recognises by the row's age. Everything below —
+    # applying a selection, the job's own claim — touches updated_at, pushing the
+    # row back inside the lease window and making the claim fail silently. Retire
+    # the dead lease first: "failed" is claimable outright and keeps the
+    # interrupted attempt visible in the queue.
     #
-    # Returns false when the row could not be retired because a worker really is
-    # importing it, so the caller can say so instead of flashing "Import queued".
+    # False when the row could not be retired because a worker really is importing
+    # it, so the caller can say so instead of flashing "Import queued".
     def reclaim_stuck_import!(detected_import)
       return true unless detected_import.stuck_importing?
 
-      reclaimed = DetectedImport
-        .where(id: detected_import.id, status: "importing")
-        .where("updated_at < ?", DetectedImport::STUCK_IMPORTING_AFTER.ago)
+      reclaimed = DetectedImport.stuck_importing
+        .where(id: detected_import.id)
         .update_all(
           status: "failed",
           error_message: "The previous import was interrupted before it finished.",
@@ -201,8 +224,8 @@ module Admin
       true
     end
 
-    # Resolve the user's decision from the approve form into the detection's
-    # target book. Defaults to the existing suggestion when no selection is made.
+    # Resolve the approve form's decision into the detection's target book,
+    # defaulting to the existing suggestion when nothing was selected.
     def apply_selection!(detected_import)
       selection = params[:selection].to_s
 
@@ -221,6 +244,9 @@ module Admin
 
     def apply_metadata_edits!(detected_import)
       attrs = { suggested_book_id: nil }
+      # The two guards differ on purpose: a blank title is a slip (nothing left
+      # to name the book by) so the parse stands, while a blank author is an
+      # instruction — the only way to clear an author the parse invented.
       attrs[:parsed_title] = params[:title].to_s.strip if params[:title].present?
       attrs[:parsed_author] = params[:author].to_s.strip if params.key?(:author)
       if DetectedImport::BOOK_TYPES.include?(params[:book_type])
@@ -229,9 +255,9 @@ module Admin
       detected_import.update!(attrs)
     end
 
-    # Resolve an online candidate (by work_id) to a Book, reusing an existing
-    # record when one already carries that work_id, otherwise creating one from
-    # the candidate metadata already captured at detection time (no network).
+    # Resolve an online candidate to a Book, reusing an existing record with that
+    # work_id or creating one from the metadata captured at detection (no
+    # network).
     def resolve_work_candidate(detected_import, work_id)
       book_type = detected_import.book_type.presence || "ebook"
       existing = Book.find_by_work_id(work_id, book_type: book_type)

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -551,10 +551,19 @@ module Admin
       if changed_keys.any? { |k| k.start_with?("audiobook_output_path") || k.start_with?("ebook_output_path") }
         run_service_health_check_now("output_paths")
       end
+      if changed_keys.any? { |k| k.start_with?("library_import") }
+        sync_watched_folder_scan
+      end
+
       nil
     rescue StandardError => e
       Rails.logger.error("[SettingsController] Settings saved but a follow-up action failed: #{e.class}: #{e.message}")
       e
+    end
+
+    def sync_watched_folder_scan
+      WatchedFolderScanJob.clear_schedule!
+      WatchedFolderScanJob.ensure_running!
     end
 
     PATH_TEMPLATE_SETTINGS = %w[audiobook_path_template ebook_path_template].freeze

--- a/app/jobs/detected_import_enrichment_job.rb
+++ b/app/jobs/detected_import_enrichment_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Fills in a fresh detection's online alternate matches out-of-band, so the
+# watched-folder scan stays local + DB only and never blocks on thousands of
+# sequential provider searches. Non-destructive: it only appends online
+# candidates the scan didn't already record, and leaves the parsed metadata and
+# the local library suggestion untouched. Network/parse failures are swallowed —
+# the admin review step (and the manual Re-match) remain the correctness
+# backstop.
+class DetectedImportEnrichmentJob < ApplicationJob
+  queue_as :default
+
+  def perform(detected_import_id)
+    detected_import = DetectedImport.find_by(id: detected_import_id)
+    return unless detected_import
+    return unless detected_import.status == "detected"
+
+    online = LibraryAcquisitionService.online_candidates_for(
+      title: detected_import.parsed_title,
+      author: detected_import.parsed_author,
+      book_type: detected_import.book_type
+    )
+    return if online.empty?
+
+    existing = detected_import.candidate_books
+    known_work_ids = existing.map { |candidate| candidate["work_id"] }.compact.to_set
+    additions = online.reject { |candidate| known_work_ids.include?(candidate["work_id"]) }
+    return if additions.empty?
+
+    detected_import.update!(candidate_books: existing + additions)
+  rescue => e
+    Rails.logger.warn "[DetectedImportEnrichmentJob] Enrichment failed for ##{detected_import_id} (#{e.class})"
+  end
+end

--- a/app/jobs/detected_import_enrichment_job.rb
+++ b/app/jobs/detected_import_enrichment_job.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-# Fills in a fresh detection's online alternate matches out-of-band, so the
-# watched-folder scan stays local + DB only and never blocks on thousands of
-# sequential provider searches. Non-destructive: it only appends online
-# candidates the scan didn't already record, and leaves the parsed metadata and
-# the local library suggestion untouched. Network/parse failures are swallowed —
-# the admin review step (and the manual Re-match) remain the correctness
-# backstop.
+# Fills in a detection's online alternates out-of-band, so the watched-folder
+# scan stays local + DB only and never blocks on thousands of sequential provider
+# searches. Non-destructive: it appends candidates the scan didn't record and
+# leaves the parsed metadata and library suggestion alone. Failures are swallowed
+# — admin review and the manual Re-match are the correctness backstop.
 class DetectedImportEnrichmentJob < ApplicationJob
   queue_as :default
 

--- a/app/jobs/detected_import_job.rb
+++ b/app/jobs/detected_import_job.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Imports an admin-approved DetectedImport into the organised library via
+# LibraryAcquisitionService. Claims the record with a compare-and-swap so a
+# double submit or redelivery cannot run two imports for the same detection.
+# A failed import leaves the source untouched and is retryable from the review
+# queue.
+class DetectedImportJob < ApplicationJob
+  queue_as :default
+
+  def perform(detected_import_id)
+    detected_import = claim(detected_import_id)
+    return unless detected_import
+
+    begin
+      book = detected_import.suggested_book || create_and_attach_book(detected_import)
+
+      result = LibraryAcquisitionService.import!(
+        source_path: detected_import.source_path,
+        book: book,
+        owner: detected_import,
+        provenance: :watched_folder
+      )
+
+      detected_import.update!(
+        status: "imported",
+        imported_book: result.book,
+        suggested_book: result.book,
+        error_message: nil
+      )
+      Rails.logger.info(
+        "[DetectedImportJob] Imported detection ##{detected_import.id} into book ##{result.book.id}"
+      )
+    rescue => e
+      Rails.logger.error(
+        "[DetectedImportJob] Import failed for detection ##{detected_import.id} (#{e.class})"
+      )
+      detected_import.update!(
+        status: "failed",
+        error_message: e.message.to_s.scrub.truncate(2_000)
+      )
+    end
+  end
+
+  private
+
+  # Compare-and-swap detected/failed (or an abandoned, stale "importing" whose
+  # worker died before finishing) -> importing, so only one worker proceeds and
+  # a wedged row can be recovered.
+  def claim(detected_import_id)
+    claimed = DetectedImport
+      .where(id: detected_import_id)
+      .where(
+        "status IN (:actionable) OR (status = 'importing' AND updated_at < :stuck_before)",
+        actionable: DetectedImport::ACTIONABLE_STATUSES,
+        stuck_before: DetectedImport::STUCK_IMPORTING_AFTER.ago
+      )
+      .update_all(status: "importing", updated_at: Time.current)
+    return unless claimed == 1
+
+    DetectedImport.find_by(id: detected_import_id)
+  end
+
+  # Persist the created Book onto the detection so a retry after a failed import
+  # reuses it instead of orphaning a new unacquired record each attempt.
+  def create_and_attach_book(detected_import)
+    book = Book.create!(
+      title: detected_import.parsed_title.presence || File.basename(detected_import.source_path.to_s),
+      author: detected_import.parsed_author,
+      book_type: detected_import.book_type.presence || "ebook"
+    )
+    detected_import.update!(suggested_book: book)
+    book
+  end
+end

--- a/app/jobs/detected_import_job.rb
+++ b/app/jobs/detected_import_job.rb
@@ -20,7 +20,8 @@ class DetectedImportJob < ApplicationJob
         book: book,
         owner: detected_import,
         provenance: :watched_folder,
-        source_identity: detected_import.source_identity
+        source_identity: detected_import.source_identity,
+        source_base: WatchedFolderScanService.import_root
       )
 
       detected_import.update!(

--- a/app/jobs/detected_import_job.rb
+++ b/app/jobs/detected_import_job.rb
@@ -19,7 +19,8 @@ class DetectedImportJob < ApplicationJob
         source_path: detected_import.source_path,
         book: book,
         owner: detected_import,
-        provenance: :watched_folder
+        provenance: :watched_folder,
+        source_identity: detected_import.source_identity
       )
 
       detected_import.update!(

--- a/app/jobs/detected_import_job.rb
+++ b/app/jobs/detected_import_job.rb
@@ -8,6 +8,20 @@
 class DetectedImportJob < ApplicationJob
   queue_as :default
 
+  # One import at a time per detection. The compare-and-swap below stops two
+  # workers claiming the same row, but a row wedged past STUCK_IMPORTING_AFTER is
+  # deliberately re-claimable — and without this lease a genuinely slow import
+  # would still be running when the admin recovers it, letting the second worker
+  # reverse what the first is finalizing. The lease serialises them instead.
+  #
+  # Its duration matches the stuck window on purpose: past that point the system
+  # treats the claiming worker as dead, so the lease must expire with it or a
+  # killed worker would block its own recovery for an hour.
+  limits_concurrency(
+    key: ->(detected_import_id) { "detected_import/#{detected_import_id}" },
+    duration: DetectedImport::STUCK_IMPORTING_AFTER
+  )
+
   def perform(detected_import_id)
     detected_import = claim(detected_import_id)
     return unless detected_import
@@ -46,17 +60,11 @@ class DetectedImportJob < ApplicationJob
 
   private
 
-  # Compare-and-swap detected/failed (or an abandoned, stale "importing" whose
-  # worker died before finishing) -> importing, so only one worker proceeds and
-  # a wedged row can be recovered.
+  # Compare-and-swap claimable -> importing, so only one worker proceeds while a
+  # wedged row stays recoverable.
   def claim(detected_import_id)
-    claimed = DetectedImport
+    claimed = DetectedImport.claimable
       .where(id: detected_import_id)
-      .where(
-        "status IN (:actionable) OR (status = 'importing' AND updated_at < :stuck_before)",
-        actionable: DetectedImport::ACTIONABLE_STATUSES,
-        stuck_before: DetectedImport::STUCK_IMPORTING_AFTER.ago
-      )
       .update_all(status: "importing", updated_at: Time.current)
     return unless claimed == 1
 

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -125,6 +125,7 @@ class PostProcessingJob < ApplicationJob
       end
       cleanup_usenet_download(download) if remove_usenet_download && cleanup_outcome == :complete
 
+      dismiss_detected_imports_for(source_path)
       run_completion_side_effects(request, download, book, book_path)
     rescue => e
       error_detail = "#{e.class}: #{bounded_exception_message(e)}"
@@ -440,6 +441,71 @@ class PostProcessingJob < ApplicationJob
     end
 
     raise source_path_not_found_message(source_path)
+  end
+
+  # The watched-folder scanner queues anything it finds under the library import
+  # path, which commonly includes the download client's completed folder. When it
+  # reaches a download before post-processing does, the same content sits in the
+  # review queue while this job imports it — and approving that row afterwards
+  # would import the title a second time. Retire those rows once the content is
+  # in the library.
+  #
+  # Matching runs in both directions because the two sides name a release
+  # differently. The client reports the file it downloaded, while the scanner
+  # records an audiobook release as its containing folder, so a detection is
+  # usually the parent of the file imported here. Enclosing folders are only
+  # ever one release — the scanner descends and emits separate detections when a
+  # folder holds several titles — so a detection above the imported source
+  # describes the same book.
+  def dismiss_detected_imports_for(source_path)
+    return if source_path.blank?
+
+    nested_pattern = "#{ActiveRecord::Base.sanitize_sql_like(source_path)}/%"
+    enclosing = enclosing_detection_paths(source_path)
+    dismissed = 0
+    DetectedImport.actionable
+      .where(
+        "source_path = :path OR source_path LIKE :nested OR source_path IN (:enclosing)",
+        path: source_path,
+        nested: nested_pattern,
+        enclosing: enclosing
+      )
+      .find_each do |detection|
+        # Saved one row at a time so the review screens receive the same
+        # Turbo refresh a manual dismissal broadcasts.
+        detection.update!(status: "dismissed")
+        dismissed += 1
+      end
+
+    return if dismissed.zero?
+
+    Rails.logger.info(
+      "[PostProcessingJob] Dismissed #{dismissed} watched-folder #{'detection'.pluralize(dismissed)} " \
+        "already imported by this job"
+    )
+  rescue => e
+    # Never fail a completed import over review-queue bookkeeping.
+    Rails.logger.warn "[PostProcessingJob] Could not dismiss watched-folder detections (#{e.class})"
+  end
+
+  # Directories between the imported source and the watched-folder root, which
+  # are the only paths above it a detection can occupy. Bounded by that root so
+  # the walk can never reach a shared parent outside the scanned tree, and the
+  # root itself is excluded because the scanner never records it as a release.
+  def enclosing_detection_paths(source_path)
+    root = SettingsService.get(:library_import_path).to_s.strip.chomp("/")
+    return [] if root.blank?
+
+    paths = []
+    current = File.dirname(source_path)
+    while current.start_with?("#{root}/")
+      paths << current
+      parent = File.dirname(current)
+      break if parent == current
+
+      current = parent
+    end
+    paths
   end
 
   def cleanup_usenet_download(download)

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -465,7 +465,10 @@ class PostProcessingJob < ApplicationJob
     dismissed = 0
     DetectedImport.actionable
       .where(
-        "source_path = :path OR source_path LIKE :nested OR source_path IN (:enclosing)",
+        # SQLite's LIKE has no default escape character, so the backslashes
+        # sanitize_sql_like inserts are only inert with an explicit ESCAPE —
+        # without it a download path containing "_" would match nothing.
+        "source_path = :path OR source_path LIKE :nested ESCAPE '\\' OR source_path IN (:enclosing)",
         path: source_path,
         nested: nested_pattern,
         enclosing: enclosing

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -443,43 +443,14 @@ class PostProcessingJob < ApplicationJob
     raise source_path_not_found_message(source_path)
   end
 
-  # The watched-folder scanner queues anything it finds under the library import
-  # path, which commonly includes the download client's completed folder. When it
-  # reaches a download before post-processing does, the same content sits in the
-  # review queue while this job imports it — and approving that row afterwards
-  # would import the title a second time. Retire those rows once the content is
-  # in the library.
-  #
-  # Matching runs in both directions because the two sides name a release
-  # differently. The client reports the file it downloaded, while the scanner
-  # records an audiobook release as its containing folder, so a detection is
-  # usually the parent of the file imported here. Enclosing folders are only
-  # ever one release — the scanner descends and emits separate detections when a
-  # folder holds several titles — so a detection above the imported source
-  # describes the same book.
+  # The watched-folder scanner queues anything under the library import path,
+  # which commonly includes the download client's completed folder. If it reaches
+  # a download before post-processing does, the same content sits in the review
+  # queue while this job imports it, and approving that row afterwards would
+  # import the title twice. Which rows to retire is the model's business (see
+  # DetectedImport.dismiss_for_imported_source!); this job just reports.
   def dismiss_detected_imports_for(source_path)
-    return if source_path.blank?
-
-    nested_pattern = "#{ActiveRecord::Base.sanitize_sql_like(source_path)}/%"
-    enclosing = enclosing_detection_paths(source_path)
-    dismissed = 0
-    DetectedImport.actionable
-      .where(
-        # SQLite's LIKE has no default escape character, so the backslashes
-        # sanitize_sql_like inserts are only inert with an explicit ESCAPE —
-        # without it a download path containing "_" would match nothing.
-        "source_path = :path OR source_path LIKE :nested ESCAPE '\\' OR source_path IN (:enclosing)",
-        path: source_path,
-        nested: nested_pattern,
-        enclosing: enclosing
-      )
-      .find_each do |detection|
-        # Saved one row at a time so the review screens receive the same
-        # Turbo refresh a manual dismissal broadcasts.
-        detection.update!(status: "dismissed")
-        dismissed += 1
-      end
-
+    dismissed = DetectedImport.dismiss_for_imported_source!(source_path)
     return if dismissed.zero?
 
     Rails.logger.info(
@@ -489,26 +460,6 @@ class PostProcessingJob < ApplicationJob
   rescue => e
     # Never fail a completed import over review-queue bookkeeping.
     Rails.logger.warn "[PostProcessingJob] Could not dismiss watched-folder detections (#{e.class})"
-  end
-
-  # Directories between the imported source and the watched-folder root, which
-  # are the only paths above it a detection can occupy. Bounded by that root so
-  # the walk can never reach a shared parent outside the scanned tree, and the
-  # root itself is excluded because the scanner never records it as a release.
-  def enclosing_detection_paths(source_path)
-    root = SettingsService.get(:library_import_path).to_s.strip.chomp("/")
-    return [] if root.blank?
-
-    paths = []
-    current = File.dirname(source_path)
-    while current.start_with?("#{root}/")
-      paths << current
-      parent = File.dirname(current)
-      break if parent == current
-
-      current = parent
-    end
-    paths
   end
 
   def cleanup_usenet_download(download)

--- a/app/jobs/watched_folder_scan_job.rb
+++ b/app/jobs/watched_folder_scan_job.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# Recurring, self-rescheduling job that scans the configured watched-folder
+# import path for pre-existing book files. Mirrors the scheduling pattern of
+# DownloadMonitorJob / TelegramPollingJob: a single concurrency key prevents
+# overlapping scans, and each run re-arms the next at the configured interval.
+class WatchedFolderScanJob < ApplicationJob
+  SCHEDULE_CACHE_KEY = "watched_folder_scan/next_run_at"
+  # Progress/result of the most recent manual scan, for the review-queue UI.
+  # Backed by the shared cache (solid_cache in production) and written only by
+  # the worker running the scan, so the web process rendering the queue sees a
+  # consistent state and never a stuck "running" flag from a crossed process.
+  STATUS_CACHE_KEY = "watched_folder_scan/status"
+  DEFAULT_INTERVAL_SECONDS = 300
+  MIN_INTERVAL_SECONDS = 30
+  MAX_INTERVAL_SECONDS = 86_400
+
+  queue_as :default
+  limits_concurrency key: "watched_folder_scan", duration: 1.hour, on_conflict: :discard
+
+  class << self
+    def scanning_enabled?
+      SettingsService.get(:library_import_enabled, default: false) &&
+        SettingsService.get(:library_import_path).to_s.strip.present?
+    end
+
+    # Snapshot of the latest manual scan for the queue UI: state ("running" /
+    # "idle"), when it completed, and how many candidates/new detections it saw.
+    # Empty until the first manual scan runs (or in an environment whose cache is
+    # not shared across processes, e.g. development's memory store).
+    def scan_status
+      Rails.cache.read(STATUS_CACHE_KEY) || {}
+    end
+
+    def scanning_now?
+      scan_status[:state] == "running"
+    end
+
+    def mark_running!
+      write_status(state: "running", started_at: Time.current)
+    end
+
+    def mark_completed!(result)
+      write_status(
+        state: "idle",
+        completed_at: Time.current,
+        scanned: result&.scanned,
+        detected: result&.detected,
+        failed: result.nil?
+      )
+    end
+
+    def broadcast_queue_refresh
+      Turbo::StreamsChannel.broadcast_refresh_to(DetectedImport::INDEX_STREAM)
+    rescue => e
+      Rails.logger.warn "[WatchedFolderScanJob] Could not broadcast queue refresh (#{e.class})"
+    end
+
+    def ensure_running!
+      return unless scanning_enabled?
+      return if scan_job_pending?
+
+      next_run_at = Rails.cache.read(SCHEDULE_CACHE_KEY).to_i
+      return if next_run_at > Time.current.to_i
+
+      reserve_schedule!
+      Rails.logger.info "[WatchedFolderScanJob] Scheduling watched-folder scan chain"
+      perform_later
+    end
+
+    def clear_schedule!
+      Rails.cache.delete(SCHEDULE_CACHE_KEY)
+    end
+
+    def scan_job_pending?(excluding_active_job_id: nil)
+      return false unless solid_queue_adapter?
+
+      scope = SolidQueue::Job.where(class_name: name, finished_at: nil)
+      scope = scope.where.not(active_job_id: excluding_active_job_id) if excluding_active_job_id.present?
+      scope.exists?
+    rescue ActiveRecord::StatementInvalid, NameError
+      false
+    end
+
+    def interval_seconds
+      SettingsService.get(:library_import_scan_interval, default: DEFAULT_INTERVAL_SECONDS)
+        .to_i
+        .clamp(MIN_INTERVAL_SECONDS, MAX_INTERVAL_SECONDS)
+    end
+
+    private
+
+    def write_status(attrs)
+      Rails.cache.write(STATUS_CACHE_KEY, attrs, expires_in: 1.day)
+    rescue => e
+      Rails.logger.warn "[WatchedFolderScanJob] Could not record scan status (#{e.class})"
+    end
+
+    def reserve_schedule!
+      Rails.cache.write(
+        SCHEDULE_CACHE_KEY,
+        interval_seconds.seconds.from_now.to_i,
+        expires_in: [ interval_seconds * 3, 300 ].max.seconds
+      )
+    end
+
+    def solid_queue_adapter?
+      ActiveJob::Base.queue_adapter.class.name == "ActiveJob::QueueAdapters::SolidQueueAdapter"
+    end
+  end
+
+  # manual: true is passed by the "Scan now" button. Such a scan announces its
+  # progress to the review queue (a spinner while it runs, its result when it
+  # finishes) and refreshes the queue on completion so new detections appear
+  # without a manual reload. The recurring background scan stays silent — it only
+  # records its completion so "last scanned" stays fresh, and relies on the
+  # per-record broadcasts to surface anything it finds.
+  def perform(manual: false)
+    unless self.class.scanning_enabled?
+      self.class.clear_schedule!
+      return
+    end
+
+    if manual
+      self.class.mark_running!
+      self.class.broadcast_queue_refresh
+    end
+
+    result = WatchedFolderScanService.scan!
+    self.class.mark_completed!(result)
+    self.class.broadcast_queue_refresh if manual
+  rescue => e
+    Rails.logger.error "[WatchedFolderScanJob] Scan failed (#{e.class}): #{e.message}"
+    self.class.mark_completed!(nil)
+    self.class.broadcast_queue_refresh if manual
+  ensure
+    schedule_next_run if self.class.scanning_enabled?
+  end
+
+  private
+
+  def schedule_next_run
+    return if self.class.scan_job_pending?(excluding_active_job_id: job_id)
+
+    self.class.send(:reserve_schedule!)
+    WatchedFolderScanJob.set(wait: self.class.interval_seconds.seconds).perform_later
+  end
+end

--- a/app/jobs/watched_folder_scan_job.rb
+++ b/app/jobs/watched_folder_scan_job.rb
@@ -14,6 +14,11 @@ class WatchedFolderScanJob < ApplicationJob
   DEFAULT_INTERVAL_SECONDS = 300
   MIN_INTERVAL_SECONDS = 30
   MAX_INTERVAL_SECONDS = 86_400
+  # How long the status cache is allowed to claim a scan is running. Matches the
+  # concurrency lease below: past it the claiming worker cannot still hold the
+  # key, so a status stuck on "running" is the residue of a worker that was
+  # killed mid-scan and must not keep disabling "Scan now" for the cache TTL.
+  RUNNING_STATUS_TTL = 1.hour
 
   queue_as :default
   limits_concurrency key: "watched_folder_scan", duration: 1.hour, on_conflict: :discard
@@ -29,7 +34,14 @@ class WatchedFolderScanJob < ApplicationJob
     # Empty until the first manual scan runs (or in an environment whose cache is
     # not shared across processes, e.g. development's memory store).
     def scan_status
-      Rails.cache.read(STATUS_CACHE_KEY) || {}
+      status = Rails.cache.read(STATUS_CACHE_KEY) || {}
+      return status unless stale_running?(status)
+
+      # Report the abandoned run as a failed scan rather than a live one, so the
+      # queue offers "Scan now" again instead of spinning until the cache
+      # expires. Left in the cache as-is: the next scan overwrites it, and a
+      # write here would race the worker that owns the key.
+      status.merge(state: "idle", completed_at: status[:started_at], failed: true)
     end
 
     def scanning_now?
@@ -89,6 +101,11 @@ class WatchedFolderScanJob < ApplicationJob
     end
 
     private
+
+    def stale_running?(status)
+      status[:state] == "running" &&
+        (status[:started_at].blank? || status[:started_at] < RUNNING_STATUS_TTL.ago)
+    end
 
     def write_status(attrs)
       Rails.cache.write(STATUS_CACHE_KEY, attrs, expires_in: 1.day)

--- a/app/jobs/watched_folder_scan_job.rb
+++ b/app/jobs/watched_folder_scan_job.rb
@@ -6,18 +6,16 @@
 # overlapping scans, and each run re-arms the next at the configured interval.
 class WatchedFolderScanJob < ApplicationJob
   SCHEDULE_CACHE_KEY = "watched_folder_scan/next_run_at"
-  # Progress/result of the most recent manual scan, for the review-queue UI.
-  # Backed by the shared cache (solid_cache in production) and written only by
-  # the worker running the scan, so the web process rendering the queue sees a
-  # consistent state and never a stuck "running" flag from a crossed process.
+  # Progress/result of the latest scan, for the review-queue UI. Backed by the
+  # shared cache (solid_cache in production) and written only by the worker
+  # running the scan, so the web process never sees a crossed-process state.
   STATUS_CACHE_KEY = "watched_folder_scan/status"
   DEFAULT_INTERVAL_SECONDS = 300
   MIN_INTERVAL_SECONDS = 30
   MAX_INTERVAL_SECONDS = 86_400
-  # How long the status cache is allowed to claim a scan is running. Matches the
-  # concurrency lease below: past it the claiming worker cannot still hold the
-  # key, so a status stuck on "running" is the residue of a worker that was
-  # killed mid-scan and must not keep disabling "Scan now" for the cache TTL.
+  # How long the cache may claim a scan is running. Matches the concurrency lease
+  # below: past it the worker cannot still hold the key, so a stuck "running" is
+  # the residue of a killed worker and must not keep disabling "Scan now".
   RUNNING_STATUS_TTL = 1.hour
 
   queue_as :default
@@ -29,18 +27,16 @@ class WatchedFolderScanJob < ApplicationJob
         SettingsService.get(:library_import_path).to_s.strip.present?
     end
 
-    # Snapshot of the latest manual scan for the queue UI: state ("running" /
-    # "idle"), when it completed, and how many candidates/new detections it saw.
-    # Empty until the first manual scan runs (or in an environment whose cache is
-    # not shared across processes, e.g. development's memory store).
+    # Snapshot for the queue UI: state ("running" / "idle"), when it completed,
+    # and how many candidates/new detections it saw. Empty until the first scan
+    # runs, or where the cache is not shared across processes (development).
     def scan_status
       status = Rails.cache.read(STATUS_CACHE_KEY) || {}
       return status unless stale_running?(status)
 
-      # Report the abandoned run as a failed scan rather than a live one, so the
-      # queue offers "Scan now" again instead of spinning until the cache
-      # expires. Left in the cache as-is: the next scan overwrites it, and a
-      # write here would race the worker that owns the key.
+      # Report an abandoned run as failed, not live, so the queue offers "Scan
+      # now" again instead of spinning until the cache expires. Not written back:
+      # the next scan overwrites it, and writing here would race the key's owner.
       status.merge(state: "idle", completed_at: status[:started_at], failed: true)
     end
 
@@ -80,6 +76,16 @@ class WatchedFolderScanJob < ApplicationJob
       perform_later
     end
 
+    # Arm the next link of the chain unless one is already pending. The running
+    # job passes its own active_job_id so it does not count itself and leave the
+    # chain unarmed.
+    def schedule_next!(excluding_active_job_id: nil)
+      return if scan_job_pending?(excluding_active_job_id: excluding_active_job_id)
+
+      reserve_schedule!
+      set(wait: interval_seconds.seconds).perform_later
+    end
+
     def clear_schedule!
       Rails.cache.delete(SCHEDULE_CACHE_KEY)
     end
@@ -87,10 +93,10 @@ class WatchedFolderScanJob < ApplicationJob
     def scan_job_pending?(excluding_active_job_id: nil)
       return false unless solid_queue_adapter?
 
-      # Solid Queue keeps a failed job row forever with finished_at still NULL,
-      # so counting it as pending would convince ensure_running! that the chain
-      # is alive and stop it ever enqueuing a replacement. Exclude those the way
-      # DownloadMonitorJob does.
+      # Solid Queue keeps failed rows forever with finished_at still NULL, so
+      # counting them as pending would convince ensure_running! the chain is
+      # alive and stop it enqueuing a replacement. Excluded as DownloadMonitorJob
+      # does.
       scope = SolidQueue::Job
         .where(class_name: name, finished_at: nil)
         .where.missing(:failed_execution)
@@ -132,29 +138,32 @@ class WatchedFolderScanJob < ApplicationJob
     end
   end
 
-  # manual: true is passed by the "Scan now" button. Such a scan announces its
-  # progress to the review queue (a spinner while it runs, its result when it
-  # finishes) and refreshes the queue on completion so new detections appear
-  # without a manual reload. The recurring background scan stays silent — it only
-  # records its completion so "last scanned" stays fresh, and relies on the
-  # per-record broadcasts to surface anything it finds.
+  # manual: true comes from the "Scan now" button, and pushes progress to the
+  # review queue (a spinner, then the result) so detections appear without a
+  # reload. The background scan stays silent — per-record broadcasts surface what
+  # it finds — but records the same status, because that status is what tells the
+  # queue a scan is in flight. Recording it only for manual scans let the screen
+  # offer "Scan now" during a background scan, whose concurrency key then
+  # discarded the manual job after the admin was told it had started.
   def perform(manual: false)
     unless self.class.scanning_enabled?
       self.class.clear_schedule!
       return
     end
 
-    if manual
-      self.class.mark_running!
-      self.class.broadcast_queue_refresh
+    self.class.mark_running!
+    self.class.broadcast_queue_refresh if manual
+
+    # Only the scan is rescued, so the status and refresh are written on exactly
+    # one path; mark_completed!(nil) already reports the run as failed.
+    result = begin
+      WatchedFolderScanService.scan!
+    rescue => e
+      Rails.logger.error "[WatchedFolderScanJob] Scan failed (#{e.class}): #{e.message}"
+      nil
     end
 
-    result = WatchedFolderScanService.scan!
     self.class.mark_completed!(result)
-    self.class.broadcast_queue_refresh if manual
-  rescue => e
-    Rails.logger.error "[WatchedFolderScanJob] Scan failed (#{e.class}): #{e.message}"
-    self.class.mark_completed!(nil)
     self.class.broadcast_queue_refresh if manual
   ensure
     schedule_next_run if self.class.scanning_enabled?
@@ -163,9 +172,6 @@ class WatchedFolderScanJob < ApplicationJob
   private
 
   def schedule_next_run
-    return if self.class.scan_job_pending?(excluding_active_job_id: job_id)
-
-    self.class.send(:reserve_schedule!)
-    WatchedFolderScanJob.set(wait: self.class.interval_seconds.seconds).perform_later
+    self.class.schedule_next!(excluding_active_job_id: job_id)
   end
 end

--- a/app/jobs/watched_folder_scan_job.rb
+++ b/app/jobs/watched_folder_scan_job.rb
@@ -87,10 +87,16 @@ class WatchedFolderScanJob < ApplicationJob
     def scan_job_pending?(excluding_active_job_id: nil)
       return false unless solid_queue_adapter?
 
-      scope = SolidQueue::Job.where(class_name: name, finished_at: nil)
+      # Solid Queue keeps a failed job row forever with finished_at still NULL,
+      # so counting it as pending would convince ensure_running! that the chain
+      # is alive and stop it ever enqueuing a replacement. Exclude those the way
+      # DownloadMonitorJob does.
+      scope = SolidQueue::Job
+        .where(class_name: name, finished_at: nil)
+        .where.missing(:failed_execution)
       scope = scope.where.not(active_job_id: excluding_active_job_id) if excluding_active_job_id.present?
       scope.exists?
-    rescue ActiveRecord::StatementInvalid, NameError
+    rescue ActiveRecord::ActiveRecordError, NameError
       false
     end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -23,6 +23,27 @@ class Book < ApplicationRecord
   scope :acquired, -> { where.not(file_path: nil).where("TRIM(file_path) <> ''") }
   scope :pending, -> { where(file_path: nil) }
   scope :acquisition_reserved, -> { where.not(acquisition_reservation_token: nil) }
+  # Rows +owner+ holds the acquisition reservation on. With .unclaimed this is
+  # the compare-and-swap used to finalize or release: only the holder of a
+  # still-unclaimed reservation may act on it.
+  scope :reserved_by, ->(owner) {
+    where(
+      acquisition_reservation_owner_type: owner.class.name,
+      acquisition_reservation_owner_id: owner.id
+    )
+  }
+  # Distinct from .pending, which only recognises a NULL file_path: a claim
+  # written as whitespace is not a claim.
+  scope :unclaimed, -> { where("file_path IS NULL OR TRIM(file_path) = ''") }
+
+  # Clears an acquisition reservation. Named once because the three columns must
+  # always go together — the validation above rejects a row that keeps an owner
+  # without its token.
+  RESERVATION_CLEARED = {
+    acquisition_reservation_token: nil,
+    acquisition_reservation_owner_type: nil,
+    acquisition_reservation_owner_id: nil
+  }.freeze
 
   def acquired?
     file_path.present?

--- a/app/models/detected_import.rb
+++ b/app/models/detected_import.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# A book file discovered in the watched-folder import path that was not acquired
+# through a Shelfarr request. Each record represents one review-queue item: the
+# scanner detects a candidate, computes a suggested match, and an admin approves
+# or dismisses it before it is imported into the organised library.
+#
+# Idempotency is anchored on the source (device, inode) pair rather than the
+# path, because a hardlink import creates a second path to the same content on
+# the same filesystem and a re-scan must not re-detect it.
+class DetectedImport < ApplicationRecord
+  STATUSES = %w[detected dismissed importing imported failed].freeze
+  ACTIONABLE_STATUSES = %w[detected failed].freeze
+  BOOK_TYPES = %w[audiobook ebook comicbook].freeze
+
+  # An "importing" row whose claim is older than this is assumed abandoned: the
+  # worker that claimed it died (redeploy, OOM, hard kill) before it could reach
+  # the success/failure update. Matches DetectedImportJob's concurrency lease so
+  # a genuinely long import is never treated as stuck. Such rows become
+  # actionable again (re-import / dismiss) and re-claimable by the job.
+  STUCK_IMPORTING_AFTER = 1.hour
+
+  belongs_to :suggested_book, class_name: "Book", optional: true
+  belongs_to :imported_book, class_name: "Book", optional: true
+
+  validates :source_path, presence: true
+  validates :status, inclusion: { in: STATUSES }
+  validates :book_type, inclusion: { in: BOOK_TYPES }, allow_nil: true
+
+  scope :detected, -> { where(status: "detected") }
+  scope :actionable, -> { where(status: ACTIONABLE_STATUSES) }
+  scope :pending_review, -> { where(status: %w[detected failed importing]) }
+  scope :recent, -> { order(Arel.sql("COALESCE(detected_at, created_at) DESC")) }
+
+  # Live-update the review screens whenever a detection is created (scanner),
+  # changes status (detected -> importing -> imported/failed via
+  # DetectedImportJob), or is removed. Mirrors the Turbo 8 morph-refresh pattern
+  # used on the request and owned-library screens. The index tracks the whole
+  # queue via a shared stream; each review (show) page tracks just its own
+  # record so it swaps to the imported/failed state without a manual reload.
+  INDEX_STREAM = "detected_imports"
+  after_create_commit  :broadcast_queue_refresh_later
+  after_update_commit  :broadcast_review_refresh_later
+  after_destroy_commit :broadcast_queue_refresh_later
+
+  def actionable?
+    ACTIONABLE_STATUSES.include?(status) || stuck_importing?
+  end
+
+  # True when this row has been wedged in "importing" long enough that the
+  # claiming worker must be gone, so the admin can recover it from the queue.
+  def stuck_importing?
+    status == "importing" && updated_at.present? && updated_at < STUCK_IMPORTING_AFTER.ago
+  end
+
+  def imported?
+    status == "imported"
+  end
+
+  def display_title
+    parsed_title.presence || File.basename(source_path.to_s)
+  end
+
+  def candidate_books
+    value = super
+    value.is_a?(Array) ? value : []
+  end
+
+  # The highest-scoring alternate the scanner found, whether an existing library
+  # book or an online work. Used to pre-select a real match instead of "new
+  # book" when no exact library suggestion exists — the same ranking the review
+  # screen lists the alternates in.
+  def best_candidate
+    candidate_books.max_by { |candidate| candidate["score"].to_i } if candidate_books.present?
+  end
+
+  # The radio value the review form should default to: the existing library
+  # suggestion when there is one, otherwise the best-scoring alternate, and only
+  # "new" when nothing was matched at all.
+  def default_selection
+    return "book:#{suggested_book_id}" if suggested_book_id
+
+    candidate = best_candidate
+    return "new" unless candidate
+
+    candidate["kind"] == "library" ? "book:#{candidate['book_id']}" : "work:#{candidate['work_id']}"
+  end
+
+  private
+
+  def broadcast_queue_refresh_later
+    broadcast_refresh_later_to(INDEX_STREAM)
+  end
+
+  def broadcast_review_refresh_later
+    broadcast_refresh_later_to(INDEX_STREAM)
+    broadcast_refresh_later_to(self)
+  end
+end

--- a/app/models/detected_import.rb
+++ b/app/models/detected_import.rb
@@ -57,6 +57,17 @@ class DetectedImport < ApplicationRecord
     status == "imported"
   end
 
+  # The (device, inode) pair recorded when this candidate was detected, or nil
+  # on filesystems that report no usable identity. The importer refuses to
+  # publish a source whose inode no longer matches, so a path swapped between
+  # detection and approval cannot substitute different bytes under an approved
+  # title.
+  def source_identity
+    return nil if source_device.blank? || source_inode.blank?
+
+    [ source_device, source_inode ]
+  end
+
   def display_title
     parsed_title.presence || File.basename(source_path.to_s)
   end

--- a/app/models/detected_import.rb
+++ b/app/models/detected_import.rb
@@ -1,23 +1,24 @@
 # frozen_string_literal: true
 
-# A book file discovered in the watched-folder import path that was not acquired
-# through a Shelfarr request. Each record represents one review-queue item: the
-# scanner detects a candidate, computes a suggested match, and an admin approves
-# or dismisses it before it is imported into the organised library.
+# A book file found in the watched-folder import path that was not acquired
+# through a Shelfarr request. One record is one review-queue item: detected,
+# matched, then approved or dismissed by an admin before import.
 #
-# Idempotency is anchored on the source (device, inode) pair rather than the
-# path, because a hardlink import creates a second path to the same content on
-# the same filesystem and a re-scan must not re-detect it.
+# Idempotency is anchored on the source (device, inode) rather than the path: a
+# hardlink import creates a second path to the same content, and a re-scan must
+# not re-detect it.
 class DetectedImport < ApplicationRecord
   STATUSES = %w[detected dismissed importing imported failed].freeze
   ACTIONABLE_STATUSES = %w[detected failed].freeze
   BOOK_TYPES = %w[audiobook ebook comicbook].freeze
 
-  # An "importing" row whose claim is older than this is assumed abandoned: the
-  # worker that claimed it died (redeploy, OOM, hard kill) before it could reach
-  # the success/failure update. Matches DetectedImportJob's concurrency lease so
-  # a genuinely long import is never treated as stuck. Such rows become
-  # actionable again (re-import / dismiss) and re-claimable by the job.
+  # An "importing" row older than this is assumed abandoned — its worker died
+  # before writing success or failure — so it becomes actionable and re-claimable.
+  #
+  # The claim is stamped once and never refreshed, so a genuinely slow import
+  # also looks stuck. DetectedImportJob's concurrency lease uses the same
+  # duration to cover that: the recovery attempt waits for the original to
+  # finish instead of reversing it mid-flight.
   STUCK_IMPORTING_AFTER = 1.hour
 
   belongs_to :suggested_book, class_name: "Book", optional: true
@@ -32,23 +33,111 @@ class DetectedImport < ApplicationRecord
   scope :pending_review, -> { where(status: %w[detected failed importing]) }
   scope :recent, -> { order(Arel.sql("COALESCE(detected_at, created_at) DESC")) }
 
-  # Live-update the review screens whenever a detection is created (scanner),
-  # changes status (detected -> importing -> imported/failed via
-  # DetectedImportJob), or is removed. Mirrors the Turbo 8 morph-refresh pattern
-  # used on the request and owned-library screens. The index tracks the whole
-  # queue via a shared stream; each review (show) page tracks just its own
-  # record so it swaps to the imported/failed state without a manual reload.
+  # Rows wedged in "importing" long enough that the claiming worker must be gone.
+  # Both recovery sites — the job's compare-and-swap and the queue's manual retry
+  # — go through this scope; #stuck_importing? is its in-memory mirror.
+  scope :stuck_importing, -> { where(status: "importing").where(updated_at: ...STUCK_IMPORTING_AFTER.ago) }
+  # Rows a worker may claim: never started, or abandoned by a dead worker.
+  scope :claimable, -> { actionable.or(stuck_importing) }
+
+  # Live-update the review screens on create, status change, and destroy (the
+  # Turbo 8 morph-refresh pattern used on the request screens). The index tracks
+  # the whole queue; each review page also tracks its own record so it swaps to
+  # imported/failed without a reload.
   INDEX_STREAM = "detected_imports"
   after_create_commit  :broadcast_queue_refresh_later
   after_update_commit  :broadcast_review_refresh_later
   after_destroy_commit :broadcast_queue_refresh_later
 
+  # Retire review-queue rows describing content another front door has already
+  # imported, so the queue never offers a file that is now in the library.
+  # Returns how many were dismissed.
+  #
+  # Matching runs both ways because the two sides name a release differently: the
+  # importer reports the file it took, the scanner records an audiobook as its
+  # containing folder. An enclosing folder is only ever one release — the scanner
+  # splits multi-title folders into separate detections — so a detection above
+  # the imported source describes the same book.
+  def self.dismiss_for_imported_source!(source_path)
+    return 0 if source_path.blank?
+
+    # Detections are recorded under File.realpath of the import root, so a source
+    # reaching the same content through a symlinked parent (/downloads ->
+    # /data/downloads) spells it differently. Match both spellings.
+    paths = [ source_path, canonical_source_path(source_path) ].uniq
+    enclosing = paths.flat_map { |path| enclosing_detection_paths(path) }.uniq
+    # SQLite's LIKE has no default escape character, so sanitize_sql_like's
+    # backslashes are only inert with an explicit ESCAPE.
+    nested_clauses = paths.each_index.map { |index| "source_path LIKE :nested#{index} ESCAPE '\\'" }
+    binds = { paths: paths, enclosing: enclosing }
+    paths.each_with_index do |path, index|
+      binds[:"nested#{index}"] = "#{sanitize_sql_like(path)}/%"
+    end
+
+    dismissed = 0
+    actionable
+      .where(
+        [ "source_path IN (:paths)", "source_path IN (:enclosing)", *nested_clauses ].join(" OR "),
+        binds
+      )
+      .find_each do |detection|
+        # One row at a time, so the screens get the same Turbo refresh a manual
+        # dismissal broadcasts.
+        detection.update!(status: "dismissed")
+        dismissed += 1
+      end
+    dismissed
+  end
+
+  # Directories between an imported source and the watched-folder root — the only
+  # paths above it a detection can occupy. Bounded by that root so the walk cannot
+  # reach a shared parent outside the scanned tree; the root itself is excluded
+  # because the scanner never records it as a release.
+  #
+  # Bounded by the scanner's canonical root, not the raw setting: detections live
+  # beneath the canonical one, so a symlinked setting would bound the walk with a
+  # prefix no detection carries.
+  def self.enclosing_detection_paths(source_path)
+    root = watched_folder_root
+    return [] if root.blank?
+
+    paths = []
+    current = File.dirname(source_path)
+    while current.start_with?("#{root}/")
+      paths << current
+      parent = File.dirname(current)
+      break if parent == current
+
+      current = parent
+    end
+    paths
+  end
+  private_class_method :enclosing_detection_paths
+
+  # The root detections are actually recorded under. Falls back to the raw
+  # setting when the scanner refuses that root (unset, missing, or overlapping an
+  # output path) — there are no live detections to match then anyway.
+  def self.watched_folder_root
+    root = WatchedFolderScanService.import_root
+    root.presence || SettingsService.get(:library_import_path).to_s.strip.chomp("/")
+  end
+  private_class_method :watched_folder_root
+
+  # The path the scanner would have recorded. Only the parent is resolved: a move
+  # import has already consumed the file itself, and realpath would raise on it.
+  def self.canonical_source_path(source_path)
+    File.join(File.realpath(File.dirname(source_path)), File.basename(source_path))
+  rescue SystemCallError
+    source_path
+  end
+  private_class_method :canonical_source_path
+
   def actionable?
     ACTIONABLE_STATUSES.include?(status) || stuck_importing?
   end
 
-  # True when this row has been wedged in "importing" long enough that the
-  # claiming worker must be gone, so the admin can recover it from the queue.
+  # In-memory mirror of the .stuck_importing scope, kept in Ruby because the
+  # review queue asks this of every row it renders.
   def stuck_importing?
     status == "importing" && updated_at.present? && updated_at < STUCK_IMPORTING_AFTER.ago
   end
@@ -57,11 +146,10 @@ class DetectedImport < ApplicationRecord
     status == "imported"
   end
 
-  # The (device, inode) pair recorded when this candidate was detected, or nil
-  # on filesystems that report no usable identity. The importer refuses to
-  # publish a source whose inode no longer matches, so a path swapped between
-  # detection and approval cannot substitute different bytes under an approved
-  # title.
+  # The (device, inode) recorded at detection, or nil on filesystems that report
+  # no usable identity. The importer refuses a source whose inode no longer
+  # matches, so a path swapped between detection and approval cannot substitute
+  # different bytes.
   def source_identity
     return nil if source_device.blank? || source_inode.blank?
 
@@ -77,17 +165,15 @@ class DetectedImport < ApplicationRecord
     value.is_a?(Array) ? value : []
   end
 
-  # The highest-scoring alternate the scanner found, whether an existing library
-  # book or an online work. Used to pre-select a real match instead of "new
-  # book" when no exact library suggestion exists — the same ranking the review
-  # screen lists the alternates in.
+  # The highest-scoring alternate — library book or online work — used to
+  # pre-select a real match instead of "new book" when no exact suggestion
+  # exists. Same ranking the review screen lists alternates in.
   def best_candidate
     candidate_books.max_by { |candidate| candidate["score"].to_i } if candidate_books.present?
   end
 
-  # The radio value the review form should default to: the existing library
-  # suggestion when there is one, otherwise the best-scoring alternate, and only
-  # "new" when nothing was matched at all.
+  # The radio the review form defaults to: the library suggestion, else the
+  # best-scoring alternate, and only "new" when nothing matched.
   def default_selection
     return "book:#{suggested_book_id}" if suggested_book_id
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,7 +4,7 @@ class Notification < ApplicationRecord
   belongs_to :user
   belongs_to :notifiable, polymorphic: true, optional: true
 
-  TYPES = %w[request_completed request_failed request_attention].freeze
+  TYPES = %w[request_completed request_failed request_attention import_detected].freeze
 
   validates :notification_type, presence: true, inclusion: { in: TYPES }
   validates :title, presence: true

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -750,6 +750,31 @@ class FileCopyService
       end
     end
 
+    # Where a path stands relative to a (device, inode) recorded for it earlier.
+    #
+    #   :absent    - nothing occupies the path
+    #   :match     - the recorded file is still there
+    #   :mismatch  - a different file occupies it, or the identity cannot be
+    #                proven (none recorded, or the path could not be read)
+    #
+    # Unprovable reports :mismatch on purpose: callers use this to decide whether
+    # they may consume or overwrite a path, and the safe answer to "I cannot
+    # tell" is "leave it alone". Callers needing only presence pass no identity
+    # and read anything but :absent as occupied.
+    #
+    # A bare lstat, not a pinned traversal — callers gate the destructive work
+    # itself on the pinned primitives above.
+    def path_identity_state(path, device: nil, inode: nil)
+      stat = File.lstat(path.to_s)
+      return :mismatch if device.blank? || inode.blank?
+
+      [ stat.dev, stat.ino ] == [ device.to_i, inode.to_i ] ? :match : :mismatch
+    rescue Errno::ENOENT, Errno::ENOTDIR
+      :absent
+    rescue SystemCallError
+      :mismatch
+    end
+
     # Remove a directory child that still has the expected (device, inode).
     #
     # +expected_entries+ pins the tree the caller believes it is deleting, in the

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -181,10 +181,11 @@ class FileCopyService
       dest,
       root: nil,
       source_root: nil,
+      source_snapshot: nil,
       heartbeat: nil,
       allow_compatibility_fallback: false
     )
-      source_snapshot = snapshot_source_file(src, source_root: source_root)
+      source_snapshot ||= snapshot_source_file(src, source_root: source_root)
       cp_noreplace(
         src,
         dest,
@@ -749,7 +750,22 @@ class FileCopyService
       end
     end
 
-    def remove_directory_child_if_identity(parent_path, child_name, root:, device:, inode:)
+    # Remove a directory child that still has the expected (device, inode).
+    #
+    # +expected_entries+ pins the tree the caller believes it is deleting, in the
+    # same shape snapshot_source_root produces. When given, remove_source_tree
+    # quarantines the directory and restores it untouched unless its contents
+    # match exactly, so a caller that only owns an empty directory can pass +{}+
+    # and never destroy entries someone else added. When omitted the current
+    # contents are snapshotted and removed wholesale (the historical behaviour).
+    def remove_directory_child_if_identity(
+      parent_path,
+      child_name,
+      root:,
+      device:,
+      inode:,
+      expected_entries: nil
+    )
       if child_name.include?(File::SEPARATOR) || child_name.in?([ ".", ".." ])
         raise UnsafePathError, "directory child name is unsafe"
       end
@@ -776,7 +792,7 @@ class FileCopyService
             canonical_parent_path: canonical_parent,
             parent_device: parent_stat.dev,
             parent_inode: parent_stat.ino,
-            entries: snapshot_pinned_regular_tree(child).freeze
+            entries: (expected_entries || snapshot_pinned_regular_tree(child)).freeze
           ).freeze
           validate_current_directory_identity!(parent_path, parent)
           validate_current_directory_identity!(snapshot.path, child)

--- a/app/services/library_acquisition_service.rb
+++ b/app/services/library_acquisition_service.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+
+# Shared "identify a book and import a source file into the organised library"
+# engine used by any front door that adopts a file which was not acquired
+# through a Shelfarr request (currently the watched-folder importer).
+#
+# The request pipeline still uses UploadProcessingJob / PostProcessingJob
+# directly; this service reuses the same underlying identification and
+# path-template services so both paths agree on structure and matching.
+#
+# +identify+ is read-only: it inspects a source file and returns a ranked
+# suggestion without creating any Book or touching the filesystem beyond
+# reading embedded metadata. +import!+ (see below) performs the actual,
+# crash-safe publication once an admin has approved a target Book.
+class LibraryAcquisitionService
+  # Audio container extensions that mark a file (or the folder containing it) as
+  # an audiobook. Distinct from Upload::AUDIOBOOK_EXTENSIONS, which also treats
+  # zip/rar archives as audiobook uploads — those are not present in a watched
+  # completed-download folder as playable media.
+  AUDIO_EXTENSIONS = %w[m4a m4b mp3 aax aac flac ogg opus wav].freeze
+  # Single-file readable formats (ebooks + comics), reused from the download
+  # importer so both front doors recognise the same file types.
+  READABLE_EXTENSIONS = PostProcessingJob::EBOOK_FILE_EXTENSIONS
+  MAX_ONLINE_CANDIDATES = 5
+
+  class AcquisitionConflictError < StandardError; end
+
+  # Outcome of a successful import into the organised library.
+  ImportResult = Data.define(:book, :destination_path, :mode)
+
+  # Read-only identification result. +candidate_books+ is a ranked array of
+  # plain hashes safe to persist as JSON on a DetectedImport.
+  Identification = Data.define(
+    :book_type,
+    :parsed_title,
+    :parsed_author,
+    :suggested_book,
+    :candidate_books,
+    :match_confidence,
+    :source_path
+  )
+
+  class << self
+    # Inspect a source file and return a ranked suggestion. No writes.
+    #
+    # source_path   - a regular file to read embedded metadata from. For an
+    #                 audiobook folder the caller passes a representative audio
+    #                 file inside it.
+    # book_type     - optional override; inferred from the path when omitted.
+    # filename_hint - name used for the filename-parse fallback (defaults to the
+    #                 source basename; the caller passes the folder name for an
+    #                 audiobook so the parse reflects the release, not one track).
+    def identify(source_path:, book_type: nil, filename_hint: nil, online: true)
+      resolved_type = (book_type || infer_book_type(source_path)).to_s
+      extracted = MetadataExtractorService.extract(source_path)
+      parsed = FilenameParserService.parse(filename_hint.presence || File.basename(source_path.to_s))
+
+      title = extracted.title.presence || parsed.title
+      author = extracted.author.presence || parsed.author
+
+      match = BookMatcherService.match(title: title, author: author, book_type: resolved_type)
+      suggested_book = match.book if match.exact? || match.fuzzy?
+
+      candidates = []
+      candidates << library_candidate(match.book, match.score) if suggested_book
+      candidates.concat(online_candidates(title, author, resolved_type)) if online
+
+      confidence = if suggested_book
+        match.score
+      elsif extracted.present?
+        90
+      else
+        parsed.confidence
+      end
+
+      Identification.new(
+        book_type: resolved_type,
+        parsed_title: title,
+        parsed_author: author,
+        suggested_book: suggested_book,
+        candidate_books: candidates,
+        match_confidence: confidence,
+        source_path: source_path.to_s
+      )
+    end
+
+    # Infer a book type from a path without reading it. A directory is treated
+    # as an audiobook release; a file is classified by extension.
+    def infer_book_type(source_path)
+      return "audiobook" if File.directory?(source_path)
+
+      case File.extname(source_path.to_s).delete_prefix(".").downcase
+      when *Upload::COMICBOOK_EXTENSIONS then "comicbook"
+      when *AUDIO_EXTENSIONS then "audiobook"
+      else "ebook"
+      end
+    end
+
+    # Import an already-decided book's source file into the organised library,
+    # marking the book acquired and triggering a library scan.
+    #
+    # source_path - file or directory to publish.
+    # book        - the target Book (must not already be acquired/reserved).
+    # owner       - the record that owns the acquisition reservation for the
+    #               duration of the import (e.g. a DetectedImport). Required so
+    #               the reservation bridges the gap between the pre-import check
+    #               and the file_path claim, exactly like the upload path.
+    # mode        - copy / move / hardlink; defaults to the configured
+    #               completed_download_import_mode.
+    def import!(source_path:, book:, owner:, mode: nil, provenance: nil)
+      mode = (mode || SettingsService.get(:completed_download_import_mode, default: "copy")).to_s
+      base_path = output_base_path(book)
+
+      reserve_book!(book, owner)
+      begin
+        result = LibraryFileImporter.new(mode: mode).import(
+          source: source_path,
+          book: book,
+          base_path: base_path
+        )
+        claim_file_path!(book, result.imported_path, owner)
+        trigger_library_scan(book)
+        Rails.logger.info(
+          "[LibraryAcquisitionService] Imported #{provenance || 'source'} for book ##{book.id} (mode=#{mode})"
+        )
+        ImportResult.new(book: book, destination_path: result.imported_path, mode: mode)
+      rescue
+        release_reservation!(book, owner)
+        raise
+      end
+    end
+
+    # Reverse a completed import so the detection returns to the review queue and
+    # can be re-imported against a different match (e.g. the admin approved "new
+    # book" by mistake when a real match existed).
+    #
+    # Copy / hardlink imports leave the watched-folder source in place, so undo
+    # simply discards the library artifact. A move import consumed the source, so
+    # undo returns the artifact to where the scanner found it. Either way the book
+    # is un-acquired, and a throwaway book created solely for this import (no
+    # metadata, no requests/uploads/owned items) is destroyed rather than left
+    # behind un-acquired.
+    def undo_import!(detected_import)
+      book = detected_import.imported_book
+      destination = book&.file_path.presence
+
+      reverse_publication!(destination, detected_import, book) if destination
+
+      ActiveRecord::Base.transaction do
+        detected_import.update!(
+          status: "detected",
+          imported_book: nil,
+          suggested_book: nil,
+          error_message: nil
+        )
+        release_book_after_undo!(book) if book
+      end
+    end
+
+    def audio_file?(path)
+      AUDIO_EXTENSIONS.include?(File.extname(path.to_s).delete_prefix(".").downcase)
+    end
+
+    def readable_file?(path)
+      READABLE_EXTENSIONS.include?(File.extname(path.to_s).delete_prefix(".").downcase)
+    end
+
+    # Compute just the online alternate list for an already-parsed title/author.
+    # Used by deferred enrichment so the (networked) provider lookups run off the
+    # scan hot path, one queued job per detection, rather than thousands of
+    # sequential searches inside a single scan.
+    def online_candidates_for(title:, author:, book_type:)
+      online_candidates(title, author, book_type.to_s)
+    end
+
+    # Run a free-text metadata search for the manual "search for the correct
+    # book" step on the review page. Unlike +online_candidates+, results are
+    # scored against the admin's query (not the auto-parsed title) and no
+    # low-score filter is applied — the admin asked for exactly these, so every
+    # provider hit is offered as a selectable candidate in the usual hash shape.
+    def search_candidates(query:, book_type:, limit: MAX_ONLINE_CANDIDATES)
+      query = query.to_s.strip
+      return [] if query.blank?
+
+      content_kind = book_type.to_s == "comicbook" ? "graphic" : nil
+      results = MetadataService.search(query, limit: limit, content_kind: content_kind)
+      normalized_query = query.downcase
+      results.map do |result|
+        haystack = [ result.title, result.author ].compact.join(" ").downcase
+        {
+          "kind" => "online",
+          "work_id" => result.work_id,
+          "title" => result.title,
+          "author" => result.author,
+          "year" => result.year,
+          "cover_url" => result.cover_url,
+          "source" => result.source,
+          "score" => string_similarity(haystack, normalized_query)
+        }
+      end.sort_by { |candidate| -candidate["score"] }
+    rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+      Rails.logger.warn "[LibraryAcquisitionService] Manual search failed (#{e.class})"
+      []
+    end
+
+    private
+
+    # Reserve the book under a row lock so a concurrent acquisition (upload or
+    # download) cannot claim the same title while the file import runs outside
+    # the transaction. Raises if the title is already acquired or reserved.
+    def reserve_book!(book, owner)
+      ActiveRecord::Base.transaction do
+        book.lock!
+        book.reload
+        if book.acquisition_blocked?
+          raise AcquisitionConflictError,
+            "This title already has an acquired or in-progress library file; the existing file was preserved"
+        end
+
+        book.update!(
+          acquisition_reservation_token: SecureRandom.hex(32),
+          acquisition_reservation_owner_type: owner.class.name,
+          acquisition_reservation_owner_id: owner.id
+        )
+      end
+    end
+
+    # Attach the imported path and clear the reservation in one compare-and-swap
+    # so only the worker still holding this owner's reservation can finalize.
+    def claim_file_path!(book, destination, owner)
+      claimed = Book.where(id: book.id)
+        .where("file_path IS NULL OR TRIM(file_path) = ''")
+        .where(
+          acquisition_reservation_owner_type: owner.class.name,
+          acquisition_reservation_owner_id: owner.id
+        )
+        .update_all(
+          file_path: destination,
+          acquisition_reservation_token: nil,
+          acquisition_reservation_owner_type: nil,
+          acquisition_reservation_owner_id: nil,
+          updated_at: Time.current
+        )
+      raise AcquisitionConflictError, "This title was acquired by another process during import" unless claimed == 1
+
+      book.reload
+    end
+
+    def release_reservation!(book, owner)
+      Book.where(id: book.id)
+        .where(
+          acquisition_reservation_owner_type: owner.class.name,
+          acquisition_reservation_owner_id: owner.id
+        )
+        .where("file_path IS NULL OR TRIM(file_path) = ''")
+        .update_all(
+          acquisition_reservation_token: nil,
+          acquisition_reservation_owner_type: nil,
+          acquisition_reservation_owner_id: nil,
+          updated_at: Time.current
+        )
+    rescue => e
+      Rails.logger.error "[LibraryAcquisitionService] Failed to release reservation for book ##{book.id} (#{e.class})"
+    end
+
+    # Remove (or, for a move import, relocate) the artifact this import published
+    # into the library. Refuses to touch anything that is not strictly inside the
+    # book's configured output root, so a corrupt file_path can never delete an
+    # arbitrary path.
+    def reverse_publication!(destination, detected_import, book)
+      return unless File.exist?(destination)
+
+      unless within_output_root?(destination, book)
+        raise AcquisitionConflictError,
+          "Refusing to undo: #{destination} is not inside the library output path"
+      end
+
+      if File.exist?(detected_import.source_path)
+        # Copy or hardlink: the watched-folder source is still present, so the
+        # library artifact is a redundant second copy — discard it.
+        FileUtils.remove_entry(destination)
+      else
+        # Move: the source is gone; put the artifact back so it can be re-imported.
+        restore_moved_source!(destination, detected_import)
+      end
+    end
+
+    # Return a moved artifact to the source path the scanner recorded. Audiobook
+    # imports are directories at both ends; single-file imports land inside a
+    # per-book directory, so the file itself is returned and the emptied wrapper
+    # directory removed.
+    def restore_moved_source!(destination, detected_import)
+      source = detected_import.source_path
+      FileUtils.mkdir_p(File.dirname(source))
+
+      if detected_import.book_type == "audiobook" || File.file?(destination)
+        FileUtils.mv(destination, source)
+      else
+        inner = Dir.glob(File.join(destination, "**", "*")).find { |path| File.file?(path) }
+        FileUtils.mv(inner || destination, source)
+        FileUtils.remove_entry(destination) if File.directory?(destination)
+      end
+    end
+
+    def within_output_root?(destination, book)
+      base = File.realpath(output_base_path(book))
+      target = File.expand_path(destination)
+      target.start_with?("#{base}#{File::SEPARATOR}")
+    rescue ArgumentError, SystemCallError
+      false
+    end
+
+    # Un-acquire the book and destroy it when it was a throwaway created solely
+    # for this import (no metadata identity and nothing else references it). A
+    # matched or metadata-bearing book is kept, merely un-acquired.
+    def release_book_after_undo!(book)
+      book.reload
+      book.update!(
+        file_path: nil,
+        acquisition_reservation_token: nil,
+        acquisition_reservation_owner_type: nil,
+        acquisition_reservation_owner_id: nil
+      )
+
+      if book.unified_work_id.blank? &&
+          book.requests.none? && book.uploads.none? && book.owned_library_items.none?
+        book.destroy
+      end
+    end
+
+    def output_base_path(book)
+      if book.comicbook?
+        SettingsService.get(:comicbook_output_path, default: "/comics")
+      elsif book.ebook?
+        SettingsService.get(:ebook_output_path, default: "/ebooks")
+      else
+        SettingsService.get(:audiobook_output_path, default: "/audiobooks")
+      end
+    end
+
+    def trigger_library_scan(book)
+      return unless LibraryPlatformClient.configured?
+
+      library_id = SettingsService.library_id_for_book(book)
+      return if library_id.blank?
+
+      LibraryPlatformClient.scan_library(library_id)
+      Rails.logger.info "[LibraryAcquisitionService] Triggered library scan for book ##{book.id}"
+    rescue LibraryPlatformClient::Error => e
+      Rails.logger.warn "[LibraryAcquisitionService] Failed to trigger library scan (#{e.class})"
+    end
+
+    def library_candidate(book, score)
+      {
+        "kind" => "library",
+        "book_id" => book.id,
+        "title" => book.title,
+        "author" => book.author,
+        "score" => score
+      }
+    end
+
+    # Best-effort online enrichment. Network/parse failures degrade to an empty
+    # alternate list — the human review step is the correctness backstop.
+    def online_candidates(title, author, book_type)
+      return [] if title.blank?
+
+      query = author.present? ? "#{title} #{author}" : title
+      content_kind = book_type.to_s == "comicbook" ? "graphic" : nil
+      results = MetadataService.search(query, limit: MAX_ONLINE_CANDIDATES, content_kind: content_kind)
+      results.filter_map do |result|
+        score = online_score(result, title, author)
+        next if score < 30
+
+        {
+          "kind" => "online",
+          "work_id" => result.work_id,
+          "title" => result.title,
+          "author" => result.author,
+          "year" => result.year,
+          "cover_url" => result.cover_url,
+          "source" => result.source,
+          "score" => score
+        }
+      end.sort_by { |candidate| -candidate["score"] }
+    rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+      Rails.logger.warn "[LibraryAcquisitionService] Metadata search failed (#{e.class})"
+      []
+    end
+
+    def online_score(result, query_title, query_author)
+      score = 0
+      if result.title.present? && query_title.present?
+        score += (string_similarity(result.title.downcase, query_title.downcase) * 0.6).round
+      end
+      if result.author.present? && query_author.present?
+        score += (string_similarity(result.author.downcase, query_author.downcase) * 0.4).round
+      elsif result.author.present?
+        score += 10
+      end
+      score
+    end
+
+    def string_similarity(str1, str2)
+      return 100 if str1 == str2
+      return 0 if str1.blank? || str2.blank?
+
+      trigrams1 = to_trigrams(str1)
+      trigrams2 = to_trigrams(str2)
+      return 0 if trigrams1.empty? || trigrams2.empty?
+
+      intersection = (trigrams1 & trigrams2).size
+      union = (trigrams1 | trigrams2).size
+      ((intersection.to_f / union) * 100).round
+    end
+
+    def to_trigrams(str)
+      padded = "  #{str}  "
+      (0..padded.length - 3).map { |i| padded[i, 3] }.to_set
+    end
+  end
+end

--- a/app/services/library_acquisition_service.rb
+++ b/app/services/library_acquisition_service.rb
@@ -1,40 +1,46 @@
 # frozen_string_literal: true
 
 # Shared "identify a book and import a source file into the organised library"
-# engine used by any front door that adopts a file which was not acquired
-# through a Shelfarr request (currently the watched-folder importer).
+# engine for any front door adopting a file that was not acquired through a
+# Shelfarr request (currently the watched-folder importer).
 #
 # The request pipeline still uses UploadProcessingJob / PostProcessingJob
-# directly; this service reuses the same underlying identification and
-# path-template services so both paths agree on structure and matching.
+# directly; this service reuses the same identification and path-template
+# services, so both paths agree on structure and matching.
 #
-# +identify+ is read-only: it inspects a source file and returns a ranked
-# suggestion without creating any Book or touching the filesystem beyond
-# reading embedded metadata. +import!+ (see below) performs the actual,
-# crash-safe publication once an admin has approved a target Book.
+# +identify+ is read-only: a ranked suggestion, no Book created and no
+# filesystem writes. +import!+ performs the crash-safe publication once an admin
+# has approved a target Book.
 class LibraryAcquisitionService
-  # Audio container extensions that mark a file (or the folder containing it) as
-  # an audiobook. Distinct from Upload::AUDIOBOOK_EXTENSIONS, which also treats
-  # zip/rar archives as audiobook uploads — those are not present in a watched
-  # completed-download folder as playable media.
+  # Audio containers that mark a file (or its folder) as an audiobook. Unlike
+  # Upload::AUDIOBOOK_EXTENSIONS this excludes zip/rar archives, which are not
+  # playable media in a completed-download folder.
   AUDIO_EXTENSIONS = %w[m4a m4b mp3 aax aac flac ogg opus wav].freeze
   # Single-file readable formats (ebooks + comics), reused from the download
-  # importer so both front doors recognise the same file types.
+  # importer so both front doors recognise the same types.
   READABLE_EXTENSIONS = PostProcessingJob::EBOOK_FILE_EXTENSIONS
   MAX_ONLINE_CANDIDATES = 5
+  # Provider failures that are still a normal outcome: both candidate builders
+  # degrade to an empty list, since human review is the correctness backstop.
+  METADATA_ERRORS = [
+    HardcoverClient::Error,
+    GoogleBooksClient::Error,
+    OpenLibraryClient::Error,
+    MetadataService::Error
+  ].freeze
 
   class AcquisitionConflictError < StandardError; end
 
   # Outcome of a successful import into the organised library.
   ImportResult = Data.define(:book, :destination_path, :mode, :publication)
 
-  # What a retry found left behind by an interrupted attempt: either a result to
-  # hand straight back, or the source identity to import against once the
-  # stranded publication has been reversed.
+  # What a retry found from an interrupted attempt: either a result to hand
+  # straight back, or the source identity to import against once the stranded
+  # publication has been reversed.
   Recovery = Data.define(:result, :reversed, :source_identity)
 
-  # Read-only identification result. +candidate_books+ is a ranked array of
-  # plain hashes safe to persist as JSON on a DetectedImport.
+  # Read-only identification result. +candidate_books+ is a ranked array of plain
+  # hashes, safe to persist as JSON on a DetectedImport.
   Identification = Data.define(
     :book_type,
     :parsed_title,
@@ -48,13 +54,12 @@ class LibraryAcquisitionService
   class << self
     # Inspect a source file and return a ranked suggestion. No writes.
     #
-    # source_path   - a regular file to read embedded metadata from. For an
-    #                 audiobook folder the caller passes a representative audio
-    #                 file inside it.
+    # source_path   - regular file to read embedded metadata from; for an
+    #                 audiobook folder, a representative audio file inside it.
     # book_type     - optional override; inferred from the path when omitted.
-    # filename_hint - name used for the filename-parse fallback (defaults to the
-    #                 source basename; the caller passes the folder name for an
-    #                 audiobook so the parse reflects the release, not one track).
+    # filename_hint - name for the filename-parse fallback (defaults to the
+    #                 source basename; callers pass the folder name for an
+    #                 audiobook so the parse reflects the release, not a track).
     def identify(source_path:, book_type: nil, filename_hint: nil, online: true)
       resolved_type = (book_type || infer_book_type(source_path)).to_s
       extracted = MetadataExtractorService.extract(source_path)
@@ -94,36 +99,33 @@ class LibraryAcquisitionService
     def infer_book_type(source_path)
       return "audiobook" if File.directory?(source_path)
 
-      case File.extname(source_path.to_s).delete_prefix(".").downcase
+      case normalized_extension(source_path)
       when *Upload::COMICBOOK_EXTENSIONS then "comicbook"
       when *AUDIO_EXTENSIONS then "audiobook"
       else "ebook"
       end
     end
 
-    # Import an already-decided book's source file into the organised library,
-    # marking the book acquired and triggering a library scan.
+    # Import an already-decided book's source into the organised library, marking
+    # the book acquired and triggering a library scan.
     #
     # source_path - file or directory to publish.
-    # book        - the target Book (must not already be acquired/reserved).
-    # owner       - the record that owns the acquisition reservation for the
-    #               duration of the import (e.g. a DetectedImport). Required so
-    #               the reservation bridges the gap between the pre-import check
-    #               and the file_path claim, exactly like the upload path.
+    # book        - target Book (must not already be acquired/reserved).
+    # owner       - record holding the acquisition reservation for the duration
+    #               of the import (e.g. a DetectedImport). Required so the
+    #               reservation bridges the pre-import check and the file_path
+    #               claim, as the upload path does.
     # mode        - copy / move / hardlink; defaults to the configured
     #               completed_download_import_mode.
-    # source_identity - optional [device, inode] recorded when the source was
-    #               detected. The importer refuses to publish a source whose
-    #               inode no longer matches, so a path swapped between approval
-    #               and import cannot substitute different bytes.
-    # source_base - the root the source was found under (the watched folder),
-    #               recorded on the publication so undo can restore a moved file
-    #               through descriptors pinned to that root.
+    # source_identity - optional [device, inode] from detection. The importer
+    #               refuses a source whose inode no longer matches, so a path
+    #               swapped between approval and import cannot substitute bytes.
+    # source_base - the root the source was found under, recorded so undo can
+    #               restore a moved file through descriptors pinned to it.
     #
-    # The publication record is persisted on +owner+ before the database claim,
-    # so a crash or a lost claim race can still be reversed precisely: bytes are
-    # already on disk at that point and only an exact record of them makes the
-    # rollback safe.
+    # The publication record is persisted on +owner+ before the database claim:
+    # bytes are on disk by then, and only an exact record of them makes a crash
+    # or a lost claim race reversible.
     def import!(source_path:, book:, owner:, mode: nil, provenance: nil, source_identity: nil, source_base: nil)
       mode = (mode || SettingsService.get(:completed_download_import_mode, default: "copy")).to_s
       base_path = output_base_path(book)
@@ -162,11 +164,10 @@ class LibraryAcquisitionService
         )
       rescue
         # Anything short of a completed claim is reversed, including a tree
-        # import that failed partway through: the importer's record covers every
-        # file it managed to publish before raising. A reversal that could not
-        # finish is logged rather than raised — the original failure is the one
-        # worth reporting — and its record is left behind so the next attempt
-        # (or an undo) can retry the reversal.
+        # import that failed partway: the importer's record covers every file it
+        # published before raising. An incomplete reversal is logged rather than
+        # raised — the original failure is the one worth reporting — and its
+        # record is kept so the next attempt (or an undo) can retry.
         reversed = claimed || reverse_publication!(importer.publication_record, owner)
         unless reversed
           Rails.logger.error(
@@ -174,39 +175,37 @@ class LibraryAcquisitionService
               "some published files remain in the library"
           )
         end
-        # A reversed move put the source back on a fresh inode, so the identity
-        # recorded at detection would fail the next attempt's check.
+        # A reversed move puts the source back on a fresh inode, so the recorded
+        # identity would fail the next attempt's check.
         refresh_source_identity!(owner) if reversed && !claimed && mode == "move"
         release_reservation!(book, owner)
         raise
       end
     end
 
-    # Reverse a completed import so the detection returns to the review queue and
-    # can be re-imported against a different match (e.g. the admin approved "new
-    # book" by mistake when a real match existed).
+    # Reverse a completed import so the detection returns to the queue and can be
+    # re-imported against a different match (e.g. "new book" approved by mistake).
     #
-    # Copy / hardlink imports leave the watched-folder source in place, so undo
-    # simply discards the library artifact. A move import consumed the source, so
-    # undo returns the artifact to where the scanner found it. Either way the book
-    # is un-acquired, and a throwaway book created solely for this import (no
-    # metadata, no requests/uploads/owned items) is destroyed rather than left
-    # behind un-acquired.
+    # Copy / hardlink imports leave the source in place, so undo just discards the
+    # library artifact; a move consumed the source, so undo returns the artifact
+    # to where the scanner found it. Either way the book is un-acquired, and a
+    # throwaway book created solely for this import (no metadata, no
+    # requests/uploads/owned items) is destroyed rather than left behind.
     def undo_import!(detected_import)
       book = detected_import.imported_book
       publication = detected_import.publication_record
 
       if publication.present?
-        # Only a complete reversal earns the state reset below. A file that is
-        # no longer the one this import published (renamed, re-tagged, replaced)
-        # is left alone, and un-acquiring the book anyway would strand it in the
-        # library and let a re-import duplicate it.
+        # Only a complete reversal earns the state reset below. A file that is no
+        # longer the one this import published (renamed, re-tagged, replaced) is
+        # left alone; un-acquiring the book anyway would strand it in the library
+        # and let a re-import duplicate it.
         #
-        # The journal is deliberately not cleared here: it is the only durable
+        # The journal is deliberately not cleared here — it is the only durable
         # description of what this import put on disk, and the transaction below
-        # can still fail (or the process die) after the files have moved. It is
-        # cleared by that transaction, so until it commits a retried undo still
-        # has a record to work from — every step below is idempotent.
+        # can still fail after the files have moved. That transaction clears it,
+        # so a retried undo always has a record to work from and every step is
+        # idempotent.
         unless reverse_publication!(publication, detected_import, clear_record: false)
           raise AcquisitionConflictError,
             "Refusing to undo: the file this import published could not be returned or removed — it has been " \
@@ -214,10 +213,9 @@ class LibraryAcquisitionService
         end
         refresh_source_identity!(detected_import) if publication["mode"].to_s == "move"
       elsif book&.file_path.present?
-        # Without an exact record of what was published there is no safe way to
-        # tell this import's files apart from anything else living under the
-        # same templated directory, and guessing is how unrelated files get
-        # deleted. Leave the artifact and the detection alone for the admin.
+        # Without an exact record there is no safe way to tell this import's
+        # files from anything else under the same templated directory, and
+        # guessing is how unrelated files get deleted. Leave both to the admin.
         raise AcquisitionConflictError,
           "Refusing to undo: this import predates publication tracking, so #{book.file_path} " \
           "must be removed manually before it can be re-imported"
@@ -236,68 +234,69 @@ class LibraryAcquisitionService
     end
 
     def audio_file?(path)
-      AUDIO_EXTENSIONS.include?(File.extname(path.to_s).delete_prefix(".").downcase)
+      AUDIO_EXTENSIONS.include?(normalized_extension(path))
     end
 
     def readable_file?(path)
-      READABLE_EXTENSIONS.include?(File.extname(path.to_s).delete_prefix(".").downcase)
+      READABLE_EXTENSIONS.include?(normalized_extension(path))
     end
 
-    # Compute just the online alternate list for an already-parsed title/author.
-    # Used by deferred enrichment so the (networked) provider lookups run off the
-    # scan hot path, one queued job per detection, rather than thousands of
-    # sequential searches inside a single scan.
+    # Just the online alternates for an already-parsed title/author. Used by
+    # deferred enrichment so provider lookups run off the scan hot path, one
+    # queued job per detection.
     def online_candidates_for(title:, author:, book_type:)
       online_candidates(title, author, book_type.to_s)
     end
 
-    # Run a free-text metadata search for the manual "search for the correct
-    # book" step on the review page. Unlike +online_candidates+, results are
-    # scored against the admin's query (not the auto-parsed title) and no
-    # low-score filter is applied — the admin asked for exactly these, so every
-    # provider hit is offered as a selectable candidate in the usual hash shape.
+    # Free-text search for the review page's manual "find the correct book" step.
+    # Unlike +online_candidates+, results are scored against the admin's query
+    # and unfiltered — the admin asked for exactly these, so every hit is offered
+    # as a selectable candidate.
     def search_candidates(query:, book_type:, limit: MAX_ONLINE_CANDIDATES)
       query = query.to_s.strip
       return [] if query.blank?
 
-      content_kind = book_type.to_s == "comicbook" ? "graphic" : nil
-      results = MetadataService.search(query, limit: limit, content_kind: content_kind)
+      results = MetadataService.search(
+        query, limit: limit, content_kind: metadata_content_kind(book_type)
+      )
       normalized_query = query.downcase
       results.map do |result|
         haystack = [ result.title, result.author ].compact.join(" ").downcase
-        {
-          "kind" => "online",
-          "work_id" => result.work_id,
-          "title" => result.title,
-          "author" => result.author,
-          "year" => result.year,
-          "cover_url" => result.cover_url,
-          "source" => result.source,
-          "score" => string_similarity(haystack, normalized_query)
-        }
+        online_candidate(result, string_similarity(haystack, normalized_query))
       end.sort_by { |candidate| -candidate["score"] }
-    rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+    rescue *METADATA_ERRORS => e
       Rails.logger.warn "[LibraryAcquisitionService] Manual search failed (#{e.class})"
       []
     end
 
     private
 
-    # An owner that already carries a publication record reached durable state on
-    # an earlier attempt: bytes are on disk and, for a move, the source is gone.
-    # Re-running the import from that source would read a path that no longer
-    # exists and fail, leaving the bytes, the journal, and the reservation
-    # stranded with no way to undo. So reconcile that phase first.
+    # An owner already carrying a publication record reached durable state on an
+    # earlier attempt: bytes are on disk and, for a move, the source is gone.
+    # Re-importing from that source would read a dead path and fail, stranding
+    # the bytes, journal, and reservation with no way to undo. Reconcile first.
     #
-    # If the earlier attempt also claimed the book, the import actually finished
-    # and only the caller's bookkeeping was lost — hand back its result rather
-    # than publishing a second copy. Otherwise reverse it, which returns a moved
-    # source to the watched folder, and import again from there.
+    # If that attempt also claimed the book, the import finished and only the
+    # bookkeeping was lost — hand back its result instead of publishing a second
+    # copy. Otherwise reverse it, returning a moved source to the watched folder,
+    # and import again from there.
     def recover_interrupted_publication!(owner, book, source_identity)
-      record = owner.respond_to?(:publication_record) ? owner.publication_record.presence : nil
-      return Recovery.new(result: nil, reversed: false, source_identity: nil) if record.blank?
-
+      record = journals_publication?(owner) ? owner.publication_record.presence : nil
       book.reload
+
+      if record.blank?
+        # An attempt killed between reserve_book! and the journal write left
+        # nothing to reverse — but its reservation outlives it, and nothing else
+        # clears one held by this owner (the upload and download recovery jobs
+        # only reclaim their own). Left in place it fails every retry with a
+        # conflict and blocks the book for the other pipelines too, permanently.
+        # Releasing it is safe for the same reason as in the branch below:
+        # release_reservation! only touches a reservation this owner still holds
+        # on an unclaimed book.
+        release_reservation!(book, owner)
+        return Recovery.new(result: nil, reversed: false, source_identity: nil)
+      end
+
       if publication_claimed_by?(record, book)
         Rails.logger.info(
           "[LibraryAcquisitionService] Resuming interrupted import for book ##{book.id}; the library file is already claimed"
@@ -317,8 +316,6 @@ class LibraryAcquisitionService
       end
 
       # The dead attempt's reservation would otherwise block reserve_book!.
-      # release_reservation! only touches a reservation still held by this owner
-      # on an unclaimed book, which is exactly the interrupted case.
       release_reservation!(book, owner)
       unless reverse_publication!(record, owner)
         raise AcquisitionConflictError,
@@ -326,10 +323,9 @@ class LibraryAcquisitionService
           "Resolve them under #{record['base_path']} and try again."
       end
 
-      # A reversed move put the source back on a fresh inode (the restore is a
-      # durable copy plus an unlink, not a rename), so the identity the caller
-      # is about to import against has to be re-read. A copy or hardlink never
-      # touched the source, so its recorded identity still stands.
+      # A reversed move puts the source back on a fresh inode (the restore is a
+      # durable copy plus unlink, not a rename), so the identity must be re-read.
+      # Copy and hardlink never touched the source, so theirs still stands.
       identity = record["mode"].to_s == "move" ? refresh_source_identity!(owner) : source_identity
       Rails.logger.warn(
         "[LibraryAcquisitionService] Reversed an interrupted import for book ##{book.id} before retrying"
@@ -337,8 +333,8 @@ class LibraryAcquisitionService
       Recovery.new(result: nil, reversed: true, source_identity: identity)
     end
 
-    # Whether the book's claimed file_path is what this publication produced —
-    # the file it published, or the per-book directory it published into.
+    # Whether the book's claimed file_path is what this publication produced: the
+    # file it published, or the per-book directory it published into.
     def publication_claimed_by?(record, book)
       claimed = book.file_path.presence
       return false if claimed.blank?
@@ -350,9 +346,9 @@ class LibraryAcquisitionService
         destinations.all? { |destination| destination.start_with?(File.join(claimed, "")) }
     end
 
-    # Reserve the book under a row lock so a concurrent acquisition (upload or
-    # download) cannot claim the same title while the file import runs outside
-    # the transaction. Raises if the title is already acquired or reserved.
+    # Reserve the book under a row lock so a concurrent upload or download cannot
+    # claim the same title while the import runs outside the transaction. Raises
+    # if the title is already acquired or reserved.
     def reserve_book!(book, owner)
       ActiveRecord::Base.transaction do
         book.lock!
@@ -373,18 +369,9 @@ class LibraryAcquisitionService
     # Attach the imported path and clear the reservation in one compare-and-swap
     # so only the worker still holding this owner's reservation can finalize.
     def claim_file_path!(book, destination, owner)
-      claimed = Book.where(id: book.id)
-        .where("file_path IS NULL OR TRIM(file_path) = ''")
-        .where(
-          acquisition_reservation_owner_type: owner.class.name,
-          acquisition_reservation_owner_id: owner.id
-        )
+      claimed = Book.where(id: book.id).unclaimed.reserved_by(owner)
         .update_all(
-          file_path: destination,
-          acquisition_reservation_token: nil,
-          acquisition_reservation_owner_type: nil,
-          acquisition_reservation_owner_id: nil,
-          updated_at: Time.current
+          Book::RESERVATION_CLEARED.merge(file_path: destination, updated_at: Time.current)
         )
       raise AcquisitionConflictError, "This title was acquired by another process during import" unless claimed == 1
 
@@ -392,60 +379,62 @@ class LibraryAcquisitionService
     end
 
     def release_reservation!(book, owner)
-      Book.where(id: book.id)
-        .where(
-          acquisition_reservation_owner_type: owner.class.name,
-          acquisition_reservation_owner_id: owner.id
-        )
-        .where("file_path IS NULL OR TRIM(file_path) = ''")
-        .update_all(
-          acquisition_reservation_token: nil,
-          acquisition_reservation_owner_type: nil,
-          acquisition_reservation_owner_id: nil,
-          updated_at: Time.current
-        )
+      Book.where(id: book.id).unclaimed.reserved_by(owner)
+        .update_all(Book::RESERVATION_CLEARED.merge(updated_at: Time.current))
     rescue => e
       Rails.logger.error "[LibraryAcquisitionService] Failed to release reservation for book ##{book.id} (#{e.class})"
     end
 
-    # Persist what an import published so a later rollback or undo can reverse
-    # exactly those entries. Written with update_columns so an in-flight import
-    # neither runs validations nor broadcasts a status change.
+    # Persist what an import published so a rollback or undo can reverse exactly
+    # those entries. update_columns so an in-flight import neither validates nor
+    # broadcasts a status change.
     #
-    # A failure here is fatal on purpose. The bytes are already on disk and a
-    # move has already consumed the source, so this write is the only durable
-    # thing that can reverse them; committing the import without it would leave
-    # an acquired book whose undo has nothing to work from. Raising instead
-    # sends the caller into the rollback below, which reverses the in-memory
-    # record while it is still available.
+    # A failure here is fatal on purpose: bytes are on disk and a move has
+    # consumed the source, so this write is the only durable thing that can
+    # reverse them. Committing without it would leave an acquired book whose undo
+    # has nothing to work from; raising instead sends the caller into the
+    # rollback, which reverses the in-memory record while it is still available.
     def record_publication!(owner, publication)
-      return unless owner.respond_to?(:publication_record=) && owner.persisted?
+      return unless journals_publication?(owner)
 
       owner.update_columns(publication_record: publication, updated_at: Time.current)
     end
 
+    # Whether +owner+ can carry this import's publication journal. Asked rather
+    # than assumed (the service accepts any record), and asked in one place so
+    # the read and the two writes agree on what counts as journalled.
+    def journals_publication?(owner)
+      owner.respond_to?(:publication_record=) && owner.persisted?
+    end
+
+    # Comics are searched against a different provider corpus than prose.
+    def metadata_content_kind(book_type)
+      book_type.to_s == "comicbook" ? "graphic" : nil
+    end
+
+    def normalized_extension(path)
+      File.extname(path.to_s).delete_prefix(".").downcase
+    end
+
     # Reverse exactly the entries this import published: discard the files it
-    # created (or, for a move, return them to where the scanner found them) and
-    # then drop only the directories it brought into existence, and only while
-    # they are still empty. A templated "Author/Book" directory is routinely
-    # shared with files this import does not own, so it is never deleted
-    # recursively.
+    # created (or, for a move, return them to where the scanner found them), then
+    # drop only the directories it brought into existence, and only while they
+    # are still empty. A templated "Author/Book" directory is routinely shared
+    # with files this import does not own, so it is never deleted recursively.
     #
-    # Containment is structural rather than a pathname comparison: every removal
-    # walks from the output root through pinned O_NOFOLLOW descriptors and is
-    # gated on the (device, inode) recorded at publication, so neither an
-    # ancestor swapped for a symlink nor a root that canonicalizes differently
-    # (/var vs /private/var) can redirect or block it.
+    # Containment is structural, not a pathname comparison: every removal walks
+    # from the output root through pinned O_NOFOLLOW descriptors, gated on the
+    # (device, inode) recorded at publication. Neither an ancestor swapped for a
+    # symlink nor a root that canonicalizes differently can redirect it.
     #
     # Returns true only when every recorded file was reversed. A caller that
-    # resets state on the strength of the reversal must not proceed on false:
-    # the library still holds an artifact this import put there. The record is
-    # kept in that case so undo can be retried once the admin has resolved it;
-    # every step is idempotent, so a retry re-reverses only what is left.
+    # resets state on the reversal must not proceed on false — the library still
+    # holds an artifact this import put there. The record is kept so undo can be
+    # retried; every step is idempotent, so a retry reverses only what is left.
     #
-    # +clear_record+ drops the journal once the reversal is complete. Callers
-    # that still have durable state to commit afterwards pass false and clear it
-    # themselves, so a failure in that window leaves a record to retry from.
+    # +clear_record+ drops the journal once complete. Callers with durable state
+    # still to commit pass false and clear it themselves, so a failure in that
+    # window leaves a record to retry from.
     def reverse_publication!(publication, owner, clear_record: true)
       publication = publication.presence || {}
       files = Array(publication["files"])
@@ -464,16 +453,16 @@ class LibraryAcquisitionService
     end
 
     def clear_publication_record!(owner)
-      return unless owner.respond_to?(:publication_record=) && owner.persisted?
+      return unless journals_publication?(owner)
 
       owner.update_columns(publication_record: nil, updated_at: Time.current)
     rescue => e
       Rails.logger.warn("[LibraryAcquisitionService] Failed to clear publication record (#{e.class})")
     end
 
-    # Copy or hardlink: the watched-folder source is still present, so the
-    # library artifact is a redundant second copy — discard it. Returns true
-    # when the entry is reversed, which includes finding it already gone.
+    # Copy or hardlink: the source is still present, so the library artifact is a
+    # redundant second copy — discard it. True when reversed, including when it
+    # was already gone.
     def discard_published_file!(entry, root)
       destination = entry["destination"].presence
       return true if destination.blank?
@@ -499,18 +488,16 @@ class LibraryAcquisitionService
     end
 
     # Move: the source is gone, so return this file to the path the scanner
-    # recorded for it. Restoring per file rebuilds a moved directory tree
-    # exactly as it was found. Returns true when the entry is reversed.
+    # recorded. Restoring per file rebuilds a moved tree exactly as it was found.
     def restore_moved_file!(entry, root, source_base)
       destination = entry["destination"].presence
       source = entry["source"].presence
       return true if destination.blank? || source.blank?
 
       # The library artifact decides what is left to do. Gone means this entry
-      # was already reversed (a retried undo, or a restore that completed), and
-      # a mismatch means something else now owns the path and must not be
-      # touched — neither case may consult the source, whose path can since have
-      # been taken over by unrelated bytes.
+      # was already reversed; a mismatch means something else owns the path now.
+      # Neither may consult the source, whose path may since have been taken over
+      # by unrelated bytes.
       case published_file_state(entry, root)
       when :absent then return true
       when :mismatch
@@ -524,15 +511,14 @@ class LibraryAcquisitionService
       case moved_source_state(entry)
       when :absent then restore_to_source!(entry, root, source_base)
       when :match
-        # A directory move publishes every file before unlinking the source
-        # tree, so a reversal partway through finds the original source still in
-        # place. The library copy is then redundant rather than the only
-        # surviving one.
+        # A directory move publishes every file before unlinking the source tree,
+        # so a partway reversal finds the original still in place — the library
+        # copy is redundant rather than the only survivor.
         discard_published_file!(entry, root)
       else
-        # Something occupies the source path that is not what this import took
-        # from it. Removing the library copy would destroy the only surviving
-        # bytes, and overwriting the occupant would destroy someone else's.
+        # Something occupies the source path that this import did not take from
+        # it. Removing the library copy would destroy the only surviving bytes;
+        # overwriting the occupant would destroy someone else's.
         Rails.logger.warn(
           "[LibraryAcquisitionService] Left #{destination} in the library during undo: " \
             "#{source} is occupied by a different file"
@@ -541,12 +527,11 @@ class LibraryAcquisitionService
       end
     end
 
-    # Return the library artifact to the path the scanner recorded, rebuilding
-    # any parent directories the move left empty. Both the mkdir and the
-    # publication walk from the watched-folder root through pinned O_NOFOLLOW
-    # descriptors, so a source ancestor swapped for a symlink since the import
-    # cannot redirect the restore outside the watched folder. Without a recorded
-    # root there is nothing safe to pin against, so the restore is refused.
+    # Return the artifact to the path the scanner recorded, rebuilding any parent
+    # directories the move left empty. Both the mkdir and the publication walk
+    # from the watched-folder root through pinned O_NOFOLLOW descriptors, so an
+    # ancestor swapped for a symlink cannot redirect the restore outside it.
+    # Without a recorded root there is nothing safe to pin against, so refuse.
     def restore_to_source!(entry, root, source_base)
       destination = entry["destination"]
       source = entry["source"]
@@ -572,28 +557,20 @@ class LibraryAcquisitionService
     end
 
     # Whether the source path still holds the file this import moved out of it.
-    # An import that recorded no source identity cannot prove it either way, so
-    # an occupied path counts as a mismatch rather than an assumed match.
-    #
-    #   :absent    - the move consumed it and nothing has taken the path since
-    #   :match     - the original file is still there (a partly-reversed move)
-    #   :mismatch  - a different file now occupies the path
+    # :absent means the move consumed it and nothing has taken the path since;
+    # :match that the original is still there (a partly-reversed move). An import
+    # with no recorded identity cannot prove it either way, and
+    # path_identity_state reports that as :mismatch — left alone, not assumed
+    # ours.
     def moved_source_state(entry)
-      stat = File.lstat(entry["source"])
-      device = entry["source_device"]
-      inode = entry["source_inode"]
-      return :mismatch if device.blank? || inode.blank?
-
-      [ stat.dev, stat.ino ] == [ device, inode ] ? :match : :mismatch
-    rescue Errno::ENOENT, Errno::ENOTDIR
-      :absent
-    rescue SystemCallError
-      :mismatch
+      FileCopyService.path_identity_state(
+        entry["source"], device: entry["source_device"], inode: entry["source_inode"]
+      )
     end
 
-    # Drop a directory this import created, but only while it is still exactly
-    # as empty as it was left. remove_directory_child_if_identity quarantines it
-    # and restores it untouched when anything has since been written into it.
+    # Drop a directory this import created, but only while still exactly as empty
+    # as it was left. remove_directory_child_if_identity quarantines it and
+    # restores it untouched if anything has since been written into it.
     def discard_created_directory!(entry, root)
       path = entry["path"].presence
       device = entry["device"]
@@ -616,9 +593,9 @@ class LibraryAcquisitionService
     # listed through descriptors pinned to the output root rather than resolved
     # from the pathname.
     #
-    #   :match     - the published file is still there, byte for byte the same
-    #   :absent    - already gone, so there is nothing left to reverse
-    #   :mismatch  - something else now occupies the path; never touch it
+    #   :match     - still there, byte for byte the same
+    #   :absent    - already gone, nothing left to reverse
+    #   :mismatch  - something else occupies the path; never touch it
     def published_file_state(entry, root)
       device = entry["device"]
       inode = entry["inode"]
@@ -637,12 +614,10 @@ class LibraryAcquisitionService
       :mismatch
     end
 
-    # A move import that has been undone put the source back with a fresh inode
-    # (the restore is a durable copy followed by an unlink, not a rename), so
-    # the identity recorded at detection no longer describes it. Re-record it,
-    # or drop it when it cannot be read — the importer treats a missing identity
-    # as "unverifiable" rather than refusing the re-import outright. Returns the
-    # identity now recorded, or nil when it could not be read.
+    # An undone move put the source back with a fresh inode (a durable copy plus
+    # unlink, not a rename), so the identity recorded at detection no longer
+    # describes it. Re-record it, or drop it when unreadable — the importer
+    # treats a missing identity as unverifiable rather than refusing outright.
     def refresh_source_identity!(detected_import)
       return nil unless detected_import.respond_to?(:source_device=)
 
@@ -652,7 +627,7 @@ class LibraryAcquisitionService
       )
       [ stat.dev, stat.ino ]
     rescue => e
-      # Never raise: this also runs while unwinding a failed import, where the
+      # Never raise: this also runs while unwinding a failed import, whose
       # original error is the one worth reporting.
       Rails.logger.warn("[LibraryAcquisitionService] Clearing source identity after undo (#{e.class})")
       begin
@@ -663,17 +638,12 @@ class LibraryAcquisitionService
       nil
     end
 
-    # Un-acquire the book and destroy it when it was a throwaway created solely
-    # for this import (no metadata identity and nothing else references it). A
+    # Un-acquire the book, destroying it when it was a throwaway created solely
+    # for this import (no metadata identity, nothing else referencing it). A
     # matched or metadata-bearing book is kept, merely un-acquired.
     def release_book_after_undo!(book)
       book.reload
-      book.update!(
-        file_path: nil,
-        acquisition_reservation_token: nil,
-        acquisition_reservation_owner_type: nil,
-        acquisition_reservation_owner_id: nil
-      )
+      book.update!(Book::RESERVATION_CLEARED.merge(file_path: nil))
 
       if book.unified_work_id.blank? &&
           book.requests.none? && book.uploads.none? && book.owned_library_items.none?
@@ -681,14 +651,11 @@ class LibraryAcquisitionService
       end
     end
 
+    # Resolved by PathTemplateService rather than restated: this root is handed
+    # to LibraryFileImporter, which renders the path template beneath it, so the
+    # two must agree on where a book type lives.
     def output_base_path(book)
-      if book.comicbook?
-        SettingsService.get(:comicbook_output_path, default: "/comics")
-      elsif book.ebook?
-        SettingsService.get(:ebook_output_path, default: "/ebooks")
-      else
-        SettingsService.get(:audiobook_output_path, default: "/audiobooks")
-      end
+      PathTemplateService.output_root_for(book)
     end
 
     def trigger_library_scan(book)
@@ -703,6 +670,22 @@ class LibraryAcquisitionService
       Rails.logger.warn "[LibraryAcquisitionService] Failed to trigger library scan (#{e.class})"
     end
 
+    # The persisted shape of one provider hit. Automatic enrichment and the
+    # admin's manual search both offer candidates through this hash; only the
+    # score differs, since they rank against different queries.
+    def online_candidate(result, score)
+      {
+        "kind" => "online",
+        "work_id" => result.work_id,
+        "title" => result.title,
+        "author" => result.author,
+        "year" => result.year,
+        "cover_url" => result.cover_url,
+        "source" => result.source,
+        "score" => score
+      }
+    end
+
     def library_candidate(book, score)
       {
         "kind" => "library",
@@ -713,30 +696,21 @@ class LibraryAcquisitionService
       }
     end
 
-    # Best-effort online enrichment. Network/parse failures degrade to an empty
-    # alternate list — the human review step is the correctness backstop.
+    # Best-effort online enrichment; failures degrade to an empty alternate list.
     def online_candidates(title, author, book_type)
       return [] if title.blank?
 
       query = author.present? ? "#{title} #{author}" : title
-      content_kind = book_type.to_s == "comicbook" ? "graphic" : nil
-      results = MetadataService.search(query, limit: MAX_ONLINE_CANDIDATES, content_kind: content_kind)
+      results = MetadataService.search(
+        query, limit: MAX_ONLINE_CANDIDATES, content_kind: metadata_content_kind(book_type)
+      )
       results.filter_map do |result|
         score = online_score(result, title, author)
         next if score < 30
 
-        {
-          "kind" => "online",
-          "work_id" => result.work_id,
-          "title" => result.title,
-          "author" => result.author,
-          "year" => result.year,
-          "cover_url" => result.cover_url,
-          "source" => result.source,
-          "score" => score
-        }
+        online_candidate(result, score)
       end.sort_by { |candidate| -candidate["score"] }
-    rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, MetadataService::Error => e
+    rescue *METADATA_ERRORS => e
       Rails.logger.warn "[LibraryAcquisitionService] Metadata search failed (#{e.class})"
       []
     end

--- a/app/services/library_acquisition_service.rb
+++ b/app/services/library_acquisition_service.rb
@@ -26,7 +26,7 @@ class LibraryAcquisitionService
   class AcquisitionConflictError < StandardError; end
 
   # Outcome of a successful import into the organised library.
-  ImportResult = Data.define(:book, :destination_path, :mode)
+  ImportResult = Data.define(:book, :destination_path, :mode, :publication)
 
   # Read-only identification result. +candidate_books+ is a ranked array of
   # plain hashes safe to persist as JSON on a DetectedImport.
@@ -107,24 +107,58 @@ class LibraryAcquisitionService
     #               and the file_path claim, exactly like the upload path.
     # mode        - copy / move / hardlink; defaults to the configured
     #               completed_download_import_mode.
-    def import!(source_path:, book:, owner:, mode: nil, provenance: nil)
+    # source_identity - optional [device, inode] recorded when the source was
+    #               detected. The importer refuses to publish a source whose
+    #               inode no longer matches, so a path swapped between approval
+    #               and import cannot substitute different bytes.
+    #
+    # The publication record is persisted on +owner+ before the database claim,
+    # so a crash or a lost claim race can still be reversed precisely: bytes are
+    # already on disk at that point and only an exact record of them makes the
+    # rollback safe.
+    def import!(source_path:, book:, owner:, mode: nil, provenance: nil, source_identity: nil)
       mode = (mode || SettingsService.get(:completed_download_import_mode, default: "copy")).to_s
       base_path = output_base_path(book)
 
       reserve_book!(book, owner)
+      importer = LibraryFileImporter.new(mode: mode)
+      claimed = false
       begin
-        result = LibraryFileImporter.new(mode: mode).import(
+        result = importer.import(
           source: source_path,
           book: book,
-          base_path: base_path
+          base_path: base_path,
+          expected_source_identity: source_identity
         )
+        record_publication!(owner, result.publication)
+
         claim_file_path!(book, result.imported_path, owner)
+        # The import owns these bytes from here on; only an explicit undo
+        # reverses them.
+        claimed = true
+
         trigger_library_scan(book)
         Rails.logger.info(
           "[LibraryAcquisitionService] Imported #{provenance || 'source'} for book ##{book.id} (mode=#{mode})"
         )
-        ImportResult.new(book: book, destination_path: result.imported_path, mode: mode)
+        ImportResult.new(
+          book: book,
+          destination_path: result.imported_path,
+          mode: mode,
+          publication: result.publication
+        )
       rescue
+        # Anything short of a completed claim is reversed, including a tree
+        # import that failed partway through: the importer's record covers every
+        # file it managed to publish before raising. A reversal that could not
+        # finish is logged rather than raised — the original failure is the one
+        # worth reporting — but the record is left behind so undo can retry it.
+        unless claimed || reverse_publication!(importer.publication_record, owner)
+          Rails.logger.error(
+            "[LibraryAcquisitionService] Could not fully reverse the failed import for book ##{book.id}; " \
+              "some published files remain in the library"
+          )
+        end
         release_reservation!(book, owner)
         raise
       end
@@ -142,16 +176,36 @@ class LibraryAcquisitionService
     # behind un-acquired.
     def undo_import!(detected_import)
       book = detected_import.imported_book
-      destination = book&.file_path.presence
+      publication = detected_import.publication_record
 
-      reverse_publication!(destination, detected_import, book) if destination
+      if publication.present?
+        # Only a complete reversal earns the state reset below. A file that is
+        # no longer the one this import published (renamed, re-tagged, replaced)
+        # is left alone, and un-acquiring the book anyway would strand it in the
+        # library and let a re-import duplicate it.
+        unless reverse_publication!(publication, detected_import)
+          raise AcquisitionConflictError,
+            "Refusing to undo: the file this import published could not be returned or removed — it has been " \
+            "renamed, replaced, or moved since. Resolve it under #{publication['base_path']} and try again."
+        end
+        refresh_source_identity!(detected_import) if publication["mode"].to_s == "move"
+      elsif book&.file_path.present?
+        # Without an exact record of what was published there is no safe way to
+        # tell this import's files apart from anything else living under the
+        # same templated directory, and guessing is how unrelated files get
+        # deleted. Leave the artifact and the detection alone for the admin.
+        raise AcquisitionConflictError,
+          "Refusing to undo: this import predates publication tracking, so #{book.file_path} " \
+          "must be removed manually before it can be re-imported"
+      end
 
       ActiveRecord::Base.transaction do
         detected_import.update!(
           status: "detected",
           imported_book: nil,
           suggested_book: nil,
-          error_message: nil
+          error_message: nil,
+          publication_record: nil
         )
         release_book_after_undo!(book) if book
       end
@@ -263,51 +317,182 @@ class LibraryAcquisitionService
       Rails.logger.error "[LibraryAcquisitionService] Failed to release reservation for book ##{book.id} (#{e.class})"
     end
 
-    # Remove (or, for a move import, relocate) the artifact this import published
-    # into the library. Refuses to touch anything that is not strictly inside the
-    # book's configured output root, so a corrupt file_path can never delete an
-    # arbitrary path.
-    def reverse_publication!(destination, detected_import, book)
-      return unless File.exist?(destination)
+    # Persist what an import published so a later rollback or undo can reverse
+    # exactly those entries. Written with update_columns so an in-flight import
+    # neither runs validations nor broadcasts a status change.
+    def record_publication!(owner, publication)
+      return unless owner.respond_to?(:publication_record=) && owner.persisted?
 
-      unless within_output_root?(destination, book)
-        raise AcquisitionConflictError,
-          "Refusing to undo: #{destination} is not inside the library output path"
-      end
-
-      if File.exist?(detected_import.source_path)
-        # Copy or hardlink: the watched-folder source is still present, so the
-        # library artifact is a redundant second copy — discard it.
-        FileUtils.remove_entry(destination)
-      else
-        # Move: the source is gone; put the artifact back so it can be re-imported.
-        restore_moved_source!(destination, detected_import)
-      end
+      owner.update_columns(publication_record: publication, updated_at: Time.current)
+    rescue => e
+      Rails.logger.error(
+        "[LibraryAcquisitionService] Failed to record publication for #{owner.class.name} ##{owner.id} (#{e.class})"
+      )
     end
 
-    # Return a moved artifact to the source path the scanner recorded. Audiobook
-    # imports are directories at both ends; single-file imports land inside a
-    # per-book directory, so the file itself is returned and the emptied wrapper
-    # directory removed.
-    def restore_moved_source!(destination, detected_import)
-      source = detected_import.source_path
-      FileUtils.mkdir_p(File.dirname(source))
+    # Reverse exactly the entries this import published: discard the files it
+    # created (or, for a move, return them to where the scanner found them) and
+    # then drop only the directories it brought into existence, and only while
+    # they are still empty. A templated "Author/Book" directory is routinely
+    # shared with files this import does not own, so it is never deleted
+    # recursively.
+    #
+    # Containment is structural rather than a pathname comparison: every removal
+    # walks from the output root through pinned O_NOFOLLOW descriptors and is
+    # gated on the (device, inode) recorded at publication, so neither an
+    # ancestor swapped for a symlink nor a root that canonicalizes differently
+    # (/var vs /private/var) can redirect or block it.
+    #
+    # Returns true only when every recorded file was reversed. A caller that
+    # resets state on the strength of the reversal must not proceed on false:
+    # the library still holds an artifact this import put there. The record is
+    # kept in that case so undo can be retried once the admin has resolved it;
+    # every step is idempotent, so a retry re-reverses only what is left.
+    def reverse_publication!(publication, owner)
+      publication = publication.presence || {}
+      files = Array(publication["files"])
+      root = publication["base_path"].presence
+      return files.empty? if root.blank?
 
-      if detected_import.book_type == "audiobook" || File.file?(destination)
-        FileUtils.mv(destination, source)
-      else
-        inner = Dir.glob(File.join(destination, "**", "*")).find { |path| File.file?(path) }
-        FileUtils.mv(inner || destination, source)
-        FileUtils.remove_entry(destination) if File.directory?(destination)
-      end
+      move = publication["mode"].to_s == "move"
+      complete = files.reverse_each.map { |entry|
+        move ? restore_moved_file!(entry, root) : discard_published_file!(entry, root)
+      }.all?
+      Array(publication["directories"]).reverse_each { |entry| discard_created_directory!(entry, root) }
+
+      clear_publication_record!(owner) if complete
+      complete
     end
 
-    def within_output_root?(destination, book)
-      base = File.realpath(output_base_path(book))
-      target = File.expand_path(destination)
-      target.start_with?("#{base}#{File::SEPARATOR}")
-    rescue ArgumentError, SystemCallError
+    def clear_publication_record!(owner)
+      return unless owner.respond_to?(:publication_record=) && owner.persisted?
+
+      owner.update_columns(publication_record: nil, updated_at: Time.current)
+    rescue => e
+      Rails.logger.warn("[LibraryAcquisitionService] Failed to clear publication record (#{e.class})")
+    end
+
+    # Copy or hardlink: the watched-folder source is still present, so the
+    # library artifact is a redundant second copy — discard it. Returns true
+    # when the entry is reversed, which includes finding it already gone.
+    def discard_published_file!(entry, root)
+      destination = entry["destination"].presence
+      return true if destination.blank?
+
+      case published_file_state(entry, root)
+      when :absent then return true
+      when :match then nil
+      else
+        Rails.logger.warn(
+          "[LibraryAcquisitionService] Left #{destination} in place during undo: " \
+            "it is no longer the file this import published"
+        )
+        return false
+      end
+
+      FileCopyService.remove_regular_file_safely(destination, root: root)
+      true
+    rescue FileCopyService::UnsafePathError, FileCopyService::AtomicPublicationUnsupportedError, SystemCallError => e
+      Rails.logger.warn(
+        "[LibraryAcquisitionService] Left #{entry['destination']} in place during undo (#{e.class})"
+      )
       false
+    end
+
+    # Move: the source is gone, so return this file to the path the scanner
+    # recorded for it. Restoring per file rebuilds a moved directory tree
+    # exactly as it was found. Returns true when the entry is reversed.
+    def restore_moved_file!(entry, root)
+      destination = entry["destination"].presence
+      source = entry["source"].presence
+      return true if destination.blank? || source.blank?
+
+      # A directory move publishes every file before unlinking the source tree,
+      # so a reversal partway through finds the source still in place. The
+      # library copy is then redundant rather than the only surviving one. The
+      # same branch makes a retried undo a no-op for entries already returned.
+      return discard_published_file!(entry, root) if File.exist?(source)
+
+      unless published_file_state(entry, root) == :match
+        Rails.logger.warn(
+          "[LibraryAcquisitionService] Could not return #{destination} to #{source}: " \
+            "it is no longer the file this import published"
+        )
+        return false
+      end
+
+      FileUtils.mkdir_p(File.dirname(source))
+      FileCopyService.mv_noreplace(
+        destination, source,
+        root: File.dirname(source), allow_compatibility_fallback: true
+      )
+      true
+    rescue FileCopyService::UnsafePathError, FileCopyService::AtomicPublicationUnsupportedError, SystemCallError => e
+      Rails.logger.warn(
+        "[LibraryAcquisitionService] Could not return #{entry['destination']} to #{entry['source']} (#{e.class})"
+      )
+      false
+    end
+
+    # Drop a directory this import created, but only while it is still exactly
+    # as empty as it was left. remove_directory_child_if_identity quarantines it
+    # and restores it untouched when anything has since been written into it.
+    def discard_created_directory!(entry, root)
+      path = entry["path"].presence
+      device = entry["device"]
+      inode = entry["inode"]
+      return if path.blank? || device.blank? || inode.blank?
+
+      FileCopyService.remove_directory_child_if_identity(
+        File.dirname(path),
+        File.basename(path),
+        root: root,
+        device: device,
+        inode: inode,
+        expected_entries: {}
+      )
+    rescue FileCopyService::UnsafePathError, SystemCallError => e
+      Rails.logger.warn("[LibraryAcquisitionService] Left directory #{entry['path']} in place during undo (#{e.class})")
+    end
+
+    # Whether the library still holds the exact inode this import published,
+    # listed through descriptors pinned to the output root rather than resolved
+    # from the pathname.
+    #
+    #   :match     - the published file is still there, byte for byte the same
+    #   :absent    - already gone, so there is nothing left to reverse
+    #   :mismatch  - something else now occupies the path; never touch it
+    def published_file_state(entry, root)
+      device = entry["device"]
+      inode = entry["inode"]
+      basename = File.basename(entry["destination"])
+      children = FileCopyService.directory_children(File.dirname(entry["destination"]), root: root)
+      child = children.find { |candidate| candidate.name == basename }
+      return :absent unless child
+      return :mismatch unless child.type == :file
+      return :match if device.blank? || inode.blank?
+
+      [ child.device, child.inode ] == [ device, inode ] ? :match : :mismatch
+    rescue Errno::ENOENT
+      # The templated directory itself is gone, so the file under it is too.
+      :absent
+    rescue FileCopyService::UnsafePathError, SystemCallError
+      :mismatch
+    end
+
+    # A move import that has been undone put the source back with a fresh inode
+    # (the restore is a durable copy followed by an unlink, not a rename), so
+    # the identity recorded at detection no longer describes it. Re-record it,
+    # or drop it when it cannot be read — the importer treats a missing identity
+    # as "unverifiable" rather than refusing the re-import outright.
+    def refresh_source_identity!(detected_import)
+      stat = File.lstat(detected_import.source_path)
+      detected_import.update_columns(
+        source_device: stat.dev, source_inode: stat.ino, updated_at: Time.current
+      )
+    rescue SystemCallError, ActiveRecord::RecordNotUnique => e
+      Rails.logger.warn("[LibraryAcquisitionService] Clearing source identity after undo (#{e.class})")
+      detected_import.update_columns(source_device: nil, source_inode: nil, updated_at: Time.current)
     end
 
     # Un-acquire the book and destroy it when it was a throwaway created solely

--- a/app/services/library_acquisition_service.rb
+++ b/app/services/library_acquisition_service.rb
@@ -28,6 +28,11 @@ class LibraryAcquisitionService
   # Outcome of a successful import into the organised library.
   ImportResult = Data.define(:book, :destination_path, :mode, :publication)
 
+  # What a retry found left behind by an interrupted attempt: either a result to
+  # hand straight back, or the source identity to import against once the
+  # stranded publication has been reversed.
+  Recovery = Data.define(:result, :reversed, :source_identity)
+
   # Read-only identification result. +candidate_books+ is a ranked array of
   # plain hashes safe to persist as JSON on a DetectedImport.
   Identification = Data.define(
@@ -111,14 +116,21 @@ class LibraryAcquisitionService
     #               detected. The importer refuses to publish a source whose
     #               inode no longer matches, so a path swapped between approval
     #               and import cannot substitute different bytes.
+    # source_base - the root the source was found under (the watched folder),
+    #               recorded on the publication so undo can restore a moved file
+    #               through descriptors pinned to that root.
     #
     # The publication record is persisted on +owner+ before the database claim,
     # so a crash or a lost claim race can still be reversed precisely: bytes are
     # already on disk at that point and only an exact record of them makes the
     # rollback safe.
-    def import!(source_path:, book:, owner:, mode: nil, provenance: nil, source_identity: nil)
+    def import!(source_path:, book:, owner:, mode: nil, provenance: nil, source_identity: nil, source_base: nil)
       mode = (mode || SettingsService.get(:completed_download_import_mode, default: "copy")).to_s
       base_path = output_base_path(book)
+
+      recovered = recover_interrupted_publication!(owner, book, source_identity)
+      return recovered.result if recovered.result
+      source_identity = recovered.source_identity if recovered.reversed
 
       reserve_book!(book, owner)
       importer = LibraryFileImporter.new(mode: mode)
@@ -128,7 +140,8 @@ class LibraryAcquisitionService
           source: source_path,
           book: book,
           base_path: base_path,
-          expected_source_identity: source_identity
+          expected_source_identity: source_identity,
+          source_base: source_base
         )
         record_publication!(owner, result.publication)
 
@@ -152,13 +165,18 @@ class LibraryAcquisitionService
         # import that failed partway through: the importer's record covers every
         # file it managed to publish before raising. A reversal that could not
         # finish is logged rather than raised — the original failure is the one
-        # worth reporting — but the record is left behind so undo can retry it.
-        unless claimed || reverse_publication!(importer.publication_record, owner)
+        # worth reporting — and its record is left behind so the next attempt
+        # (or an undo) can retry the reversal.
+        reversed = claimed || reverse_publication!(importer.publication_record, owner)
+        unless reversed
           Rails.logger.error(
             "[LibraryAcquisitionService] Could not fully reverse the failed import for book ##{book.id}; " \
               "some published files remain in the library"
           )
         end
+        # A reversed move put the source back on a fresh inode, so the identity
+        # recorded at detection would fail the next attempt's check.
+        refresh_source_identity!(owner) if reversed && !claimed && mode == "move"
         release_reservation!(book, owner)
         raise
       end
@@ -183,7 +201,13 @@ class LibraryAcquisitionService
         # no longer the one this import published (renamed, re-tagged, replaced)
         # is left alone, and un-acquiring the book anyway would strand it in the
         # library and let a re-import duplicate it.
-        unless reverse_publication!(publication, detected_import)
+        #
+        # The journal is deliberately not cleared here: it is the only durable
+        # description of what this import put on disk, and the transaction below
+        # can still fail (or the process die) after the files have moved. It is
+        # cleared by that transaction, so until it commits a retried undo still
+        # has a record to work from — every step below is idempotent.
+        unless reverse_publication!(publication, detected_import, clear_record: false)
           raise AcquisitionConflictError,
             "Refusing to undo: the file this import published could not be returned or removed — it has been " \
             "renamed, replaced, or moved since. Resolve it under #{publication['base_path']} and try again."
@@ -259,6 +283,73 @@ class LibraryAcquisitionService
 
     private
 
+    # An owner that already carries a publication record reached durable state on
+    # an earlier attempt: bytes are on disk and, for a move, the source is gone.
+    # Re-running the import from that source would read a path that no longer
+    # exists and fail, leaving the bytes, the journal, and the reservation
+    # stranded with no way to undo. So reconcile that phase first.
+    #
+    # If the earlier attempt also claimed the book, the import actually finished
+    # and only the caller's bookkeeping was lost — hand back its result rather
+    # than publishing a second copy. Otherwise reverse it, which returns a moved
+    # source to the watched folder, and import again from there.
+    def recover_interrupted_publication!(owner, book, source_identity)
+      record = owner.respond_to?(:publication_record) ? owner.publication_record.presence : nil
+      return Recovery.new(result: nil, reversed: false, source_identity: nil) if record.blank?
+
+      book.reload
+      if publication_claimed_by?(record, book)
+        Rails.logger.info(
+          "[LibraryAcquisitionService] Resuming interrupted import for book ##{book.id}; the library file is already claimed"
+        )
+        # The interrupted attempt may have died before announcing the file.
+        trigger_library_scan(book)
+        return Recovery.new(
+          result: ImportResult.new(
+            book: book,
+            destination_path: book.file_path,
+            mode: record["mode"].to_s,
+            publication: record
+          ),
+          reversed: false,
+          source_identity: nil
+        )
+      end
+
+      # The dead attempt's reservation would otherwise block reserve_book!.
+      # release_reservation! only touches a reservation still held by this owner
+      # on an unclaimed book, which is exactly the interrupted case.
+      release_reservation!(book, owner)
+      unless reverse_publication!(record, owner)
+        raise AcquisitionConflictError,
+          "An earlier import attempt was interrupted and its files could not be reversed. " \
+          "Resolve them under #{record['base_path']} and try again."
+      end
+
+      # A reversed move put the source back on a fresh inode (the restore is a
+      # durable copy plus an unlink, not a rename), so the identity the caller
+      # is about to import against has to be re-read. A copy or hardlink never
+      # touched the source, so its recorded identity still stands.
+      identity = record["mode"].to_s == "move" ? refresh_source_identity!(owner) : source_identity
+      Rails.logger.warn(
+        "[LibraryAcquisitionService] Reversed an interrupted import for book ##{book.id} before retrying"
+      )
+      Recovery.new(result: nil, reversed: true, source_identity: identity)
+    end
+
+    # Whether the book's claimed file_path is what this publication produced —
+    # the file it published, or the per-book directory it published into.
+    def publication_claimed_by?(record, book)
+      claimed = book.file_path.presence
+      return false if claimed.blank?
+
+      destinations = Array(record["files"]).filter_map { |entry| entry["destination"].presence }
+      return false if destinations.empty?
+
+      destinations.include?(claimed) ||
+        destinations.all? { |destination| destination.start_with?(File.join(claimed, "")) }
+    end
+
     # Reserve the book under a row lock so a concurrent acquisition (upload or
     # download) cannot claim the same title while the file import runs outside
     # the transaction. Raises if the title is already acquired or reserved.
@@ -320,14 +411,17 @@ class LibraryAcquisitionService
     # Persist what an import published so a later rollback or undo can reverse
     # exactly those entries. Written with update_columns so an in-flight import
     # neither runs validations nor broadcasts a status change.
+    #
+    # A failure here is fatal on purpose. The bytes are already on disk and a
+    # move has already consumed the source, so this write is the only durable
+    # thing that can reverse them; committing the import without it would leave
+    # an acquired book whose undo has nothing to work from. Raising instead
+    # sends the caller into the rollback below, which reverses the in-memory
+    # record while it is still available.
     def record_publication!(owner, publication)
       return unless owner.respond_to?(:publication_record=) && owner.persisted?
 
       owner.update_columns(publication_record: publication, updated_at: Time.current)
-    rescue => e
-      Rails.logger.error(
-        "[LibraryAcquisitionService] Failed to record publication for #{owner.class.name} ##{owner.id} (#{e.class})"
-      )
     end
 
     # Reverse exactly the entries this import published: discard the files it
@@ -348,19 +442,24 @@ class LibraryAcquisitionService
     # the library still holds an artifact this import put there. The record is
     # kept in that case so undo can be retried once the admin has resolved it;
     # every step is idempotent, so a retry re-reverses only what is left.
-    def reverse_publication!(publication, owner)
+    #
+    # +clear_record+ drops the journal once the reversal is complete. Callers
+    # that still have durable state to commit afterwards pass false and clear it
+    # themselves, so a failure in that window leaves a record to retry from.
+    def reverse_publication!(publication, owner, clear_record: true)
       publication = publication.presence || {}
       files = Array(publication["files"])
       root = publication["base_path"].presence
       return files.empty? if root.blank?
 
       move = publication["mode"].to_s == "move"
+      source_base = publication["source_base"].presence
       complete = files.reverse_each.map { |entry|
-        move ? restore_moved_file!(entry, root) : discard_published_file!(entry, root)
+        move ? restore_moved_file!(entry, root, source_base) : discard_published_file!(entry, root)
       }.all?
       Array(publication["directories"]).reverse_each { |entry| discard_created_directory!(entry, root) }
 
-      clear_publication_record!(owner) if complete
+      clear_publication_record!(owner) if complete && clear_record
       complete
     end
 
@@ -402,18 +501,19 @@ class LibraryAcquisitionService
     # Move: the source is gone, so return this file to the path the scanner
     # recorded for it. Restoring per file rebuilds a moved directory tree
     # exactly as it was found. Returns true when the entry is reversed.
-    def restore_moved_file!(entry, root)
+    def restore_moved_file!(entry, root, source_base)
       destination = entry["destination"].presence
       source = entry["source"].presence
       return true if destination.blank? || source.blank?
 
-      # A directory move publishes every file before unlinking the source tree,
-      # so a reversal partway through finds the source still in place. The
-      # library copy is then redundant rather than the only surviving one. The
-      # same branch makes a retried undo a no-op for entries already returned.
-      return discard_published_file!(entry, root) if File.exist?(source)
-
-      unless published_file_state(entry, root) == :match
+      # The library artifact decides what is left to do. Gone means this entry
+      # was already reversed (a retried undo, or a restore that completed), and
+      # a mismatch means something else now owns the path and must not be
+      # touched — neither case may consult the source, whose path can since have
+      # been taken over by unrelated bytes.
+      case published_file_state(entry, root)
+      when :absent then return true
+      when :mismatch
         Rails.logger.warn(
           "[LibraryAcquisitionService] Could not return #{destination} to #{source}: " \
             "it is no longer the file this import published"
@@ -421,10 +521,47 @@ class LibraryAcquisitionService
         return false
       end
 
-      FileUtils.mkdir_p(File.dirname(source))
+      case moved_source_state(entry)
+      when :absent then restore_to_source!(entry, root, source_base)
+      when :match
+        # A directory move publishes every file before unlinking the source
+        # tree, so a reversal partway through finds the original source still in
+        # place. The library copy is then redundant rather than the only
+        # surviving one.
+        discard_published_file!(entry, root)
+      else
+        # Something occupies the source path that is not what this import took
+        # from it. Removing the library copy would destroy the only surviving
+        # bytes, and overwriting the occupant would destroy someone else's.
+        Rails.logger.warn(
+          "[LibraryAcquisitionService] Left #{destination} in the library during undo: " \
+            "#{source} is occupied by a different file"
+        )
+        false
+      end
+    end
+
+    # Return the library artifact to the path the scanner recorded, rebuilding
+    # any parent directories the move left empty. Both the mkdir and the
+    # publication walk from the watched-folder root through pinned O_NOFOLLOW
+    # descriptors, so a source ancestor swapped for a symlink since the import
+    # cannot redirect the restore outside the watched folder. Without a recorded
+    # root there is nothing safe to pin against, so the restore is refused.
+    def restore_to_source!(entry, root, source_base)
+      destination = entry["destination"]
+      source = entry["source"]
+      if source_base.blank?
+        Rails.logger.warn(
+          "[LibraryAcquisitionService] Could not return #{destination} to #{source}: " \
+            "the import recorded no watched-folder root to restore through"
+        )
+        return false
+      end
+
+      FileCopyService.ensure_directory(File.dirname(source), root: source_base)
       FileCopyService.mv_noreplace(
         destination, source,
-        root: File.dirname(source), allow_compatibility_fallback: true
+        root: source_base, allow_compatibility_fallback: true
       )
       true
     rescue FileCopyService::UnsafePathError, FileCopyService::AtomicPublicationUnsupportedError, SystemCallError => e
@@ -432,6 +569,26 @@ class LibraryAcquisitionService
         "[LibraryAcquisitionService] Could not return #{entry['destination']} to #{entry['source']} (#{e.class})"
       )
       false
+    end
+
+    # Whether the source path still holds the file this import moved out of it.
+    # An import that recorded no source identity cannot prove it either way, so
+    # an occupied path counts as a mismatch rather than an assumed match.
+    #
+    #   :absent    - the move consumed it and nothing has taken the path since
+    #   :match     - the original file is still there (a partly-reversed move)
+    #   :mismatch  - a different file now occupies the path
+    def moved_source_state(entry)
+      stat = File.lstat(entry["source"])
+      device = entry["source_device"]
+      inode = entry["source_inode"]
+      return :mismatch if device.blank? || inode.blank?
+
+      [ stat.dev, stat.ino ] == [ device, inode ] ? :match : :mismatch
+    rescue Errno::ENOENT, Errno::ENOTDIR
+      :absent
+    rescue SystemCallError
+      :mismatch
     end
 
     # Drop a directory this import created, but only while it is still exactly
@@ -484,15 +641,26 @@ class LibraryAcquisitionService
     # (the restore is a durable copy followed by an unlink, not a rename), so
     # the identity recorded at detection no longer describes it. Re-record it,
     # or drop it when it cannot be read — the importer treats a missing identity
-    # as "unverifiable" rather than refusing the re-import outright.
+    # as "unverifiable" rather than refusing the re-import outright. Returns the
+    # identity now recorded, or nil when it could not be read.
     def refresh_source_identity!(detected_import)
+      return nil unless detected_import.respond_to?(:source_device=)
+
       stat = File.lstat(detected_import.source_path)
       detected_import.update_columns(
         source_device: stat.dev, source_inode: stat.ino, updated_at: Time.current
       )
-    rescue SystemCallError, ActiveRecord::RecordNotUnique => e
+      [ stat.dev, stat.ino ]
+    rescue => e
+      # Never raise: this also runs while unwinding a failed import, where the
+      # original error is the one worth reporting.
       Rails.logger.warn("[LibraryAcquisitionService] Clearing source identity after undo (#{e.class})")
-      detected_import.update_columns(source_device: nil, source_inode: nil, updated_at: Time.current)
+      begin
+        detected_import.update_columns(source_device: nil, source_inode: nil, updated_at: Time.current)
+      rescue => inner
+        Rails.logger.warn("[LibraryAcquisitionService] Could not clear source identity (#{inner.class})")
+      end
+      nil
     end
 
     # Un-acquire the book and destroy it when it was a throwaway created solely

--- a/app/services/library_file_importer.rb
+++ b/app/services/library_file_importer.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+# Publishes a source file or directory into the organised library using the
+# configured import mode (copy / move / hardlink), reusing FileCopyService's
+# atomic, no-replace, TOCTOU-safe primitives — the same ones PostProcessingJob
+# uses for request downloads. Only the mode dispatch and traversal live here;
+# every actual filesystem publication goes through FileCopyService so the hard
+# safety guarantees are shared, not re-implemented.
+#
+# Single files are renamed with the book's filename template. Directory imports
+# (multi-file audiobooks) preserve the source layout and filenames. The source
+# is never mutated except by an explicit "move", which FileCopyService performs
+# only after a durable publication.
+class LibraryFileImporter
+  MODES = %w[copy move hardlink].freeze
+
+  Result = Data.define(:imported_path, :hardlinked, :copied, :moved)
+
+  def initialize(mode:)
+    @mode = MODES.include?(mode.to_s) ? mode.to_s : "copy"
+    @hardlinked = 0
+    @copied = 0
+    @moved = 0
+  end
+
+  # Import +source+ into the library for +book+, rooted at +base_path+ (the
+  # book type's output root). Returns a Result whose imported_path is the file
+  # (flat output / single file) or the per-book directory.
+  def import(source:, book:, base_path:)
+    source = File.expand_path(source.to_s)
+    raise Errno::ENOENT, source unless File.exist?(source)
+
+    stat = File.lstat(source)
+    raise "Refusing to import symbolic link: #{source}" if stat.symlink?
+
+    @root = Pathname(base_path).expand_path
+    destination_dir = PathTemplateService.build_destination(book, base_path: @root.to_s)
+
+    imported_path =
+      if stat.directory?
+        import_directory(source, destination_dir)
+        destination_dir
+      elsif stat.file?
+        import_single_file(source, destination_dir, book)
+      else
+        raise "Refusing to import non-regular path: #{source}"
+      end
+
+    Result.new(imported_path: imported_path, hardlinked: @hardlinked, copied: @copied, moved: @moved)
+  end
+
+  private
+
+  def import_single_file(source, destination_dir, book)
+    FileCopyService.ensure_directory(destination_dir, root: @root, mode: 0o750)
+    filename = PathTemplateService.build_filename(book, File.extname(source))
+    destination_file = File.join(destination_dir, filename)
+    imported = publish(source, destination_file, source_root: nil)
+
+    PathTemplateService.flat_output?(book) ? imported : destination_dir
+  end
+
+  def import_directory(source, destination_dir)
+    @source_root = FileCopyService.snapshot_source_root(source)
+    FileCopyService.ensure_directory(destination_dir, root: @root, mode: 0o750)
+    import_tree(source, destination_dir)
+  end
+
+  def import_tree(source_dir, destination_dir)
+    manifest_children(source_dir).each do |name|
+      source_path = File.join(source_dir, name)
+      stat = File.lstat(source_path)
+
+      if stat.directory?
+        nested = File.join(destination_dir, name)
+        FileCopyService.ensure_directory(nested, root: @root, mode: 0o750)
+        import_tree(source_path, nested)
+      elsif stat.file?
+        publish(source_path, File.join(destination_dir, name), source_root: @source_root)
+      end
+      # Non-regular entries are absent from the immutable manifest and skipped.
+    end
+  end
+
+  # Enumerate a directory's children from the immutable source snapshot rather
+  # than a fresh readdir, so a mid-import path swap cannot introduce new entries.
+  # The snapshot is grouped by parent directory once (see children_by_parent) so
+  # a deep tree costs O(entries) total instead of O(entries) per directory.
+  def manifest_children(directory)
+    relative = Pathname(directory).expand_path.relative_path_from(@source_root.path)
+    (children_by_parent[relative] || []).sort
+  rescue ArgumentError
+    []
+  end
+
+  # Index of parent directory (relative to the source root) => immediate child
+  # basenames, built once per import from the immutable entry snapshot.
+  def children_by_parent
+    @children_by_parent ||= @source_root.entries.each_key.with_object({}) do |entry, index|
+      path = Pathname(entry)
+      (index[path.dirname] ||= []) << path.basename.to_s
+    end.tap { |index| index.each_value(&:uniq!) }
+  end
+
+  # Publish one regular file with the configured mode, retrying under a numbered
+  # filename when a concurrent writer claims the exclusive destination.
+  def publish(source, destination, source_root:)
+    original = destination
+    counter = 1
+
+    begin
+      destination = unique_destination(original, counter)
+      publish_with_mode(source, destination, source_root: source_root)
+      destination
+    rescue Errno::EEXIST
+      counter += 1
+      retry
+    end
+  end
+
+  def publish_with_mode(source, destination, source_root:)
+    case @mode
+    when "move"
+      FileCopyService.mv_noreplace(
+        source, destination,
+        root: @root, source_root: source_root, allow_compatibility_fallback: true
+      )
+      @moved += 1
+    when "hardlink"
+      begin
+        FileCopyService.hardlink_noreplace(
+          source, destination,
+          root: @root, source_root: source_root
+        )
+        @hardlinked += 1
+      rescue FileCopyService::HardlinkUnsupportedError
+        FileCopyService.cp_noreplace(
+          source, destination,
+          root: @root, source_root: source_root,
+          hardlink_mode: true, allow_compatibility_fallback: true
+        )
+        @copied += 1
+      end
+    else
+      FileCopyService.cp_noreplace(
+        source, destination,
+        root: @root, source_root: source_root, allow_compatibility_fallback: true
+      )
+      @copied += 1
+    end
+  end
+
+  def unique_destination(path, counter)
+    return path if counter <= 1 && !occupied?(path)
+
+    dir = File.dirname(path)
+    ext = File.extname(path)
+    base = File.basename(path, ext)
+    candidate = path
+    while occupied?(candidate)
+      candidate = File.join(dir, "#{base} (#{counter})#{ext}")
+      counter += 1
+    end
+    candidate
+  end
+
+  def occupied?(path)
+    File.exist?(path) || File.symlink?(path)
+  end
+end

--- a/app/services/library_file_importer.rb
+++ b/app/services/library_file_importer.rb
@@ -35,6 +35,7 @@ class LibraryFileImporter
   def initialize(mode:)
     @mode = MODES.include?(mode.to_s) ? mode.to_s : "copy"
     @root = nil
+    @source_base = nil
     @source_root = nil
     @source_snapshot = nil
     @hardlinked = 0
@@ -51,13 +52,18 @@ class LibraryFileImporter
   # expected_source_identity - optional [device, inode] recorded when the source
   #                            was detected. Nil skips the check (filesystems
   #                            that report no usable inode).
-  def import(source:, book:, base_path:, expected_source_identity: nil)
+  # source_base - the root the source was found under (the watched folder). Only
+  #               recorded, never traversed here; undo needs it to return a moved
+  #               file through descriptors pinned to that root instead of
+  #               trusting the source's parent path.
+  def import(source:, book:, base_path:, expected_source_identity: nil, source_base: nil)
     source = File.expand_path(source.to_s)
     raise Errno::ENOENT, source unless File.exist?(source)
 
     stat = File.lstat(source)
     raise "Refusing to import symbolic link: #{source}" if stat.symlink?
 
+    @source_base = source_base.presence
     @root = Pathname(base_path).expand_path
     destination_dir = PathTemplateService.build_destination(book, base_path: @root.to_s)
 
@@ -88,6 +94,7 @@ class LibraryFileImporter
     {
       "mode" => @mode,
       "base_path" => @root.to_s,
+      "source_base" => @source_base,
       "files" => @published_files,
       "directories" => @created_directories
     }
@@ -216,6 +223,10 @@ class LibraryFileImporter
   def publish(source, destination, source_root:)
     original = destination
     counter = 1
+    # Read before publishing: a move unlinks the source, and undo needs the
+    # identity the source had to tell "this file is still where the scanner
+    # found it" apart from "something unrelated has taken over that path".
+    source_identity = path_identity(source)
 
     begin
       destination = unique_destination(original, counter)
@@ -225,7 +236,7 @@ class LibraryFileImporter
       retry
     end
 
-    record_published_file(source, destination)
+    record_published_file(source, destination, source_identity)
     destination
   end
 
@@ -280,16 +291,24 @@ class LibraryFileImporter
     source_root ? nil : @source_snapshot
   end
 
-  def record_published_file(source, destination)
-    stat = File.lstat(destination)
-    @published_files << {
+  def record_published_file(source, destination, source_identity)
+    entry = {
       "destination" => destination,
       "source" => source,
-      "device" => stat.dev,
-      "inode" => stat.ino
+      "source_device" => source_identity&.first,
+      "source_inode" => source_identity&.last
     }
+    stat = File.lstat(destination)
+    @published_files << entry.merge("device" => stat.dev, "inode" => stat.ino)
   rescue SystemCallError
-    @published_files << { "destination" => destination, "source" => source }
+    @published_files << entry
+  end
+
+  def path_identity(path)
+    stat = File.lstat(path)
+    [ stat.dev, stat.ino ]
+  rescue SystemCallError
+    nil
   end
 
   # Refuse to publish a source whose inode no longer matches the one recorded

--- a/app/services/library_file_importer.rb
+++ b/app/services/library_file_importer.rb
@@ -1,27 +1,25 @@
 # frozen_string_literal: true
 
 # Publishes a source file or directory into the organised library using the
-# configured import mode (copy / move / hardlink), reusing FileCopyService's
-# atomic, no-replace, TOCTOU-safe primitives — the same ones PostProcessingJob
-# uses for request downloads. Only the mode dispatch and traversal live here;
-# every actual filesystem publication goes through FileCopyService so the hard
-# safety guarantees are shared, not re-implemented.
+# configured import mode (copy / move / hardlink), on FileCopyService's atomic,
+# no-replace, TOCTOU-safe primitives — the same ones PostProcessingJob uses for
+# request downloads. Only mode dispatch and traversal live here; every actual
+# publication goes through FileCopyService, so the safety guarantees are shared
+# rather than re-implemented.
 #
-# Single files are renamed with the book's filename template. Directory imports
-# (multi-file audiobooks) preserve the source layout and filenames. The source
-# is never mutated except by an explicit "move", which FileCopyService performs
-# only after a durable publication.
+# Single files are renamed with the book's filename template; directory imports
+# (multi-file audiobooks) preserve the source layout. The source is never mutated
+# except by an explicit "move", performed only after a durable publication.
 #
-# Every import is anchored on one immutable source snapshot taken up front. The
-# caller may pass the (device, inode) pair recorded when the source was first
-# detected; publication is refused unless the pinned snapshot still has that
-# identity, so a source swapped between detection and approval cannot smuggle
-# different bytes in under an approved title.
+# Every import is anchored on one immutable snapshot taken up front. The caller
+# may pass the (device, inode) recorded at detection; publication is refused
+# unless the snapshot still has that identity, so a source swapped between
+# detection and approval cannot smuggle different bytes under an approved title.
 #
 # The result carries an exact record of what was published — every file created
-# and every directory this import brought into existence — so a failed
-# finalization or an admin undo can reverse precisely this import instead of
-# deleting a templated destination directory shared with other books.
+# and every directory brought into existence — so a failed finalization or an
+# admin undo reverses precisely this import instead of deleting a templated
+# directory shared with other books.
 class LibraryFileImporter
   MODES = %w[copy move hardlink].freeze
 
@@ -45,17 +43,15 @@ class LibraryFileImporter
     @created_directories = []
   end
 
-  # Import +source+ into the library for +book+, rooted at +base_path+ (the
-  # book type's output root). Returns a Result whose imported_path is the file
-  # (flat output / single file) or the per-book directory.
+  # Import +source+ into the library for +book+, rooted at +base_path+ (the book
+  # type's output root). imported_path is the file (flat output / single file) or
+  # the per-book directory.
   #
-  # expected_source_identity - optional [device, inode] recorded when the source
-  #                            was detected. Nil skips the check (filesystems
-  #                            that report no usable inode).
-  # source_base - the root the source was found under (the watched folder). Only
-  #               recorded, never traversed here; undo needs it to return a moved
-  #               file through descriptors pinned to that root instead of
-  #               trusting the source's parent path.
+  # expected_source_identity - optional [device, inode] from detection; nil skips
+  #                            the check (filesystems with no usable inode).
+  # source_base - the root the source was found under. Only recorded, never
+  #               traversed here; undo needs it to return a moved file through
+  #               descriptors pinned to that root.
   def import(source:, book:, base_path:, expected_source_identity: nil, source_base: nil)
     source = File.expand_path(source.to_s)
     raise Errno::ENOENT, source unless File.exist?(source)
@@ -86,10 +82,10 @@ class LibraryFileImporter
     )
   end
 
-  # The exact, replayable description of what this import put on disk. Ordered
-  # so a reversal can remove files first and then the directories it created,
-  # deepest last-created first. Readable after a failure too, so a caller can
-  # reverse a tree import that raised partway through.
+  # The exact, replayable description of what this import put on disk, ordered so
+  # a reversal removes files first, then the directories it created, deepest
+  # first. Readable after a failure too, so a caller can reverse a tree import
+  # that raised partway through.
   def publication_record
     {
       "mode" => @mode,
@@ -115,10 +111,10 @@ class LibraryFileImporter
     PathTemplateService.flat_output?(book) ? imported : destination_dir
   end
 
-  # A single-file hardlink resolves the source pathname again inside
-  # FileCopyService, so the approved inode is confirmed after the fact: a
-  # hardlink shares its target's inode, and the caller reverses the publication
-  # when this does not match. Tree hardlinks are already pinned to the snapshot.
+  # A single-file hardlink re-resolves the source pathname inside FileCopyService,
+  # so the approved inode is confirmed after the fact: a hardlink shares its
+  # target's inode, and the caller reverses the publication on a mismatch. Tree
+  # hardlinks are already pinned to the snapshot.
   def verify_hardlink_identity!(destination, expected_source_identity)
     return unless @mode == "hardlink" && @hardlinked.positive?
 
@@ -134,8 +130,8 @@ class LibraryFileImporter
 
   def import_directory(source, destination_dir, book, expected_source_identity)
     # A blank path template writes straight into the output root, which a
-    # multi-file release cannot survive: its tracks would be scattered loose
-    # among every other book and book.file_path would claim the root itself.
+    # multi-file release cannot survive: its tracks would scatter among every
+    # other book and book.file_path would claim the root itself.
     # UploadZipImportFileService refuses the same configuration.
     if PathTemplateService.flat_output?(book)
       raise FlatOutputUnsupportedError,
@@ -151,11 +147,10 @@ class LibraryFileImporter
     consume_source_tree! if @mode == "move"
   end
 
-  # A directory move publishes every file durably first and only then unlinks
-  # the source tree in one validated step. Removing each file as it was
-  # published would invalidate the immutable snapshot the remaining files are
-  # pinned against, failing the import partway through with the source already
-  # half-consumed.
+  # A directory move publishes every file durably first, then unlinks the source
+  # tree in one validated step. Removing each file as it was published would
+  # invalidate the snapshot the remaining files are pinned against, failing the
+  # import with the source already half-consumed.
   def consume_source_tree!
     unless FileCopyService.remove_source_tree(@source_root)
       raise Errno::ESTALE, "source tree changed during move import"
@@ -182,9 +177,9 @@ class LibraryFileImporter
   end
 
   # Create +path+ under the output root, remembering the components that did not
-  # exist beforehand. Only those are candidates for removal on undo, and even
-  # then only while still empty — a templated "Author/Book" directory is
-  # routinely shared with files this import does not own.
+  # exist beforehand. Only those may be removed on undo, and only while still
+  # empty — a templated "Author/Book" directory is routinely shared with files
+  # this import does not own.
   def ensure_recorded_directory(path)
     missing = missing_components(path)
     FileCopyService.ensure_directory(path, root: @root, mode: 0o750)
@@ -223,9 +218,9 @@ class LibraryFileImporter
   def publish(source, destination, source_root:)
     original = destination
     counter = 1
-    # Read before publishing: a move unlinks the source, and undo needs the
-    # identity the source had to tell "this file is still where the scanner
-    # found it" apart from "something unrelated has taken over that path".
+    # Read before publishing: a move unlinks the source, and undo needs its
+    # identity to tell "still where the scanner found it" from "something
+    # unrelated has taken over that path".
     source_identity = path_identity(source)
 
     begin
@@ -244,7 +239,7 @@ class LibraryFileImporter
     case @mode
     when "move"
       # A directory move defers source removal to consume_source_tree!, so the
-      # per-file step here is a durable copy against the pinned snapshot.
+      # per-file step is a durable copy against the pinned snapshot.
       if source_root
         FileCopyService.cp_noreplace(
           source, destination,
@@ -324,10 +319,10 @@ class LibraryFileImporter
       "Refusing to import #{source}: it is no longer the file that was detected and approved"
   end
 
-  # Enumerate a directory's children from the immutable source snapshot rather
-  # than a fresh readdir, so a mid-import path swap cannot introduce new entries.
-  # The snapshot is grouped by parent directory once (see children_by_parent) so
-  # a deep tree costs O(entries) total instead of O(entries) per directory.
+  # A directory's children from the immutable snapshot rather than a fresh
+  # readdir, so a mid-import path swap cannot introduce new entries. Grouped by
+  # parent once (see children_by_parent), so a deep tree costs O(entries) total
+  # instead of per directory.
   def manifest_children(directory)
     relative = Pathname(directory).expand_path.relative_path_from(@source_root.path)
     (children_by_parent[relative] || []).sort

--- a/app/services/library_file_importer.rb
+++ b/app/services/library_file_importer.rb
@@ -11,22 +11,47 @@
 # (multi-file audiobooks) preserve the source layout and filenames. The source
 # is never mutated except by an explicit "move", which FileCopyService performs
 # only after a durable publication.
+#
+# Every import is anchored on one immutable source snapshot taken up front. The
+# caller may pass the (device, inode) pair recorded when the source was first
+# detected; publication is refused unless the pinned snapshot still has that
+# identity, so a source swapped between detection and approval cannot smuggle
+# different bytes in under an approved title.
+#
+# The result carries an exact record of what was published — every file created
+# and every directory this import brought into existence — so a failed
+# finalization or an admin undo can reverse precisely this import instead of
+# deleting a templated destination directory shared with other books.
 class LibraryFileImporter
   MODES = %w[copy move hardlink].freeze
 
-  Result = Data.define(:imported_path, :hardlinked, :copied, :moved)
+  class SourceIdentityMismatchError < StandardError; end
+  # Raised when a multi-file release would have to be published into the output
+  # root because the book type has no path template configured.
+  class FlatOutputUnsupportedError < StandardError; end
+
+  Result = Data.define(:imported_path, :hardlinked, :copied, :moved, :publication)
 
   def initialize(mode:)
     @mode = MODES.include?(mode.to_s) ? mode.to_s : "copy"
+    @root = nil
+    @source_root = nil
+    @source_snapshot = nil
     @hardlinked = 0
     @copied = 0
     @moved = 0
+    @published_files = []
+    @created_directories = []
   end
 
   # Import +source+ into the library for +book+, rooted at +base_path+ (the
   # book type's output root). Returns a Result whose imported_path is the file
   # (flat output / single file) or the per-book directory.
-  def import(source:, book:, base_path:)
+  #
+  # expected_source_identity - optional [device, inode] recorded when the source
+  #                            was detected. Nil skips the check (filesystems
+  #                            that report no usable inode).
+  def import(source:, book:, base_path:, expected_source_identity: nil)
     source = File.expand_path(source.to_s)
     raise Errno::ENOENT, source unless File.exist?(source)
 
@@ -38,32 +63,99 @@ class LibraryFileImporter
 
     imported_path =
       if stat.directory?
-        import_directory(source, destination_dir)
+        import_directory(source, destination_dir, book, expected_source_identity)
         destination_dir
       elsif stat.file?
-        import_single_file(source, destination_dir, book)
+        import_single_file(source, destination_dir, book, expected_source_identity)
       else
         raise "Refusing to import non-regular path: #{source}"
       end
 
-    Result.new(imported_path: imported_path, hardlinked: @hardlinked, copied: @copied, moved: @moved)
+    Result.new(
+      imported_path: imported_path,
+      hardlinked: @hardlinked,
+      copied: @copied,
+      moved: @moved,
+      publication: publication_record
+    )
+  end
+
+  # The exact, replayable description of what this import put on disk. Ordered
+  # so a reversal can remove files first and then the directories it created,
+  # deepest last-created first. Readable after a failure too, so a caller can
+  # reverse a tree import that raised partway through.
+  def publication_record
+    {
+      "mode" => @mode,
+      "base_path" => @root.to_s,
+      "files" => @published_files,
+      "directories" => @created_directories
+    }
   end
 
   private
 
-  def import_single_file(source, destination_dir, book)
-    FileCopyService.ensure_directory(destination_dir, root: @root, mode: 0o750)
+  def import_single_file(source, destination_dir, book, expected_source_identity)
+    @source_snapshot = FileCopyService.snapshot_source_file(source)
+    verify_source_identity!(@source_snapshot.manifest.first(2), expected_source_identity, source)
+
+    ensure_recorded_directory(destination_dir)
     filename = PathTemplateService.build_filename(book, File.extname(source))
     destination_file = File.join(destination_dir, filename)
     imported = publish(source, destination_file, source_root: nil)
+    verify_hardlink_identity!(imported, expected_source_identity)
 
     PathTemplateService.flat_output?(book) ? imported : destination_dir
   end
 
-  def import_directory(source, destination_dir)
+  # A single-file hardlink resolves the source pathname again inside
+  # FileCopyService, so the approved inode is confirmed after the fact: a
+  # hardlink shares its target's inode, and the caller reverses the publication
+  # when this does not match. Tree hardlinks are already pinned to the snapshot.
+  def verify_hardlink_identity!(destination, expected_source_identity)
+    return unless @mode == "hardlink" && @hardlinked.positive?
+
+    published = @published_files.last
+    return unless published && published["destination"] == destination
+
+    verify_source_identity!(
+      [ published["device"], published["inode"] ],
+      expected_source_identity || @source_snapshot.manifest.first(2),
+      destination
+    )
+  end
+
+  def import_directory(source, destination_dir, book, expected_source_identity)
+    # A blank path template writes straight into the output root, which a
+    # multi-file release cannot survive: its tracks would be scattered loose
+    # among every other book and book.file_path would claim the root itself.
+    # UploadZipImportFileService refuses the same configuration.
+    if PathTemplateService.flat_output?(book)
+      raise FlatOutputUnsupportedError,
+        "Importing the folder #{File.basename(source)} requires a per-book path template for " \
+        "#{book.book_type} output; set one in Settings and import again"
+    end
+
     @source_root = FileCopyService.snapshot_source_root(source)
-    FileCopyService.ensure_directory(destination_dir, root: @root, mode: 0o750)
+    verify_source_identity!([ @source_root.device, @source_root.inode ], expected_source_identity, source)
+
+    ensure_recorded_directory(destination_dir)
     import_tree(source, destination_dir)
+    consume_source_tree! if @mode == "move"
+  end
+
+  # A directory move publishes every file durably first and only then unlinks
+  # the source tree in one validated step. Removing each file as it was
+  # published would invalidate the immutable snapshot the remaining files are
+  # pinned against, failing the import partway through with the source already
+  # half-consumed.
+  def consume_source_tree!
+    unless FileCopyService.remove_source_tree(@source_root)
+      raise Errno::ESTALE, "source tree changed during move import"
+    end
+
+    @moved = @copied
+    @copied = 0
   end
 
   def import_tree(source_dir, destination_dir)
@@ -73,13 +165,144 @@ class LibraryFileImporter
 
       if stat.directory?
         nested = File.join(destination_dir, name)
-        FileCopyService.ensure_directory(nested, root: @root, mode: 0o750)
+        ensure_recorded_directory(nested)
         import_tree(source_path, nested)
       elsif stat.file?
         publish(source_path, File.join(destination_dir, name), source_root: @source_root)
       end
       # Non-regular entries are absent from the immutable manifest and skipped.
     end
+  end
+
+  # Create +path+ under the output root, remembering the components that did not
+  # exist beforehand. Only those are candidates for removal on undo, and even
+  # then only while still empty — a templated "Author/Book" directory is
+  # routinely shared with files this import does not own.
+  def ensure_recorded_directory(path)
+    missing = missing_components(path)
+    FileCopyService.ensure_directory(path, root: @root, mode: 0o750)
+
+    missing.each do |created|
+      identity = FileCopyService.directory_identity(created, root: @root)
+      next unless identity
+
+      @created_directories << { "path" => created, "device" => identity[0], "inode" => identity[1] }
+    end
+    path
+  end
+
+  def missing_components(path)
+    relative = Pathname(path).expand_path.relative_path_from(@root)
+    current = @root
+    relative.each_filename.filter_map do |part|
+      next if part == "."
+
+      current = current.join(part)
+      current.to_s unless exists?(current)
+    end
+  rescue ArgumentError
+    []
+  end
+
+  def exists?(path)
+    File.lstat(path)
+    true
+  rescue SystemCallError
+    false
+  end
+
+  # Publish one regular file with the configured mode, retrying under a numbered
+  # filename when a concurrent writer claims the exclusive destination.
+  def publish(source, destination, source_root:)
+    original = destination
+    counter = 1
+
+    begin
+      destination = unique_destination(original, counter)
+      publish_with_mode(source, destination, source_root: source_root)
+    rescue Errno::EEXIST
+      counter += 1
+      retry
+    end
+
+    record_published_file(source, destination)
+    destination
+  end
+
+  def publish_with_mode(source, destination, source_root:)
+    case @mode
+    when "move"
+      # A directory move defers source removal to consume_source_tree!, so the
+      # per-file step here is a durable copy against the pinned snapshot.
+      if source_root
+        FileCopyService.cp_noreplace(
+          source, destination,
+          root: @root, source_root: source_root,
+          allow_compatibility_fallback: true, require_durable: true
+        )
+        @copied += 1
+      else
+        FileCopyService.mv_noreplace(
+          source, destination,
+          root: @root, source_root: nil, source_snapshot: @source_snapshot,
+          allow_compatibility_fallback: true
+        )
+        @moved += 1
+      end
+    when "hardlink"
+      begin
+        FileCopyService.hardlink_noreplace(
+          source, destination,
+          root: @root, source_root: source_root
+        )
+        @hardlinked += 1
+      rescue FileCopyService::HardlinkUnsupportedError
+        FileCopyService.cp_noreplace(
+          source, destination,
+          root: @root, source_root: source_root,
+          hardlink_mode: true, allow_compatibility_fallback: true
+        )
+        @copied += 1
+      end
+    else
+      FileCopyService.cp_noreplace(
+        source, destination,
+        root: @root, source_root: source_root, source_snapshot: single_file_snapshot(source_root),
+        allow_compatibility_fallback: true
+      )
+      @copied += 1
+    end
+  end
+
+  # Single-file imports pin the snapshot taken (and identity-checked) up front;
+  # tree imports are already pinned through the source root manifest.
+  def single_file_snapshot(source_root)
+    source_root ? nil : @source_snapshot
+  end
+
+  def record_published_file(source, destination)
+    stat = File.lstat(destination)
+    @published_files << {
+      "destination" => destination,
+      "source" => source,
+      "device" => stat.dev,
+      "inode" => stat.ino
+    }
+  rescue SystemCallError
+    @published_files << { "destination" => destination, "source" => source }
+  end
+
+  # Refuse to publish a source whose inode no longer matches the one recorded
+  # when it was detected and approved.
+  def verify_source_identity!(actual, expected, source)
+    return if expected.nil?
+
+    expected = Array(expected).map(&:to_i)
+    return if expected.any?(&:zero?) || expected.size != 2
+    return if actual.map(&:to_i) == expected
+
+    raise SourceIdentityMismatchError,
+      "Refusing to import #{source}: it is no longer the file that was detected and approved"
   end
 
   # Enumerate a directory's children from the immutable source snapshot rather
@@ -100,54 +323,6 @@ class LibraryFileImporter
       path = Pathname(entry)
       (index[path.dirname] ||= []) << path.basename.to_s
     end.tap { |index| index.each_value(&:uniq!) }
-  end
-
-  # Publish one regular file with the configured mode, retrying under a numbered
-  # filename when a concurrent writer claims the exclusive destination.
-  def publish(source, destination, source_root:)
-    original = destination
-    counter = 1
-
-    begin
-      destination = unique_destination(original, counter)
-      publish_with_mode(source, destination, source_root: source_root)
-      destination
-    rescue Errno::EEXIST
-      counter += 1
-      retry
-    end
-  end
-
-  def publish_with_mode(source, destination, source_root:)
-    case @mode
-    when "move"
-      FileCopyService.mv_noreplace(
-        source, destination,
-        root: @root, source_root: source_root, allow_compatibility_fallback: true
-      )
-      @moved += 1
-    when "hardlink"
-      begin
-        FileCopyService.hardlink_noreplace(
-          source, destination,
-          root: @root, source_root: source_root
-        )
-        @hardlinked += 1
-      rescue FileCopyService::HardlinkUnsupportedError
-        FileCopyService.cp_noreplace(
-          source, destination,
-          root: @root, source_root: source_root,
-          hardlink_mode: true, allow_compatibility_fallback: true
-        )
-        @copied += 1
-      end
-    else
-      FileCopyService.cp_noreplace(
-        source, destination,
-        root: @root, source_root: source_root, allow_compatibility_fallback: true
-      )
-      @copied += 1
-    end
   end
 
   def unique_destination(path, counter)

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -59,6 +59,34 @@ class NotificationService
       )
     end
 
+    # Batched notification that new watched-folder files were detected and are
+    # waiting for review. Import is an admin action, so only admins are notified
+    # in-app; outbound channels fire if the "import_detected" event is enabled.
+    def import_detected(count:)
+      return if count.to_i <= 0
+
+      noun = count == 1 ? "book file" : "book files"
+      title = "New #{count == 1 ? 'file' : 'files'} detected"
+      message = "#{count} new #{noun} detected in your watched folder and #{count == 1 ? 'is' : 'are'} waiting for review."
+
+      User.active.where(role: :admin).find_each do |admin|
+        create_for_user(
+          user: admin,
+          notifiable: nil,
+          type: "import_detected",
+          title: title,
+          message: message
+        )
+      end
+
+      dispatch_outbound_event(
+        event: "import_detected",
+        request: nil,
+        title: title,
+        message: message
+      )
+    end
+
     private
 
     def create_for_user(user:, notifiable:, type:, title:, message:)

--- a/app/services/outbound_notifications/webhook_delivery.rb
+++ b/app/services/outbound_notifications/webhook_delivery.rb
@@ -5,7 +5,7 @@ module OutboundNotifications
     class ConfigurationError < StandardError; end
     class DeliveryError < StandardError; end
 
-    EVENTS = %w[request_created request_completed request_failed request_attention].freeze
+    EVENTS = %w[request_created request_completed request_failed request_attention import_detected].freeze
     TEST_EVENT = "test"
 
     class << self

--- a/app/services/path_template_service.rb
+++ b/app/services/path_template_service.rb
@@ -82,7 +82,7 @@ class PathTemplateService
 
     # Build the full destination path for a book
     def build_destination(book, base_path: nil)
-      base = base_path || default_base_path(book)
+      base = base_path || output_root_for(book)
       template = template_for(book)
       relative_path = build_path(book, template)
 
@@ -117,9 +117,12 @@ class PathTemplateService
       end
     end
 
-    private
-
-    def default_base_path(book)
+    # The configured output root for a book's type — the directory every template
+    # renders beneath. Public because callers that build a destination themselves
+    # must resolve it the same way build_destination would; a second definition
+    # is how a caller ends up publishing under a root the templating does not
+    # expect.
+    def output_root_for(book)
       if book.audiobook?
         SettingsService.get(:audiobook_output_path, default: "/audiobooks")
       elsif book.comicbook?
@@ -128,6 +131,19 @@ class PathTemplateService
         SettingsService.get(:ebook_output_path, default: "/ebooks")
       end
     end
+
+    # Every configured output root, for callers reasoning about the set rather
+    # than one book's — e.g. refusing a watched folder that overlaps somewhere
+    # Shelfarr imports into.
+    def output_roots
+      [
+        SettingsService.get(:audiobook_output_path, default: "/audiobooks"),
+        SettingsService.get(:ebook_output_path, default: "/ebooks"),
+        SettingsService.get(:comicbook_output_path, default: "/comics")
+      ]
+    end
+
+    private
 
     def sanitize_filename(name)
       name

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -103,6 +103,11 @@ class SettingsService
     split_audiobook_bundle_imports: { type: "boolean", default: false, category: "download", description: "Split releases containing multiple self-contained M4B/AAX books into per-book folders. MP3, FLAC, and other chapter-based releases stay together." },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 
+    # Watched Folder Import
+    library_import_enabled: { type: "boolean", default: false, category: "import", description: "Scan a watched folder for pre-existing book files that were not acquired through a Shelfarr request and queue them for review before importing into the library." },
+    library_import_path: { type: "string", default: "", category: "import", description: "Absolute path (Shelfarr container perspective) to scan for un-imported book files, e.g. /data/torrents/shelfarr. Must be readable by Shelfarr and outside the configured output paths." },
+    library_import_scan_interval: { type: "integer", default: 300, category: "import", description: "Seconds between watched-folder scans" },
+
     # Library Platform Integration
     library_platform: { type: "string", default: "audiobookshelf", category: "audiobookshelf", description: "Library platform to sync and scan: audiobookshelf, bookorbit, or grimmory" },
     audiobookshelf_url: { type: "string", default: "", category: "audiobookshelf", description: "Base URL for Audiobookshelf (e.g., http://localhost:13378)" },
@@ -265,6 +270,7 @@ class SettingsService
   CATEGORIES = {
     "indexer" => "Indexer",
     "download" => "Download Settings",
+    "import" => "Watched Folder Import",
     "audiobookshelf" => "Library Platform",
     "anna_archive" => "Anna's Archive",
     "zlibrary" => "Z-Library",

--- a/app/services/watched_folder_scan_service.rb
+++ b/app/services/watched_folder_scan_service.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+# Scans the configured watched-folder import path for book files that were not
+# acquired through a Shelfarr request and records each new one as a
+# DetectedImport awaiting admin review. Read-only with respect to the watched
+# folder — it never moves, renames, or deletes source files.
+#
+# The walk uses FileCopyService's pinned, no-follow directory primitives so a
+# symlink or a mid-scan path swap can never redirect it outside the configured
+# root. Candidates are grouped the same way the download importer sees releases:
+# a single ebook/comic file, a self-contained audiobook folder, or — for a box
+# set / collection whose subfolders each hold a distinct title — one audiobook
+# per subfolder (see #classify_directory).
+class WatchedFolderScanService
+  MAX_DEPTH = 8
+  AUDIO_SEARCH_DEPTH = 4
+  MAX_CANDIDATES_PER_SCAN = 5_000
+
+  # Subfolder names that denote a disc/part of one audiobook rather than a
+  # distinct title: "CD1", "Disc 2", "Part 03", "Vol 1", "Tape 2", or a bare
+  # "1"/"01". Such folders must be kept together as a single multi-disc book,
+  # never split into separate books the way a titled subfolder is.
+  DISC_SUBFOLDER = /\A(?:(?:cd|dis[ck]|part|pt|vol(?:ume)?|section|tape|track)[\s._-]*)?\d{1,3}\z/i
+
+  Candidate = Struct.new(
+    :source_path,
+    :book_type,
+    :device,
+    :inode,
+    :filename_hint,
+    :metadata_path,
+    keyword_init: true
+  )
+
+  Result = Data.define(:scanned, :detected, :skipped)
+
+  def self.scan!
+    new.scan!
+  end
+
+  # Returns a Result summarising the scan, or nil when scanning is disabled or
+  # the configured path is invalid.
+  def scan!
+    return nil unless SettingsService.get(:library_import_enabled, default: false)
+
+    root = resolved_root
+    unless root
+      Rails.logger.warn "[WatchedFolderScanService] Watched-folder import path is unset or invalid; skipping scan"
+      return nil
+    end
+
+    candidates = build_candidates(root)
+    detected = 0
+    candidates.each do |candidate|
+      detected += 1 if record_candidate(candidate)
+    end
+
+    NotificationService.import_detected(count: detected) if detected.positive?
+    Rails.logger.info(
+      "[WatchedFolderScanService] Scan complete: #{candidates.size} candidates, #{detected} new"
+    )
+    Result.new(scanned: candidates.size, detected: detected, skipped: candidates.size - detected)
+  end
+
+  private
+
+  # --- Filesystem walk -----------------------------------------------------
+
+  def build_candidates(root)
+    candidates = []
+    walk(root, root, 0, candidates)
+    candidates
+  end
+
+  def walk(dir, root, depth, candidates)
+    return if depth > MAX_DEPTH
+    return if candidates.size >= MAX_CANDIDATES_PER_SCAN
+
+    FileCopyService.directory_children(dir, root: root).each do |child|
+      break if candidates.size >= MAX_CANDIDATES_PER_SCAN
+      next if child.name.start_with?(".")
+
+      path = File.join(dir, child.name)
+      case child.type
+      when :file
+        candidates << file_candidate(path, child) if LibraryAcquisitionService.readable_file?(child.name)
+        # Loose audio files directly under a directory become part of that
+        # directory's audiobook candidate (below), never standalone imports.
+      when :directory
+        classify_directory(path, child, root, depth, candidates)
+      end
+    end
+  rescue FileCopyService::UnsafePathError, SystemCallError => e
+    Rails.logger.warn "[WatchedFolderScanService] Skipping unreadable directory (#{e.class})"
+  end
+
+  # Resolve how one directory maps onto audiobook candidates. Three shapes look
+  # alike from the top and have to be told apart:
+  #
+  #   * plain audiobook   Book/*.mp3              -> one candidate (this folder)
+  #   * multi-disc book   Book/CD1/*.mp3, ...     -> one candidate (this folder)
+  #   * collection/set    Set/Title A/*.mp3, ...  -> one candidate PER subfolder
+  #
+  # The signal is where the audio lives. Loose audio directly in the folder
+  # means the folder itself is the release. Otherwise the audio sits in
+  # subfolders: if those are all disc markers (CD1, Disc 2, ...) the folder is a
+  # single multi-disc book; if any carries a real title the folder is a
+  # collection, so we descend and each audio-bearing subfolder becomes its own
+  # book (recursively — a nested subfolder may itself be multi-disc).
+  def classify_directory(dir, child, root, depth, candidates)
+    direct = direct_audio_file(dir, root)
+    if direct
+      candidates << audiobook_candidate(dir, child, direct)
+      return
+    end
+
+    audio_subdirs = audio_bearing_subdirectories(dir, root)
+    if audio_subdirs.empty?
+      # No audio at any level yet: a plain intermediate folder — keep walking.
+      walk(dir, root, depth + 1, candidates)
+    elsif audio_subdirs.all? { |name| disc_subfolder?(name) }
+      # Discs of one book: import the whole folder as a single audiobook.
+      nested = first_audio_file(dir, root, 0)
+      candidates << audiobook_candidate(dir, child, nested) if nested
+    else
+      # A collection: descend so each titled subfolder becomes its own book.
+      walk(dir, root, depth + 1, candidates)
+    end
+  end
+
+  # An audio file lying directly inside dir (not in any subfolder). Its presence
+  # marks dir as a self-contained audiobook release rather than a container of
+  # further releases.
+  def direct_audio_file(dir, root)
+    FileCopyService.directory_children(dir, root: root).each do |child|
+      next if child.name.start_with?(".")
+
+      if child.type == :file && LibraryAcquisitionService.audio_file?(child.name)
+        return File.join(dir, child.name)
+      end
+    end
+    nil
+  rescue FileCopyService::UnsafePathError, SystemCallError
+    nil
+  end
+
+  # Names of the immediate subdirectories of dir that contain audio somewhere in
+  # their subtree. Empty when dir holds no nested audiobook material. Used to
+  # decide whether dir is a multi-disc book or a collection of separate books.
+  def audio_bearing_subdirectories(dir, root)
+    FileCopyService.directory_children(dir, root: root).filter_map do |child|
+      next if child.name.start_with?(".")
+      next unless child.type == :directory
+
+      child.name if first_audio_file(File.join(dir, child.name), root, 0)
+    end
+  rescue FileCopyService::UnsafePathError, SystemCallError
+    []
+  end
+
+  def disc_subfolder?(name)
+    DISC_SUBFOLDER.match?(name.to_s.strip)
+  end
+
+  # Bounded search for the first playable audio file within a directory subtree.
+  # Its presence marks the directory as a single audiobook release.
+  def first_audio_file(dir, root, depth)
+    return nil if depth > AUDIO_SEARCH_DEPTH
+
+    children = FileCopyService.directory_children(dir, root: root)
+    children.each do |child|
+      next if child.name.start_with?(".")
+
+      if child.type == :file && LibraryAcquisitionService.audio_file?(child.name)
+        return File.join(dir, child.name)
+      end
+    end
+    children.each do |child|
+      next if child.name.start_with?(".")
+      next unless child.type == :directory
+
+      found = first_audio_file(File.join(dir, child.name), root, depth + 1)
+      return found if found
+    end
+    nil
+  rescue FileCopyService::UnsafePathError, SystemCallError
+    nil
+  end
+
+  def file_candidate(path, child)
+    Candidate.new(
+      source_path: path,
+      book_type: LibraryAcquisitionService.infer_book_type(path),
+      device: reliable_identity(child.device),
+      inode: reliable_identity(child.inode),
+      filename_hint: File.basename(path),
+      metadata_path: path
+    )
+  end
+
+  def audiobook_candidate(path, child, audio_path)
+    Candidate.new(
+      source_path: path,
+      book_type: "audiobook",
+      device: reliable_identity(child.device),
+      inode: reliable_identity(child.inode),
+      filename_hint: File.basename(path),
+      metadata_path: audio_path
+    )
+  end
+
+  # Some filesystems (certain FUSE/network/overlay mounts) report a device or
+  # inode of 0 for every entry. A non-positive value is not a usable identity —
+  # keeping it would collapse unrelated files onto one (device, inode) key and
+  # make de-duplication drop all but the first file per device. Discard it so
+  # known? falls back to path-based de-duplication instead.
+  def reliable_identity(value)
+    value.to_i.positive? ? value.to_i : nil
+  end
+
+  # --- Persistence ---------------------------------------------------------
+
+  # Returns true when a new DetectedImport was created.
+  def record_candidate(candidate)
+    return false if known?(candidate)
+
+    # Local-only identification (metadata extract + library match). The online
+    # provider lookups are deferred to DetectedImportEnrichmentJob so a large
+    # first scan never fires thousands of sequential network searches inside a
+    # single run (which would also hold the scan's concurrency lease and stall
+    # the recurring chain).
+    identification = LibraryAcquisitionService.identify(
+      source_path: candidate.metadata_path,
+      book_type: candidate.book_type,
+      filename_hint: candidate.filename_hint,
+      online: false
+    )
+
+    detected_import = DetectedImport.create!(
+      source_path: candidate.source_path,
+      source_device: candidate.device,
+      source_inode: candidate.inode,
+      book_type: identification.book_type,
+      parsed_title: identification.parsed_title,
+      parsed_author: identification.parsed_author,
+      match_confidence: identification.match_confidence,
+      suggested_book: identification.suggested_book,
+      candidate_books: identification.candidate_books,
+      status: "detected",
+      detected_at: Time.current
+    )
+    DetectedImportEnrichmentJob.perform_later(detected_import.id)
+    true
+  rescue ActiveRecord::RecordNotUnique
+    # A concurrent scan already recorded this (device, inode).
+    false
+  rescue => e
+    Rails.logger.error "[WatchedFolderScanService] Failed to record candidate (#{e.class})"
+    false
+  end
+
+  def known?(candidate)
+    if candidate.device && candidate.inode
+      return true if DetectedImport.where(source_device: candidate.device, source_inode: candidate.inode).exists?
+    elsif DetectedImport.where(source_path: candidate.source_path).exists?
+      # No reliable (device, inode) identity available — de-duplicate on the
+      # source path instead, so files on inode-less filesystems still surface
+      # exactly once.
+      return true
+    end
+
+    Book.acquired.where(file_path: candidate.source_path).exists?
+  end
+
+  # --- Path validation -----------------------------------------------------
+
+  def resolved_root
+    raw = SettingsService.get(:library_import_path).to_s.strip
+    return nil if raw.blank?
+
+    expanded = File.expand_path(raw)
+    return nil unless File.directory?(expanded)
+
+    canonical = File.realpath(expanded)
+    return nil if Pathname(canonical).root?
+    return nil if overlaps_output_paths?(canonical)
+
+    canonical
+  rescue ArgumentError, SystemCallError
+    nil
+  end
+
+  # Refuse a watched path that is the same as, inside, or a parent of any
+  # configured output path — otherwise Shelfarr would re-detect its own imports.
+  def overlaps_output_paths?(canonical)
+    output_roots.any? do |output|
+      output == canonical || path_inside?(canonical, output) || path_inside?(output, canonical)
+    end
+  end
+
+  def output_roots
+    [
+      SettingsService.get(:audiobook_output_path, default: "/audiobooks"),
+      SettingsService.get(:ebook_output_path, default: "/ebooks"),
+      SettingsService.get(:comicbook_output_path, default: "/comics")
+    ].filter_map { |path| canonical_directory(path) }.uniq
+  end
+
+  def canonical_directory(path)
+    expanded = File.expand_path(path.to_s)
+    return nil unless File.directory?(expanded)
+
+    File.realpath(expanded)
+  rescue ArgumentError, SystemCallError
+    nil
+  end
+
+  def path_inside?(path, root)
+    path.start_with?("#{root}#{File::SEPARATOR}")
+  end
+end

--- a/app/services/watched_folder_scan_service.rb
+++ b/app/services/watched_folder_scan_service.rb
@@ -55,6 +55,31 @@ class WatchedFolderScanService
     source_path
   end
 
+  # The canonical watched-folder root, or nil when the configured path is unset,
+  # missing, or overlaps an output path. An import records it so undoing a move
+  # can rebuild the source's parents and return the file through descriptors
+  # pinned to this root, rather than trusting the mutable parent path the
+  # importer happened to see.
+  def self.import_root
+    new.resolved_root
+  end
+
+  def resolved_root
+    raw = SettingsService.get(:library_import_path).to_s.strip
+    return nil if raw.blank?
+
+    expanded = File.expand_path(raw)
+    return nil unless File.directory?(expanded)
+
+    canonical = File.realpath(expanded)
+    return nil if Pathname(canonical).root?
+    return nil if overlaps_output_paths?(canonical)
+
+    canonical
+  rescue ArgumentError, SystemCallError
+    nil
+  end
+
   # Returns a Result summarising the scan, or nil when scanning is disabled or
   # the configured path is invalid.
   def scan!
@@ -322,22 +347,6 @@ class WatchedFolderScanService
   end
 
   # --- Path validation -----------------------------------------------------
-
-  def resolved_root
-    raw = SettingsService.get(:library_import_path).to_s.strip
-    return nil if raw.blank?
-
-    expanded = File.expand_path(raw)
-    return nil unless File.directory?(expanded)
-
-    canonical = File.realpath(expanded)
-    return nil if Pathname(canonical).root?
-    return nil if overlaps_output_paths?(canonical)
-
-    canonical
-  rescue ArgumentError, SystemCallError
-    nil
-  end
 
   # Refuse a watched path that is the same as, inside, or a parent of any
   # configured output path — otherwise Shelfarr would re-detect its own imports.

--- a/app/services/watched_folder_scan_service.rb
+++ b/app/services/watched_folder_scan_service.rb
@@ -1,25 +1,22 @@
 # frozen_string_literal: true
 
-# Scans the configured watched-folder import path for book files that were not
-# acquired through a Shelfarr request and records each new one as a
-# DetectedImport awaiting admin review. Read-only with respect to the watched
-# folder — it never moves, renames, or deletes source files.
+# Scans the configured watched-folder import path for book files not acquired
+# through a Shelfarr request, recording each new one as a DetectedImport awaiting
+# review. Read-only: it never moves, renames, or deletes source files.
 #
-# The walk uses FileCopyService's pinned, no-follow directory primitives so a
-# symlink or a mid-scan path swap can never redirect it outside the configured
-# root. Candidates are grouped the same way the download importer sees releases:
-# a single ebook/comic file, a self-contained audiobook folder, or — for a box
-# set / collection whose subfolders each hold a distinct title — one audiobook
-# per subfolder (see #classify_directory).
+# The walk uses FileCopyService's pinned, no-follow primitives, so a symlink or a
+# mid-scan path swap cannot redirect it outside the configured root. Candidates
+# are grouped the way the download importer sees releases: a single ebook/comic
+# file, a self-contained audiobook folder, or one audiobook per subfolder for a
+# collection (see #classify_directory).
 class WatchedFolderScanService
   MAX_DEPTH = 8
   AUDIO_SEARCH_DEPTH = 4
   MAX_CANDIDATES_PER_SCAN = 5_000
 
-  # Subfolder names that denote a disc/part of one audiobook rather than a
-  # distinct title: "CD1", "Disc 2", "Part 03", "Vol 1", "Tape 2", or a bare
-  # "1"/"01". Such folders must be kept together as a single multi-disc book,
-  # never split into separate books the way a titled subfolder is.
+  # Subfolder names denoting a disc/part of one audiobook rather than a distinct
+  # title ("CD1", "Disc 2", "Part 03", "Vol 1", a bare "01"). These stay together
+  # as one multi-disc book instead of splitting like a titled subfolder.
   DISC_SUBFOLDER = /\A(?:(?:cd|dis[ck]|part|pt|vol(?:ume)?|section|tape|track)[\s._-]*)?\d{1,3}\z/i
 
   Candidate = Struct.new(
@@ -34,15 +31,18 @@ class WatchedFolderScanService
 
   Result = Data.define(:scanned, :detected, :skipped)
 
+  # Accumulator for one walk: how many candidates it examined, and those not
+  # already accounted for by a detection or an acquired book.
+  Walk = Struct.new(:candidates, :scanned, keyword_init: true)
+
   def self.scan!
     new.scan!
   end
 
-  # The file embedded metadata should be read from for a given detection source:
-  # the source itself for a single file, or the first playable audio file inside
-  # an audiobook folder — the same one the scan picked when it recorded the
-  # detection. Used by the review page's Re-match so it reads what the scanner
-  # read. Falls back to the source when the folder holds no readable audio.
+  # Where embedded metadata should be read from: the source itself for a single
+  # file, or the first playable audio file inside an audiobook folder — the same
+  # one the scan picked. Used by the review page's Re-match so it reads what the
+  # scanner read. Falls back to the source when the folder holds no audio.
   def self.metadata_path_for(source_path)
     new.metadata_path_for(source_path)
   end
@@ -58,8 +58,7 @@ class WatchedFolderScanService
   # The canonical watched-folder root, or nil when the configured path is unset,
   # missing, or overlaps an output path. An import records it so undoing a move
   # can rebuild the source's parents and return the file through descriptors
-  # pinned to this root, rather than trusting the mutable parent path the
-  # importer happened to see.
+  # pinned to this root, rather than a mutable parent path.
   def self.import_root
     new.resolved_root
   end
@@ -91,17 +90,14 @@ class WatchedFolderScanService
       return nil
     end
 
-    candidates = build_candidates(root)
-    detected = 0
-    candidates.each do |candidate|
-      detected += 1 if record_candidate(candidate)
-    end
+    walked = build_candidates(root)
+    detected = walked.candidates.count { |candidate| record_candidate(candidate) }
 
     NotificationService.import_detected(count: detected) if detected.positive?
     Rails.logger.info(
-      "[WatchedFolderScanService] Scan complete: #{candidates.size} candidates, #{detected} new"
+      "[WatchedFolderScanService] Scan complete: #{walked.scanned} candidates, #{detected} new"
     )
-    Result.new(scanned: candidates.size, detected: detected, skipped: candidates.size - detected)
+    Result.new(scanned: walked.scanned, detected: detected, skipped: walked.scanned - detected)
   end
 
   private
@@ -109,95 +105,112 @@ class WatchedFolderScanService
   # --- Filesystem walk -----------------------------------------------------
 
   def build_candidates(root)
-    candidates = []
-    walk(root, root, 0, candidates)
-    candidates
+    walked = Walk.new(candidates: [], scanned: 0)
+    walk(root, root, 0, walked)
+    walked
   end
 
-  def walk(dir, root, depth, candidates)
+  def walk(dir, root, depth, walked)
     return if depth > MAX_DEPTH
-    return if candidates.size >= MAX_CANDIDATES_PER_SCAN
+    return if capped?(walked)
 
-    FileCopyService.directory_children(dir, root: root).each do |child|
-      break if candidates.size >= MAX_CANDIDATES_PER_SCAN
-      next if child.name.start_with?(".")
+    # The rescue below stays despite visible_children having its own: it also
+    # covers the loop body, where collect -> known? and the nested classification
+    # raise the same errors and must skip this directory, not abort the scan.
+    visible_children(dir, root).each do |child|
+      break if capped?(walked)
 
       path = File.join(dir, child.name)
       case child.type
       when :file
-        candidates << file_candidate(path, child) if LibraryAcquisitionService.readable_file?(child.name)
+        collect(walked, file_candidate(path, child)) if LibraryAcquisitionService.readable_file?(child.name)
         # Loose audio files directly under a directory become part of that
         # directory's audiobook candidate (below), never standalone imports.
       when :directory
-        classify_directory(path, child, root, depth, candidates)
+        classify_directory(path, child, root, depth, walked)
       end
     end
   rescue FileCopyService::UnsafePathError, SystemCallError => e
-    Rails.logger.warn "[WatchedFolderScanService] Skipping unreadable directory (#{e.class})"
+    Rails.logger.warn "[WatchedFolderScanService] Abandoning directory mid-walk (#{e.class})"
+  end
+
+  # One directory's entries minus dotfiles, through FileCopyService's pinned
+  # no-follow listing. An unreadable directory yields nothing, so the walk steps
+  # over it instead of failing the scan.
+  def visible_children(dir, root)
+    FileCopyService.directory_children(dir, root: root).reject { |child| child.name.start_with?(".") }
+  rescue FileCopyService::UnsafePathError, SystemCallError => e
+    Rails.logger.warn "[WatchedFolderScanService] Skipping unlistable directory (#{e.class})"
+    []
+  end
+
+  # Set aside a candidate the scan has not accounted for yet. Known ones are
+  # filtered here rather than at record time so they cost nothing against the
+  # cap: a copy or hardlink import never consumes its source, so a folder over
+  # MAX_CANDIDATES_PER_SCAN would otherwise re-walk the same already-imported
+  # first 5,000 every scan, and the files past them would never be detected.
+  def collect(walked, candidate)
+    walked.scanned += 1
+    walked.candidates << candidate unless known?(candidate)
+  end
+
+  def capped?(walked)
+    walked.candidates.size >= MAX_CANDIDATES_PER_SCAN
   end
 
   # Resolve how one directory maps onto audiobook candidates. Three shapes look
-  # alike from the top and have to be told apart:
+  # alike from the top:
   #
   #   * plain audiobook   Book/*.mp3              -> one candidate (this folder)
   #   * multi-disc book   Book/CD1/*.mp3, ...     -> one candidate (this folder)
   #   * collection/set    Set/Title A/*.mp3, ...  -> one candidate PER subfolder
   #
-  # The signal is where the audio lives. Loose audio directly in the folder
-  # means the folder itself is the release. Otherwise the audio sits in
-  # subfolders: if those are all disc markers (CD1, Disc 2, ...) the folder is a
-  # single multi-disc book; if any carries a real title the folder is a
-  # collection, so we descend and each audio-bearing subfolder becomes its own
-  # book (recursively — a nested subfolder may itself be multi-disc).
-  def classify_directory(dir, child, root, depth, candidates)
+  # The signal is where the audio lives. Loose audio directly in the folder means
+  # the folder is the release. Otherwise it sits in subfolders: all disc markers
+  # means one multi-disc book; any real title means a collection, so we descend
+  # and each audio-bearing subfolder becomes its own book (recursively, since a
+  # nested subfolder may itself be multi-disc).
+  def classify_directory(dir, child, root, depth, walked)
     direct = direct_audio_file(dir, root)
     if direct
-      candidates << audiobook_candidate(dir, child, direct)
+      collect(walked, audiobook_candidate(dir, child, direct))
       return
     end
 
     audio_subdirs = audio_bearing_subdirectories(dir, root)
     if audio_subdirs.empty?
       # No audio at any level yet: a plain intermediate folder — keep walking.
-      walk(dir, root, depth + 1, candidates)
+      walk(dir, root, depth + 1, walked)
     elsif audio_subdirs.all? { |name| disc_subfolder?(name) }
       # Discs of one book: import the whole folder as a single audiobook.
       nested = first_audio_file(dir, root, 0)
-      candidates << audiobook_candidate(dir, child, nested) if nested
+      collect(walked, audiobook_candidate(dir, child, nested)) if nested
     else
       # A collection: descend so each titled subfolder becomes its own book.
-      walk(dir, root, depth + 1, candidates)
+      walk(dir, root, depth + 1, walked)
     end
   end
 
-  # An audio file lying directly inside dir (not in any subfolder). Its presence
-  # marks dir as a self-contained audiobook release rather than a container of
-  # further releases.
+  # An audio file lying directly inside dir. Its presence marks dir as a
+  # self-contained release rather than a container of further releases.
   def direct_audio_file(dir, root)
-    FileCopyService.directory_children(dir, root: root).each do |child|
-      next if child.name.start_with?(".")
-
-      if child.type == :file && LibraryAcquisitionService.audio_file?(child.name)
-        return File.join(dir, child.name)
-      end
-    end
-    nil
-  rescue FileCopyService::UnsafePathError, SystemCallError
-    nil
+    audio_child(dir, visible_children(dir, root))
   end
 
-  # Names of the immediate subdirectories of dir that contain audio somewhere in
-  # their subtree. Empty when dir holds no nested audiobook material. Used to
-  # decide whether dir is a multi-disc book or a collection of separate books.
+  # The first playable audio file among an already-listed set of children.
+  def audio_child(dir, children)
+    child = children.find { |c| c.type == :file && LibraryAcquisitionService.audio_file?(c.name) }
+    File.join(dir, child.name) if child
+  end
+
+  # Immediate subdirectories of dir holding audio anywhere in their subtree, used
+  # to tell a multi-disc book from a collection of separate books.
   def audio_bearing_subdirectories(dir, root)
-    FileCopyService.directory_children(dir, root: root).filter_map do |child|
-      next if child.name.start_with?(".")
+    visible_children(dir, root).filter_map do |child|
       next unless child.type == :directory
 
       child.name if first_audio_file(File.join(dir, child.name), root, 0)
     end
-  rescue FileCopyService::UnsafePathError, SystemCallError
-    []
   end
 
   def disc_subfolder?(name)
@@ -209,23 +222,16 @@ class WatchedFolderScanService
   def first_audio_file(dir, root, depth)
     return nil if depth > AUDIO_SEARCH_DEPTH
 
-    children = FileCopyService.directory_children(dir, root: root)
-    children.each do |child|
-      next if child.name.start_with?(".")
+    children = visible_children(dir, root)
+    direct = audio_child(dir, children)
+    return direct if direct
 
-      if child.type == :file && LibraryAcquisitionService.audio_file?(child.name)
-        return File.join(dir, child.name)
-      end
-    end
     children.each do |child|
-      next if child.name.start_with?(".")
       next unless child.type == :directory
 
       found = first_audio_file(File.join(dir, child.name), root, depth + 1)
       return found if found
     end
-    nil
-  rescue FileCopyService::UnsafePathError, SystemCallError
     nil
   end
 
@@ -251,26 +257,23 @@ class WatchedFolderScanService
     )
   end
 
-  # Some filesystems (certain FUSE/network/overlay mounts) report a device or
-  # inode of 0 for every entry. A non-positive value is not a usable identity —
-  # keeping it would collapse unrelated files onto one (device, inode) key and
-  # make de-duplication drop all but the first file per device. Discard it so
-  # known? falls back to path-based de-duplication instead.
+  # Some FUSE/network/overlay mounts report device or inode 0 for every entry.
+  # Keeping a non-positive value would collapse unrelated files onto one key and
+  # make de-duplication drop all but the first file per device, so discard it and
+  # let known? fall back to path-based de-duplication.
   def reliable_identity(value)
     value.to_i.positive? ? value.to_i : nil
   end
 
   # --- Persistence ---------------------------------------------------------
 
-  # Returns true when a new DetectedImport was created.
+  # Persist a candidate the walk kept (already established as unknown). Returns
+  # true when a new DetectedImport was created.
   def record_candidate(candidate)
-    return false if known?(candidate)
-
-    # Local-only identification (metadata extract + library match). The online
-    # provider lookups are deferred to DetectedImportEnrichmentJob so a large
-    # first scan never fires thousands of sequential network searches inside a
-    # single run (which would also hold the scan's concurrency lease and stall
-    # the recurring chain).
+    # Local-only identification (metadata extract + library match). Online
+    # lookups are deferred to DetectedImportEnrichmentJob so a large first scan
+    # never fires thousands of sequential searches inside one run, holding the
+    # concurrency lease and stalling the recurring chain.
     identification = LibraryAcquisitionService.identify(
       source_path: candidate.metadata_path,
       book_type: candidate.book_type,
@@ -305,9 +308,11 @@ class WatchedFolderScanService
     if candidate.device && candidate.inode
       claim = DetectedImport.find_by(source_device: candidate.device, source_inode: candidate.inode)
       if claim
-        return true unless stale_identity?(claim, candidate)
-
-        release_identity!(claim)
+        case identity_state(claim, candidate)
+        when :match then return true
+        when :absent then retire_stale_detection!(claim)
+        else release_identity!(claim)
+        end
       end
     elsif DetectedImport.where(source_path: candidate.source_path).exists?
       # No reliable (device, inode) identity available — de-duplicate on the
@@ -319,27 +324,54 @@ class WatchedFolderScanService
     Book.acquired.where(file_path: candidate.source_path).exists?
   end
 
-  # A detection's (device, inode) claim is only meaningful while the file it was
-  # recorded for still carries that identity. A move import consumes its source,
-  # and the filesystem is then free to hand the inode to an unrelated file —
-  # which the unique index on the pair would otherwise make permanently
-  # undetectable. A claim held by a path that is gone, or that now has a
-  # different identity, is stale.
+  # How a detection's (device, inode) claim relates to the candidate now carrying
+  # that identity. The claim only means something while the file it was recorded
+  # for still holds it: a move import consumes its source, and the filesystem may
+  # then hand the inode to an unrelated file — which the unique index on the pair
+  # would otherwise make permanently undetectable.
   #
-  # Two live paths sharing one inode are a hardlink of the same content, not a
-  # recycled inode, so that case stays known.
-  def stale_identity?(claim, candidate)
-    return false if claim.source_path == candidate.source_path
+  # In FileCopyService's vocabulary, read here as:
+  #
+  #   :match    - still the file it was recorded for, or a hardlink to it
+  #   :absent   - the recorded path is gone: the identity travelled to the
+  #               candidate's path (a rename keeps the inode) or was consumed
+  #   :mismatch - a different file holds that path now, or it could not be read
+  def identity_state(claim, candidate)
+    return :match if claim.source_path == candidate.source_path
 
-    stat = File.lstat(claim.source_path)
-    [ stat.dev, stat.ino ] != [ candidate.device, candidate.inode ]
-  rescue SystemCallError
-    true
+    FileCopyService.path_identity_state(
+      claim.source_path, device: candidate.device, inode: candidate.inode
+    )
   end
 
-  # Drop the stale claim so the new occupant of the inode can be recorded under
-  # it. Written with update_columns: this is index bookkeeping, not a change to
-  # the detection worth broadcasting to the review screens.
+  # The source is gone from the recorded path while the same content is detected
+  # under a new one, so the row can never be imported — it would fail on the dead
+  # path — and nothing else prunes it. Left alone it sits in the queue forever
+  # beside the row replacing it, so retire it.
+  #
+  # Rows past review get their identity released and nothing more: an "importing"
+  # row is having its source consumed right now, an imported or dismissed row's
+  # path records where the file came from rather than a target, and a row holding
+  # a publication record needs it to reverse files an earlier attempt left behind.
+  def retire_stale_detection!(claim)
+    return release_identity!(claim) unless retirable?(claim)
+
+    claim.destroy
+    Rails.logger.info(
+      "[WatchedFolderScanService] Retired detection ##{claim.id}: its source moved to another path"
+    )
+  rescue => e
+    Rails.logger.warn "[WatchedFolderScanService] Could not retire a stale detection (#{e.class})"
+    release_identity!(claim)
+  end
+
+  def retirable?(claim)
+    DetectedImport::ACTIONABLE_STATUSES.include?(claim.status) && claim.publication_record.blank?
+  end
+
+  # Drop the stale claim so the inode's new occupant can be recorded under it.
+  # update_columns because this is index bookkeeping, not a change worth
+  # broadcasting to the review screens.
   def release_identity!(claim)
     claim.update_columns(source_device: nil, source_inode: nil, updated_at: Time.current)
   rescue => e
@@ -348,8 +380,8 @@ class WatchedFolderScanService
 
   # --- Path validation -----------------------------------------------------
 
-  # Refuse a watched path that is the same as, inside, or a parent of any
-  # configured output path — otherwise Shelfarr would re-detect its own imports.
+  # Refuse a watched path equal to, inside, or a parent of any configured output
+  # path — otherwise Shelfarr re-detects its own imports.
   def overlaps_output_paths?(canonical)
     output_roots.any? do |output|
       output == canonical || path_inside?(canonical, output) || path_inside?(output, canonical)
@@ -357,18 +389,27 @@ class WatchedFolderScanService
   end
 
   def output_roots
-    [
-      SettingsService.get(:audiobook_output_path, default: "/audiobooks"),
-      SettingsService.get(:ebook_output_path, default: "/ebooks"),
-      SettingsService.get(:comicbook_output_path, default: "/comics")
-    ].filter_map { |path| canonical_directory(path) }.uniq
+    PathTemplateService.output_roots.filter_map { |path| canonical_directory(path) }.uniq
   end
 
+  # The canonical form of an output path, which need not exist yet: on a first
+  # run none of them do, and skipping those would let the scanner adopt a root it
+  # is about to import into. So canonicalise the deepest existing ancestor and
+  # re-attach the components below it — enough to compare against a canonical
+  # root.
   def canonical_directory(path)
     expanded = File.expand_path(path.to_s)
-    return nil unless File.directory?(expanded)
+    existing = expanded
+    missing = []
+    until File.directory?(existing)
+      parent = File.dirname(existing)
+      return nil if parent == existing
 
-    File.realpath(expanded)
+      missing.unshift(File.basename(existing))
+      existing = parent
+    end
+
+    File.join(File.realpath(existing), *missing)
   rescue ArgumentError, SystemCallError
     nil
   end

--- a/app/services/watched_folder_scan_service.rb
+++ b/app/services/watched_folder_scan_service.rb
@@ -38,6 +38,23 @@ class WatchedFolderScanService
     new.scan!
   end
 
+  # The file embedded metadata should be read from for a given detection source:
+  # the source itself for a single file, or the first playable audio file inside
+  # an audiobook folder — the same one the scan picked when it recorded the
+  # detection. Used by the review page's Re-match so it reads what the scanner
+  # read. Falls back to the source when the folder holds no readable audio.
+  def self.metadata_path_for(source_path)
+    new.metadata_path_for(source_path)
+  end
+
+  def metadata_path_for(source_path)
+    return source_path unless File.directory?(source_path)
+
+    first_audio_file(source_path, source_path, 0) || source_path
+  rescue SystemCallError
+    source_path
+  end
+
   # Returns a Result summarising the scan, or nil when scanning is disabled or
   # the configured path is invalid.
   def scan!
@@ -261,7 +278,12 @@ class WatchedFolderScanService
 
   def known?(candidate)
     if candidate.device && candidate.inode
-      return true if DetectedImport.where(source_device: candidate.device, source_inode: candidate.inode).exists?
+      claim = DetectedImport.find_by(source_device: candidate.device, source_inode: candidate.inode)
+      if claim
+        return true unless stale_identity?(claim, candidate)
+
+        release_identity!(claim)
+      end
     elsif DetectedImport.where(source_path: candidate.source_path).exists?
       # No reliable (device, inode) identity available — de-duplicate on the
       # source path instead, so files on inode-less filesystems still surface
@@ -270,6 +292,33 @@ class WatchedFolderScanService
     end
 
     Book.acquired.where(file_path: candidate.source_path).exists?
+  end
+
+  # A detection's (device, inode) claim is only meaningful while the file it was
+  # recorded for still carries that identity. A move import consumes its source,
+  # and the filesystem is then free to hand the inode to an unrelated file —
+  # which the unique index on the pair would otherwise make permanently
+  # undetectable. A claim held by a path that is gone, or that now has a
+  # different identity, is stale.
+  #
+  # Two live paths sharing one inode are a hardlink of the same content, not a
+  # recycled inode, so that case stays known.
+  def stale_identity?(claim, candidate)
+    return false if claim.source_path == candidate.source_path
+
+    stat = File.lstat(claim.source_path)
+    [ stat.dev, stat.ino ] != [ candidate.device, candidate.inode ]
+  rescue SystemCallError
+    true
+  end
+
+  # Drop the stale claim so the new occupant of the inode can be recorded under
+  # it. Written with update_columns: this is index bookkeeping, not a change to
+  # the detection worth broadcasting to the review screens.
+  def release_identity!(claim)
+    claim.update_columns(source_device: nil, source_inode: nil, updated_at: Time.current)
+  rescue => e
+    Rails.logger.warn "[WatchedFolderScanService] Could not release stale source identity (#{e.class})"
   end
 
   # --- Path validation -----------------------------------------------------

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -133,6 +133,7 @@
         <%= link_to "Audible Backup (Beta)", admin_owned_library_connections_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Download Routing", admin_download_routing_rules_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Manual Uploads", admin_uploads_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
+        <%= link_to "Watched Folder Imports", admin_detected_imports_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Settings", admin_settings_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Activity Log", admin_activity_logs_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Back to Dashboard", root_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>

--- a/app/views/admin/detected_imports/_scan_spinner.html.erb
+++ b/app/views/admin/detected_imports/_scan_spinner.html.erb
@@ -1,0 +1,6 @@
+<%# Shown while a scan runs, in the disabled "Scanning…" button and the status
+    line beneath it. %>
+<svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+</svg>

--- a/app/views/admin/detected_imports/index.html.erb
+++ b/app/views/admin/detected_imports/index.html.erb
@@ -1,0 +1,194 @@
+<%= turbo_stream_from "detected_imports" %>
+<% turbo_refreshes_with(method: :morph, scroll: :preserve) %>
+
+<div class="mx-auto max-w-6xl">
+  <div class="flex justify-between items-start mb-4">
+    <div>
+      <h1 class="font-bold text-4xl text-white">Watched Folder Imports</h1>
+      <p class="text-gray-400 mt-2">Book files found in your watched folder that were not acquired through a Shelfarr request. Review each one, then import it into your organised library.</p>
+    </div>
+    <% if @scan_status[:state] == "running" %>
+      <button type="button" disabled aria-busy="true"
+              class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600/60 text-white/80 font-medium rounded-lg whitespace-nowrap cursor-not-allowed">
+        <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+        Scanning…
+      </button>
+    <% else %>
+      <%= button_to "Scan now", scan_admin_detected_imports_path, method: :post,
+            class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition cursor-pointer whitespace-nowrap" %>
+    <% end %>
+  </div>
+
+  <div class="mb-8 min-h-5">
+    <% if @scan_status[:state] == "running" %>
+      <p class="flex items-center gap-2 text-sm text-blue-300">
+        <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+        Scanning your watched folder for new book files…
+      </p>
+    <% elsif @scan_status[:completed_at].present? %>
+      <p class="text-sm text-gray-500">
+        <% if @scan_status[:failed] %>
+          Last scan failed <%= time_ago_in_words(@scan_status[:completed_at]) %> ago. Check the logs for details.
+        <% else %>
+          <% new_count = @scan_status[:detected].to_i %>
+          Last scan completed <%= time_ago_in_words(@scan_status[:completed_at]) %> ago ·
+          <%= new_count.zero? ? "no new files" : "#{new_count} new #{'file'.pluralize(new_count)}" %>.
+        <% end %>
+      </p>
+    <% end %>
+  </div>
+
+  <% unless SettingsService.get(:library_import_enabled, default: false) %>
+    <div class="bg-yellow-900/30 border border-yellow-700 rounded-lg p-4 mb-6 text-yellow-200">
+      Watched-folder import is disabled. Enable it and set a path in
+      <%= link_to "Settings", admin_settings_path(anchor: "import"), class: "underline hover:text-yellow-100" %>.
+    </div>
+  <% end %>
+
+  <% if @pending.empty? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg p-12 text-center">
+      <h3 class="text-lg font-medium text-white mb-2">Nothing waiting for review</h3>
+      <p class="text-gray-500">New files found in your watched folder will appear here.</p>
+    </div>
+  <% else %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-800">
+        <thead class="bg-gray-800/50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Detected file</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Suggested match</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Type</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          <% @pending.each do |item| %>
+            <tr class="hover:bg-gray-800/50 transition align-top">
+              <td class="px-6 py-4 text-sm text-white">
+                <div class="font-medium"><%= item.display_title %></div>
+                <div class="text-gray-500 text-xs mt-1 break-all"><%= item.source_path %></div>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-300 wrap-anywhere">
+                <% if item.suggested_book %>
+                  <div><%= item.suggested_book.display_name %></div>
+                  <div class="text-gray-500 text-xs mt-1">Confidence: <%= item.match_confidence || 0 %>%</div>
+                <% elsif (candidate = item.best_candidate) %>
+                  <div><%= candidate["author"].present? ? "#{candidate['title']} by #{candidate['author']}" : candidate["title"] %></div>
+                  <div class="text-gray-500 text-xs mt-1"><%= candidate["source"]&.titleize || "Suggested" %> match · score <%= candidate["score"] %></div>
+                <% else %>
+                  <span class="text-gray-500">New book from “<%= item.parsed_title %>”<%= " by #{item.parsed_author}" if item.parsed_author.present? %></span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-400 whitespace-nowrap"><%= item.book_type&.titleize %></td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <% status_colors = {
+                     "detected" => "bg-blue-500/20 text-blue-400",
+                     "importing" => "bg-yellow-500/20 text-yellow-300",
+                     "failed" => "bg-red-500/20 text-red-400"
+                   } %>
+                <span class="px-2 py-1 text-xs rounded <%= status_colors[item.status] || 'bg-gray-700 text-gray-300' %>">
+                  <%= item.status.titleize %>
+                </span>
+                <% if item.status == "failed" && item.error_message.present? %>
+                  <div class="text-red-400 text-xs mt-1 break-words max-w-xs"><%= item.error_message %></div>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
+                <% if item.actionable? %>
+                  <div class="flex items-center justify-end gap-2">
+                    <%= button_to "Import", import_admin_detected_import_path(item), method: :post,
+                          class: "px-3 py-1 bg-green-600 hover:bg-green-500 text-white rounded transition cursor-pointer" %>
+                    <%= link_to "Review", admin_detected_import_path(item),
+                          class: "px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded transition inline-block" %>
+                    <%= button_to "Dismiss", dismiss_admin_detected_import_path(item), method: :post,
+                          class: "px-3 py-1 bg-gray-800 hover:bg-gray-700 text-gray-400 rounded transition cursor-pointer",
+                          form: { data: { turbo_confirm: "Dismiss this detection? It won't be shown again." } } %>
+                  </div>
+                <% else %>
+                  <span class="text-gray-500 text-xs">In progress…</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+
+  <% if @imported_total.positive? %>
+    <%= turbo_frame_tag "imported_history" do %>
+      <div class="flex items-center justify-between mt-10 mb-4">
+        <h2 class="text-2xl font-bold text-white">
+          Imported <span class="text-gray-500 text-lg font-normal">(<%= @imported_total %>)</span>
+        </h2>
+        <% if @imported_has_more %>
+          <% if @imported_expanded %>
+            <%= link_to "Show recent only", admin_detected_imports_path,
+                  data: { turbo_action: "advance" },
+                  class: "text-blue-400 hover:text-blue-300 text-sm" %>
+          <% else %>
+            <%= link_to "Show all (#{@imported_total})", admin_detected_imports_path(imported: "all"),
+                  data: { turbo_action: "advance" },
+                  class: "text-blue-400 hover:text-blue-300 text-sm" %>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+        <table class="min-w-full divide-y divide-gray-800">
+          <tbody class="divide-y divide-gray-800">
+            <% @imported.each do |item| %>
+              <tr>
+                <td class="px-6 py-3 text-sm text-gray-300"><%= item.imported_book&.display_name || item.display_title %></td>
+                <td class="px-6 py-3 text-sm text-gray-500 whitespace-nowrap">
+                  <%= (item.updated_at || item.detected_at)&.strftime("%b %d, %H:%M") %>
+                </td>
+                <td class="px-6 py-3 text-sm whitespace-nowrap text-right">
+                  <%= button_to "Undo", undo_admin_detected_import_path(item), method: :post,
+                        class: "px-3 py-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded transition cursor-pointer",
+                        form: { data: { turbo_confirm: "Undo this import? The library file is removed and the item returns to the review queue." } } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <% if @imported_has_more && !@imported_expanded %>
+        <p class="text-gray-600 text-xs mt-2">Showing the <%= @imported.size %> most recent of <%= @imported_total %>.</p>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if @dismissed.any? %>
+    <h2 class="text-2xl font-bold text-white mt-10 mb-4">Dismissed</h2>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-800">
+        <tbody class="divide-y divide-gray-800">
+          <% @dismissed.each do |item| %>
+            <tr>
+              <td class="px-6 py-3 text-sm text-gray-400">
+                <div><%= item.display_title %></div>
+                <div class="text-gray-600 text-xs mt-1 break-all"><%= item.source_path %></div>
+              </td>
+              <td class="px-6 py-3 text-sm whitespace-nowrap text-right">
+                <div class="flex items-center justify-end gap-2">
+                  <%= button_to "Restore", restore_admin_detected_import_path(item), method: :post,
+                        class: "px-3 py-1 bg-blue-600 hover:bg-blue-500 text-white rounded transition cursor-pointer" %>
+                  <%= button_to "Remove", admin_detected_import_path(item), method: :delete,
+                        class: "px-3 py-1 bg-gray-800 hover:bg-gray-700 text-gray-400 rounded transition cursor-pointer",
+                        form: { data: { turbo_confirm: "Remove this dismissed detection permanently?" } } %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/detected_imports/index.html.erb
+++ b/app/views/admin/detected_imports/index.html.erb
@@ -10,10 +10,7 @@
     <% if @scan_status[:state] == "running" %>
       <button type="button" disabled aria-busy="true"
               class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600/60 text-white/80 font-medium rounded-lg whitespace-nowrap cursor-not-allowed">
-        <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-        </svg>
+        <%= render "scan_spinner" %>
         Scanning…
       </button>
     <% else %>
@@ -25,10 +22,7 @@
   <div class="mb-8 min-h-5">
     <% if @scan_status[:state] == "running" %>
       <p class="flex items-center gap-2 text-sm text-blue-300">
-        <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-        </svg>
+        <%= render "scan_spinner" %>
         Scanning your watched folder for new book files…
       </p>
     <% elsif @scan_status[:completed_at].present? %>
@@ -47,7 +41,9 @@
   <% unless SettingsService.get(:library_import_enabled, default: false) %>
     <div class="bg-yellow-900/30 border border-yellow-700 rounded-lg p-4 mb-6 text-yellow-200">
       Watched-folder import is disabled. Enable it and set a path in
-      <%= link_to "Settings", admin_settings_path(anchor: "import"), class: "underline hover:text-yellow-100" %>.
+      <%# The settings page has no per-category anchors — its panels are tabs keyed by
+          tab name, and the import settings live under Downloads. %>
+      <%= link_to "Settings", admin_settings_path(anchor: "downloads"), class: "underline hover:text-yellow-100" %>.
     </div>
   <% end %>
 
@@ -69,6 +65,11 @@
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-800">
+          <% status_colors = {
+               "detected" => "bg-blue-500/20 text-blue-400",
+               "importing" => "bg-yellow-500/20 text-yellow-300",
+               "failed" => "bg-red-500/20 text-red-400"
+             } %>
           <% @pending.each do |item| %>
             <tr class="hover:bg-gray-800/50 transition align-top">
               <td class="px-6 py-4 text-sm text-white">
@@ -88,11 +89,6 @@
               </td>
               <td class="px-6 py-4 text-sm text-gray-400 whitespace-nowrap"><%= item.book_type&.titleize %></td>
               <td class="px-6 py-4 whitespace-nowrap">
-                <% status_colors = {
-                     "detected" => "bg-blue-500/20 text-blue-400",
-                     "importing" => "bg-yellow-500/20 text-yellow-300",
-                     "failed" => "bg-red-500/20 text-red-400"
-                   } %>
                 <span class="px-2 py-1 text-xs rounded <%= status_colors[item.status] || 'bg-gray-700 text-gray-300' %>">
                   <%= item.status.titleize %>
                 </span>
@@ -103,9 +99,9 @@
               <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                 <% if item.actionable? %>
                   <div class="flex items-center justify-end gap-2">
-                    <%# Submit the match this row displays. Without it the import falls
-                        back to the filename parse and invents a new book, ignoring the
-                        suggestion the admin is approving by clicking Import. %>
+                    <%# Submit the match this row displays. Without it the import falls back
+                        to the filename parse and invents a new book, ignoring the very
+                        suggestion the admin is approving. %>
                     <%= button_to "Import", import_admin_detected_import_path(item), method: :post,
                           params: { selection: item.default_selection },
                           class: "px-3 py-1 bg-green-600 hover:bg-green-500 text-white rounded transition cursor-pointer" %>
@@ -184,9 +180,11 @@
                 <div class="flex items-center justify-end gap-2">
                   <%= button_to "Restore", restore_admin_detected_import_path(item), method: :post,
                         class: "px-3 py-1 bg-blue-600 hover:bg-blue-500 text-white rounded transition cursor-pointer" %>
+                  <%# Removing the entry un-suppresses the file, so this is only for pruning
+                      entries whose source is gone — which the controller enforces. %>
                   <%= button_to "Remove", admin_detected_import_path(item), method: :delete,
                         class: "px-3 py-1 bg-gray-800 hover:bg-gray-700 text-gray-400 rounded transition cursor-pointer",
-                        form: { data: { turbo_confirm: "Remove this dismissed detection permanently?" } } %>
+                        form: { data: { turbo_confirm: "Remove this entry? Only possible once the file is gone from your watched folder — while it is there, this entry is what keeps it dismissed." } } %>
                 </div>
               </td>
             </tr>

--- a/app/views/admin/detected_imports/index.html.erb
+++ b/app/views/admin/detected_imports/index.html.erb
@@ -103,7 +103,11 @@
               <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                 <% if item.actionable? %>
                   <div class="flex items-center justify-end gap-2">
+                    <%# Submit the match this row displays. Without it the import falls
+                        back to the filename parse and invents a new book, ignoring the
+                        suggestion the admin is approving by clicking Import. %>
                     <%= button_to "Import", import_admin_detected_import_path(item), method: :post,
+                          params: { selection: item.default_selection },
                           class: "px-3 py-1 bg-green-600 hover:bg-green-500 text-white rounded transition cursor-pointer" %>
                     <%= link_to "Review", admin_detected_import_path(item),
                           class: "px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded transition inline-block" %>

--- a/app/views/admin/detected_imports/show.html.erb
+++ b/app/views/admin/detected_imports/show.html.erb
@@ -1,0 +1,116 @@
+<%= turbo_stream_from @detected_import %>
+<% turbo_refreshes_with(method: :morph, scroll: :preserve) %>
+
+<div class="mx-auto max-w-3xl">
+  <div class="mb-6">
+    <%= link_to "← Back to review queue", admin_detected_imports_path, class: "text-blue-400 hover:text-blue-300 text-sm" %>
+    <h1 class="font-bold text-3xl text-white mt-3">Review detected file</h1>
+    <p class="text-gray-500 text-sm mt-2 break-all"><%= @detected_import.source_path %></p>
+  </div>
+
+  <% if @detected_import.status == "failed" && @detected_import.error_message.present? %>
+    <div class="bg-red-900/30 border border-red-700 rounded-lg p-4 mb-6 text-red-300">
+      <div class="font-medium mb-1">Previous import failed</div>
+      <div class="text-sm break-words"><%= @detected_import.error_message %></div>
+    </div>
+  <% end %>
+
+  <% if @detected_import.imported? %>
+    <div class="bg-green-900/30 border border-green-700 rounded-lg p-4 mb-6 text-green-200">
+      <div class="font-medium mb-1">Imported</div>
+      <div class="text-sm">
+        This file was imported<%= " as #{@detected_import.imported_book.display_name}" if @detected_import.imported_book %>.
+        Undo to remove the library file and pick a different match.
+      </div>
+    </div>
+    <div class="flex items-center gap-3">
+      <%= button_to "Undo import", undo_admin_detected_import_path(@detected_import), method: :post,
+            class: "px-5 py-2 bg-yellow-600 hover:bg-yellow-500 text-white font-medium rounded-lg transition cursor-pointer",
+            form: { data: { turbo_confirm: "Undo this import? The library file is removed and the item returns to the review queue." } } %>
+      <%= link_to "Back to review queue", admin_detected_imports_path,
+            class: "px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded-lg transition inline-block" %>
+    </div>
+  <% else %>
+  <%= form_with url: search_admin_detected_import_path(@detected_import), method: :post, class: "mb-4" do %>
+    <label for="query" class="block text-sm font-medium text-gray-400 mb-1">Not the right match? Search manually</label>
+    <div class="flex gap-2">
+      <%= text_field_tag :query,
+            params[:query].presence || [ @detected_import.parsed_title, @detected_import.parsed_author ].reject(&:blank?).join(" "),
+            placeholder: "Title and author…",
+            class: "flex-1 px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+      <%= submit_tag "Search", class: "px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition cursor-pointer whitespace-nowrap" %>
+    </div>
+  <% end %>
+
+  <%= form_with url: import_admin_detected_import_path(@detected_import), method: :post, id: "detected-import-form", class: "space-y-4" do |f| %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg divide-y divide-gray-800">
+      <% default_selection = @detected_import.default_selection %>
+
+      <% if @detected_import.suggested_book %>
+        <label class="flex items-start gap-3 p-4 cursor-pointer hover:bg-gray-800/50">
+          <%= radio_button_tag :selection, "book:#{@detected_import.suggested_book_id}", "book:#{@detected_import.suggested_book_id}" == default_selection, class: "mt-1" %>
+          <span>
+            <span class="text-white font-medium"><%= @detected_import.suggested_book.display_name %></span>
+            <span class="block text-gray-500 text-xs mt-1">Existing library match · confidence <%= @detected_import.match_confidence || 0 %>%</span>
+          </span>
+        </label>
+      <% end %>
+
+      <% @detected_import.candidate_books.each do |candidate| %>
+        <%
+          if candidate["kind"] == "library"
+            next if candidate["book_id"] == @detected_import.suggested_book_id
+            value = "book:#{candidate['book_id']}"
+            label = candidate["author"].present? ? "#{candidate['title']} by #{candidate['author']}" : candidate["title"]
+            sub = "Library match · score #{candidate['score']}"
+          else
+            value = "work:#{candidate['work_id']}"
+            label = candidate["author"].present? ? "#{candidate['title']} by #{candidate['author']}" : candidate["title"]
+            sub = "#{candidate['source']&.titleize} · score #{candidate['score']}"
+          end
+        %>
+        <label class="flex items-start gap-3 p-4 cursor-pointer hover:bg-gray-800/50">
+          <%= radio_button_tag :selection, value, value == default_selection, class: "mt-1" %>
+          <span>
+            <span class="text-white font-medium"><%= label %></span>
+            <span class="block text-gray-500 text-xs mt-1"><%= sub %></span>
+          </span>
+        </label>
+      <% end %>
+
+      <label class="flex items-start gap-3 p-4 cursor-pointer hover:bg-gray-800/50">
+        <%= radio_button_tag :selection, "new", default_selection == "new", class: "mt-1" %>
+        <span class="flex-1">
+          <span class="text-white font-medium">Create a new book from these details</span>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-3">
+            <div>
+              <%= label_tag :title, "Title", class: "block text-xs text-gray-400 mb-1" %>
+              <%= text_field_tag :title, @detected_import.parsed_title, class: "w-full px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+            </div>
+            <div>
+              <%= label_tag :author, "Author", class: "block text-xs text-gray-400 mb-1" %>
+              <%= text_field_tag :author, @detected_import.parsed_author, class: "w-full px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+            </div>
+            <div>
+              <%= label_tag :book_type, "Type", class: "block text-xs text-gray-400 mb-1" %>
+              <%= select_tag :book_type,
+                    options_for_select(DetectedImport::BOOK_TYPES.map { |t| [ t.titleize, t ] }, @detected_import.book_type),
+                    class: "w-full px-3 py-2 bg-gray-800 border border-gray-700 text-white rounded-md text-sm" %>
+            </div>
+          </div>
+        </span>
+      </label>
+    </div>
+
+  <% end %>
+
+  <div class="flex flex-wrap items-center gap-3 mt-4">
+    <%= submit_tag "Import", form: "detected-import-form",
+          class: "px-5 py-2 bg-green-600 hover:bg-green-500 text-white font-medium rounded-lg transition cursor-pointer" %>
+    <%= button_to "Re-match", rematch_admin_detected_import_path(@detected_import), method: :post,
+          class: "px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded-lg transition cursor-pointer" %>
+    <%= button_to "Dismiss", dismiss_admin_detected_import_path(@detected_import), method: :post,
+          class: "px-4 py-2 bg-gray-800 hover:bg-gray-700 text-gray-400 rounded-lg transition cursor-pointer" %>
+  </div>
+  <% end %>
+</div>

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -7,7 +7,7 @@
     },
     "downloads" => {
       label: "Downloads",
-      categories: %w[download paths format_preferences]
+      categories: %w[download paths import format_preferences]
     },
     "integrations" => {
       label: "Integrations",

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -7,7 +7,7 @@
     <svg class="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
       <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
     </svg>
-    <p class="text-green-400 text-sm flex-grow"><%= flash[:notice] %></p>
+    <p class="text-green-400 text-sm flex-grow min-w-0 wrap-anywhere"><%= flash[:notice] %></p>
     <button type="button" aria-label="Dismiss notification" data-action="click->toast#dismiss" class="-m-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded text-gray-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
       <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
         <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -24,7 +24,7 @@
     <svg class="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
       <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
     </svg>
-    <p class="text-red-400 text-sm flex-grow"><%= flash[:alert] %></p>
+    <p class="text-red-400 text-sm flex-grow min-w-0 wrap-anywhere"><%= flash[:alert] %></p>
     <button type="button" aria-label="Dismiss notification" data-action="click->toast#dismiss" class="-m-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded text-gray-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500">
       <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
         <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />

--- a/config/initializers/watched_folder_scan.rb
+++ b/config/initializers/watched_folder_scan.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Start the watched-folder scan job chain when the application boots, if the
+# feature is enabled and a path is configured.
+Rails.application.config.after_initialize do
+  # Only start in server mode, not in console or rake tasks.
+  if defined?(Rails::Server)
+    if WatchedFolderScanJob.scanning_enabled?
+      Rails.logger.info "[Shelfarr] Starting WatchedFolderScanJob chain"
+      WatchedFolderScanJob.ensure_running!
+    else
+      Rails.logger.info "[Shelfarr] Watched-folder import disabled, WatchedFolderScanJob not started"
+    end
+  end
+rescue => e
+  # Don't crash the app if there's an issue starting the scanner.
+  Rails.logger.error "[Shelfarr] Failed to start WatchedFolderScanJob: #{e.message}"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,19 @@ Rails.application.routes.draw do
       post :retry_all
     end
     resources :activity_logs, only: [ :index ]
+    resources :detected_imports, only: [ :index, :show, :destroy ] do
+      member do
+        post :import
+        post :dismiss
+        post :restore
+        post :rematch
+        post :search
+        post :undo
+      end
+      collection do
+        post :scan
+      end
+    end
     resources :requests, only: [] do
       resources :search_results, only: [ :index ] do
         member do

--- a/db/migrate/20260722120000_create_detected_imports.rb
+++ b/db/migrate/20260722120000_create_detected_imports.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateDetectedImports < ActiveRecord::Migration[8.1]
+  def change
+    create_table :detected_imports do |t|
+      t.references :suggested_book, null: true, foreign_key: { to_table: :books, on_delete: :nullify }
+      t.references :imported_book, null: true, foreign_key: { to_table: :books, on_delete: :nullify }
+      t.string :source_path, null: false
+      t.bigint :source_device
+      t.bigint :source_inode
+      t.string :content_fingerprint
+      t.string :book_type
+      t.string :parsed_title
+      t.string :parsed_author
+      t.integer :match_confidence
+      t.json :candidate_books, null: false, default: []
+      t.string :status, null: false, default: "detected"
+      t.text :error_message
+      t.datetime :detected_at
+
+      t.timestamps
+    end
+
+    add_index :detected_imports, :status
+    add_index :detected_imports, :detected_at
+    add_index :detected_imports,
+      [ :source_device, :source_inode ],
+      unique: true,
+      where: "source_device IS NOT NULL AND source_inode IS NOT NULL",
+      name: "index_detected_imports_on_source_identity"
+  end
+end

--- a/db/migrate/20260731120000_add_publication_record_to_detected_imports.rb
+++ b/db/migrate/20260731120000_add_publication_record_to_detected_imports.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Records exactly which library entries an import published, so a rollback or an
+# admin undo reverses only this import's own files instead of recursively
+# deleting a templated destination directory it may share with other books.
+class AddPublicationRecordToDetectedImports < ActiveRecord::Migration[8.1]
+  def change
+    add_column :detected_imports, :publication_record, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_31_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -114,6 +114,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
     t.integer "match_confidence"
     t.string "parsed_author"
     t.string "parsed_title"
+    t.json "publication_record"
     t.bigint "source_device"
     t.bigint "source_inode"
     t.string "source_path", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,6 +103,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
     t.index ["series_position"], name: "index_books_on_series_position"
   end
 
+  create_table "detected_imports", force: :cascade do |t|
+    t.string "book_type"
+    t.json "candidate_books", default: [], null: false
+    t.string "content_fingerprint"
+    t.datetime "created_at", null: false
+    t.datetime "detected_at"
+    t.text "error_message"
+    t.integer "imported_book_id"
+    t.integer "match_confidence"
+    t.string "parsed_author"
+    t.string "parsed_title"
+    t.bigint "source_device"
+    t.bigint "source_inode"
+    t.string "source_path", null: false
+    t.string "status", default: "detected", null: false
+    t.integer "suggested_book_id"
+    t.datetime "updated_at", null: false
+    t.index ["detected_at"], name: "index_detected_imports_on_detected_at"
+    t.index ["imported_book_id"], name: "index_detected_imports_on_imported_book_id"
+    t.index ["source_device", "source_inode"], name: "index_detected_imports_on_source_identity", unique: true, where: "source_device IS NOT NULL AND source_inode IS NOT NULL"
+    t.index ["status"], name: "index_detected_imports_on_status"
+    t.index ["suggested_book_id"], name: "index_detected_imports_on_suggested_book_id"
+  end
+
   create_table "download_clients", force: :cascade do |t|
     t.string "api_key"
     t.string "category"
@@ -575,6 +599,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
 
   add_foreign_key "activity_logs", "users"
   add_foreign_key "api_tokens", "users"
+  add_foreign_key "detected_imports", "books", column: "imported_book_id", on_delete: :nullify
+  add_foreign_key "detected_imports", "books", column: "suggested_book_id", on_delete: :nullify
   add_foreign_key "download_routing_rules", "download_clients"
   add_foreign_key "downloads", "requests"
   add_foreign_key "downloads", "search_results", on_delete: :nullify

--- a/test/controllers/admin/detected_imports_controller_test.rb
+++ b/test/controllers/admin/detected_imports_controller_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    @admin = users(:two)
+    sign_in_as(@admin)
+  end
+
+  test "index requires admin" do
+    delete session_url
+    get admin_detected_imports_url
+    assert_response :redirect
+  end
+
+  test "index lists pending detections" do
+    detection = create_detection(status: "detected", parsed_title: "Waiting For Review")
+
+    get admin_detected_imports_url
+
+    assert_response :success
+    assert_select "div.font-medium", text: detection.display_title
+  end
+
+  test "index shows only a preview of the imported history when collapsed" do
+    preview = Admin::DetectedImportsController::IMPORTED_PREVIEW_COUNT
+    total = preview + 1
+    total.times { |i| create_detection(status: "imported", parsed_title: "Imported Book #{i}") }
+
+    get admin_detected_imports_url
+
+    assert_response :success
+    # Only the preview slice, plus the "show all" affordance and the truncation note.
+    assert_select "turbo-frame#imported_history tbody tr", preview
+    assert_select "turbo-frame#imported_history h2", text: /Imported\s+\(#{total}\)/
+    assert_select "turbo-frame#imported_history a", text: /Show all \(#{total}\)/
+    assert_select "turbo-frame#imported_history p", text: /Showing the #{preview} most recent of #{total}\./
+  end
+
+  test "index expands the full imported history with imported=all" do
+    total = Admin::DetectedImportsController::IMPORTED_PREVIEW_COUNT + 1
+    total.times { |i| create_detection(status: "imported", parsed_title: "Imported Book #{i}") }
+
+    get admin_detected_imports_url(imported: "all")
+
+    assert_response :success
+    assert_select "turbo-frame#imported_history tbody tr", total
+    assert_select "turbo-frame#imported_history a", text: /Show recent only/
+  end
+
+  test "scan enqueues a manual watched-folder scan when enabled" do
+    enable_watched_folder_import
+
+    assert_enqueued_with(job: WatchedFolderScanJob) do
+      post scan_admin_detected_imports_url
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_equal "Watched-folder scan started.", flash[:notice]
+  end
+
+  test "scan is rejected when watched-folder import is disabled" do
+    set_setting("library_import_enabled", "false", "boolean", "import")
+
+    assert_no_enqueued_jobs only: WatchedFolderScanJob do
+      post scan_admin_detected_imports_url
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/Enable watched-folder import/, flash[:alert])
+  end
+
+  test "import queues the import job for an actionable detection" do
+    detection = create_detection(status: "detected", parsed_title: "Ready To Import")
+
+    assert_enqueued_with(job: DetectedImportJob, args: [ detection.id ]) do
+      post import_admin_detected_import_url(detection)
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/Import queued/, flash[:notice])
+  end
+
+  test "dismiss moves an actionable detection out of the queue" do
+    detection = create_detection(status: "detected", parsed_title: "Not Wanted")
+
+    post dismiss_admin_detected_import_url(detection)
+
+    assert_redirected_to admin_detected_imports_path
+    assert_equal "dismissed", detection.reload.status
+  end
+
+  test "restore returns a dismissed detection to the review queue" do
+    detection = create_detection(status: "dismissed", parsed_title: "Second Chance")
+
+    post restore_admin_detected_import_url(detection)
+
+    assert_redirected_to admin_detected_imports_path
+    assert_equal "detected", detection.reload.status
+  end
+
+  test "undo reverses a completed import" do
+    detection = create_detection(status: "imported", parsed_title: "Imported By Mistake")
+
+    LibraryAcquisitionService.stub(:undo_import!, nil) do
+      post undo_admin_detected_import_url(detection)
+    end
+
+    assert_redirected_to admin_detected_import_path(detection)
+    assert_match(/Undid the import/, flash[:notice])
+  end
+
+  test "undo refuses a detection that was never imported" do
+    detection = create_detection(status: "detected", parsed_title: "Never Imported")
+
+    post undo_admin_detected_import_url(detection)
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/nothing to undo/, flash[:alert])
+  end
+
+  private
+
+  def create_detection(status:, parsed_title:)
+    DetectedImport.create!(
+      source_path: "/watched/#{parsed_title.parameterize}-#{SecureRandom.hex(4)}",
+      status: status,
+      book_type: "ebook",
+      parsed_title: parsed_title,
+      detected_at: Time.current
+    )
+  end
+
+  def enable_watched_folder_import
+    set_setting("library_import_enabled", "true", "boolean", "import")
+    set_setting("library_import_path", Dir.mktmpdir("wf-controller"), "string", "import")
+  end
+
+  def set_setting(key, value, type, category)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: type, category: category
+    )
+  end
+end

--- a/test/controllers/admin/detected_imports_controller_test.rb
+++ b/test/controllers/admin/detected_imports_controller_test.rb
@@ -113,6 +113,26 @@ class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/can no longer be imported/, flash[:alert])
   end
 
+  test "the queue's one-click Import submits the match the row displays" do
+    detection = create_detection(status: "detected", parsed_title: "Wrongly Parsed Title")
+    match = Book.create!(title: "The Real Title", author: "Brandon Sanderson", book_type: :ebook)
+    detection.update!(candidate_books: [
+      { "kind" => "library", "book_id" => match.id, "title" => "The Real Title", "score" => 99 }
+    ])
+
+    get admin_detected_imports_url
+
+    assert_response :success
+    assert_select "form[action=?] input[name=selection][value=?]",
+      import_admin_detected_import_path(detection), "book:#{match.id}"
+
+    # Following that form resolves the displayed candidate rather than falling
+    # back to the filename parse and inventing a book from it.
+    post import_admin_detected_import_url(detection), params: { selection: detection.default_selection }
+
+    assert_equal match, detection.reload.suggested_book
+  end
+
   test "rematch reads embedded metadata from inside an audiobook folder" do
     release = File.join(Dir.mktmpdir("wf-rematch"), "Warbreaker")
     FileUtils.mkdir_p(release)

--- a/test/controllers/admin/detected_imports_controller_test.rb
+++ b/test/controllers/admin/detected_imports_controller_test.rb
@@ -84,6 +84,58 @@ class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Import queued/, flash[:notice])
   end
 
+  test "import retires the dead lease on a stuck row so the job can still claim it" do
+    detection = create_detection(status: "importing", parsed_title: "Wedged Importing")
+    detection.update_columns(updated_at: (DetectedImport::STUCK_IMPORTING_AFTER + 1.minute).ago)
+    book = Book.create!(title: "Wedged Importing", book_type: :ebook)
+
+    assert_enqueued_with(job: DetectedImportJob, args: [ detection.id ]) do
+      post import_admin_detected_import_url(detection), params: { selection: "book:#{book.id}" }
+    end
+
+    assert_match(/Import queued/, flash[:notice])
+    detection.reload
+    assert_equal "failed", detection.status,
+      "the expired lease is retired before the edit bumps updated_at back inside its window"
+    assert_equal book, detection.suggested_book
+    assert DetectedImport::ACTIONABLE_STATUSES.include?(detection.status),
+      "and lands in a status DetectedImportJob#claim accepts outright"
+  end
+
+  test "import refuses a row a worker is still importing" do
+    detection = create_detection(status: "importing", parsed_title: "Actively Importing")
+
+    assert_no_enqueued_jobs only: DetectedImportJob do
+      post import_admin_detected_import_url(detection)
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/can no longer be imported/, flash[:alert])
+  end
+
+  test "rematch reads embedded metadata from inside an audiobook folder" do
+    release = File.join(Dir.mktmpdir("wf-rematch"), "Warbreaker")
+    FileUtils.mkdir_p(release)
+    track = File.join(release, "01 - Chapter One.mp3")
+    File.write(track, "chapter one bytes")
+    detection = DetectedImport.create!(
+      source_path: release, status: "detected", book_type: "audiobook", detected_at: Time.current
+    )
+
+    seen = {}
+    identification = LibraryAcquisitionService::Identification.new(
+      book_type: "audiobook", parsed_title: "Warbreaker", parsed_author: "Brandon Sanderson",
+      suggested_book: nil, candidate_books: [], match_confidence: 50, source_path: track
+    )
+    LibraryAcquisitionService.stub(:identify, ->(**kwargs) { seen = kwargs; identification }) do
+      post rematch_admin_detected_import_url(detection)
+    end
+
+    assert_equal track, seen[:source_path], "metadata is read from the release's audio file"
+    assert_equal "Warbreaker", seen[:filename_hint], "but the filename parse still sees the release name"
+    assert_equal "Brandon Sanderson", detection.reload.parsed_author
+  end
+
   test "dismiss moves an actionable detection out of the queue" do
     detection = create_detection(status: "detected", parsed_title: "Not Wanted")
 

--- a/test/controllers/admin/detected_imports_controller_test.rb
+++ b/test/controllers/admin/detected_imports_controller_test.rb
@@ -40,6 +40,18 @@ class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#imported_history p", text: /Showing the #{preview} most recent of #{total}\./
   end
 
+  test "index renders the scanning state while a scan is running" do
+    create_detection(status: "detected", parsed_title: "Waiting For Review")
+
+    WatchedFolderScanJob.stub(:scan_status, { state: "running", started_at: Time.current }) do
+      get admin_detected_imports_url
+    end
+
+    assert_response :success
+    assert_select "button[disabled][aria-busy=?]", "true", text: /Scanning/
+    assert_select "svg.animate-spin", 2, "the shared spinner renders in the button and the status line"
+  end
+
   test "index expands the full imported history with imported=all" do
     total = Admin::DetectedImportsController::IMPORTED_PREVIEW_COUNT + 1
     total.times { |i| create_detection(status: "imported", parsed_title: "Imported Book #{i}") }
@@ -62,8 +74,32 @@ class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Watched-folder scan started.", flash[:notice]
   end
 
+  test "scan says so instead of claiming to start one while a scan is running" do
+    enable_watched_folder_import
+
+    # The job's concurrency key is declared on_conflict: :discard, so a second
+    # scan enqueued now would be thrown away without ever running.
+    assert_no_enqueued_jobs only: WatchedFolderScanJob do
+      WatchedFolderScanJob.stub(:scanning_now?, true) do
+        post scan_admin_detected_imports_url
+      end
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/already running/, flash[:notice])
+  end
+
+  test "the disabled banner links to a settings tab that exists" do
+    set_setting("library_import_enabled", "false", type: "boolean")
+
+    get admin_detected_imports_url
+
+    assert_response :success
+    assert_select "a[href=?]", "#{admin_settings_path}#downloads", text: "Settings"
+  end
+
   test "scan is rejected when watched-folder import is disabled" do
-    set_setting("library_import_enabled", "false", "boolean", "import")
+    set_setting("library_import_enabled", "false", type: "boolean")
 
     assert_no_enqueued_jobs only: WatchedFolderScanJob do
       post scan_admin_detected_imports_url
@@ -174,6 +210,35 @@ class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "detected", detection.reload.status
   end
 
+  test "remove refuses while the file is still in the watched folder" do
+    file = File.join(Dir.mktmpdir("wf-remove"), "still-there.epub")
+    File.write(file, "dummy epub")
+    detection = DetectedImport.create!(
+      source_path: file, status: "dismissed", book_type: "ebook", parsed_title: "Still There"
+    )
+
+    assert_no_difference "DetectedImport.count" do
+      delete admin_detected_import_url(detection)
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_match(/still in your watched folder/, flash[:alert],
+      "removing the row would only hand the file back to the next scan")
+  ensure
+    FileUtils.rm_rf(File.dirname(file)) if file
+  end
+
+  test "remove prunes an entry whose source is gone" do
+    detection = create_detection(status: "dismissed", parsed_title: "Long Gone")
+
+    assert_difference "DetectedImport.count", -1 do
+      delete admin_detected_import_url(detection)
+    end
+
+    assert_redirected_to admin_detected_imports_path
+    assert_equal "Removed detection.", flash[:notice]
+  end
+
   test "undo reverses a completed import" do
     detection = create_detection(status: "imported", parsed_title: "Imported By Mistake")
 
@@ -207,11 +272,11 @@ class Admin::DetectedImportsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def enable_watched_folder_import
-    set_setting("library_import_enabled", "true", "boolean", "import")
-    set_setting("library_import_path", Dir.mktmpdir("wf-controller"), "string", "import")
+    set_setting("library_import_enabled", "true", type: "boolean")
+    set_setting("library_import_path", Dir.mktmpdir("wf-controller"))
   end
 
-  def set_setting(key, value, type, category)
+  def set_setting(key, value, type: "string", category: "import")
     Setting.find_or_create_by(key: key).update!(
       value: value, value_type: type, category: category
     )

--- a/test/jobs/detected_import_job_test.rb
+++ b/test/jobs/detected_import_job_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DetectedImportJobTest < ActiveJob::TestCase
+  setup do
+    @source_dir = Dir.mktmpdir("di-source")
+    @ebook_dest = Dir.mktmpdir("di-ebooks")
+
+    set_setting("ebook_output_path", @ebook_dest)
+    set_setting("completed_download_import_mode", "copy")
+    Setting.where(key: "audiobookshelf_url").destroy_all
+  end
+
+  teardown do
+    [ @source_dir, @ebook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  test "imports a detection and creates a book when there is no suggestion" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub")
+    detection = DetectedImport.create!(
+      source_path: source, status: "detected", book_type: "ebook",
+      parsed_title: "Elantris", parsed_author: "Brandon Sanderson"
+    )
+
+    assert_difference "Book.count", 1 do
+      DetectedImportJob.perform_now(detection.id)
+    end
+
+    detection.reload
+    assert_equal "imported", detection.status
+    assert detection.imported_book.present?
+    assert detection.imported_book.acquired?
+    assert File.exist?(File.join(@ebook_dest, "Brandon Sanderson", "Elantris", "Brandon Sanderson - Elantris.epub"))
+  end
+
+  test "marks the detection failed when the source is missing" do
+    detection = DetectedImport.create!(
+      source_path: File.join(@source_dir, "gone.epub"), status: "detected", book_type: "ebook",
+      parsed_title: "Gone", parsed_author: "Nobody"
+    )
+
+    DetectedImportJob.perform_now(detection.id)
+
+    detection.reload
+    assert_equal "failed", detection.status
+    assert detection.error_message.present?
+  end
+
+  test "re-claims and imports a detection wedged in importing by a dead worker" do
+    source = File.join(@source_dir, "Brandon Sanderson - Wedged.epub")
+    File.write(source, "dummy epub")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Wedged", parsed_author: "Brandon Sanderson"
+    )
+    detection.update_column(:updated_at, 2.hours.ago)
+
+    DetectedImportJob.perform_now(detection.id)
+
+    assert_equal "imported", detection.reload.status
+  end
+
+  test "does not re-claim a freshly importing detection" do
+    detection = DetectedImport.create!(source_path: "/x", status: "importing")
+
+    assert_no_difference "Book.count" do
+      DetectedImportJob.perform_now(detection.id)
+    end
+
+    assert_equal "importing", detection.reload.status
+  end
+
+  test "does not re-import a detection that is already imported" do
+    detection = DetectedImport.create!(source_path: "/x", status: "imported")
+
+    assert_no_difference "Book.count" do
+      DetectedImportJob.perform_now(detection.id)
+    end
+
+    assert_equal "imported", detection.reload.status
+  end
+
+  private
+
+  def set_setting(key, value)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: "string", category: "paths"
+    )
+  end
+end

--- a/test/jobs/detected_import_job_test.rb
+++ b/test/jobs/detected_import_job_test.rb
@@ -72,6 +72,45 @@ class DetectedImportJobTest < ActiveJob::TestCase
     assert_equal "importing", detection.reload.status
   end
 
+  test "refuses to import a source that was replaced after it was detected" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "the approved book")
+    stat = File.stat(source)
+    detection = DetectedImport.create!(
+      source_path: source, status: "detected", book_type: "ebook",
+      parsed_title: "Elantris", parsed_author: "Brandon Sanderson",
+      source_device: stat.dev, source_inode: stat.ino
+    )
+
+    # Atomically swap the approved path for different content on a new inode.
+    replacement = File.join(@source_dir, "replacement.epub")
+    File.write(replacement, "something else entirely")
+    File.rename(replacement, source)
+
+    DetectedImportJob.perform_now(detection.id)
+
+    detection.reload
+    assert_equal "failed", detection.status
+    assert_empty Dir.glob(File.join(@ebook_dest, "**", "*.epub")),
+      "the substituted bytes are never published under the approved title"
+  end
+
+  test "imports a source whose recorded identity still matches" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "the approved book")
+    stat = File.stat(source)
+    detection = DetectedImport.create!(
+      source_path: source, status: "detected", book_type: "ebook",
+      parsed_title: "Elantris", parsed_author: "Brandon Sanderson",
+      source_device: stat.dev, source_inode: stat.ino
+    )
+
+    DetectedImportJob.perform_now(detection.id)
+
+    assert_equal "imported", detection.reload.status
+    assert File.exist?(File.join(@ebook_dest, "Brandon Sanderson", "Elantris", "Brandon Sanderson - Elantris.epub"))
+  end
+
   test "does not re-import a detection that is already imported" do
     detection = DetectedImport.create!(source_path: "/x", status: "imported")
 

--- a/test/jobs/detected_import_job_test.rb
+++ b/test/jobs/detected_import_job_test.rb
@@ -121,11 +121,32 @@ class DetectedImportJobTest < ActiveJob::TestCase
     assert_equal "imported", detection.reload.status
   end
 
+  test "each detection carries its own concurrency lease for the stuck window" do
+    first = DetectedImport.create!(source_path: "/x", status: "detected")
+    second = DetectedImport.create!(source_path: "/y", status: "detected")
+
+    # A slow import is still running when the row looks stuck and the admin
+    # recovers it; the lease makes the recovery attempt wait rather than reverse
+    # the publication the original is finalizing.
+    assert_equal 1, DetectedImportJob.concurrency_limit
+    assert_equal DetectedImport::STUCK_IMPORTING_AFTER, DetectedImportJob.concurrency_duration
+    assert_equal :block, DetectedImportJob.concurrency_on_conflict
+    assert_equal(
+      DetectedImportJob.new(first.id).concurrency_key,
+      DetectedImportJob.new(first.id).concurrency_key
+    )
+    assert_not_equal(
+      DetectedImportJob.new(first.id).concurrency_key,
+      DetectedImportJob.new(second.id).concurrency_key,
+      "unrelated detections still import in parallel"
+    )
+  end
+
   private
 
-  def set_setting(key, value)
+  def set_setting(key, value, type: "string", category: "import")
     Setting.find_or_create_by(key: key).update!(
-      value: value, value_type: "string", category: "paths"
+      value: value, value_type: type, category: category
     )
   end
 end

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -2703,6 +2703,33 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_not File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
   end
 
+  test "retires the watched-folder detection for a release reached through a symlinked import path" do
+    real_root = Dir.mktmpdir("pp-watched-real")
+    link_base = Dir.mktmpdir("pp-watched-link")
+    link_root = File.join(link_base, "downloads")
+    File.symlink(real_root, link_root)
+    SettingsService.set(:library_import_path, link_root)
+
+    # The scanner canonicalises the root, so the detection it recorded for this
+    # release is named under the real path.
+    release = File.join(File.realpath(real_root), "Some Audiobook")
+    FileUtils.mkdir_p(release)
+    detection = DetectedImport.create!(
+      source_path: release, status: "detected", book_type: "audiobook", detected_at: Time.current
+    )
+
+    # Post-processing imports the same release, naming the track through the
+    # symlink the download client reported.
+    PostProcessingJob.new.send(
+      :dismiss_detected_imports_for, File.join(link_root, "Some Audiobook", "track01.mp3")
+    )
+
+    assert_equal "dismissed", detection.reload.status,
+      "otherwise approving the detection afterwards imports the same title a second time"
+  ensure
+    [ real_root, link_base ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
   private
 
   def without_atomic_file_publication(&operation)

--- a/test/jobs/watched_folder_scan_job_test.rb
+++ b/test/jobs/watched_folder_scan_job_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WatchedFolderScanJobTest < ActiveJob::TestCase
+  # The default test cache is a null store, so status writes would be dropped.
+  # Swap in a real in-memory store for the duration of each test so the
+  # running/idle transitions are observable.
+  def with_memory_cache
+    Rails.stub(:cache, ActiveSupport::Cache::MemoryStore.new) { yield }
+  end
+
+  test "scan status starts empty" do
+    with_memory_cache do
+      assert_equal({}, WatchedFolderScanJob.scan_status)
+      assert_not WatchedFolderScanJob.scanning_now?
+    end
+  end
+
+  test "status transitions from running to idle and records the result" do
+    with_memory_cache do
+      WatchedFolderScanJob.mark_running!
+      assert WatchedFolderScanJob.scanning_now?
+
+      result = WatchedFolderScanService::Result.new(scanned: 5, detected: 3, skipped: 2)
+      WatchedFolderScanJob.mark_completed!(result)
+
+      assert_not WatchedFolderScanJob.scanning_now?
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state]
+      assert_equal 3, status[:detected]
+      assert_equal 5, status[:scanned]
+      assert_not status[:failed]
+      assert status[:completed_at].present?
+    end
+  end
+
+  test "a failed scan is recorded as failed" do
+    with_memory_cache do
+      WatchedFolderScanJob.mark_completed!(nil)
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state]
+      assert status[:failed]
+    end
+  end
+
+  test "a manual scan records its completion" do
+    watched = Dir.mktmpdir("wfsj-watched")
+    audiobook_dest = Dir.mktmpdir("wfsj-audiobooks")
+    set_setting("audiobook_output_path", audiobook_dest, "paths")
+    set_setting("library_import_enabled", "true", "import", "boolean")
+    set_setting("library_import_path", watched, "import")
+    File.write(File.join(watched, "Some Author - A Book.epub"), "dummy epub")
+
+    with_memory_cache do
+      MetadataService.stub(:search, []) do
+        WatchedFolderScanJob.new.perform(manual: true)
+      end
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state]
+      assert_equal 1, status[:detected]
+    end
+  ensure
+    [ watched, audiobook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  private
+
+  def set_setting(key, value, category = "paths", value_type = "string")
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: value_type, category: category
+    )
+  end
+end

--- a/test/jobs/watched_folder_scan_job_test.rb
+++ b/test/jobs/watched_folder_scan_job_test.rb
@@ -35,6 +35,21 @@ class WatchedFolderScanJobTest < ActiveJob::TestCase
     end
   end
 
+  test "a run still marked running past the concurrency lease is reported as failed" do
+    with_memory_cache do
+      WatchedFolderScanJob.mark_running!
+      Rails.cache.write(
+        WatchedFolderScanJob::STATUS_CACHE_KEY,
+        { state: "running", started_at: (WatchedFolderScanJob::RUNNING_STATUS_TTL + 1.minute).ago }
+      )
+
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state], "so the queue offers Scan now again"
+      assert status[:failed]
+      assert_not WatchedFolderScanJob.scanning_now?
+    end
+  end
+
   test "a failed scan is recorded as failed" do
     with_memory_cache do
       WatchedFolderScanJob.mark_completed!(nil)

--- a/test/jobs/watched_folder_scan_job_test.rb
+++ b/test/jobs/watched_folder_scan_job_test.rb
@@ -62,9 +62,9 @@ class WatchedFolderScanJobTest < ActiveJob::TestCase
   test "a manual scan records its completion" do
     watched = Dir.mktmpdir("wfsj-watched")
     audiobook_dest = Dir.mktmpdir("wfsj-audiobooks")
-    set_setting("audiobook_output_path", audiobook_dest, "paths")
-    set_setting("library_import_enabled", "true", "import", "boolean")
-    set_setting("library_import_path", watched, "import")
+    set_setting("audiobook_output_path", audiobook_dest, category: "paths")
+    set_setting("library_import_enabled", "true", type: "boolean")
+    set_setting("library_import_path", watched)
     File.write(File.join(watched, "Some Author - A Book.epub"), "dummy epub")
 
     with_memory_cache do
@@ -79,11 +79,31 @@ class WatchedFolderScanJobTest < ActiveJob::TestCase
     [ watched, audiobook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
   end
 
+  test "a failing scan still reports completion and re-arms the chain" do
+    watched = Dir.mktmpdir("wfsj-failing")
+    set_setting("library_import_enabled", "true", type: "boolean")
+    set_setting("library_import_path", watched)
+
+    with_memory_cache do
+      assert_enqueued_with(job: WatchedFolderScanJob) do
+        WatchedFolderScanService.stub(:scan!, ->(*) { raise "boom" }) do
+          WatchedFolderScanJob.new.perform(manual: true)
+        end
+      end
+
+      status = WatchedFolderScanJob.scan_status
+      assert_equal "idle", status[:state], "a crashed scan must not leave Scan now disabled"
+      assert status[:failed]
+    end
+  ensure
+    FileUtils.rm_rf(watched) if watched
+  end
+
   private
 
-  def set_setting(key, value, category = "paths", value_type = "string")
+  def set_setting(key, value, type: "string", category: "import")
     Setting.find_or_create_by(key: key).update!(
-      value: value, value_type: value_type, category: category
+      value: value, value_type: type, category: category
     )
   end
 end

--- a/test/models/detected_import_test.rb
+++ b/test/models/detected_import_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DetectedImportTest < ActiveSupport::TestCase
+  test "requires a source path and a valid status" do
+    detection = DetectedImport.new(source_path: "", status: "detected")
+    assert_not detection.valid?
+    assert_includes detection.errors[:source_path], "can't be blank"
+
+    detection.source_path = "/data/torrents/shelfarr/book.epub"
+    detection.status = "bogus"
+    assert_not detection.valid?
+    assert_includes detection.errors[:status], "is not included in the list"
+  end
+
+  test "rejects an unknown book_type but allows nil" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected", book_type: "movie")
+    assert_not detection.valid?
+
+    detection.book_type = nil
+    assert detection.valid?
+  end
+
+  test "actionable? is true only for detected and failed" do
+    assert DetectedImport.new(status: "detected").actionable?
+    assert DetectedImport.new(status: "failed").actionable?
+    assert_not DetectedImport.new(status: "importing").actionable?
+    assert_not DetectedImport.new(status: "imported").actionable?
+    assert_not DetectedImport.new(status: "dismissed").actionable?
+  end
+
+  test "a stale importing row becomes actionable again for recovery" do
+    detection = DetectedImport.create!(source_path: "/x", status: "importing")
+    detection.update_column(:updated_at, 2.hours.ago)
+
+    assert detection.stuck_importing?
+    assert detection.actionable?
+  end
+
+  test "a freshly importing row is not treated as stuck" do
+    detection = DetectedImport.create!(source_path: "/y", status: "importing")
+
+    assert_not detection.stuck_importing?
+    assert_not detection.actionable?
+  end
+
+  test "default_selection prefers an existing library suggestion" do
+    book = Book.create!(title: "Elantris", book_type: :ebook)
+    detection = DetectedImport.new(
+      source_path: "/x", status: "detected", suggested_book: book,
+      candidate_books: [ { "kind" => "online", "work_id" => "hardcover:1", "score" => 90 } ]
+    )
+    assert_equal "book:#{book.id}", detection.default_selection
+  end
+
+  test "default_selection falls back to the highest-scoring alternate, not new" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected", candidate_books: [
+      { "kind" => "online", "work_id" => "hardcover:1", "score" => 40 },
+      { "kind" => "online", "work_id" => "hardcover:2", "score" => 88 }
+    ])
+    assert_equal "hardcover:2", detection.best_candidate["work_id"]
+    assert_equal "work:hardcover:2", detection.default_selection
+  end
+
+  test "default_selection is new only when nothing was matched" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected")
+    assert_nil detection.best_candidate
+    assert_equal "new", detection.default_selection
+  end
+
+  test "candidate_books always reads back as an array" do
+    detection = DetectedImport.new(source_path: "/x", status: "detected")
+    assert_equal [], detection.candidate_books
+
+    detection.candidate_books = [ { "kind" => "library", "book_id" => 1 } ]
+    assert_equal 1, detection.candidate_books.size
+  end
+
+  test "display_title falls back to the source basename" do
+    detection = DetectedImport.new(source_path: "/data/torrents/shelfarr/Some Book.epub")
+    assert_equal "Some Book.epub", detection.display_title
+
+    detection.parsed_title = "Some Book"
+    assert_equal "Some Book", detection.display_title
+  end
+
+  test "pending_review excludes dismissed and imported" do
+    detected = DetectedImport.create!(source_path: "/a", status: "detected")
+    failed = DetectedImport.create!(source_path: "/b", status: "failed")
+    DetectedImport.create!(source_path: "/c", status: "dismissed")
+    DetectedImport.create!(source_path: "/d", status: "imported")
+
+    ids = DetectedImport.pending_review.pluck(:id)
+    assert_includes ids, detected.id
+    assert_includes ids, failed.id
+    assert_equal 2, ids.size
+  end
+end

--- a/test/models/detected_import_test.rb
+++ b/test/models/detected_import_test.rb
@@ -96,4 +96,73 @@ class DetectedImportTest < ActiveSupport::TestCase
     assert_includes ids, failed.id
     assert_equal 2, ids.size
   end
+
+  test "dismiss_for_imported_source! retires the folder detection above an imported file" do
+    root = Dir.mktmpdir("di-dismiss")
+    SettingsService.set(:library_import_path, root)
+    release = File.join(File.realpath(root), "Some Audiobook")
+    FileUtils.mkdir_p(release)
+
+    # The scanner records an audiobook release as its folder, so the detection
+    # sits above the track the importer actually took.
+    enclosing = DetectedImport.create!(source_path: release, status: "detected", book_type: "audiobook")
+    sibling = DetectedImport.create!(
+      source_path: File.join(File.realpath(root), "Other Audiobook"), status: "detected"
+    )
+    already_imported = DetectedImport.create!(source_path: release, status: "imported")
+
+    dismissed = DetectedImport.dismiss_for_imported_source!(File.join(release, "track01.mp3"))
+
+    assert_equal 1, dismissed
+    assert_equal "dismissed", enclosing.reload.status
+    assert_equal "detected", sibling.reload.status
+    assert_equal "imported", already_imported.reload.status,
+      "only actionable rows are retired — an imported row records where the file came from"
+  ensure
+    FileUtils.rm_rf(root) if root
+  end
+
+  test "dismiss_for_imported_source! retires the detections inside an imported folder" do
+    root = Dir.mktmpdir("di-dismiss-nested")
+    SettingsService.set(:library_import_path, root)
+    release = File.join(File.realpath(root), "Some Release")
+    FileUtils.mkdir_p(release)
+
+    itself = DetectedImport.create!(source_path: release, status: "detected", book_type: "audiobook")
+    nested = DetectedImport.create!(
+      source_path: File.join(release, "bonus.epub"), status: "failed", book_type: "ebook"
+    )
+
+    assert_equal 2, DetectedImport.dismiss_for_imported_source!(release)
+    assert_equal "dismissed", itself.reload.status
+    assert_equal "dismissed", nested.reload.status
+  ensure
+    FileUtils.rm_rf(root) if root
+  end
+
+  test "dismiss_for_imported_source! does nothing without a source path" do
+    detection = DetectedImport.create!(source_path: "/watched/book.epub", status: "detected")
+
+    assert_equal 0, DetectedImport.dismiss_for_imported_source!(nil)
+    assert_equal 0, DetectedImport.dismiss_for_imported_source!("")
+    assert_equal "detected", detection.reload.status
+  end
+
+  test "dismiss_for_imported_source! escapes LIKE wildcards in the imported path" do
+    root = Dir.mktmpdir("di-wildcard")
+    SettingsService.set(:library_import_path, root)
+    canonical = File.realpath(root)
+    # "_" matches any single character in LIKE, so an unescaped prefix would
+    # sweep up the sibling release as well.
+    release = File.join(canonical, "A_Book")
+    FileUtils.mkdir_p(release)
+    decoy = DetectedImport.create!(source_path: File.join(canonical, "AxBook", "x.epub"), status: "detected")
+    target = DetectedImport.create!(source_path: File.join(release, "x.epub"), status: "detected")
+
+    assert_equal 1, DetectedImport.dismiss_for_imported_source!(release)
+    assert_equal "dismissed", target.reload.status
+    assert_equal "detected", decoy.reload.status
+  ensure
+    FileUtils.rm_rf(root) if root
+  end
 end

--- a/test/services/library_acquisition_service_test.rb
+++ b/test/services/library_acquisition_service_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
+  setup do
+    @source_dir = Dir.mktmpdir("laq-source")
+    @ebook_dest = Dir.mktmpdir("laq-ebooks")
+    @audiobook_dest = Dir.mktmpdir("laq-audiobooks")
+
+    set_setting("ebook_output_path", @ebook_dest)
+    set_setting("audiobook_output_path", @audiobook_dest)
+    set_setting("completed_download_import_mode", "copy")
+    # Keep identification offline and library scans disabled.
+    Setting.where(key: "audiobookshelf_url").destroy_all
+  end
+
+  teardown do
+    [ @source_dir, @ebook_dest, @audiobook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  test "infers book type from path" do
+    assert_equal "ebook", LibraryAcquisitionService.infer_book_type("/x/Book.epub")
+    assert_equal "comicbook", LibraryAcquisitionService.infer_book_type("/x/Book.cbz")
+    assert_equal "audiobook", LibraryAcquisitionService.infer_book_type("/x/Book.m4b")
+    assert_equal "audiobook", LibraryAcquisitionService.infer_book_type(@source_dir)
+  end
+
+  test "identify suggests an existing library book from the filename" do
+    book = Book.create!(title: "Mistborn", author: "Brandon Sanderson", book_type: :ebook)
+    source = File.join(@source_dir, "Brandon Sanderson - Mistborn.epub")
+    File.write(source, "dummy epub bytes")
+
+    identification = MetadataService.stub(:search, []) do
+      LibraryAcquisitionService.identify(source_path: source)
+    end
+
+    assert_equal "ebook", identification.book_type
+    assert_equal "Mistborn", identification.parsed_title
+    assert_equal "Brandon Sanderson", identification.parsed_author
+    assert_equal book, identification.suggested_book
+    assert identification.candidate_books.any? { |c| c["kind"] == "library" && c["book_id"] == book.id }
+  end
+
+  test "import! copies the source into the organised library and marks the book acquired" do
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    owner = DetectedImport.create!(source_path: "unused", status: "importing")
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: owner, mode: "copy"
+    )
+
+    expected_dir = File.join(@ebook_dest, "Brandon Sanderson", "Elantris")
+    expected_file = File.join(expected_dir, "Brandon Sanderson - Elantris.epub")
+    assert File.exist?(expected_file), "imported file should exist in the library"
+    assert File.exist?(source), "copy mode preserves the source"
+
+    book.reload
+    assert book.acquired?
+    assert_equal expected_dir, book.file_path
+    assert_nil book.acquisition_reservation_token
+    assert_equal "copy", result.mode
+  end
+
+  test "import! refuses a book that is already acquired" do
+    book = Book.create!(
+      title: "Warbreaker", author: "Brandon Sanderson", book_type: :ebook,
+      file_path: "/ebooks/Brandon Sanderson/Warbreaker"
+    )
+    owner = DetectedImport.create!(source_path: "unused", status: "importing")
+    source = File.join(@source_dir, "Brandon Sanderson - Warbreaker.epub")
+    File.write(source, "dummy epub bytes")
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.import!(source_path: source, book: book, owner: owner)
+    end
+  end
+
+  test "undo_import! discards the copied library file and re-queues the detection" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Elantris", parsed_author: "Brandon Sanderson"
+    )
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    LibraryAcquisitionService.undo_import!(detection)
+
+    detection.reload
+    assert_equal "detected", detection.status
+    assert_nil detection.imported_book_id
+    assert_nil detection.suggested_book_id
+    assert File.exist?(source), "copy mode leaves the watched-folder source in place"
+    assert_not File.exist?(result.destination_path), "the redundant library copy is removed"
+    assert_not Book.exists?(book.id), "the throwaway book created for the import is destroyed"
+  end
+
+  test "undo_import! restores a moved source so it can be re-imported" do
+    set_setting("completed_download_import_mode", "move")
+    source = File.join(@source_dir, "Brandon Sanderson - Warbreaker.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Warbreaker", parsed_author: "Brandon Sanderson"
+    )
+    book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :ebook)
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "move"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+    assert_not File.exist?(source), "move consumed the source"
+
+    LibraryAcquisitionService.undo_import!(detection)
+
+    assert File.exist?(source), "undo returns the moved file to the watched folder"
+    assert_not File.exist?(result.destination_path), "the library directory is cleared"
+    assert_equal "detected", detection.reload.status
+  end
+
+  test "undo_import! un-acquires but keeps a metadata-bearing matched book" do
+    source = File.join(@source_dir, "Brandon Sanderson - Mistborn.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook",
+      parsed_title: "Mistborn", parsed_author: "Brandon Sanderson"
+    )
+    book = Book.create!(
+      title: "Mistborn", author: "Brandon Sanderson", book_type: :ebook, hardcover_id: "12345"
+    )
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    LibraryAcquisitionService.undo_import!(detection)
+
+    assert Book.exists?(book.id), "a matched book with metadata is kept"
+    assert_not book.reload.acquired?, "but it is un-acquired so it can be re-imported"
+  end
+
+  test "undo_import! refuses to delete a file outside the library output root" do
+    outside = File.join(@source_dir, "not-in-library.epub")
+    File.write(outside, "dummy")
+    book = Book.create!(title: "Rogue", book_type: :ebook, file_path: outside)
+    detection = DetectedImport.create!(
+      source_path: File.join(@source_dir, "still-here.epub"), status: "imported",
+      book_type: "ebook", imported_book: book
+    )
+    File.write(detection.source_path, "dummy")
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.undo_import!(detection)
+    end
+    assert File.exist?(outside), "a path outside the library is never removed"
+    assert_equal "imported", detection.reload.status
+  end
+
+  test "search_candidates maps provider results into scored online candidates" do
+    results = [
+      MetadataService::SearchResult.new(
+        source: "hardcover", source_id: "42", title: "The Fellowship of the Ring",
+        author: "J.R.R. Tolkien", description: nil, year: 1954, cover_url: "http://x/c.jpg",
+        has_audiobook: true, has_ebook: true, series_name: nil, series_position: nil
+      )
+    ]
+
+    candidates = MetadataService.stub(:search, results) do
+      LibraryAcquisitionService.search_candidates(
+        query: "The Fellowship of the Ring Tolkien", book_type: "audiobook"
+      )
+    end
+
+    assert_equal 1, candidates.size
+    candidate = candidates.first
+    assert_equal "online", candidate["kind"]
+    assert_equal "hardcover:42", candidate["work_id"]
+    assert_equal "The Fellowship of the Ring", candidate["title"]
+    assert candidate["score"].positive?, "a matching query should score above zero"
+  end
+
+  test "search_candidates returns [] for a blank query without hitting the network" do
+    # A blank query must return early; if it did not, the (unstubbed) provider
+    # lookup would fail in the offline test environment.
+    assert_empty LibraryAcquisitionService.search_candidates(query: "   ", book_type: "ebook")
+  end
+
+  private
+
+  def set_setting(key, value)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: "string", category: "paths"
+    )
+  end
+end

--- a/test/services/library_acquisition_service_test.rb
+++ b/test/services/library_acquisition_service_test.rb
@@ -112,7 +112,7 @@ class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
     )
     book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :ebook)
     result = LibraryAcquisitionService.import!(
-      source_path: source, book: book, owner: detection, mode: "move"
+      source_path: source, book: book, owner: detection, mode: "move", source_base: @source_dir
     )
     detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
     assert_not File.exist?(source), "move consumed the source"
@@ -218,7 +218,7 @@ class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
     assert_raises LibraryAcquisitionService::AcquisitionConflictError do
       LibraryAcquisitionService.stub(:claim_file_path!, conflict) do
         LibraryAcquisitionService.import!(
-          source_path: source, book: book, owner: detection, mode: "move"
+          source_path: source, book: book, owner: detection, mode: "move", source_base: @source_dir
         )
       end
     end
@@ -229,6 +229,171 @@ class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
     assert_nil book.reload.file_path
     assert_not book.acquired?
     assert_nil detection.reload.publication_record
+  end
+
+  test "import! fails instead of committing an import it could not journal" do
+    set_setting("completed_download_import_mode", "move")
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    detection = DetectedImport.create!(source_path: source, status: "importing", book_type: "ebook")
+
+    unwritable = lambda do |*|
+      raise ActiveRecord::StatementInvalid, "journal write failed"
+    end
+
+    assert_raises ActiveRecord::StatementInvalid do
+      LibraryAcquisitionService.stub(:record_publication!, unwritable) do
+        LibraryAcquisitionService.import!(
+          source_path: source, book: book, owner: detection, mode: "move", source_base: @source_dir
+        )
+      end
+    end
+
+    assert File.exist?(source), "the move is reversed while the in-memory record is still available"
+    assert_empty Dir.glob(File.join(@ebook_dest, "**", "*.epub")),
+      "an import whose journal could not persist never keeps its library artifact"
+    assert_not book.reload.acquired?
+  end
+
+  test "undo_import! keeps the journal until the state reset commits" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook", parsed_title: "Elantris"
+    )
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy", source_base: @source_dir
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    failing = ->(*) { raise ActiveRecord::RecordInvalid.new(book) }
+    assert_raises ActiveRecord::RecordInvalid do
+      LibraryAcquisitionService.stub(:release_book_after_undo!, failing) do
+        LibraryAcquisitionService.undo_import!(detection)
+      end
+    end
+
+    detection.reload
+    assert_equal "imported", detection.status, "the transaction rolled the state back"
+    assert detection.publication_record.present?,
+      "so the journal has to survive too — without it a retried undo has nothing to work from"
+
+    # And the retry succeeds: every reversal step is idempotent, so the already
+    # removed file simply reads as absent.
+    LibraryAcquisitionService.undo_import!(detection)
+    assert_equal "detected", detection.reload.status
+    assert_nil detection.publication_record
+  end
+
+  test "undo_import! refuses to restore over a source path taken by a different file" do
+    set_setting("completed_download_import_mode", "move")
+    source = File.join(@source_dir, "Brandon Sanderson - Warbreaker.epub")
+    File.write(source, "dummy epub bytes")
+    detection = DetectedImport.create!(
+      source_path: source, status: "importing", book_type: "ebook", parsed_title: "Warbreaker"
+    )
+    book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :ebook)
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "move", source_base: @source_dir
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    # Unrelated bytes take over the pathname the move freed.
+    File.write(source, "somebody else's file")
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.undo_import!(detection)
+    end
+
+    assert_equal "somebody else's file", File.read(source), "the occupant is left alone"
+    assert File.exist?(result.destination_path),
+      "and the library keeps the only surviving copy of the imported bytes"
+    assert_equal "imported", detection.reload.status
+  end
+
+  test "undo_import! will not restore through a swapped source ancestor symlink" do
+    set_setting("completed_download_import_mode", "move")
+    release = File.join(@source_dir, "Warbreaker")
+    FileUtils.mkdir_p(release)
+    File.write(File.join(release, "01 - Chapter One.mp3"), "chapter one bytes")
+    book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :audiobook)
+    detection = DetectedImport.create!(source_path: release, status: "importing", book_type: "audiobook")
+    result = LibraryAcquisitionService.import!(
+      source_path: release, book: book, owner: detection, mode: "move", source_base: @source_dir
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+    assert_not File.exist?(release), "move consumed the source tree"
+
+    outside = Dir.mktmpdir("laq-outside-source")
+    File.symlink(outside, release)
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.undo_import!(detection)
+    end
+
+    assert_empty Dir.glob(File.join(outside, "**", "*.mp3")),
+      "the restore walks the watched-folder root through pinned descriptors, not the recorded parent"
+    assert File.exist?(File.join(result.destination_path, "01 - Chapter One.mp3")),
+      "and the library copy is kept rather than moved somewhere unreachable"
+  ensure
+    FileUtils.rm_rf(outside) if outside
+  end
+
+  test "import! reverses an interrupted publication instead of re-importing a consumed source" do
+    set_setting("completed_download_import_mode", "move")
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    detection = DetectedImport.create!(source_path: source, status: "importing", book_type: "ebook")
+
+    # Stand in for a worker killed after the journal was persisted but before
+    # the book claim. Interrupt is not a StandardError, so import!'s rollback
+    # never runs: the source stays consumed and the bytes sit in the library,
+    # exactly as a hard kill leaves them.
+    interrupted = ->(*) { raise Interrupt }
+    assert_raises Interrupt do
+      LibraryAcquisitionService.stub(:claim_file_path!, interrupted) do
+        LibraryAcquisitionService.import!(
+          source_path: source, book: book, owner: detection, mode: "move", source_base: @source_dir
+        )
+      end
+    end
+    assert_not File.exist?(source), "the interrupted attempt left the source consumed"
+    assert detection.reload.publication_record.present?, "and its journal behind"
+
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "move", source_base: @source_dir
+    )
+
+    assert File.exist?(result.destination_path), "the retry publishes from the restored source"
+    assert_not File.exist?(source), "which this second move consumes in turn"
+    assert detection.reload.source_identity.present?,
+      "the restored source's new identity is recorded so the retry can verify it"
+    assert book.reload.acquired?
+  end
+
+  test "import! resumes an interrupted attempt that already claimed the book" do
+    source = File.join(@source_dir, "Brandon Sanderson - Mistborn.epub")
+    File.write(source, "dummy epub bytes")
+    book = Book.create!(title: "Mistborn", author: "Brandon Sanderson", book_type: :ebook)
+    detection = DetectedImport.create!(source_path: source, status: "importing", book_type: "ebook")
+
+    first = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy", source_base: @source_dir
+    )
+    # The worker died before recording "imported", so the journal is still set
+    # and a redelivery runs the whole import again.
+    published = Dir.glob(File.join(@ebook_dest, "**", "*.epub"))
+
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy", source_base: @source_dir
+    )
+
+    assert_equal first.destination_path, result.destination_path
+    assert_equal published, Dir.glob(File.join(@ebook_dest, "**", "*.epub")),
+      "a completed import is handed back rather than publishing a numbered duplicate"
   end
 
   test "undo_import! leaves pre-existing files in a shared destination directory" do

--- a/test/services/library_acquisition_service_test.rb
+++ b/test/services/library_acquisition_service_test.rb
@@ -145,7 +145,7 @@ class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
     assert_not book.reload.acquired?, "but it is un-acquired so it can be re-imported"
   end
 
-  test "undo_import! refuses to delete a file outside the library output root" do
+  test "undo_import! refuses to guess when the import has no publication record" do
     outside = File.join(@source_dir, "not-in-library.epub")
     File.write(outside, "dummy")
     book = Book.create!(title: "Rogue", book_type: :ebook, file_path: outside)
@@ -158,8 +158,133 @@ class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
     assert_raises LibraryAcquisitionService::AcquisitionConflictError do
       LibraryAcquisitionService.undo_import!(detection)
     end
-    assert File.exist?(outside), "a path outside the library is never removed"
+    assert File.exist?(outside), "nothing is removed without a record of what was published"
     assert_equal "imported", detection.reload.status
+  end
+
+  test "import! in move mode consumes a whole source directory" do
+    set_setting("completed_download_import_mode", "move")
+    release = File.join(@source_dir, "Warbreaker")
+    FileUtils.mkdir_p(release)
+    File.write(File.join(release, "01 - Chapter One.mp3"), "chapter one bytes")
+    File.write(File.join(release, "02 - Chapter Two.mp3"), "chapter two bytes")
+
+    book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :audiobook)
+    detection = DetectedImport.create!(source_path: release, status: "importing", book_type: "audiobook")
+
+    result = LibraryAcquisitionService.import!(
+      source_path: release, book: book, owner: detection, mode: "move"
+    )
+
+    assert File.exist?(File.join(result.destination_path, "01 - Chapter One.mp3"))
+    assert File.exist?(File.join(result.destination_path, "02 - Chapter Two.mp3")),
+      "every file in the release is imported, not just the first"
+    assert_not File.exist?(release), "move consumes the source directory once the tree is published"
+    assert_equal 2, result.publication["files"].size
+  end
+
+  test "import! refuses a multi-file release when the output has no path template" do
+    set_setting("audiobook_path_template", "")
+    release = File.join(@source_dir, "Warbreaker")
+    FileUtils.mkdir_p(release)
+    File.write(File.join(release, "01 - Chapter One.mp3"), "chapter one bytes")
+    File.write(File.join(release, "02 - Chapter Two.mp3"), "chapter two bytes")
+    book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :audiobook)
+    detection = DetectedImport.create!(source_path: release, status: "importing", book_type: "audiobook")
+
+    assert_raises LibraryFileImporter::FlatOutputUnsupportedError do
+      LibraryAcquisitionService.import!(
+        source_path: release, book: book, owner: detection, mode: "copy"
+      )
+    end
+
+    assert_empty Dir.glob(File.join(@audiobook_dest, "*")),
+      "the tracks are never scattered loose into the output root"
+    assert_nil book.reload.file_path, "and the book never claims the root as its path"
+    assert File.exist?(File.join(release, "01 - Chapter One.mp3")), "the source is untouched"
+  end
+
+  test "import! reverses the publication when the database claim is lost" do
+    set_setting("completed_download_import_mode", "move")
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    detection = DetectedImport.create!(source_path: source, status: "importing", book_type: "ebook")
+
+    conflict = lambda do |*|
+      raise LibraryAcquisitionService::AcquisitionConflictError, "claimed by another process"
+    end
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.stub(:claim_file_path!, conflict) do
+        LibraryAcquisitionService.import!(
+          source_path: source, book: book, owner: detection, mode: "move"
+        )
+      end
+    end
+
+    assert File.exist?(source), "a lost claim returns the moved source to the watched folder"
+    assert_empty Dir.glob(File.join(@ebook_dest, "**", "*.epub")),
+      "no unclaimed artifact is left behind in the library"
+    assert_nil book.reload.file_path
+    assert_not book.acquired?
+    assert_nil detection.reload.publication_record
+  end
+
+  test "undo_import! leaves pre-existing files in a shared destination directory" do
+    release = File.join(@source_dir, "Warbreaker")
+    FileUtils.mkdir_p(release)
+    File.write(File.join(release, "01 - Chapter One.mp3"), "chapter one bytes")
+
+    book = Book.create!(title: "Warbreaker", author: "Brandon Sanderson", book_type: :audiobook)
+    detection = DetectedImport.create!(source_path: release, status: "importing", book_type: "audiobook")
+    result = LibraryAcquisitionService.import!(
+      source_path: release, book: book, owner: detection, mode: "copy"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    bystander = File.join(result.destination_path, "preexisting.txt")
+    File.write(bystander, "not ours")
+
+    LibraryAcquisitionService.undo_import!(detection)
+
+    assert File.exist?(bystander), "undo never deletes files this import did not publish"
+    assert_not File.exist?(File.join(result.destination_path, "01 - Chapter One.mp3")),
+      "the imported file itself is removed"
+    assert File.directory?(result.destination_path),
+      "a destination directory that still holds other files is kept"
+  end
+
+  test "undo_import! will not delete outside the library through a swapped ancestor symlink" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    detection = DetectedImport.create!(source_path: source, status: "importing", book_type: "ebook")
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy"
+    )
+    detection.update!(status: "imported", imported_book: result.book, suggested_book: result.book)
+
+    outside = Dir.mktmpdir("laq-outside")
+    victim = File.join(outside, "Elantris", "victim.txt")
+    FileUtils.mkdir_p(File.dirname(victim))
+    File.write(victim, "unrelated data")
+
+    author_dir = File.join(@ebook_dest, "Brandon Sanderson")
+    FileUtils.rm_rf(author_dir)
+    File.symlink(outside, author_dir)
+
+    assert_raises LibraryAcquisitionService::AcquisitionConflictError do
+      LibraryAcquisitionService.undo_import!(detection)
+    end
+
+    assert File.exist?(victim), "removal resolves through pinned no-follow descriptors, not a pathname"
+    assert_equal "imported", detection.reload.status,
+      "a reversal that could not reach the published file leaves the detection imported"
+    assert book.reload.acquired?, "and leaves the book acquired rather than stranding the artifact"
+    assert detection.publication_record.present?, "the record is kept so undo can be retried"
+  ensure
+    FileUtils.rm_rf(outside) if outside
   end
 
   test "search_candidates maps provider results into scored online candidates" do

--- a/test/services/library_acquisition_service_test.rb
+++ b/test/services/library_acquisition_service_test.rb
@@ -374,6 +374,34 @@ class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
     assert book.reload.acquired?
   end
 
+  test "import! reclaims a reservation stranded by a worker killed before the journal" do
+    source = File.join(@source_dir, "Brandon Sanderson - Elantris.epub")
+    File.write(source, "dummy epub bytes")
+    book = Book.create!(title: "Elantris", author: "Brandon Sanderson", book_type: :ebook)
+    detection = DetectedImport.create!(source_path: source, status: "importing", book_type: "ebook")
+
+    # A worker killed while copying bytes, before the journal write. Interrupt is
+    # not a StandardError, so import!'s rollback never runs and the reservation
+    # it took out is left behind with nothing to recover it.
+    assert_raises Interrupt do
+      LibraryAcquisitionService.stub(:record_publication!, ->(*) { raise Interrupt }) do
+        LibraryAcquisitionService.import!(
+          source_path: source, book: book, owner: detection, mode: "copy", source_base: @source_dir
+        )
+      end
+    end
+    assert book.reload.acquisition_blocked?, "the killed worker left its reservation behind"
+    assert_nil detection.reload.publication_record, "and no journal to recover from"
+
+    result = LibraryAcquisitionService.import!(
+      source_path: source, book: book, owner: detection, mode: "copy", source_base: @source_dir
+    )
+
+    assert book.reload.acquired?,
+      "the retry reclaims its own stranded reservation instead of failing for good"
+    assert File.exist?(result.destination_path)
+  end
+
   test "import! resumes an interrupted attempt that already claimed the book" do
     source = File.join(@source_dir, "Brandon Sanderson - Mistborn.epub")
     File.write(source, "dummy epub bytes")
@@ -483,9 +511,9 @@ class LibraryAcquisitionServiceTest < ActiveSupport::TestCase
 
   private
 
-  def set_setting(key, value)
+  def set_setting(key, value, type: "string", category: "import")
     Setting.find_or_create_by(key: key).update!(
-      value: value, value_type: "string", category: "paths"
+      value: value, value_type: type, category: category
     )
   end
 end

--- a/test/services/watched_folder_scan_service_test.rb
+++ b/test/services/watched_folder_scan_service_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WatchedFolderScanServiceTest < ActiveSupport::TestCase
+  setup do
+    @watched = Dir.mktmpdir("watched")
+    @ebook_dest = Dir.mktmpdir("wf-ebooks")
+    @audiobook_dest = Dir.mktmpdir("wf-audiobooks")
+
+    set_setting("ebook_output_path", @ebook_dest, "string", "paths")
+    set_setting("audiobook_output_path", @audiobook_dest, "string", "paths")
+    set_setting("library_import_enabled", "true", "boolean", "import")
+    set_setting("library_import_path", @watched, "string", "import")
+    Setting.where(key: "audiobookshelf_url").destroy_all
+
+    # A loose ebook file and an audiobook folder, mirroring a completed-download
+    # layout.
+    File.write(File.join(@watched, "Brandon Sanderson - Mistborn.epub"), "dummy epub")
+    audiobook_dir = File.join(@watched, "Brandon Sanderson - Elantris")
+    FileUtils.mkdir_p(audiobook_dir)
+    File.write(File.join(audiobook_dir, "track01.mp3"), "dummy audio")
+  end
+
+  teardown do
+    [ @watched, @ebook_dest, @audiobook_dest ].each { |dir| FileUtils.rm_rf(dir) if dir }
+  end
+
+  test "detects an ebook file and an audiobook folder" do
+    result = MetadataService.stub(:search, []) do
+      assert_difference "DetectedImport.count", 2 do
+        WatchedFolderScanService.scan!
+      end
+    end
+
+    assert_equal 2, result.detected
+
+    canonical = File.realpath(@watched)
+
+    ebook = DetectedImport.find_by(book_type: "ebook")
+    assert_equal File.join(canonical, "Brandon Sanderson - Mistborn.epub"), ebook.source_path
+    assert_equal "Mistborn", ebook.parsed_title
+
+    audiobook = DetectedImport.find_by(book_type: "audiobook")
+    assert_equal File.join(canonical, "Brandon Sanderson - Elantris"), audiobook.source_path
+  end
+
+  test "splits a collection folder into one audiobook per titled subfolder" do
+    collection = File.join(@watched, "Tolkien Audiobook Collection")
+    {
+      "01 The Hobbit" => 3,
+      "02 The Fellowship Of The Ring" => 4,
+      "03 The Two Towers" => 2
+    }.each do |title, tracks|
+      dir = File.join(collection, title)
+      FileUtils.mkdir_p(dir)
+      tracks.times { |i| File.write(File.join(dir, format("%<title>s - %<n>02d.mp3", title: title, n: i + 1)), "dummy audio") }
+    end
+
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+    end
+
+    canonical = File.realpath(@watched)
+    subfolders = [ "01 The Hobbit", "02 The Fellowship Of The Ring", "03 The Two Towers" ]
+
+    # One audiobook per titled subfolder, none for the collection root itself.
+    subfolders.each do |title|
+      path = File.join(canonical, "Tolkien Audiobook Collection", title)
+      assert DetectedImport.exists?(source_path: path, book_type: "audiobook"),
+        "expected a detection for #{title}"
+    end
+    assert_not DetectedImport.exists?(source_path: File.join(canonical, "Tolkien Audiobook Collection")),
+      "the collection root must not be detected as a single audiobook"
+  end
+
+  test "keeps a multi-disc audiobook folder as a single import" do
+    book = File.join(@watched, "Some Long Book")
+    [ "CD1", "CD2", "Disc 3" ].each do |disc|
+      dir = File.join(book, disc)
+      FileUtils.mkdir_p(dir)
+      File.write(File.join(dir, "track01.mp3"), "dummy audio")
+    end
+
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+    end
+
+    canonical = File.realpath(@watched)
+    assert DetectedImport.exists?(source_path: File.join(canonical, "Some Long Book"), book_type: "audiobook"),
+      "the whole multi-disc folder should be one audiobook"
+    assert_not DetectedImport.exists?(source_path: File.join(canonical, "Some Long Book", "CD1")),
+      "disc subfolders must not become separate audiobooks"
+  end
+
+  test "does not re-detect known files on a second scan" do
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+
+      assert_no_difference "DetectedImport.count" do
+        result = WatchedFolderScanService.scan!
+        assert_equal 0, result.detected
+      end
+    end
+  end
+
+  test "returns nil when scanning is disabled" do
+    set_setting("library_import_enabled", "false", "boolean", "import")
+    assert_nil WatchedFolderScanService.scan!
+  end
+
+  test "refuses a watched path that overlaps an output path" do
+    set_setting("library_import_path", @ebook_dest, "string", "import")
+    assert_nil WatchedFolderScanService.scan!
+  end
+
+  private
+
+  def set_setting(key, value, type, category)
+    Setting.find_or_create_by(key: key).update!(
+      value: value, value_type: type, category: category
+    )
+  end
+end

--- a/test/services/watched_folder_scan_service_test.rb
+++ b/test/services/watched_folder_scan_service_test.rb
@@ -8,10 +8,10 @@ class WatchedFolderScanServiceTest < ActiveSupport::TestCase
     @ebook_dest = Dir.mktmpdir("wf-ebooks")
     @audiobook_dest = Dir.mktmpdir("wf-audiobooks")
 
-    set_setting("ebook_output_path", @ebook_dest, "string", "paths")
-    set_setting("audiobook_output_path", @audiobook_dest, "string", "paths")
-    set_setting("library_import_enabled", "true", "boolean", "import")
-    set_setting("library_import_path", @watched, "string", "import")
+    set_setting("ebook_output_path", @ebook_dest, category: "paths")
+    set_setting("audiobook_output_path", @audiobook_dest, category: "paths")
+    set_setting("library_import_enabled", "true", type: "boolean")
+    set_setting("library_import_path", @watched)
     Setting.where(key: "audiobookshelf_url").destroy_all
 
     # A loose ebook file and an audiobook folder, mirroring a completed-download
@@ -108,8 +108,9 @@ class WatchedFolderScanServiceTest < ActiveSupport::TestCase
     MetadataService.stub(:search, []) do
       WatchedFolderScanService.scan!
       consumed = DetectedImport.find_by(book_type: "ebook")
-      # Stand in for a move import: the detection keeps the identity of a source
-      # that no longer exists, and the filesystem hands the pair to a new file.
+      # Stand in for a completed move import: the detection keeps the identity of
+      # the source it consumed, and the filesystem hands the pair to a new file.
+      consumed.update!(status: "imported")
       File.delete(consumed.source_path)
       replacement = File.join(File.realpath(@watched), "Brandon Sanderson - Warbreaker.epub")
       File.write(replacement, "dummy epub")
@@ -139,6 +140,65 @@ class WatchedFolderScanServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "renaming a source retires the detection left pointing at the dead path" do
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+      stale = DetectedImport.find_by(book_type: "ebook")
+      renamed = File.join(File.dirname(stale.source_path), "Mistborn (2006).epub")
+      # A rename preserves the inode, so the next scan finds the same identity
+      # under a new path and records it afresh.
+      File.rename(stale.source_path, renamed)
+
+      assert_no_difference "DetectedImport.count" do
+        WatchedFolderScanService.scan!
+      end
+
+      assert_not DetectedImport.exists?(stale.id),
+        "the row pointing at a path that no longer exists is retired, not left in the queue"
+      assert DetectedImport.exists?(source_path: renamed, status: "detected")
+    end
+  end
+
+  test "a stale detection still holding a publication journal is kept" do
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+      stale = DetectedImport.find_by(book_type: "ebook")
+      # A failed import whose reversal could not finish keeps its journal: it is
+      # the only description of the library files still to be taken back.
+      stale.update!(
+        status: "failed",
+        publication_record: { "base_path" => @ebook_dest, "mode" => "move", "files" => [] }
+      )
+      File.rename(stale.source_path, File.join(File.dirname(stale.source_path), "Mistborn (2006).epub"))
+
+      assert_difference "DetectedImport.count", 1 do
+        WatchedFolderScanService.scan!
+      end
+
+      assert DetectedImport.exists?(stale.id), "the journal outlives the dead source path"
+      assert_nil stale.reload.source_inode, "but its identity claim is released"
+    end
+  end
+
+  test "the per-scan cap counts only new candidates, so known files never wedge it" do
+    File.write(File.join(@watched, "Brandon Sanderson - Warbreaker.epub"), "dummy epub")
+
+    MetadataService.stub(:search, []) do
+      # Two of the three candidates fit under the cap; the third has to wait for
+      # the next scan, and only reaches it because the first two stop counting.
+      with_candidate_cap(2) do
+        assert_difference "DetectedImport.count", 2 do
+          WatchedFolderScanService.scan!
+        end
+
+        assert_difference "DetectedImport.count", 1 do
+          result = WatchedFolderScanService.scan!
+          assert_equal 1, result.detected
+        end
+      end
+    end
+  end
+
   test "metadata_path_for points at the audio file inside an audiobook folder" do
     release = File.join(@watched, "Brandon Sanderson - Elantris")
 
@@ -152,18 +212,38 @@ class WatchedFolderScanServiceTest < ActiveSupport::TestCase
   end
 
   test "returns nil when scanning is disabled" do
-    set_setting("library_import_enabled", "false", "boolean", "import")
+    set_setting("library_import_enabled", "false", type: "boolean")
     assert_nil WatchedFolderScanService.scan!
   end
 
   test "refuses a watched path that overlaps an output path" do
-    set_setting("library_import_path", @ebook_dest, "string", "import")
+    set_setting("library_import_path", @ebook_dest)
     assert_nil WatchedFolderScanService.scan!
+  end
+
+  test "refuses a watched path that contains an output path not created yet" do
+    set_setting("ebook_output_path", File.join(@watched, "ebooks"), category: "paths")
+
+    assert_nil WatchedFolderScanService.scan!,
+      "an output directory that only appears on the first import still overlaps"
   end
 
   private
 
-  def set_setting(key, value, type, category)
+  def with_candidate_cap(cap)
+    original = WatchedFolderScanService::MAX_CANDIDATES_PER_SCAN
+    set_candidate_cap(cap)
+    yield
+  ensure
+    set_candidate_cap(original)
+  end
+
+  def set_candidate_cap(cap)
+    WatchedFolderScanService.send(:remove_const, :MAX_CANDIDATES_PER_SCAN)
+    WatchedFolderScanService.const_set(:MAX_CANDIDATES_PER_SCAN, cap)
+  end
+
+  def set_setting(key, value, type: "string", category: "import")
     Setting.find_or_create_by(key: key).update!(
       value: value, value_type: type, category: category
     )

--- a/test/services/watched_folder_scan_service_test.rb
+++ b/test/services/watched_folder_scan_service_test.rb
@@ -104,6 +104,53 @@ class WatchedFolderScanServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "a new file that reuses a consumed inode is detected, not swallowed by the stale claim" do
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+      consumed = DetectedImport.find_by(book_type: "ebook")
+      # Stand in for a move import: the detection keeps the identity of a source
+      # that no longer exists, and the filesystem hands the pair to a new file.
+      File.delete(consumed.source_path)
+      replacement = File.join(File.realpath(@watched), "Brandon Sanderson - Warbreaker.epub")
+      File.write(replacement, "dummy epub")
+      stat = File.lstat(replacement)
+      consumed.update_columns(source_device: stat.dev, source_inode: stat.ino)
+
+      assert_difference "DetectedImport.count", 1 do
+        WatchedFolderScanService.scan!
+      end
+
+      consumed.reload
+      assert_nil consumed.source_inode, "the stale claim is released so the index is free"
+      assert DetectedImport.exists?(source_path: replacement)
+    end
+  end
+
+  test "a hardlinked second path to a live source stays known" do
+    MetadataService.stub(:search, []) do
+      WatchedFolderScanService.scan!
+      known = DetectedImport.find_by(book_type: "ebook")
+      File.link(known.source_path, File.join(@watched, "Mistborn (hardlink).epub"))
+
+      assert_no_difference "DetectedImport.count" do
+        WatchedFolderScanService.scan!
+      end
+      assert_equal known.source_inode, known.reload.source_inode
+    end
+  end
+
+  test "metadata_path_for points at the audio file inside an audiobook folder" do
+    release = File.join(@watched, "Brandon Sanderson - Elantris")
+
+    assert_equal File.join(release, "track01.mp3"), WatchedFolderScanService.metadata_path_for(release)
+  end
+
+  test "metadata_path_for returns a single file unchanged" do
+    ebook = File.join(@watched, "Brandon Sanderson - Mistborn.epub")
+
+    assert_equal ebook, WatchedFolderScanService.metadata_path_for(ebook)
+  end
+
   test "returns nil when scanning is disabled" do
     set_setting("library_import_enabled", "false", "boolean", "import")
     assert_nil WatchedFolderScanService.scan!


### PR DESCRIPTION
This adds a watched-folder import feature to allow preexisting files to be imported without uploading through shelfarr.
I needed this because i have a large amount of torrents that i wanted to import into a managed library, and since shelfarr is taking the role that both radarr and seer takes for movies but for books, that falls unto shelfarr. 

Video stack | Books stack | Role
-- | -- | --
Seerr / Jellyseerr | Shelfarr | Request + acquire (search indexers, download, deliver)
Radarr / Sonarr | (baked into Shelfarr) | Grab + import automation
Jellyfin | Audiobookshelf | Library server — organize, browse, stream/read

These are the relevant pages:

| Target Page | Relative Route / Fragment | Description |
| --- | --- | --- |
| **Imports** | `/admin/detected_imports` | Page route |
| **Settings** | `/admin/settings#Downloads:~:text=Watched%20Folder%20Import` |  *Watched Folder Import* section |

>[!Note]
>I don't speak ruby so,
>**The feature and the rest of the PR is written by Opus**

---

## Suggested reading order for the reviewer

1. **[config/routes.rb:159-171](/config/routes.rb#L159-L171)** — the routes above.
2. **[Admin::DetectedImportsController](/app/controllers/admin/detected_imports_controller.rb)** — thin actions; `index` (lazy imported-history), `import`→`apply_selection!`, `scan`, `undo`.
3. **[LibraryAcquisitionService](/app/services/library_acquisition_service.rb)** — `identify` (read-only ranking), `import!` (reserve → import → record publication → claim `file_path` → scan), and `undo_import!` / `reverse_publication!`. The heart of it.
4. **[LibraryFileImporter](/app/services/library_file_importer.rb)** — copy/move/hardlink dispatch over `FileCopyService`, plus the publication record it returns (the safety-critical bit).
5. **[WatchedFolderScanService](/app/services/watched_folder_scan_service.rb)** — the walk + candidate classification (plain / multi-disc / collection).
6. **[DetectedImport](/app/models/detected_import.rb)** + **[migration](/db/migrate/20260722120000_create_detected_imports.rb)** — statuses and the `(device, inode)` idempotency index.

---

## Summary
- add an **attended** watched-folder importer (behind a default-off `library_import_enabled` setting) that detects pre-existing book files which were not acquired through a Shelfarr request and queues them for admin review before importing — filling the gap where Shelfarr replaces both requester and acquirer but, unlike Radarr/Sonarr, can't adopt files it didn't download
- group candidates the way the download importer sees releases: a single ebook/comic file, a self-contained audiobook folder, a multi-disc book (CD/Disc subfolders collapse to one import), or a collection/box set (each titled subfolder becomes its own import)
- import approved items into the organised library using the existing `completed_download_import_mode` (copy/move/hardlink), reusing `FileCopyService`'s atomic, no-follow, TOCTOU-safe primitives; the source is never mutated except by an explicit move, and a failed import leaves it untouched
- anchor idempotency on the source `(device, inode)` pair rather than the path, so hardlink imports and re-scans never re-detect the same content
- record exactly what each import published and offer a **reversible undo**, so an item approved against the wrong match can be returned to the review queue and re-imported (see below)
- add the admin review queue (live Turbo morph-refresh, manual "Scan now" with in-progress/last-result feedback, and an expand/collapse imported-history section that lazy-loads the full history) plus a batched `import_detected` admin notification wired into the webhook/Discord event allow-list

## Reversible import (publication record + undo)

An attended importer needs an undo — the whole point of the review step is that a human can be wrong about a match, and without a way back the only remedy is hand-editing the library. Making that safe is the bulk of the code added since the first review pass.

- every import writes a **publication record** onto the detection (one additive migration, `publication_record` json) listing every file it created and every directory it brought into existence, with each entry's `(device, inode)`. It is persisted *before* the database claim, so a crash or a lost claim race is still precisely reversible: the bytes are already on disk at that point and only an exact record of them makes the rollback safe.
- undo reverses exactly those entries. A copy/hardlink import discards the redundant library artifact; a move import returns each file to the path the scanner recorded, rebuilding a moved tree as it was found. Directories are removed only if this import created them **and** they are still empty — a templated `Author/Book` directory is routinely shared with files this import does not own, so it is never deleted recursively.
- containment is structural rather than a pathname comparison: every removal walks from the output root through pinned `O_NOFOLLOW` descriptors and is gated on the recorded `(device, inode)`, so neither an ancestor swapped for a symlink nor a root that canonicalizes differently (`/var` vs `/private/var`) can redirect or block it.
- undo resets the detection and un-acquires the book **only when the reversal actually completed**. A library file that is no longer the one this import published (renamed, re-tagged, replaced) is left alone and the undo raises, rather than reporting success while stranding an artifact a re-import would then duplicate. The record is kept until that state reset commits, so a failure (or a process death) in that window still leaves something to retry from.
- returning a moved file is gated on identity at both ends. Each entry records the source `(device, inode)` taken *before* publication, so undo can tell "the original is still there" from "unrelated bytes have taken the path over" — the second is a conflict, not a licence to delete the library's only copy. The restore itself walks the recorded watched-folder root through pinned no-follow descriptors, so a source ancestor swapped for a symlink cannot redirect it.
- an import that finds a journal from an interrupted attempt reconciles it before running: a publication that already claimed the book is handed back rather than repeated, and a stranded one is reversed so the retry imports from the restored source instead of a path a move consumed.
- an import that predates publication tracking refuses to undo rather than guess which files under the templated directory were its own.
- the `(device, inode)` recorded at detection is now carried into the importer, which refuses to publish a source whose inode changed between approval and import — a path swapped in that window cannot substitute different bytes under an approved title.

Two `FileCopyService` primitives grew optional parameters to support this, both backward-compatible: `mv_noreplace` accepts a caller-supplied `source_snapshot` (so a tree import can pin one immutable snapshot for the whole release), and `remove_directory_child_if_identity` accepts `expected_entries` (so a caller that only owns an *empty* directory can pass `{}` and have the removal restore the directory untouched if anything has since been written into it). Omitting either keeps the previous behaviour.

## Design notes
- a human gates every import, so the matcher only produces a ranked suggestion (embedded metadata → filename → online) and never has to be autonomously correct — this removes the confidence-threshold policy and the risk of silently mis-tagging the library
- the import engine is a new `LibraryFileImporter` that delegates every filesystem publication to `FileCopyService`, rather than extracting the core out of `UploadProcessingJob`/`PostProcessingJob`. This leaves the most safety-critical request pipeline untouched (zero regression risk) and confines all new code to a default-off feature. Unifying both importers behind one engine is a reasonable follow-up once this is proven in CI.
- a multi-file release is refused when its book type has no path template, instead of scattering the tracks loose into the output root and claiming the root itself as `book.file_path`. `UploadZipImportFileService` already refuses the same configuration.
- ships behind `library_import_enabled` (default off) with two additive migrations (`create_detected_imports`, `add_publication_record_to_detected_imports`); existing installs are unaffected
- the one change outside the feature's own files is in `PostProcessingJob`: the scanner queues anything under the library import path, which commonly includes the download client's completed folder, so a download the scanner reached first would sit in the review queue while post-processing imports it — and approving that row afterwards would import the title twice. Those rows are now retired once the content is in the library.

## Test plan
- focused feature suites (Docker, `RAILS_ENV=test`): `DetectedImport` model, `LibraryAcquisitionService` (incl. journal-write abort, undo-transaction rollback and retry, reoccupied source path, swapped source ancestor, interrupted-publication reversal, resumed claim), scanner (incl. collection-split and multi-disc grouping, known-item skipping, symlink refusal, output-root overlap rejection, stale-inode release), scan job, import job, and controller — **69 runs, 244 assertions, 0 failures**
- full `bin/rails test` in Docker — **2961 runs, 11045 assertions, 0 failures, 0 errors**. The 10 pre-existing failures reported on the previous revision of this PR were an artifact of running the suite over a Docker-on-Windows bind mount, which lacks atomic publication (`linkat`/`renameat2(RENAME_NOREPLACE)`) and extended attributes (the environmental limitation noted in #379); copying the source into the container's overlayfs instead, the suite is clean.
- RuboCop (`--fail-level warning`) on all new/changed Ruby files — no offenses
- not covered by a unit test: the `scan_job_pending?` failed-execution exclusion. Solid Queue's tables live in a separate database that the test suite does not prepare, which is also why the identical scopes on `DownloadMonitorJob` and friends are untested.
- not run in this environment (no Ruby toolchain on the Windows host — everything above ran in the app Docker image): Brakeman, system/browser tests, coverage, and mutant. Please run the full `bin/quality push` / `bin/quality deep` gate in CI before merging.
