### PR TITLE
fix: add Bearer scheme to Hardcover API token

### DIFF
--- a/app/services/hardcover_client.rb
+++ b/app/services/hardcover_client.rb
@@ -234,7 +234,7 @@ class HardcoverClient
         f.response :json, parser_options: { symbolize_names: false }
         f.adapter Faraday.default_adapter
         f.headers["Content-Type"] = "application/json"
-        f.headers["authorization"] = api_token
+        f.headers["Authorization"] = authorization_header
         f.headers["User-Agent"] = "Shelfarr/1.0"
         f.options.timeout = 30
         f.options.open_timeout = 10
@@ -243,6 +243,11 @@ class HardcoverClient
 
     def api_token
       SettingsService.get(:hardcover_api_token)
+    end
+
+    def authorization_header
+      token = api_token.to_s.strip
+      token.match?(/\ABearer\s+/i) ? token : "Bearer #{token}"
     end
 
     def handle_response(response)

--- a/test/services/hardcover_client_test.rb
+++ b/test/services/hardcover_client_test.rb
@@ -228,6 +228,23 @@ class HardcoverClientTest < ActiveSupport::TestCase
 
     VCR.turned_off do
       stub_request(:post, HardcoverClient::BASE_URL)
+        .with(headers: { "Authorization" => "Bearer test_token" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "data" => { "me" => { "id" => 123 } } }.to_json
+        )
+
+      assert HardcoverClient.test_connection
+    end
+  end
+
+  test "test_connection preserves an existing bearer authorization scheme" do
+    SettingsService.set(:hardcover_api_token, "Bearer test_token")
+
+    VCR.turned_off do
+      stub_request(:post, HardcoverClient::BASE_URL)
+        .with(headers: { "Authorization" => "Bearer test_token" })
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },


### PR DESCRIPTION
## Summary

- send Hardcover API tokens with the required `Bearer` authorization scheme
- preserve already-prefixed tokens so existing workarounds are not double-prefixed
- assert the outgoing Authorization header for both token formats

## Root cause

Shelfarr passed the configured Hardcover token directly into the Authorization header. Hardcover expects that header to use the Bearer authentication scheme, so raw tokens copied from account settings were rejected as malformed.

## User impact

Hardcover connection tests and metadata requests now authenticate correctly when users paste the API token from Hardcover account settings.

Fixes #398

## Validation

- `bundle exec rails test test/services/hardcover_client_test.rb`
- full Rails suite: 2,892 runs, 10,797 assertions, 0 failures, 0 errors
- RuboCop and `git diff --check`
- `bin/quality commit --staged`
- `bin/quality push`
- independent adversarial `codex review --uncommitted` with no actionable findings