### PR TITLE
fix: preserve shared library permissions

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -174,14 +174,34 @@ class DownloadJob < ApplicationJob
   end
 
   def handle_direct_download_failure(download, error, message: nil)
+    library_configuration_error = direct_library_configuration_error?(error)
+    message = direct_library_failure_message if library_configuration_error
     message ||= "Direct download failed: #{error.message}"
     if error.is_a?(BookAcquisitionConflictError) ||
         error.is_a?(DirectDownloadFileService::ConflictError) ||
+        library_configuration_error ||
         transient_direct_download_error?(error)
       download.request.mark_for_attention!(message)
     else
       download.request.handle_download_failure!(download, reason: message)
     end
+  end
+
+  def direct_library_configuration_error?(error)
+    case error
+    when FileCopyService::DirectoryNotWritableError,
+         FileCopyService::UnsafeFilePermissionsError,
+         FileCopyService::AtomicPublicationUnsupportedError,
+         FileCopyService::DurabilityUnsupportedError,
+         Errno::EACCES, Errno::EPERM, Errno::EROFS, Errno::ENOSPC
+      true
+    else
+      false
+    end
+  end
+
+  def direct_library_failure_message
+    "Direct download could not write to the configured library storage"
   end
 
   def transient_direct_download_error?(error)
@@ -1497,7 +1517,12 @@ class DownloadJob < ApplicationJob
 
       Rails.logger.error "[DownloadJob] #{message}"
       Rails.logger.error error.backtrace.first(5).join("\n") if error.backtrace
-      track_request_event(download.request, "failed", download: download, message: error.message, level: :error)
+      event_message = if direct_library_configuration_error?(error)
+        direct_library_failure_message
+      else
+        error.message
+      end
+      track_request_event(download.request, "failed", download: download, message: event_message, level: :error)
       download.update!(status: :failed)
       handle_direct_download_failure(download, error, message: message)
       true

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -128,6 +128,8 @@ class PostProcessingJob < ApplicationJob
       run_completion_side_effects(request, download, book, book_path)
     rescue => e
       error_detail = "#{e.class}: #{bounded_exception_message(e)}"
+      diagnostic_path = bounded_error_path(e)
+      error_detail << " at #{diagnostic_path.inspect}" if diagnostic_path
       cause = e.cause
       if cause && !cause.equal?(e)
         error_detail << " (caused by #{cause.class}: #{bounded_exception_message(cause)})"
@@ -263,8 +265,13 @@ class PostProcessingJob < ApplicationJob
     detail = case error
     when BookAcquisitionConflictError
       bounded_exception_message(error)
+    when FileCopyService::DirectoryNotWritableError
+      location = safe_attention_library_path(error)
+      "Shelfarr cannot write to #{location || "the configured library directory"}"
     when FileCopyService::UnsafeFilePermissionsError
-      "The library filesystem reported unsupported file or directory permissions"
+      location = safe_attention_library_path(error)
+      message = "The library filesystem reported unsupported file or directory permissions"
+      location ? "#{message} at #{location}" : message
     when FileCopyService::DurabilityUnsupportedError
       "The library filesystem cannot safely complete destructive imports because fsync is unsupported; use another filesystem or retain the download source"
     when FileCopyService::UnsafePathError
@@ -285,18 +292,44 @@ class PostProcessingJob < ApplicationJob
   end
 
   def bounded_exception_message(error)
-    raw = error.message.to_s.dup
+    bounded_diagnostic_text(error.message)
+  rescue StandardError
+    "[unavailable error detail]"
+  end
+
+  def bounded_diagnostic_text(value)
+    raw = value.to_s.dup
     raw = raw.byteslice(0, ERROR_DETAIL_INPUT_BYTE_LIMIT).to_s
     raw.force_encoding(Encoding::UTF_8) if raw.encoding == Encoding::BINARY
-    normalized = raw.encode(
+    raw.encode(
       Encoding::UTF_8,
       invalid: :replace,
       undef: :replace,
       replace: "\uFFFD"
-    )
-    normalized.squish.first(ERROR_DETAIL_CHARACTER_LIMIT)
+    ).squish.first(ERROR_DETAIL_CHARACTER_LIMIT)
+  end
+
+  def bounded_error_path(error)
+    return unless error.respond_to?(:path) && error.path.present?
+
+    bounded_diagnostic_text(error.path)
   rescue StandardError
-    "[unavailable error detail]"
+    nil
+  end
+
+  def safe_attention_library_path(error)
+    return unless error.respond_to?(:path) && error.path.present?
+    return unless error.respond_to?(:root) && error.root.present?
+
+    path = Pathname(error.path).expand_path
+    root = Pathname(error.root).expand_path
+    relative = path.relative_path_from(root)
+    return if relative.each_filename.any? { |part| part == ".." }
+    return "the configured library root" if relative.to_s == "."
+
+    "library path #{bounded_diagnostic_text(relative.to_s).inspect}"
+  rescue StandardError
+    nil
   end
 
   def safe_attention_detail(error)

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -41,7 +41,17 @@ class FileCopyService
   DARWIN_RENAME_EXCL = 0x4
   AT_REMOVEDIR = RUBY_PLATFORM.include?("darwin") ? 0x80 : 0x200
 
-  class UnsafePathError < StandardError; end
+  class UnsafePathError < StandardError
+    attr_reader :path, :root
+
+    def initialize(message = nil, path: nil, root: nil)
+      @path = path&.to_s
+      @root = root&.to_s
+      super(message)
+    end
+  end
+
+  class DirectoryNotWritableError < UnsafePathError; end
   class UnsafeFilePermissionsError < UnsafePathError; end
   class AtomicPublicationUnsupportedError < StandardError; end
   class DurabilityUnsupportedError < StandardError; end
@@ -290,12 +300,25 @@ class FileCopyService
     end
 
     # Create a destination directory relative to a trusted output root while
-    # rejecting symlinks and non-directories in every path component.
+    # rejecting symlinks and non-directories in every path component. Existing
+    # library directories are never chmodded: shared NFS/CIFS libraries may be
+    # writable through group permissions or ACLs without being owned by this
+    # process. Validate the effective ACL-backed write/traverse access instead.
+    # Explicit private modes retain the strict chmod behavior expected by their
+    # callers.
     def ensure_directory(path, root:, mode: DIRECTORY_MODE)
-      expanded_path = Pathname(path).expand_path
-      expanded_root = Pathname(root).expand_path
-      with_pinned_directory(path, root: root, create: true, mode: mode) do |directory|
-        apply_directory_mode!(directory, mode) unless expanded_path == expanded_root
+      preserve_shared_permissions = mode == DIRECTORY_MODE
+      with_pinned_directory(
+        path,
+        root: root,
+        create: true,
+        mode: mode,
+        chmod_existing: !preserve_shared_permissions,
+        chmod_created: !preserve_shared_permissions
+      ) do |directory|
+        if preserve_shared_permissions
+          verify_directory_writable!(directory, path: path, root: root)
+        end
         sync_io(directory)
       end
       path
@@ -1097,7 +1120,9 @@ class FileCopyService
           expected_mode = apply_file_mode!(
             file,
             LIBRARY_FILE_MODE,
-            accepted_modes: LIBRARY_FILE_MODES
+            accepted_modes: LIBRARY_FILE_MODES,
+            path: path,
+            root: root
           )
           file_durable = sync_io(file)
           expected_identity = file_identity(file.stat)
@@ -1168,7 +1193,9 @@ class FileCopyService
               apply_file_mode!(
                 destination,
                 LIBRARY_FILE_MODE,
-                accepted_modes: LIBRARY_FILE_MODES
+                accepted_modes: LIBRARY_FILE_MODES,
+                path: destination_path,
+                root: root
               )
             end
             file_durable = sync_io(destination)
@@ -1435,6 +1462,24 @@ class FileCopyService
       false
     end
 
+    def verify_directory_writable!(directory, path:, root:)
+      accessible = File.writable?(path) && File.executable?(path)
+      validate_current_directory_identity!(Pathname(path).expand_path, directory)
+      return true if accessible
+
+      raise DirectoryNotWritableError.new(
+        "library directory is not writable",
+        path: path,
+        root: root
+      )
+    rescue Errno::EACCES, Errno::EPERM, Errno::EROFS => error
+      raise DirectoryNotWritableError.new(
+        "library directory is not writable",
+        path: path,
+        root: root
+      ), cause: error
+    end
+
     def safe_relative_path(path)
       relative = Pathname(path.to_s)
       if relative.absolute? || relative.each_filename.any? { |part| part.in?([ ".", ".." ]) }
@@ -1443,7 +1488,7 @@ class FileCopyService
       relative
     end
 
-    def apply_file_mode!(file, requested_mode, accepted_modes:)
+    def apply_file_mode!(file, requested_mode, accepted_modes:, path: nil, root: nil)
       mode_error = nil
       begin
         native_fchmod(file.fileno, requested_mode)
@@ -1453,9 +1498,12 @@ class FileCopyService
 
       effective_mode = file.stat.mode & 0o7777
       unless effective_mode.in?(accepted_modes)
-        raise UnsafeFilePermissionsError,
+        error = UnsafeFilePermissionsError.new(
           "library filesystem did not preserve safe file permissions",
-          cause: mode_error
+          path: path,
+          root: root
+        )
+        raise error, cause: mode_error
       end
       if mode_error || effective_mode != requested_mode
         Rails.logger.warn(
@@ -1465,7 +1513,13 @@ class FileCopyService
       effective_mode
     end
 
-    def apply_directory_mode!(directory, requested_mode, accepted_modes: nil)
+    def apply_directory_mode!(
+      directory,
+      requested_mode,
+      accepted_modes: nil,
+      path: nil,
+      root: nil
+    )
       accepted_modes ||= requested_mode == DIRECTORY_MODE ? LIBRARY_DIRECTORY_MODES : [ requested_mode ]
       mode_error = nil
       begin
@@ -1476,9 +1530,12 @@ class FileCopyService
 
       effective_mode = directory.stat.mode & 0o7777
       unless effective_mode.in?(accepted_modes)
-        raise UnsafeFilePermissionsError,
+        error = UnsafeFilePermissionsError.new(
           "filesystem did not preserve safe directory permissions",
-          cause: mode_error
+          path: path,
+          root: root
+        )
+        raise error, cause: mode_error
       end
       if mode_error || effective_mode != requested_mode
         Rails.logger.warn(
@@ -1516,7 +1573,13 @@ class FileCopyService
             lock_identity = file_identity(lock.stat)
             raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
 
-            apply_file_mode!(lock, 0o600, accepted_modes: LIBRARY_FILE_MODES)
+            apply_file_mode!(
+              lock,
+              0o600,
+              accepted_modes: LIBRARY_FILE_MODES,
+              path: destination,
+              root: root
+            )
             sync_io(parent)
             persist_copy_lock_pending!(lock, token)
 
@@ -1524,7 +1587,13 @@ class FileCopyService
               temporary_identity = file_identity(temporary.stat)
               persist_copy_lock_identity!(lock, token, temporary_identity)
               sync_io(parent)
-              apply_file_mode!(temporary, 0o600, accepted_modes: accepted_modes)
+              apply_file_mode!(
+                temporary,
+                0o600,
+                accepted_modes: accepted_modes,
+                path: destination,
+                root: root
+              )
               if heartbeat
                 copy_source_io(source, temporary, heartbeat: heartbeat)
               else
@@ -1533,7 +1602,9 @@ class FileCopyService
               published_mode = apply_file_mode!(
                 temporary,
                 LIBRARY_FILE_MODE,
-                accepted_modes: accepted_modes
+                accepted_modes: accepted_modes,
+                path: destination,
+                root: root
               )
               published_file_durable = flush_and_sync(temporary)
               if require_durable && !published_file_durable
@@ -1567,14 +1638,16 @@ class FileCopyService
                 )
                 published_identity, published_mode, published_file_durable =
                   publish_private_child_by_copy_noreplace!(
-                  parent,
-                  temporary_basename,
-                  basename,
-                  temporary_identity,
-                  lock: lock,
-                  token: token,
-                  heartbeat: heartbeat,
-                  accepted_modes: accepted_modes
+                    parent,
+                    temporary_basename,
+                    basename,
+                    temporary_identity,
+                    lock: lock,
+                    token: token,
+                    heartbeat: heartbeat,
+                    accepted_modes: accepted_modes,
+                    path: destination,
+                    root: root
                   )
               end
               validate_published_child!(
@@ -1636,7 +1709,13 @@ class FileCopyService
             lock_identity = file_identity(lock.stat)
             raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
 
-            apply_file_mode!(lock, 0o600, accepted_modes: LIBRARY_FILE_MODES)
+            apply_file_mode!(
+              lock,
+              0o600,
+              accepted_modes: LIBRARY_FILE_MODES,
+              path: destination,
+              root: root
+            )
             sync_io(parent)
 
             validate_hardlink_source!(
@@ -1802,6 +1881,8 @@ class FileCopyService
       token:,
       heartbeat:,
       accepted_modes:,
+      path:,
+      root:,
       mode: LIBRARY_FILE_MODE
     )
       destination_identity = nil
@@ -1826,7 +1907,13 @@ class FileCopyService
           )
           with_created_regular_child(parent, destination_basename, 0o600) do |destination|
             destination_identity = file_identity(destination.stat)
-            apply_file_mode!(destination, 0o600, accepted_modes: accepted_modes)
+            apply_file_mode!(
+              destination,
+              0o600,
+              accepted_modes: accepted_modes,
+              path: path,
+              root: root
+            )
             persist_copy_lock_compatibility!(
               lock,
               token,
@@ -1842,7 +1929,13 @@ class FileCopyService
             else
               copy_source_io(source, destination)
             end
-            destination_mode = apply_file_mode!(destination, mode, accepted_modes: accepted_modes)
+            destination_mode = apply_file_mode!(
+              destination,
+              mode,
+              accepted_modes: accepted_modes,
+              path: path,
+              root: root
+            )
             destination_durable = flush_and_sync(destination)
             unless file_identity(source.stat) == temporary_identity &&
                 source.stat.size == source_size && destination.stat.size == source_size
@@ -2647,15 +2740,30 @@ class FileCopyService
       end
     end
 
-    def with_pinned_directory(path, root:, create:, mode:)
+    def with_pinned_directory(
+      path,
+      root:,
+      create:,
+      mode:,
+      chmod_existing: true,
+      chmod_created: true
+    )
       path = Pathname(path).expand_path
       expanded_root, canonical_root, relative = destination_root_and_relative(path, root)
 
       with_pinned_absolute_directory(canonical_root) do |root_directory|
         validate_current_directory_identity!(expanded_root, root_directory)
-        with_pinned_relative_directory(root_directory, relative, create: create, mode: mode) do |directory|
+        with_pinned_relative_directory(
+          root_directory,
+          relative,
+          create: create,
+          mode: mode,
+          chmod_existing: chmod_existing,
+          chmod_created: chmod_created,
+          root_path: expanded_root
+        ) do |directory, created|
           validate_current_directory_identity!(path, directory)
-          yield directory
+          yield directory, created
         end
       end
     end
@@ -2691,31 +2799,62 @@ class FileCopyService
       handles&.reverse_each { |handle| handle.close unless handle.closed? }
     end
 
-    def with_pinned_relative_directory(root, relative, create:, mode: DIRECTORY_MODE)
+    def with_pinned_relative_directory(
+      root,
+      relative,
+      create:,
+      mode: DIRECTORY_MODE,
+      chmod_existing: true,
+      chmod_created: true,
+      root_path: nil
+    )
       handles = []
       current = root
+      current_path = Pathname(root_path) if root_path
+      last_created = false
       relative.each_filename do |part|
         next if part == "."
         raise UnsafePathError, "parent traversal is not allowed" if part == ".."
 
+        current_path = current_path.join(part) if current_path
+        created = false
         begin
-          child = open_pinned_directory_child(current, part)
-        rescue Errno::ENOENT
-          raise unless create
-
           begin
-            native_mkdirat(current.fileno, part, mode)
-          rescue Errno::EEXIST
-            nil
+            child = open_pinned_directory_child(current, part)
+          rescue Errno::ENOENT
+            raise unless create
+
+            begin
+              native_mkdirat(current.fileno, part, mode)
+              created = true
+            rescue Errno::EEXIST
+              nil
+            end
+            child = open_pinned_directory_child(current, part)
+            sync_io(current)
           end
-          child = open_pinned_directory_child(current, part)
-          sync_io(current)
+          handles << child
+          current = child
+          if create && ((created && chmod_created) || (!created && chmod_existing))
+            apply_directory_mode!(
+              child,
+              mode,
+              path: current_path,
+              root: root_path
+            )
+          end
+        rescue Errno::EACCES, Errno::EPERM, Errno::EROFS => error
+          raise unless current_path && root_path
+
+          raise DirectoryNotWritableError.new(
+            "library directory is not writable",
+            path: current_path,
+            root: root_path
+          ), cause: error
         end
-        apply_directory_mode!(child, mode) if create
-        handles << child
-        current = child
+        last_created = created
       end
-      yield current
+      yield current, last_created
     ensure
       handles&.reverse_each { |handle| handle.close unless handle.closed? }
     end

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -300,12 +300,13 @@ class FileCopyService
     end
 
     # Create a destination directory relative to a trusted output root while
-    # rejecting symlinks and non-directories in every path component. Existing
+    # rejecting symlinks and non-directories in every path component. Pre-existing
     # library directories are never chmodded: shared NFS/CIFS libraries may be
-    # writable through group permissions or ACLs without being owned by this
-    # process. Validate the effective ACL-backed write/traverse access instead.
-    # Explicit private modes retain the strict chmod behavior expected by their
-    # callers.
+    # libraries may be writable through group permissions or ACLs without being
+    # owned by this process. Newly created components still recover the requested
+    # access bits from a restrictive umask while retaining inherited special bits.
+    # Validate the effective ACL-backed write/traverse access afterward. Explicit
+    # private modes retain the strict chmod behavior expected by their callers.
     def ensure_directory(path, root:, mode: DIRECTORY_MODE)
       preserve_shared_permissions = mode == DIRECTORY_MODE
       with_pinned_directory(
@@ -314,7 +315,8 @@ class FileCopyService
         create: true,
         mode: mode,
         chmod_existing: !preserve_shared_permissions,
-        chmod_created: !preserve_shared_permissions
+        chmod_created: true,
+        preserve_created_special_bits: preserve_shared_permissions
       ) do |directory|
         if preserve_shared_permissions
           verify_directory_writable!(directory, path: path, root: root)
@@ -1545,6 +1547,24 @@ class FileCopyService
       effective_mode
     end
 
+    def apply_created_shared_directory_mode!(directory, requested_mode, path:, root:)
+      special_bits = directory.stat.mode & 0o7000
+      requested_access = requested_mode & 0o777
+      accepted_modes = LIBRARY_DIRECTORY_MODES.filter_map do |effective_access|
+        next unless (effective_access & requested_access) == requested_access
+
+        special_bits | effective_access
+      end
+
+      apply_directory_mode!(
+        directory,
+        special_bits | requested_access,
+        accepted_modes: accepted_modes,
+        path: path,
+        root: root
+      )
+    end
+
     def publish_source_io_noreplace(
       source,
       destination,
@@ -2746,7 +2766,8 @@ class FileCopyService
       create:,
       mode:,
       chmod_existing: true,
-      chmod_created: true
+      chmod_created: true,
+      preserve_created_special_bits: false
     )
       path = Pathname(path).expand_path
       expanded_root, canonical_root, relative = destination_root_and_relative(path, root)
@@ -2760,6 +2781,7 @@ class FileCopyService
           mode: mode,
           chmod_existing: chmod_existing,
           chmod_created: chmod_created,
+          preserve_created_special_bits: preserve_created_special_bits,
           root_path: expanded_root
         ) do |directory, created|
           validate_current_directory_identity!(path, directory)
@@ -2806,6 +2828,7 @@ class FileCopyService
       mode: DIRECTORY_MODE,
       chmod_existing: true,
       chmod_created: true,
+      preserve_created_special_bits: false,
       root_path: nil
     )
       handles = []
@@ -2836,12 +2859,21 @@ class FileCopyService
           handles << child
           current = child
           if create && ((created && chmod_created) || (!created && chmod_existing))
-            apply_directory_mode!(
-              child,
-              mode,
-              path: current_path,
-              root: root_path
-            )
+            if created && preserve_created_special_bits
+              apply_created_shared_directory_mode!(
+                child,
+                mode,
+                path: current_path,
+                root: root_path
+              )
+            else
+              apply_directory_mode!(
+                child,
+                mode,
+                path: current_path,
+                root: root_path
+              )
+            end
           end
         rescue Errno::EACCES, Errno::EPERM, Errno::EROFS => error
           raise unless current_path && root_path

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -338,6 +338,27 @@ class DownloadJobTest < ActiveJob::TestCase
     end
   end
 
+  test "does not blocklist on a direct download library configuration error" do
+    @download.update!(status: :downloading, download_type: "direct")
+    error = FileCopyService::DirectoryNotWritableError.new(
+      "library directory is not writable",
+      path: "/private/library/author/title",
+      root: "/private/library"
+    )
+
+    DownloadJob.new.send(
+      :handle_direct_download_failure,
+      @download,
+      error,
+      message: "Direct download failed at /private/library/author/title"
+    )
+
+    assert @request.reload.attention_needed?
+    assert_not @selected_result.reload.blocklisted?
+    assert_includes @request.issue_description, "configured library storage"
+    refute_includes @request.issue_description, "/private/library"
+  end
+
   test "does not blocklist on LibriVox direct audiobook transient download error" do
     Dir.mktmpdir do |dir|
       setup_librivox_download(output_path: dir)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -1378,6 +1378,55 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal 0o755, File.stat(File.dirname(destination)).mode & 0o7777
   end
 
+  test "imports through a pre-existing shared author directory without changing its mode" do
+    destination = PathTemplateService.build_destination(@book, base_path: @temp_dest_base)
+    shared_author = File.dirname(destination)
+    FileUtils.mkdir_p(shared_author)
+    File.chmod(0o2775, shared_author)
+    shared_mode = File.stat(shared_author).mode & 0o7777
+    skip "host filesystem does not retain setgid directory modes" unless shared_mode == 0o2775
+    SettingsService.set(:audiobookshelf_url, "")
+
+    PostProcessingJob.perform_now(@download.id)
+
+    destination = File.join(destination, "audiobook.mp3")
+    assert @request.reload.completed?
+    assert_equal "test audio content", File.binread(destination)
+    assert_equal 0o2775, File.stat(shared_author).mode & 0o7777
+    assert_equal 0o750, File.stat(File.dirname(destination)).mode & 0o7777
+  end
+
+  test "non-writable shared directories report the failing relative library path" do
+    destination = PathTemplateService.build_destination(@book, base_path: @temp_dest_base)
+    FileUtils.mkdir_p(destination)
+    real_ensure = FileCopyService.method(:ensure_directory)
+    denied_access = lambda do |path, root:, mode: FileCopyService::DIRECTORY_MODE|
+      if File.expand_path(path.to_s) == File.expand_path(destination)
+        raise FileCopyService::DirectoryNotWritableError.new(
+          "library directory is not writable",
+          path: path,
+          root: root
+        )
+      end
+
+      real_ensure.call(path, root: root, mode: mode)
+    end
+    SettingsService.set(:audiobookshelf_url, "")
+
+    output = FileCopyService.stub(:ensure_directory, denied_access) do
+      capture_private_post_processing_logs do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    relative_destination = Pathname(destination).relative_path_from(Pathname(@temp_dest_base)).to_s
+    assert_includes output, "FileCopyService::DirectoryNotWritableError"
+    assert_includes output, destination
+    assert @request.reload.attention_needed?
+    assert_includes @request.issue_description, relative_destination
+    refute_includes @request.issue_description, @temp_dest_base
+  end
+
   test "unsafe synthetic directory modes preserve typed permission diagnostics" do
     SettingsService.set(:audiobookshelf_url, "")
 
@@ -1390,6 +1439,8 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_includes output, "Download ##{@download.id} failed: FileCopyService::UnsafeFilePermissionsError"
     refute_includes output, "Download ##{@download.id} failed: RuntimeError"
     assert_match(/unsupported file or directory permissions/i, @request.reload.issue_description)
+    assert_includes @request.issue_description, @book.author
+    refute_includes @request.issue_description, @temp_dest_base
   end
 
   test "nested import permission failures preserve typed diagnostics" do

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -1393,7 +1393,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.reload.completed?
     assert_equal "test audio content", File.binread(destination)
     assert_equal 0o2775, File.stat(shared_author).mode & 0o7777
-    assert_equal 0o750, File.stat(File.dirname(destination)).mode & 0o7777
+    assert_equal 0o750, File.stat(File.dirname(destination)).mode & 0o777
   end
 
   test "non-writable shared directories report the failing relative library path" do

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -143,6 +143,57 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal 0o777, File.stat(directory).mode & 0o7777
   end
 
+  test "ensure_directory restores shared access bits on every component after a restrictive umask" do
+    parent = File.join(@dest_dir, "restrictive-umask-parent")
+    directory = File.join(parent, "restrictive-umask-child")
+    previous_umask = File.umask(0o077)
+
+    begin
+      FileCopyService.ensure_directory(directory, root: @dest_dir)
+    ensure
+      File.umask(previous_umask)
+    end
+
+    assert_equal 0o750, File.stat(parent).mode & 0o777
+    assert_equal 0o750, File.stat(directory).mode & 0o777
+  end
+
+  test "ensure_directory rejects a created directory that cannot recover shared access bits" do
+    directory = File.join(@dest_dir, "unrepairable-umask-directory")
+    previous_umask = File.umask(0o077)
+
+    begin
+      error = FileCopyService.stub(:native_fchmod, ->(*) { raise Errno::EOPNOTSUPP }) do
+        assert_raises(FileCopyService::UnsafeFilePermissionsError) do
+          FileCopyService.ensure_directory(directory, root: @dest_dir)
+        end
+      end
+    ensure
+      File.umask(previous_umask)
+    end
+
+    assert_equal directory, error.path
+    assert_equal @dest_dir, error.root
+    assert_equal 0o700, File.stat(directory).mode & 0o777
+  end
+
+  test "ensure_directory retains special bits on a newly created shared directory" do
+    directory = File.join(@dest_dir, "setgid-directory")
+    real_mkdirat = FileCopyService.method(:native_mkdirat)
+    setgid_mkdirat = lambda do |directory_fd, basename, mode|
+      result = real_mkdirat.call(directory_fd, basename, mode)
+      parent_path = synthetic_mode_descriptor_path(directory_fd)
+      File.chmod(0o2700, File.join(parent_path, basename))
+      result
+    end
+
+    FileCopyService.stub(:native_mkdirat, setgid_mkdirat) do
+      FileCopyService.ensure_directory(directory, root: @dest_dir)
+    end
+
+    assert_equal 0o2750, File.stat(directory).mode & 0o7777
+  end
+
   test "ensure_directory does not chmod pre-existing shared directories" do
     shared_parent = File.join(@dest_dir, "shared-author")
     directory = File.join(shared_parent, "existing-title")
@@ -251,7 +302,12 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     directory = File.join(@dest_dir, "cifs-directory")
     destination = File.join(directory, "cifs-file.txt")
 
-    with_synthetic_library_modes(root: @dest_dir, file_mode: 0o775, directory_mode: 0o775) do
+    with_synthetic_library_modes(
+      root: @dest_dir,
+      file_mode: 0o775,
+      directory_mode: 0o775,
+      fchmod_error: Errno::EOPNOTSUPP
+    ) do
       FileCopyService.ensure_directory(directory, root: @dest_dir)
       without_atomic_file_publication do
         FileCopyService.cp_noreplace(

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -143,6 +143,131 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal 0o777, File.stat(directory).mode & 0o7777
   end
 
+  test "ensure_directory does not chmod pre-existing shared directories" do
+    shared_parent = File.join(@dest_dir, "shared-author")
+    directory = File.join(shared_parent, "existing-title")
+    FileUtils.mkdir_p(directory)
+    File.chmod(0o2775, shared_parent)
+    File.chmod(0o777, directory)
+    parent_mode = File.stat(shared_parent).mode & 0o7777
+    skip "host filesystem does not retain setgid directory modes" unless parent_mode == 0o2775
+
+    FileCopyService.ensure_directory(directory, root: @dest_dir)
+
+    assert_equal 0o2775, File.stat(shared_parent).mode & 0o7777
+    assert_equal 0o777, File.stat(directory).mode & 0o7777
+  end
+
+  test "ensure_directory preserves a shared parent when creating a child" do
+    shared_parent = File.join(@dest_dir, "shared-author")
+    directory = File.join(shared_parent, "new-title")
+    FileUtils.mkdir_p(shared_parent)
+    File.chmod(0o2775, shared_parent)
+    parent_mode = File.stat(shared_parent).mode & 0o7777
+    skip "host filesystem does not retain setgid directory modes" unless parent_mode == 0o2775
+
+    FileCopyService.ensure_directory(directory, root: @dest_dir)
+
+    assert_equal 0o2775, File.stat(shared_parent).mode & 0o7777
+    assert_equal 0o750, File.stat(directory).mode & 0o777
+  end
+
+  test "ensure_directory reports a path-aware error when an existing directory is not writable" do
+    directory = File.join(@dest_dir, "shared-author")
+    FileUtils.mkdir_p(directory)
+
+    error = File.stub(:writable?, ->(path) { path != directory }) do
+      assert_raises(FileCopyService::DirectoryNotWritableError) do
+        FileCopyService.ensure_directory(directory, root: @dest_dir)
+      end
+    end
+
+    assert_equal directory, error.path
+    assert_equal @dest_dir, error.root
+    assert_equal "library directory is not writable", error.message
+    refute_includes error.message, @dest_dir
+  end
+
+  test "ensure_directory checks access after creating a directory" do
+    directory = File.join(@dest_dir, "new-shared-author")
+
+    error = File.stub(:writable?, ->(path) { path != directory }) do
+      assert_raises(FileCopyService::DirectoryNotWritableError) do
+        FileCopyService.ensure_directory(directory, root: @dest_dir)
+      end
+    end
+
+    assert File.directory?(directory)
+    assert_equal directory, error.path
+    assert_equal @dest_dir, error.root
+  end
+
+  test "ensure_directory reports a path-aware creation permission error" do
+    directory = File.join(@dest_dir, "denied-directory")
+    real_mkdir = FileCopyService.method(:native_mkdirat)
+    denied_mkdir = lambda do |directory_fd, basename, mode|
+      raise Errno::EACCES, "simulated ACL denial" if basename == "denied-directory"
+
+      real_mkdir.call(directory_fd, basename, mode)
+    end
+
+    error = FileCopyService.stub(:native_mkdirat, denied_mkdir) do
+      assert_raises(FileCopyService::DirectoryNotWritableError) do
+        FileCopyService.ensure_directory(directory, root: @dest_dir)
+      end
+    end
+
+    assert_equal directory, error.path
+    assert_equal @dest_dir, error.root
+    assert_instance_of Errno::EACCES, error.cause
+  end
+
+  test "ensure_directory keeps strict chmod behavior for explicit private modes" do
+    directory = File.join(@dest_dir, "private-directory")
+    FileUtils.mkdir_p(directory)
+    File.chmod(0o755, directory)
+
+    FileCopyService.ensure_directory(directory, root: @dest_dir, mode: 0o700)
+
+    assert_equal 0o700, File.stat(directory).mode & 0o7777
+  end
+
+  test "ensure_directory ignores unrelated entries with invalid UTF-8 names" do
+    directory = File.join(@dest_dir, "shared-author")
+    FileUtils.mkdir_p(directory)
+    invalid_entry = File.join(directory.b, "invalid-\xFF".b)
+    begin
+      File.binwrite(invalid_entry, "unrelated")
+    rescue Errno::EILSEQ
+      skip "host filesystem does not accept invalid UTF-8 filenames"
+    end
+
+    FileCopyService.ensure_directory(directory, root: @dest_dir)
+
+    assert_equal "unrelated", File.binread(invalid_entry)
+  end
+
+  test "cp_noreplace supports fixed CIFS 0775 modes" do
+    directory = File.join(@dest_dir, "cifs-directory")
+    destination = File.join(directory, "cifs-file.txt")
+
+    with_synthetic_library_modes(root: @dest_dir, file_mode: 0o775, directory_mode: 0o775) do
+      FileCopyService.ensure_directory(directory, root: @dest_dir)
+      without_atomic_file_publication do
+        FileCopyService.cp_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          allow_compatibility_fallback: true
+        )
+      end
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_equal 0o775, File.stat(directory).mode & 0o7777
+    assert_equal 0o775, File.stat(destination).mode & 0o7777
+  end
+
   test "cp_noreplace supports synthetic Windows ACL modes and compatibility publication" do
     destination = File.join(@dest_dir, "windows-mode.txt")
 

--- a/test/test_helpers/synthetic_library_modes_test_helper.rb
+++ b/test/test_helpers/synthetic_library_modes_test_helper.rb
@@ -14,6 +14,15 @@ module SyntheticLibraryModesTestHelper
   )
     root = File.realpath(root)
     real_fchmod = FileCopyService.method(:native_fchmod)
+    real_mkdirat = FileCopyService.method(:native_mkdirat)
+    synthetic_mkdirat = lambda do |directory_fd, basename, requested_mode|
+      result = real_mkdirat.call(directory_fd, basename, requested_mode)
+      parent_path = synthetic_mode_descriptor_path(directory_fd)
+      if parent_path == root || parent_path.start_with?("#{root}/")
+        File.chmod(directory_mode, File.join(parent_path, basename))
+      end
+      result
+    end
     synthetic_fchmod = lambda do |descriptor, requested_mode|
       descriptor_path = synthetic_mode_descriptor_path(descriptor)
       unless descriptor_path == root || descriptor_path.start_with?("#{root}/")
@@ -25,7 +34,9 @@ module SyntheticLibraryModesTestHelper
       raise fchmod_error if fchmod_error
     end
 
-    FileCopyService.stub(:native_fchmod, synthetic_fchmod, &operation)
+    FileCopyService.stub(:native_mkdirat, synthetic_mkdirat) do
+      FileCopyService.stub(:native_fchmod, synthetic_fchmod, &operation)
+    end
   end
 
   private


### PR DESCRIPTION
## Summary

- preserve pre-existing shared library directory permissions instead of attempting to `chmod` every destination component
- restore the requested access bits on newly created library directories after a restrictive umask while retaining inherited special bits such as setgid
- validate effective ACL-backed write and traverse access without creating probe files
- retain exact `0700` enforcement for application-private staging and lock directories
- keep filesystem failures typed, attach the failing path/root as structured diagnostics, show root-relative paths to users, and keep absolute paths in private logs only
- treat direct-download library filesystem failures as configuration errors requiring attention instead of blocklisting a valid release

Closes #405.

Related to #401 and the Windows/CIFS compatibility work in #403.

## Reproduction against current `main`

The original foreign-owned `0777` failure reported in #405 is already partially mitigated by #403, but the underlying unconditional directory chmod remains. A descriptor-level harness on current `main` (`2b7adeb`) produced:

| case | current `main` | this branch |
|---|---|---|
| foreign-owned `0777`, `fchmod` returns `EPERM` | succeeds, mode remains `0777` | succeeds, mode remains `0777` |
| foreign-owned shared `2775`, `fchmod` returns `EPERM` | `UnsafeFilePermissionsError`; destination not created | succeeds, mode remains `2775` |
| owned shared `0777` | succeeds but silently changes parent to `0750` | succeeds, mode remains `0777` |

This confirms the relationship: #403 taught ordinary library paths to tolerate synthetic safe modes, while #405 exposes that Shelfarr still tries to mutate shared directory components and rejects legitimate shared modes such as setgid `2775`.

## Adversarial review findings addressed

The initial implementation used a create/remove probe to prove directory writability. Independent filesystem-security, portability, caller-regression, and test reviews found that design unsafe on the filesystems this fix targets:

- unstable WSL/CIFS inode identities could make probe cleanup fail and leave quarantine artifacts
- stale-probe cleanup scanned the entire library directory and could fail on unrelated invalid filenames
- probe cleanup had replacement races, and newly created directories skipped the check
- explicit private `0700` callers risked losing their strict chmod contract
- direct-download filesystem failures could blocklist the selected release and persist absolute paths in user-visible events
- skipping chmod for newly created shared components allowed a restrictive process umask such as `0077` to leave owner-only `0700` directory trees

The final implementation removes the probe lifecycle entirely. It performs ACL-aware write/traverse checks on every ordinary library directory, revalidates the descriptor-pinned directory identity, preserves strict private-directory behavior, wraps creation permission failures with structured path context, and sanitizes direct-download attention events. Pre-existing shared components remain untouched; newly created components recover all requested access bits, retain inherited special bits, and reject an effective owner-only mode if the filesystem cannot repair it.

## Verification

- file-copy regressions: `150 runs, 535 assertions, 0 failures, 0 errors`
- focused file-copy and job regressions: `363 runs, 1410 assertions, 0 failures, 0 errors`
- restrictive-umask coverage includes nested components, inherited setgid, unrepairable `0700`, and fixed CIFS `0775` behavior
- `bin/quality commit --staged`
- enforced pre-commit quality hook
- `bin/quality push`
- enforced pre-push quality hook (full tests, coverage, lint, and security checks)
- descriptor-level reproduction harness verified all three shared-directory cases above
