### PR TITLE
Schedule weekly calendar releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,66 @@ jobs:
           RAILS_ENV: test
         run: bin/quality push
 
+  companion:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.302
+
+      - name: Restore locked dependencies
+        working-directory: services/libation_companion
+        run: >-
+          dotnet restore
+          tests/Shelfarr.Libation.Companion.Tests/Shelfarr.Libation.Companion.Tests.csproj
+          --locked-mode
+          --nologo
+
+      - name: Verify formatting
+        working-directory: services/libation_companion
+        run: |
+          dotnet format src/Shelfarr.Libation.Companion/Shelfarr.Libation.Companion.csproj --no-restore --verify-no-changes
+          dotnet format tests/Shelfarr.Libation.Companion.Tests/Shelfarr.Libation.Companion.Tests.csproj --no-restore --verify-no-changes
+
+      - name: Run tests
+        working-directory: services/libation_companion
+        run: >-
+          dotnet test
+          tests/Shelfarr.Libation.Companion.Tests/Shelfarr.Libation.Companion.Tests.csproj
+          --configuration Release
+          --no-restore
+          --nologo
+
+      - name: Smoke test container
+        working-directory: services/libation_companion
+        run: ./tests/container-smoke.sh
+
+  container:
+    needs: [quality, companion]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build Shelfarr image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: false
+          build-args: |
+            APP_VERSION=ci
+          cache-from: type=gha,scope=shelfarr
+          cache-to: type=gha,mode=max,scope=shelfarr
+
   security:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,35 +1,95 @@
-name: Build and Push Docker Image
+name: Weekly Release
 
 on:
-  pull_request:
-  push:
-    branches: [main, dev]
+  schedule:
+    # Monday at 04:17 UTC. The off-hour minute avoids GitHub's busiest cron window.
+    - cron: "17 4 * * 1"
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   LIBATION_COMPANION_IMAGE_NAME: ${{ github.repository }}-libation
-  # github-tag-action is pinned but still declares node20. GitHub-hosted
-  # runners execute it on Node 24 during the migration; force that supported
-  # runtime now so a hidden Node 20 dependency cannot reach a release.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-# Serialize releases for the same branch. Otherwise two main commits could
-# calculate and publish the same next semantic version concurrently.
+# A manual run and the weekly run must never calculate the same calendar
+# version or move the stable image tags at the same time.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: weekly-release-main
   cancel-in-progress: false
 
 jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_release: ${{ steps.plan.outputs.should_release }}
+      previous_tag: ${{ steps.plan.outputs.previous_tag }}
+      head_sha: ${{ steps.plan.outputs.head_sha }}
+      tag: ${{ steps.plan.outputs.tag }}
+      version: ${{ steps.plan.outputs.version }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Plan release
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --tags --force
+          head_sha="$(git rev-parse HEAD)"
+          previous_tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*' HEAD 2>/dev/null || true)"
+
+          if [[ -n "${previous_tag}" ]] && git diff --quiet "${previous_tag}"..HEAD; then
+            echo "No changes since ${previous_tag}; skipping release."
+            {
+              echo "should_release=false"
+              echo "previous_tag=${previous_tag}"
+              echo "head_sha=${head_sha}"
+              echo "tag="
+              echo "version="
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          date_version="$(date -u +'%Y.%m.%d')"
+          release_number=1
+          while IFS= read -r existing_tag; do
+            suffix="${existing_tag##*.}"
+            if [[ "${suffix}" =~ ^[0-9]+$ ]] && (( suffix >= release_number )); then
+              release_number=$((suffix + 1))
+            fi
+          done < <(git tag --list "v${date_version}.*" --sort=version:refname)
+
+          version="${date_version}.${release_number}"
+          tag="v${version}"
+          {
+            echo "should_release=true"
+            echo "previous_tag=${previous_tag}"
+            echo "head_sha=${head_sha}"
+            echo "tag=${tag}"
+            echo "version=${version}"
+          } >> "${GITHUB_OUTPUT}"
+
   validate:
+    needs: [plan]
+    if: needs.plan.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Checkout planned commit
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          ref: ${{ needs.plan.outputs.head_sha }}
 
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
@@ -85,48 +145,19 @@ jobs:
         working-directory: services/libation_companion
         run: ./tests/container-smoke.sh
 
-  version:
-    needs: [validate]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      version: ${{ steps.tag.outputs.new_version }}
-      tag: ${{ steps.tag.outputs.new_tag }}
-      changelog: ${{ steps.tag.outputs.changelog }}
-    steps:
-      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-        with:
-          fetch-depth: 0
-
-      - name: Calculate the next version without publishing a tag
-        id: tag
-        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: true
-          default_bump: patch
-          release_branches: main
-          fetch_all_tags: true
-
   docker:
-    needs: [validate, version]
-    if: >-
-      ${{
-        always() &&
-        !cancelled() &&
-        needs.validate.result == 'success' &&
-        (needs.version.result == 'success' || needs.version.result == 'skipped')
-      }}
+    needs: [plan, validate]
+    if: needs.plan.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout
+      - name: Checkout planned commit
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          ref: ${{ needs.plan.outputs.head_sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -140,34 +171,31 @@ jobs:
           driver-opts: image=moby/buildkit:buildx-stable-1@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Extract Shelfarr release metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=false
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
-            type=raw,value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.version != '' }}
-            type=sha,prefix=
+            type=raw,value=${{ needs.plan.outputs.version }}
+            type=raw,value=latest
 
-      - name: Extract Libation companion metadata
+      - name: Extract Libation companion release metadata
         id: libation_meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.LIBATION_COMPANION_IMAGE_NAME }}
+          flavor: latest=false
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
-            type=raw,value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.version != '' }}
-            type=sha,prefix=
+            type=raw,value=${{ needs.plan.outputs.version }}
+            type=raw,value=latest
 
       - name: Extract immutable Shelfarr candidate metadata
         id: shelfarr_candidate_meta
@@ -175,7 +203,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=false
-          tags: type=sha,format=long,prefix=candidate-
+          tags: type=raw,value=candidate-${{ needs.plan.outputs.head_sha }}
 
       - name: Extract immutable Libation candidate metadata
         id: libation_candidate_meta
@@ -183,23 +211,21 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.LIBATION_COMPANION_IMAGE_NAME }}
           flavor: latest=false
-          tags: type=sha,format=long,prefix=candidate-
+          tags: type=raw,value=candidate-${{ needs.plan.outputs.head_sha }}
 
-      # On branch/manual builds each completed multi-architecture candidate is
-      # pushed once under its full commit SHA. Pull requests perform the same
-      # builds without pushing. Stable tags do not move until both exact
-      # candidate manifests exist in the registry.
+      # Both complete multi-architecture images are pushed under the planned
+      # commit before either stable tag moves.
       - name: Build Shelfarr candidate
         id: shelfarr_candidate
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.shelfarr_candidate_meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APP_VERSION=${{ needs.version.outputs.version || '' }}
+            APP_VERSION=${{ needs.plan.outputs.version }}
           cache-from: type=gha,scope=shelfarr
           cache-to: type=gha,mode=max,scope=shelfarr
 
@@ -209,21 +235,18 @@ jobs:
         with:
           context: ./services/libation_companion
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.libation_candidate_meta.outputs.tags }}
           labels: ${{ steps.libation_meta.outputs.labels }}
           build-args: |
-            APP_VERSION=${{ needs.version.outputs.version || '' }}
+            APP_VERSION=${{ needs.plan.outputs.version }}
           cache-from: type=gha,scope=libation-companion
           cache-to: type=gha,mode=max,scope=libation-companion
 
       # OCI registries cannot atomically update tags in two repositories. The
-      # exact paired manifests now both exist, so promote the backward-
-      # compatible companion first. If the second promotion fails, the release
-      # is not created and a retry re-promotes these immutable candidates; an
-      # application tag never advances ahead of its required companion.
+      # backward-compatible companion moves first, after both exact candidates
+      # exist. A retry safely re-promotes the same immutable commit images.
       - name: Promote exact Libation companion candidate
-        if: github.event_name != 'pull_request'
         shell: bash
         env:
           CANDIDATE_TAG: ${{ steps.libation_candidate_meta.outputs.tags }}
@@ -242,7 +265,6 @@ jobs:
           docker buildx imagetools create "${tag_arguments[@]}" "${source_reference}"
 
       - name: Promote exact Shelfarr candidate
-        if: github.event_name != 'pull_request'
         shell: bash
         env:
           CANDIDATE_TAG: ${{ steps.shelfarr_candidate_meta.outputs.tags }}
@@ -261,37 +283,64 @@ jobs:
           docker buildx imagetools create "${tag_arguments[@]}" "${source_reference}"
 
   publish-release:
-    needs: [validate, version, docker]
-    if: >-
-      ${{
-        always() &&
-        !cancelled() &&
-        github.ref == 'refs/heads/main' &&
-        needs.validate.result == 'success' &&
-        needs.version.result == 'success' &&
-        needs.docker.result == 'success' &&
-        needs.version.outputs.tag != ''
-      }}
+    needs: [plan, validate, docker]
+    if: needs.plan.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - name: Publish GitHub Release after paired images
-        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
+      - name: Checkout planned commit
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          target_commitish: ${{ github.sha }}
-          name: Release ${{ needs.version.outputs.version }}
-          body: ${{ needs.version.outputs.changelog }}
+          ref: ${{ needs.plan.outputs.head_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Create tag and GitHub release after paired images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ needs.plan.outputs.head_sha }}
+          PREVIOUS_TAG: ${{ needs.plan.outputs.previous_tag }}
+          TAG: ${{ needs.plan.outputs.tag }}
+          VERSION: ${{ needs.plan.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name="$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
+          if [[ -n "${PREVIOUS_TAG}" ]]; then
+            git log --oneline --no-decorate "${PREVIOUS_TAG}"..HEAD > release-notes.txt
+          else
+            git log --oneline --no-decorate -n 50 > release-notes.txt
+          fi
+
+          {
+            echo "Weekly or manually triggered Shelfarr release."
+            echo
+            echo "Docker images:"
+            echo "- ghcr.io/${image_name}:${VERSION}"
+            echo "- ghcr.io/${image_name}:latest"
+            echo "- ghcr.io/${image_name}-libation:${VERSION}"
+            echo "- ghcr.io/${image_name}-libation:latest"
+            echo
+            echo "Changes:"
+            sed 's/^/- /' release-notes.txt
+          } > release-body.txt
+
+          gh release create "${TAG}" \
+            --target "${HEAD_SHA}" \
+            --title "Release ${VERSION}" \
+            --notes-file release-body.txt
 
       - name: Verify release tag and release target
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ needs.version.outputs.tag }}
+          HEAD_SHA: ${{ needs.plan.outputs.head_sha }}
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
         run: |
           set -euo pipefail
           tag_commit="$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha')"
-          test "${tag_commit}" = "${GITHUB_SHA}"
+          test "${tag_commit}" = "${HEAD_SHA}"
           gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <img src="https://img.shields.io/github/license/Pedro-Revez-Silva/shelfarr" alt="License">
   </a>
   <a href="https://github.com/Pedro-Revez-Silva/shelfarr/actions/workflows/docker.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/Pedro-Revez-Silva/shelfarr/docker.yml?label=build" alt="Build Status">
+    <img src="https://img.shields.io/github/actions/workflow/status/Pedro-Revez-Silva/shelfarr/docker.yml?label=release" alt="Release Status">
   </a>
   <a href="https://github.com/Pedro-Revez-Silva/shelfarr/pkgs/container/shelfarr">
     <img src="https://img.shields.io/badge/ghcr.io-shelfarr-blue?logo=docker" alt="Docker Image">
@@ -76,7 +76,7 @@ mv docker-compose.example.yml docker-compose.yml
 #    - /path/to/ebooks → your Audiobookshelf ebooks folder
 #    - /path/to/downloads → your download client's completed folder
 #    - Optionally set SHELFARR_VERSION in .env to pin Shelfarr and its companion
-#      (use the OCI image version without the GitHub tag's leading "v")
+#      (for GitHub release vYYYY.MM.DD.N, use OCI version YYYY.MM.DD.N)
 
 # 3. Start
 docker compose up -d
@@ -99,7 +99,7 @@ Visit `http://localhost:5056` — the first user to register becomes admin.
 | `HTTP_PORT` | `80` | Internal container port. Change if port 80 is in use (e.g., behind gluetun) |
 | `RAILS_MASTER_KEY` | Auto-generated | Encryption key for secrets. Auto-generated on first run if not set |
 | `RAILS_RELATIVE_URL_ROOT` | `/` | Base path for running behind a reverse proxy at a sub-path (e.g., `/shelfarr`) |
-| `SHELFARR_VERSION` | `latest` | Pin both Shelfarr images to one OCI image version, without a leading `v` (for a GitHub release shown as `vX.Y.Z`, use `X.Y.Z`) |
+| `SHELFARR_VERSION` | `latest` | Pin both Shelfarr images to one OCI image version, without a leading `v` (for a GitHub release shown as `vYYYY.MM.DD.N`, use `YYYY.MM.DD.N`) |
 | `LIBATION_BOOKS_PATH` | Docker named volume | Optional host path for retained Audible backup copies; useful for large libraries |
 
 Audible Backup additionally requires the audiobook output filesystem to support advisory locks, hard links within that same mount, and Unix mode changes. Keep Shelfarr's `.shelfarr-staging` directory on the audiobook output filesystem and run the documented preflight before connecting Audible. mergerfs/libfuse mounts with a `umask=` mode override need a compatible underlying bind or a coordinated mount correction; do not bypass the check. See the [Audible Backup storage requirements and filesystem preflight](docs/audible-backup.md#preflight-the-audiobook-filesystem).

--- a/docs/audible-backup.md
+++ b/docs/audible-backup.md
@@ -65,10 +65,10 @@ The companion starts idle and does not contact Audible until an administrator ex
 For a reproducible deployment, put the exact published Shelfarr **OCI image version** in `.env`; the same value selects the matching companion. Use the numeric version without the GitHub release tag's leading `v`:
 
 ```dotenv
-SHELFARR_VERSION=X.Y.Z
+SHELFARR_VERSION=YYYY.MM.DD.N
 ```
 
-For example, GitHub release `vX.Y.Z` is published as container image tag `X.Y.Z`; setting `SHELFARR_VERSION=vX.Y.Z` will not select that image. Replace `X.Y.Z` with the release number you are deploying.
+For example, GitHub release `vYYYY.MM.DD.N` is published as container image tag `YYYY.MM.DD.N`; setting `SHELFARR_VERSION=vYYYY.MM.DD.N` will not select that image. Replace `YYYY.MM.DD.N` with the release number you are deploying.
 
 Normal installations should use a published release. Shelfarr publishes the application and matching companion images for releases, but pull-request builds are not published as installable image tags. Building both images from source is a contributor or release-candidate test workflow, not part of a normal update.
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -268,7 +268,7 @@
 <pre><span class="k">mkdir</span> shelfarr &amp;&amp; <span class="k">cd</span> shelfarr
 <span class="k">curl</span> -O https://raw.githubusercontent.com/Pedro-Revez-Silva/shelfarr/main/docker-compose.example.yml
 <span class="k">mv</span> docker-compose.example.yml docker-compose.yml</pre>
-          <p>Edit the left side of the three media mounts: <code>/path/to/audiobooks</code>, <code>/path/to/ebooks</code>, and <code>/path/to/downloads</code>. Optionally set <code>SHELFARR_VERSION</code> to a concrete OCI image version in <code>.env</code> so the Shelfarr and companion images remain paired. Omit the GitHub release tag's leading <code>v</code>: for a release shown as <code>vX.Y.Z</code>, use <code>X.Y.Z</code>.</p>
+          <p>Edit the left side of the three media mounts: <code>/path/to/audiobooks</code>, <code>/path/to/ebooks</code>, and <code>/path/to/downloads</code>. Optionally set <code>SHELFARR_VERSION</code> to a concrete OCI image version in <code>.env</code> so the Shelfarr and companion images remain paired. Omit the GitHub release tag's leading <code>v</code>: for a release shown as <code>vYYYY.MM.DD.N</code>, use <code>YYYY.MM.DD.N</code>.</p>
 
           <div class="callout">
             <span class="ico">📁</span>

--- a/test/config/docker_workflow_test.rb
+++ b/test/config/docker_workflow_test.rb
@@ -10,7 +10,42 @@ class DockerWorkflowTest < ActiveSupport::TestCase
       Rails.root.join(".github/workflows/docker.yml"),
       aliases: true
     )
+    @triggers = @workflow["on"] || @workflow.fetch(true)
     @jobs = @workflow.fetch("jobs")
+  end
+
+  test "release runs weekly or manually and skips main when it is unchanged" do
+    refute @triggers.key?("push")
+    refute @triggers.key?("pull_request")
+    assert @triggers.key?("workflow_dispatch")
+    assert_equal [ "17 4 * * 1" ], @triggers.fetch("schedule").pluck("cron")
+
+    plan_job = @jobs.fetch("plan")
+    checkout = plan_job.fetch("steps").find { |step| step["name"] == "Checkout main" }
+    planner = plan_job.fetch("steps").find { |step| step["name"] == "Plan release" }.fetch("run")
+
+    assert_equal "main", checkout.dig("with", "ref")
+    assert_equal "read", plan_job.dig("permissions", "contents")
+    assert_includes planner, "git diff --quiet"
+    assert_includes planner, "date -u +'%Y.%m.%d'"
+    assert_includes planner, 'version="${date_version}.${release_number}"'
+    assert_includes planner, 'git tag --list "v${date_version}.*"'
+    assert_includes planner, 'echo "should_release=false"'
+    assert_equal "weekly-release-main", @workflow.dig("concurrency", "group")
+    assert_equal false, @workflow.dig("concurrency", "cancel-in-progress")
+  end
+
+  test "calendar versioning does not derive a bump from commit messages" do
+    workflow_source = Rails.root.join(".github/workflows/docker.yml").read
+    planner = @jobs.fetch("plan").fetch("steps").find do |step|
+      step["name"] == "Plan release"
+    end.fetch("run")
+
+    refute_includes workflow_source, "github-tag-action"
+    refute_includes workflow_source, "default_bump"
+    refute_includes workflow_source, "new_version"
+    refute_includes workflow_source, "new_tag"
+    refute_includes planner, "git log"
   end
 
   test "release waits for the full validation gate and paired Docker images" do
@@ -20,21 +55,16 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert validation_commands.any? { |command| command.include?("bin/bundler-audit --update") }
 
     docker_job = @jobs.fetch("docker")
-    assert_equal %w[validate version], docker_job.fetch("needs")
-    assert_includes docker_job.fetch("if"), "always()"
-    assert_includes docker_job.fetch("if"), "needs.version.result == 'skipped'"
+    assert_equal %w[plan validate], docker_job.fetch("needs")
+    assert_includes docker_job.fetch("if"), "needs.plan.outputs.should_release == 'true'"
 
     docker_steps = docker_job.fetch("steps")
     candidate_steps = docker_steps.select { |step| step["name"]&.match?(/Build .* candidate\z/) }
     promotion_steps = docker_steps.select { |step| step["name"]&.start_with?("Promote exact ") }
     assert_equal 2, candidate_steps.size
     assert_equal 2, promotion_steps.size
-    assert candidate_steps.all? { |step|
-      step.dig("with", "push").include?("github.event_name != 'pull_request'")
-    }
-    assert promotion_steps.all? { |step|
-      step.fetch("if").include?("github.event_name != 'pull_request'")
-    }
+    assert candidate_steps.all? { |step| step.dig("with", "push") == true }
+    assert promotion_steps.none? { |step| step.key?("if") }
     assert promotion_steps.all? { |step| step.fetch("run").include?("docker buildx imagetools create") }
     assert promotion_steps.all? { |step| step.dig("env", "CANDIDATE_DIGEST").include?("outputs.digest") }
 
@@ -46,34 +76,33 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert_equal "Promote exact Shelfarr candidate", promotion_steps.last.fetch("name")
 
     release_job = @jobs.fetch("publish-release")
-    assert_equal %w[validate version docker], release_job.fetch("needs")
-    assert_includes release_job.fetch("if"), "needs.docker.result == 'success'"
-    assert release_job.fetch("steps").any? { |step|
-      step["uses"]&.start_with?("softprops/action-gh-release@")
-    }
-
-    version_step = @jobs.fetch("version").fetch("steps").find do |step|
-      step["uses"]&.start_with?("mathieudutour/github-tag-action@")
-    end
-    assert_equal true, version_step.dig("with", "dry_run")
-    assert_equal true, version_step.dig("with", "fetch_all_tags")
-    assert_equal "read", @jobs.fetch("version").dig("permissions", "contents")
-
+    assert_equal %w[plan validate docker], release_job.fetch("needs")
+    assert_equal "write", release_job.dig("permissions", "contents")
     release_step = release_job.fetch("steps").find do |step|
-      step["uses"]&.start_with?("softprops/action-gh-release@")
+      step["name"] == "Create tag and GitHub release after paired images"
     end
     tag_verification_step = release_job.fetch("steps").find do |step|
       step["name"] == "Verify release tag and release target"
     end
-    assert_equal "${{ github.sha }}", release_step.dig("with", "target_commitish")
+    assert_includes release_step.fetch("run"), 'gh release create "${TAG}"'
+    assert_includes release_step.fetch("run"), '--target "${HEAD_SHA}"'
     assert_includes tag_verification_step.fetch("run"), "git/ref/tags/${RELEASE_TAG}"
-    assert_includes tag_verification_step.fetch("run"), 'test "${tag_commit}" = "${GITHUB_SHA}"'
+    assert_includes tag_verification_step.fetch("run"), 'test "${tag_commit}" = "${HEAD_SHA}"'
     assert_includes tag_verification_step.fetch("run"), "gh release view"
-    assert_equal false, @workflow.dig("concurrency", "cancel-in-progress")
 
-    refute @jobs.fetch("version").fetch("steps").any? { |step|
+    refute @jobs.values.flat_map { |job| job.fetch("steps", []) }.any? { |step|
       step["uses"]&.start_with?("softprops/action-gh-release@")
     }
+  end
+
+  test "every release job uses the commit selected by the planner" do
+    %w[validate docker publish-release].each do |job_name|
+      checkout = @jobs.fetch(job_name).fetch("steps").find do |step|
+        step["name"] == "Checkout planned commit"
+      end
+
+      assert_equal "${{ needs.plan.outputs.head_sha }}", checkout.dig("with", "ref")
+    end
   end
 
   test "all workflow actions use immutable commit references" do
@@ -104,6 +133,24 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert commands.any? { |command| command.include?("dotnet format") && command.include?("--verify-no-changes") }
     assert commands.any? { |command| command.include?("dotnet test") && command.include?("--no-restore") }
     assert_equal "10.0.302", setup_step.dig("with", "dotnet-version")
+  end
+
+  test "pull request CI keeps companion and container validation without publishing" do
+    workflow = YAML.safe_load_file(
+      Rails.root.join(".github/workflows/ci.yml"),
+      aliases: true
+    )
+    jobs = workflow.fetch("jobs")
+    companion_commands = jobs.fetch("companion").fetch("steps").filter_map { |step| step["run"] }
+    container_build = jobs.fetch("container").fetch("steps").find do |step|
+      step["name"] == "Build Shelfarr image"
+    end
+
+    assert companion_commands.any? { |command| command.include?("dotnet restore") && command.include?("--locked-mode") }
+    assert companion_commands.any? { |command| command.include?("dotnet format") && command.include?("--verify-no-changes") }
+    assert companion_commands.any? { |command| command.include?("dotnet test") && command.include?("--no-restore") }
+    assert companion_commands.any? { |command| command.include?("container-smoke.sh") }
+    assert_equal false, container_build.dig("with", "push")
   end
 
   test "companion build inputs and upstream source are immutable" do
@@ -144,6 +191,5 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert_equal "arm64", qemu.dig("with", "platforms")
     assert_match %r{\Aimage=moby/buildkit:[^@]+@sha256:[0-9a-f]{64}\z},
       buildx.dig("with", "driver-opts")
-    assert_equal "true", @workflow.dig("env", "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24")
   end
 end

--- a/test/services/update_checker_service_test.rb
+++ b/test/services/update_checker_service_test.rb
@@ -31,6 +31,31 @@ class UpdateCheckerServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "calendar release supersedes the legacy semantic version" do
+    VCR.turned_off do
+      stub_github_release("2026.08.03.1", name: "Release 2026.08.03.1")
+
+      UpdateCheckerService.stub(:current_version, "0.39.4") do
+        result = UpdateCheckerService.check(force: true)
+
+        assert result.update_available?
+        assert_equal "2026.08.03.1", result.latest_version
+      end
+    end
+  end
+
+  test "compares calendar releases by date and release number" do
+    VCR.turned_off do
+      stub_github_release("2026.08.03.2")
+
+      UpdateCheckerService.stub(:current_version, "2026.08.03.1") do
+        result = UpdateCheckerService.check(force: true)
+
+        assert result.update_available?
+      end
+    end
+  end
+
   test "no update when versions match" do
     VCR.turned_off do
       stub_github_release("0.1.0")


### PR DESCRIPTION
## Summary

- replace per-push semantic releases with calendar versions in the form `vYYYY.MM.DD.N`
- release from `main` once per week on Monday at 04:17 UTC, or on manual dispatch
- skip scheduled/manual runs when no commits have landed since the previous release
- keep Shelfarr and Libation multi-architecture images paired and promote versioned/`latest` tags only after both candidates build
- move non-publishing companion and Shelfarr container checks into CI
- update deployment documentation and add regression coverage for calendar-version update checks

## Why

Publishing on every merge moved `latest`, created a GitHub release, and notified users for every individual change. The new cadence allows changes to settle on `main` and makes releases intentional while preserving an immediate manual release path.

Version numbers no longer depend on conventional-commit bump categories or commit-message analysis. The date and same-day release sequence are the only version inputs.

## Impact

Existing semantic image tags remain available. Deployments following `latest` update only on a weekly or manually triggered release, while pinned deployments remain unchanged. Shelfarr's update checker treats the first calendar release as newer than the existing semantic releases.

## Validation

- `bin/quality commit --staged`
- `bin/quality push`
- `actionlint`
- 25 focused tests, 172 assertions
- native Shelfarr and Libation image builds with `APP_VERSION=2026.08.03.1`
- live companion `/version` response verified as `2026.08.03.1`
- Compose resolution verified both services use the same calendar image tag
