### PR TITLE
fix: treat linkat EINVAL as unsupported on CIFS imports

### DIFF
--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -1817,8 +1817,10 @@ class FileCopyService
                 temporary_basename
               )
               temporary_identity = source_identity
+            # Include EINVAL: some network filesystems (notably CIFS) report
+            # "hardlink unsupported" that way instead of EXDEV/EOPNOTSUPP.
             rescue Errno::EXDEV, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP,
-                Errno::ENOSYS, Errno::EMLINK, Fiddle::DLError, NotImplementedError => error
+                Errno::ENOSYS, Errno::EMLINK, Errno::EINVAL, Fiddle::DLError, NotImplementedError => error
               raise HardlinkUnsupportedError,
                 "The source and destination filesystems cannot create the requested hardlink",
                 cause: error
@@ -1939,8 +1941,11 @@ class FileCopyService
         parent.fileno,
         destination_basename
       )
+    # CIFS/SMB often returns EINVAL rather than EOPNOTSUPP/ENOTSUP when
+    # hardlinks are unsupported. Treat it as "link unsupported" so the
+    # rename-based atomic publish path still runs (same as native_rename_noreplace).
     rescue Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS, Errno::EMLINK,
-        Fiddle::DLError, NotImplementedError
+        Errno::EINVAL, Fiddle::DLError, NotImplementedError
       result = native_rename_noreplace(
         parent.fileno,
         temporary_basename,

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -694,6 +694,20 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(outside_dest)
   end
 
+  test "cp_noreplace falls back to rename when same-directory linkat returns EINVAL" do
+    # CIFS/SMB often returns EINVAL for unsupported hardlinks instead of
+    # EOPNOTSUPP. Intra-directory publish must still rename into place.
+    destination = File.join(@dest_dir, "cifs-einval.txt")
+
+    FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EINVAL }) do
+      FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_equal 0o640, File.stat(destination).mode & 0o777
+    assert_empty Dir.children(@dest_dir) - [ "cifs-einval.txt" ]
+  end
+
   test "hardlink_noreplace classifies only initial unsupported link errors" do
     unsupported_errors = [
       Errno::EXDEV,
@@ -702,6 +716,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       Errno::ENOTSUP,
       Errno::ENOSYS,
       Errno::EMLINK,
+      Errno::EINVAL,
       Fiddle::DLError,
       NotImplementedError
     ]


### PR DESCRIPTION
## Summary
- On CIFS/SMB library mounts, `linkat()` returns `EINVAL` when hardlinks are unsupported. `FileCopyService#publish_private_child_noreplace!` did not rescue that errno, so every import crashed with an uncaught `Errno::EINVAL` instead of falling back to atomic rename.
- Rescue `Errno::EINVAL` in the same-directory publish path (rename fallback) and in the initial hardlink path (`HardlinkUnsupportedError`), matching how `native_rename_noreplace` and `fsync` already treat `EINVAL` in this service.
- Add regression coverage for copy publish and hardlink classification.

Closes #414

## Proof
Reproduced before the fix by stubbing `native_linkat` to raise `Errno::EINVAL` during `cp_noreplace` — crash originated at `publish_private_child_noreplace!`. After the fix the same path succeeds via rename and writes the destination file.

## Test plan
- [x] `bundle exec rails test test/services/file_copy_service_test.rb -n "/EINVAL|unsupported link|atomic publication|cp_noreplace falls back/"`
- [x] Manual reproduction: `cp_noreplace` with `native_linkat` → `EINVAL` succeeds
- [ ] Import an ebook/audiobook into a CIFS-backed library root (reporter path)

## Adversarial review
APPROVE — no critical/high issues. Residual: sibling `linkat` call sites outside `FileCopyService` can still hit the same CIFS pattern (tracked as follow-up, out of #414 scope).