### PR TITLE
test: lock OIDC login Referrer-Policy against no-referrer

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -37,6 +37,24 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='username']", count: 0
   end
 
+  # Chromium nulls Origin on full-page POST navigations when Referrer-Policy is
+  # no-referrer, which breaks Rails origin-based CSRF and the OmniAuth OIDC
+  # request phase (#381 / #416). same-origin retains Origin for that handoff
+  # while still omitting the referrer on cross-origin cover/store fetches.
+  test "login page does not use no-referrer so OIDC handoff keeps an Origin" do
+    SettingsService.set(:oidc_enabled, true)
+    SettingsService.set(:oidc_auto_redirect, true)
+    SettingsService.set(:oidc_issuer, "https://auth.example.com")
+    SettingsService.set(:oidc_client_id, "client-id")
+    SettingsService.set(:oidc_client_secret, "client-secret")
+
+    get new_session_path
+
+    assert_response :success
+    assert_equal "same-origin", response.headers["Referrer-Policy"]
+    assert_select "form[action='/auth/oidc'][method='post']"
+  end
+
   test "new shows local login form when local bypass is requested" do
     SettingsService.set(:oidc_enabled, true)
     SettingsService.set(:oidc_auto_redirect, true)


### PR DESCRIPTION
## Summary
- Issue #416 reports OIDC login failing with `InvalidAuthenticityToken` / null Origin, attributing it to `Referrer-Policy: no-referrer`.
- That regression was already fixed in #389 (ships in ≥ v0.38.2) by switching the global policy to `same-origin`. Main still has that config; the reported code snippet is stale.
- This PR adds an OIDC login-path regression test so the handoff page cannot silently return to `no-referrer`.

Closes #416 (duplicate of #381; production fix already shipped)

## Proof
- Current main config: `Referrer-Policy` is `same-origin`, not `no-referrer`.
- Login/OIDC auto-redirect response asserts `same-origin` and the `POST /auth/oidc` form.

If symptoms persist on a post-0.38.2 image, check reverse-proxy header rewrites (forcing `no-referrer`) or a stale tag—not app config.

## Test plan
- [x] `bundle exec rails test test/controllers/sessions_controller_test.rb -n "/login page does not use no-referrer|OIDC auto handoff/"`

## Adversarial review
APPROVE — no production code change required; test-only closeout is correct.