### PR TITLE
fix: clarify BookOrbit library sync and refresh after grab

### DIFF
--- a/app/jobs/audiobookshelf_library_sync_job.rb
+++ b/app/jobs/audiobookshelf_library_sync_job.rb
@@ -6,12 +6,25 @@ class AudiobookshelfLibrarySyncJob < ApplicationJob
     key: "audiobookshelf-library-sync",
     duration: 10.minutes
 
-  def perform
+  # Delay after a library-platform scan so remote indexers (BookOrbit, ABS,
+  # Grimmory) have time to discover newly imported files before we refresh
+  # Shelfarr's inventory cache used for duplicate detection.
+  POST_SCAN_REFRESH_WAIT = 90.seconds
+
+  # schedule_next: false for one-shot post-grab refreshes that must not reset
+  # the periodic sync cadence.
+  def perform(schedule_next: true)
     return unless LibraryPlatformClient.configured?
 
     AudiobookshelfLibrarySyncService.new.sync!
   ensure
-    schedule_next_run
+    schedule_next_run if schedule_next
+  end
+
+  def self.schedule_post_scan_refresh!
+    return unless LibraryPlatformClient.configured?
+
+    set(wait: POST_SCAN_REFRESH_WAIT).perform_later(schedule_next: false)
   end
 
   private

--- a/app/jobs/audiobookshelf_library_sync_job.rb
+++ b/app/jobs/audiobookshelf_library_sync_job.rb
@@ -10,6 +10,7 @@ class AudiobookshelfLibrarySyncJob < ApplicationJob
   # Grimmory) have time to discover newly imported files before we refresh
   # Shelfarr's inventory cache used for duplicate detection.
   POST_SCAN_REFRESH_WAIT = 90.seconds
+  POST_SCAN_REFRESH_CACHE_KEY = "library-platform-post-scan-refresh"
 
   # schedule_next: false for one-shot post-grab refreshes that must not reset
   # the periodic sync cadence.
@@ -21,8 +22,18 @@ class AudiobookshelfLibrarySyncJob < ApplicationJob
     schedule_next_run if schedule_next
   end
 
+  # Coalesce bulk imports: only one delayed full-inventory sync is scheduled
+  # per wait window, no matter how many files call this method.
   def self.schedule_post_scan_refresh!
     return unless LibraryPlatformClient.configured?
+
+    claimed = Rails.cache.write(
+      POST_SCAN_REFRESH_CACHE_KEY,
+      true,
+      expires_in: POST_SCAN_REFRESH_WAIT,
+      unless_exist: true
+    )
+    return unless claimed
 
     set(wait: POST_SCAN_REFRESH_WAIT).perform_later(schedule_next: false)
   end

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -1306,6 +1306,7 @@ class DownloadJob < ApplicationJob
     return unless lib_id.present?
 
     LibraryPlatformClient.scan_library(lib_id)
+    AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh!
     Rails.logger.info "[DownloadJob] Triggered #{LibraryPlatformClient.display_name} library scan for #{book.book_type}"
   rescue LibraryPlatformClient::Error => e
     Rails.logger.warn "[DownloadJob] Failed to trigger scan: #{e.message}"

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -1376,6 +1376,7 @@ class PostProcessingJob < ApplicationJob
     return unless lib_id.present?
 
     LibraryPlatformClient.scan_library(lib_id)
+    AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh!
     Rails.logger.info "[PostProcessingJob] Triggered library scan for book ##{book.id}"
   rescue LibraryPlatformClient::Error => e
     Rails.logger.warn "[PostProcessingJob] Library scan failed for book ##{book.id}: #{e.class}"

--- a/app/jobs/upload_processing_job.rb
+++ b/app/jobs/upload_processing_job.rb
@@ -981,6 +981,7 @@ class UploadProcessingJob < ApplicationJob
     return unless library_id.present?
 
     LibraryPlatformClient.scan_library(library_id)
+    AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh!
     Rails.logger.info "[UploadProcessingJob] Triggered library scan for book ##{book.id}"
   rescue LibraryPlatformClient::Error => e
     Rails.logger.warn "[UploadProcessingJob] Failed to trigger library scan (#{e.class})"

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -314,9 +314,29 @@ class SettingsService
     audiobookshelf_library_sync_interval: "Library Sync Interval"
   }.freeze
 
+  # Delivery/scan library settings keep ABS-era keys for compatibility, but the
+  # labels must name the active platform so BookOrbit/Grimmory installs are not
+  # misread as Audiobookshelf-only (#400).
+  PLATFORM_SCOPED_LIBRARY_LABEL_KEYS = %i[
+    audiobookshelf_audiobook_library_id
+    audiobookshelf_ebook_library_id
+    audiobookshelf_comicbook_library_id
+    audiobookshelf_audiobook_scan_library_ids
+    audiobookshelf_ebook_scan_library_ids
+    audiobookshelf_comicbook_scan_library_ids
+    audiobookshelf_library_sync_interval
+  ].freeze
+
   class << self
     def label_for(key)
-      LABELS.fetch(key.to_sym, key.to_s.titleize)
+      key = key.to_sym
+      base = LABELS.fetch(key, key.to_s.titleize)
+      return base unless PLATFORM_SCOPED_LIBRARY_LABEL_KEYS.include?(key)
+
+      platform = active_library_platform
+      return base if platform == "audiobookshelf"
+
+      "#{base} (#{LibraryPlatformClient.display_name(platform)})"
     end
 
     def env_override_name(key)

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -236,9 +236,14 @@
                     </div>
                   </div>
                 <% elsif category == "audiobookshelf" %>
+                  <% active_library_platform_name = LibraryPlatformClient.display_name %>
                   <div class="grid grid-cols-1 gap-2 border-t border-gray-800 pt-4">
                     <div class="space-y-2">
-                      <p class="text-sm text-gray-300 font-medium">Library Sync</p>
+                      <p class="text-sm text-gray-300 font-medium"><%= active_library_platform_name %> Library Sync</p>
+                      <p class="text-xs text-gray-500">
+                        Inventory cache for duplicate detection against <%= active_library_platform_name %>.
+                        This is separate from Shelfarr&apos;s own Library page (books imported by Shelfarr).
+                      </p>
                       <% if @audiobookshelf_library_items_count.to_i > 0 %>
                         <p class="text-xs text-gray-500">
                           Cached items: <%= @audiobookshelf_library_items_count %> ·
@@ -251,7 +256,7 @@
                           No cached items yet. Run a sync to populate.
                         </p>
                       <% end %>
-                      <%= link_to "Sync Library Platform", sync_audiobookshelf_library_admin_settings_path, data: { turbo_method: :post }, class: "inline-block rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm cursor-pointer" %>
+                      <%= link_to "Sync #{active_library_platform_name} Inventory", sync_audiobookshelf_library_admin_settings_path, data: { turbo_method: :post }, class: "inline-block rounded-md px-4 py-2 bg-blue-700 hover:bg-blue-600 text-white text-sm cursor-pointer" %>
                     </div>
                     <div>
                       <% if @audiobookshelf_library_items.any? %>

--- a/app/views/search/_result_card.html.erb
+++ b/app/views/search/_result_card.html.erb
@@ -115,7 +115,7 @@
       <p class="mt-1 truncate text-xs text-gray-500"><%= result.series_name %></p>
     <% end %>
     <% if audiobookshelf_matches.any? %>
-      <p class="mt-2 border-t border-gray-800 pt-2 text-[11px] text-amber-300">Related titles in your library</p>
+      <p class="mt-2 border-t border-gray-800 pt-2 text-[11px] text-amber-300">Related titles in <%= LibraryPlatformClient.display_name %></p>
       <ul class="mt-2 space-y-1">
         <% audiobookshelf_matches.each do |match| %>
           <li class="flex items-start justify-between gap-2 text-[11px]">

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -429,6 +429,8 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index shows neutral and brand-correct library platform labels" do
+    SettingsService.set(:library_platform, "audiobookshelf")
+
     get admin_settings_url
 
     assert_response :success
@@ -449,8 +451,27 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "label[for='settings_audiobookshelf_ebook_scan_library_ids']", text: "Additional Ebook Libraries to Scan"
     assert_select "label[for='settings_audiobookshelf_comicbook_scan_library_ids']", text: "Additional Comics & Manga Libraries to Scan"
     assert_select "label[for='settings_audiobookshelf_library_sync_interval']", text: "Library Sync Interval"
+    assert_match(/Audiobookshelf Library Sync/, @response.body)
     assert_no_match /Bookorbit/, @response.body
     assert_no_match /Audiobookshelf Audiobook Library/, @response.body
+  end
+
+  test "index scopes library delivery labels and sync copy to BookOrbit" do
+    SettingsService.set(:library_platform, "bookorbit")
+    SettingsService.set(:bookorbit_url, "http://localhost:3000")
+    SettingsService.set(:bookorbit_username, "admin")
+    SettingsService.set(:bookorbit_password, "secret")
+
+    get admin_settings_url
+
+    assert_response :success
+    assert_select "label[for='settings_audiobookshelf_audiobook_library_id']", text: "Audiobook Library (BookOrbit)"
+    assert_select "label[for='settings_audiobookshelf_ebook_library_id']", text: "Ebook Library (BookOrbit)"
+    assert_select "label[for='settings_audiobookshelf_library_sync_interval']", text: "Library Sync Interval (BookOrbit)"
+    assert_match(/BookOrbit Library Sync/, @response.body)
+    assert_match(/Inventory cache for duplicate detection against BookOrbit/, @response.body)
+    assert_match(/Sync BookOrbit Inventory/, @response.body)
+    assert_match(/separate from Shelfarr/, @response.body)
   end
 
   test "index shows text input when audiobookshelf not configured" do

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -207,7 +207,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match "Related titles", response.body
-    assert_match "Related titles in your library", response.body
+    assert_match "Related titles in Audiobookshelf", response.body
     assert_match "Likely match", response.body
     assert_match "There and Back Again", response.body
     assert_match "Andy Serkis", response.body
@@ -390,7 +390,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_no_match "Related titles in your library", response.body
+    assert_no_match "Related titles in Audiobookshelf", response.body
   end
 
   test "results ignores missing audiobookshelf items" do
@@ -416,7 +416,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_no_match "Related titles in your library", response.body
+    assert_no_match "Related titles in Audiobookshelf", response.body
   end
 
   test "results renders one request action without passing formats in the URL" do

--- a/test/jobs/audiobookshelf_library_sync_job_test.rb
+++ b/test/jobs/audiobookshelf_library_sync_job_test.rb
@@ -98,12 +98,24 @@ class AudiobookshelfLibrarySyncJobTest < ActiveJob::TestCase
   test "schedule_post_scan_refresh! enqueues a delayed one-shot sync" do
     clear_enqueued_jobs
 
-    assert_enqueued_with(
-      job: AudiobookshelfLibrarySyncJob,
-      args: [ { schedule_next: false } ],
-      at: AudiobookshelfLibrarySyncJob::POST_SCAN_REFRESH_WAIT.from_now
-    ) do
-      AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh!
+    with_post_scan_refresh_cache do
+      assert_enqueued_with(
+        job: AudiobookshelfLibrarySyncJob,
+        args: [ { schedule_next: false } ],
+        at: AudiobookshelfLibrarySyncJob::POST_SCAN_REFRESH_WAIT.from_now
+      ) do
+        AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh!
+      end
+    end
+  end
+
+  test "schedule_post_scan_refresh! coalesces repeated calls into one delayed job" do
+    clear_enqueued_jobs
+
+    with_post_scan_refresh_cache do
+      assert_enqueued_jobs 1, only: AudiobookshelfLibrarySyncJob do
+        5.times { AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh! }
+      end
     end
   end
 
@@ -130,5 +142,14 @@ class AudiobookshelfLibrarySyncJobTest < ActiveJob::TestCase
     yield
   ensure
     singleton.define_method(:get, original_get)
+  end
+
+  def with_post_scan_refresh_cache
+    previous = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.clear
+    yield
+  ensure
+    Rails.cache = previous
   end
 end

--- a/test/jobs/audiobookshelf_library_sync_job_test.rb
+++ b/test/jobs/audiobookshelf_library_sync_job_test.rb
@@ -62,6 +62,63 @@ class AudiobookshelfLibrarySyncJobTest < ActiveJob::TestCase
     end
   end
 
+  test "one-shot post-scan refresh does not reschedule the periodic job" do
+    LibraryItem.destroy_all
+    clear_enqueued_jobs
+
+    VCR.turned_off do
+      stub_request(:get, "http://localhost:13378/api/libraries/lib-audio/items")
+        .with(
+          headers: { "Authorization" => "Bearer test-api-key" },
+          query: hash_including("limit" => "500", "page" => "0")
+        )
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            "results" => [
+              {
+                "id" => "ab-1",
+                "title" => "The Hobbit",
+                "author" => "J.R.R. Tolkien"
+              }
+            ],
+            "total" => 1
+          }.to_json
+        )
+
+      assert_no_enqueued_jobs(only: AudiobookshelfLibrarySyncJob) do
+        AudiobookshelfLibrarySyncJob.perform_now(schedule_next: false)
+      end
+    end
+
+    assert_equal 1, LibraryItem.count
+  end
+
+  test "schedule_post_scan_refresh! enqueues a delayed one-shot sync" do
+    clear_enqueued_jobs
+
+    assert_enqueued_with(
+      job: AudiobookshelfLibrarySyncJob,
+      args: [ { schedule_next: false } ],
+      at: AudiobookshelfLibrarySyncJob::POST_SCAN_REFRESH_WAIT.from_now
+    ) do
+      AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh!
+    end
+  end
+
+  test "schedule_post_scan_refresh! is a no-op when no platform is configured" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:audiobookshelf_api_key, "")
+    SettingsService.set(:bookorbit_url, "")
+    SettingsService.set(:grimmory_url, "")
+    clear_enqueued_jobs
+
+    assert_no_enqueued_jobs(only: AudiobookshelfLibrarySyncJob) do
+      AudiobookshelfLibrarySyncJob.schedule_post_scan_refresh!
+    end
+  end
+
   private
 
   def with_sync_interval_stub(interval)

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -2054,6 +2054,26 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_equal "Indexer Result Title", result
   end
 
+  test "trigger_library_scan schedules a delayed inventory refresh after scan" do
+    SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "audio-lib")
+    book = books(:audiobook_acquired)
+    scanned = []
+    clear_enqueued_jobs
+
+    LibraryPlatformClient.stub(:scan_library, ->(library_id) { scanned << library_id }) do
+      assert_enqueued_with(
+        job: AudiobookshelfLibrarySyncJob,
+        args: [ { schedule_next: false } ]
+      ) do
+        DownloadJob.new.send(:trigger_library_scan, book)
+      end
+    end
+
+    assert_equal [ "audio-lib" ], scanned
+  end
+
   private
 
   def setup_zlibrary_download

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -2754,6 +2754,25 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_not File.exist?(File.join(expected_dest, "Test Author - Test Audiobook.epub"))
   end
 
+  test "trigger_library_scan schedules a delayed inventory refresh after scan" do
+    SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "audio-lib")
+    scanned = []
+    clear_enqueued_jobs
+
+    LibraryPlatformClient.stub(:scan_library, ->(library_id) { scanned << library_id }) do
+      assert_enqueued_with(
+        job: AudiobookshelfLibrarySyncJob,
+        args: [ { schedule_next: false } ]
+      ) do
+        PostProcessingJob.new.send(:trigger_library_scan, @book)
+      end
+    end
+
+    assert_equal [ "audio-lib" ], scanned
+  end
+
   private
 
   def without_atomic_file_publication(&operation)

--- a/test/jobs/upload_processing_job_test.rb
+++ b/test/jobs/upload_processing_job_test.rb
@@ -1369,18 +1369,29 @@ class UploadProcessingJobTest < ActiveJob::TestCase
   end
 
   test "trigger_library_scan uses configured library and swallows client errors" do
+    SettingsService.set(:audiobookshelf_url, "http://localhost:13378")
+    SettingsService.set(:audiobookshelf_api_key, "test-api-key")
     SettingsService.set(:audiobookshelf_audiobook_library_id, "audio-lib")
     book = books(:audiobook_acquired)
     scanned = []
+    clear_enqueued_jobs
 
     LibraryPlatformClient.stub(:scan_library, ->(library_id) { scanned << library_id }) do
-      UploadProcessingJob.new.send(:trigger_library_scan, book)
+      assert_enqueued_with(
+        job: AudiobookshelfLibrarySyncJob,
+        args: [ { schedule_next: false } ]
+      ) do
+        UploadProcessingJob.new.send(:trigger_library_scan, book)
+      end
     end
 
     assert_equal [ "audio-lib" ], scanned
 
+    clear_enqueued_jobs
     LibraryPlatformClient.stub(:scan_library, ->(*) { raise LibraryPlatformClient::Error, "scan failed" }) do
-      assert_nothing_raised { UploadProcessingJob.new.send(:trigger_library_scan, book) }
+      assert_no_enqueued_jobs(only: AudiobookshelfLibrarySyncJob) do
+        assert_nothing_raised { UploadProcessingJob.new.send(:trigger_library_scan, book) }
+      end
     end
   end
 

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -341,11 +341,24 @@ class SettingsServiceTest < ActiveSupport::TestCase
   end
 
   test "label_for uses brand and neutral library platform labels" do
+    SettingsService.set(:library_platform, "audiobookshelf")
+
     assert_equal "BookOrbit URL", SettingsService.label_for(:bookorbit_url)
     assert_equal "Grimmory URL", SettingsService.label_for(:grimmory_url)
     assert_equal "Audiobook Library", SettingsService.label_for(:audiobookshelf_audiobook_library_id)
     assert_equal "Comics & Manga Library", SettingsService.label_for(:audiobookshelf_comicbook_library_id)
     assert_equal "Max Retries", SettingsService.label_for(:max_retries)
+  end
+
+  test "label_for scopes delivery library labels to the active non-ABS platform" do
+    SettingsService.set(:library_platform, "bookorbit")
+
+    assert_equal "Audiobook Library (BookOrbit)", SettingsService.label_for(:audiobookshelf_audiobook_library_id)
+    assert_equal "Ebook Library (BookOrbit)", SettingsService.label_for(:audiobookshelf_ebook_library_id)
+    assert_equal "Library Sync Interval (BookOrbit)", SettingsService.label_for(:audiobookshelf_library_sync_interval)
+
+    SettingsService.set(:library_platform, "grimmory")
+    assert_equal "Comics & Manga Library (Grimmory)", SettingsService.label_for(:audiobookshelf_comicbook_library_id)
   end
 
   test "library_id_for_book resolves separate comic library with ebook fallback" do


### PR DESCRIPTION
## Summary
- #400 reported BookOrbit inventory as “pulled” (Cached/Available counts) but not “in the library,” with Audiobookshelf-flavored labeling while BookOrbit was active.
- Inventory cache is only for duplicate detection / related titles — not Shelfarr’s Library page. Settings now name the active platform (e.g. `Audiobook Library (BookOrbit)`, `BookOrbit Library Sync`) and explain that distinction.
- After a successful post-grab/upload library platform scan, schedule a delayed one-shot inventory refresh (`schedule_next: false`, 90s) so newly imported titles enter the cache without resetting the periodic sync cadence.

Closes #400

## Proof
- Labels: with `library_platform=bookorbit`, settings show BookOrbit-scoped delivery labels and “BookOrbit Library Sync.”
- Post-grab path: `trigger_library_scan` previously only called `scan_library`; it now also enqueues `AudiobookshelfLibrarySyncJob` with `schedule_next: false`.

## Test plan
- [x] Sync job unit tests (one-shot, schedule_post_scan_refresh!, no reschedule)
- [x] Upload / download / post-processing scan → refresh enqueue
- [x] Settings labels (ABS + BookOrbit)
- [x] Search related-titles copy for Audiobookshelf

## Adversarial review
Two rounds; final **APPROVE** after fixing search assertions and grab-path coverage.