### PR TITLE
feat: add API endpoint to grab a request release

### DIFF
--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -279,6 +279,13 @@ class API::V1::RequestsController < API::V1::ApplicationController
   end
 
   def grab_search_result
+    unless @request.manual_download_allowed?
+      render json: {
+        errors: [ "Cannot grab a release while the request is completed, processing, or dispatching" ]
+      }, status: :unprocessable_entity
+      return
+    end
+
     result = @request.search_results.find(params[:search_result_id])
     @request.select_result!(result)
     render json: request_payload_with_selected_result(@request.reload)

--- a/app/controllers/api/v1/requests_controller.rb
+++ b/app/controllers/api/v1/requests_controller.rb
@@ -2,9 +2,9 @@
 
 class API::V1::RequestsController < API::V1::ApplicationController
   before_action -> { require_scope!("requests:read") }, only: [ :index, :show, :search_results ]
-  before_action -> { require_scope!("requests:write") }, only: [ :create, :destroy ]
+  before_action -> { require_scope!("requests:write") }, only: [ :create, :destroy, :grab ]
   before_action -> { require_scope!("requests:admin") }, only: [ :retry, :blocklist_and_next ]
-  before_action :set_request, only: [ :show, :destroy, :retry, :search_results, :blocklist_and_next ]
+  before_action :set_request, only: [ :show, :destroy, :retry, :search_results, :grab, :blocklist_and_next ]
 
   def index
     requests = request_scope.includes(:book, :user).order(created_at: :desc)
@@ -97,7 +97,19 @@ class API::V1::RequestsController < API::V1::ApplicationController
     }
   end
 
+  # Select a downloadable acquisition candidate and start download (Quartermaster, etc.).
+  # Body: { "search_result_id": 123 }
+  def grab
+    if params[:search_result_id].blank?
+      render json: { errors: [ "search_result_id is required" ] }, status: :unprocessable_entity
+      return
+    end
+
+    grab_search_result
+  end
+
   def blocklist_and_next
+    # Backward-compatible grab overload used before POST .../grab existed.
     if params[:search_result_id].present?
       grab_search_result
       return

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
       resources :requests, only: [ :index, :create, :show, :destroy ] do
         member do
           get :search_results
+          post :grab
           post :blocklist_and_next
           post :retry
         end

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,7 +90,7 @@ Requires `requests:write`. Selects a downloadable acquisition candidate and star
 }
 ```
 
-Returns the request payload plus `selected_result`. Clears a previous blocklist flag on that result when re-grabbing it. Returns `404` if the result is missing, and `422` if it is not downloadable or `search_result_id` is omitted.
+Returns the request payload plus `selected_result`. Clears a previous blocklist flag on that result when re-grabbing it. Returns `404` if the result is missing, and `422` if it is not downloadable, `search_result_id` is omitted, or the request is already `completed`, `processing`, or mid-dispatch (same rules as manual magnet/NZB selection).
 
 `POST /api/v1/requests/:id/blocklist_and_next`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,7 +18,7 @@ Scopes:
 
 - `search:read` - search metadata providers
 - `requests:read` - list and read visible requests
-- `requests:write` - create and cancel requests for the token user
+- `requests:write` - create, cancel, and grab a release for visible requests
 - `requests:admin` - retry requests and act across users
 - `users:write` - create users
 
@@ -79,6 +79,22 @@ Requires `requests:admin`.
 `GET /api/v1/requests/:id/search_results`
 
 Requires `requests:read`. Returns downloadable acquisition candidates in `search_results` and currently enabled, market-valid third-party purchase options in a separate `store_offers` array. The first beta provider returns DRM-free ebook offers. Store offers include normalized provider, format, DRM, market, price, product URL, and quote-time fields; they are never downloadable or auto-selected by Shelfarr.
+
+`POST /api/v1/requests/:id/grab`
+
+Requires `requests:write`. Selects a downloadable acquisition candidate and starts the download for a request the token can see (own requests for user tokens; all requests for admin/global tokens).
+
+```json
+{
+  "search_result_id": 123
+}
+```
+
+Returns the request payload plus `selected_result`. Clears a previous blocklist flag on that result when re-grabbing it. Returns `404` if the result is missing, and `422` if it is not downloadable or `search_result_id` is omitted.
+
+`POST /api/v1/requests/:id/blocklist_and_next`
+
+Requires `requests:admin`. Blocklists the currently selected release and auto-selects the next downloadable candidate. Passing `search_result_id` is still accepted as a compatibility alias for grab, but new clients should use `POST .../grab` instead (and can use `requests:write`).
 
 ## Users
 

--- a/test/controllers/api/v1/requests_controller_test.rb
+++ b/test/controllers/api/v1/requests_controller_test.rb
@@ -624,6 +624,43 @@ class API::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  test "grab rejects completed and processing requests" do
+    _token, raw = APIToken.issue!(
+      name: "Writer",
+      user: @user,
+      scopes: %w[requests:write]
+    )
+    result = search_results(:pending_result)
+
+    completed = requests(:pending_request)
+    completed.update!(status: :completed)
+    post grab_api_v1_request_path(completed),
+      headers: { "Authorization" => "Bearer #{raw}" },
+      params: { search_result_id: result.id }
+    assert_response :unprocessable_entity
+    assert_match(/completed|processing|dispatching/i, JSON.parse(response.body)["errors"].join)
+
+    processing = Request.create!(
+      book: Book.create!(title: "Processing Grab", book_type: :ebook, open_library_work_id: "OL_API_GRAB_PROC"),
+      user: @user,
+      status: :processing
+    )
+    processing_result = processing.search_results.create!(
+      guid: "test-guid-grab-processing",
+      title: "Processing release",
+      indexer: "TestIndexer",
+      magnet_url: "magnet:?xt=urn:btih:grabproc",
+      size_bytes: 1_000,
+      seeders: 5,
+      status: :pending
+    )
+    post grab_api_v1_request_path(processing),
+      headers: { "Authorization" => "Bearer #{raw}" },
+      params: { search_result_id: processing_result.id }
+    assert_response :unprocessable_entity
+    assert_no_enqueued_jobs(only: DownloadJob)
+  end
+
   test "grab does not allow writing another users request without admin scope" do
     other = users(:two)
     other_request = Request.create!(

--- a/test/controllers/api/v1/requests_controller_test.rb
+++ b/test/controllers/api/v1/requests_controller_test.rb
@@ -574,6 +574,85 @@ class API::V1::RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_includes body["issue_description"], "No suitable alternative"
   end
 
+  test "grab selects a search result with requests:write and starts download" do
+    _token, raw = APIToken.issue!(
+      name: "Writer",
+      user: @user,
+      scopes: %w[requests:write]
+    )
+    request = requests(:pending_request)
+    result = search_results(:blocklisted_result)
+
+    assert_enqueued_with(job: DownloadJob) do
+      post grab_api_v1_request_path(request),
+        headers: { "Authorization" => "Bearer #{raw}" },
+        params: { search_result_id: result.id }
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal result.id, body.dig("selected_result", "id")
+    assert_not result.reload.blocklisted?
+    assert result.selected?
+  end
+
+  test "grab requires search_result_id" do
+    _token, raw = APIToken.issue!(
+      name: "Writer",
+      user: @user,
+      scopes: %w[requests:write]
+    )
+
+    post grab_api_v1_request_path(requests(:pending_request)),
+      headers: { "Authorization" => "Bearer #{raw}" }
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "search_result_id is required"
+  end
+
+  test "grab rejects tokens that only have read scope" do
+    _token, raw = APIToken.issue!(
+      name: "Reader",
+      user: @user,
+      scopes: %w[requests:read]
+    )
+
+    post grab_api_v1_request_path(requests(:pending_request)),
+      headers: { "Authorization" => "Bearer #{raw}" },
+      params: { search_result_id: search_results(:pending_result).id }
+
+    assert_response :forbidden
+  end
+
+  test "grab does not allow writing another users request without admin scope" do
+    other = users(:two)
+    other_request = Request.create!(
+      book: Book.create!(title: "Other Book", book_type: :ebook, open_library_work_id: "OL_API_OTHER_GRAB"),
+      user: other,
+      status: :pending
+    )
+    result = other_request.search_results.create!(
+      guid: "test-guid-other-grab",
+      title: "Other release",
+      indexer: "TestIndexer",
+      magnet_url: "magnet:?xt=urn:btih:othergrab",
+      size_bytes: 1_000,
+      seeders: 5,
+      status: :pending
+    )
+    _token, raw = APIToken.issue!(
+      name: "Writer",
+      user: @user,
+      scopes: %w[requests:write]
+    )
+
+    post grab_api_v1_request_path(other_request),
+      headers: { "Authorization" => "Bearer #{raw}" },
+      params: { search_result_id: result.id }
+
+    assert_response :not_found
+  end
+
   test "blocklist_and_next can grab a specific search result and clear its blocklist" do
     _token, raw = APIToken.issue!(
       name: "Admin",


### PR DESCRIPTION
## Summary
- Quartermaster can view requests/search results but could not grab a release: selection was only reachable via `POST .../blocklist_and_next` with `search_result_id`, which requires `requests:admin`.
- Self-service tokens (`search:read`, `requests:read`, `requests:write`) therefore could not start a download from an external client.
- Adds `POST /api/v1/requests/:id/grab` with `{ "search_result_id": … }`, authorized with `requests:write` and scoped to visible requests.
- Keeps the old `blocklist_and_next` overload for compatibility; documents grab + blocklist in `docs/api.md`.

Closes #420

## Proof
- `requests:write` token on own request → grab selects result, clears blocklist, enqueues `DownloadJob`.
- `requests:read` → 403; other user’s request → 404; missing `search_result_id` → 422.

## Test plan
- [x] `bundle exec rails test test/controllers/api/v1/requests_controller_test.rb -n "/grab|blocklist_and_next can grab/"`

## Adversarial review
**APPROVE**