### PR TITLE
feat: search requests and skip Unknown Series folders

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -39,6 +39,16 @@ class RequestsController < ApplicationController
     # Apply attention filter
     @requests = @requests.needs_attention if params[:attention] == "true"
 
+    # Title/author search within the current filtered request list (#407)
+    @request_query = params[:q].to_s.strip.first(200)
+    if @request_query.present?
+      like = "%#{ActiveRecord::Base.sanitize_sql_like(@request_query.downcase)}%"
+      @requests = @requests.joins(:book).where(
+        "LOWER(books.title) LIKE :q ESCAPE '\\' OR LOWER(books.author) LIKE :q ESCAPE '\\'",
+        q: like
+      )
+    end
+
     @requests = @requests.order(created_at: :desc)
 
     # Counts for filter tabs

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -39,12 +39,15 @@ class RequestsController < ApplicationController
     # Apply attention filter
     @requests = @requests.needs_attention if params[:attention] == "true"
 
-    # Title/author search within the current filtered request list (#407)
+    # Title/author search within the current filtered request list (#407).
+    # SQLite LOWER() is ASCII-only; use a Ruby-backed function for Unicode folds.
     @request_query = params[:q].to_s.strip.first(200)
     if @request_query.present?
-      like = "%#{ActiveRecord::Base.sanitize_sql_like(@request_query.downcase)}%"
+      register_request_search_functions!
+      like = "%#{ActiveRecord::Base.sanitize_sql_like(unicode_fold(@request_query))}%"
       @requests = @requests.joins(:book).where(
-        "LOWER(books.title) LIKE :q ESCAPE '\\' OR LOWER(books.author) LIKE :q ESCAPE '\\'",
+        "shelfarr_request_search_lower(books.title) LIKE :q ESCAPE '\\' OR " \
+        "shelfarr_request_search_lower(books.author) LIKE :q ESCAPE '\\'",
         q: like
       )
     end
@@ -327,6 +330,19 @@ class RequestsController < ApplicationController
   end
 
   private
+
+  def register_request_search_functions!
+    database = Request.connection.raw_connection
+    return unless database.respond_to?(:create_function)
+
+    database.create_function("shelfarr_request_search_lower", 1) do |function, value|
+      function.result = unicode_fold(value)
+    end
+  end
+
+  def unicode_fold(value)
+    value.to_s.unicode_normalize(:nfc).downcase
+  end
 
   def send_single_file(boundary, book)
     path = boundary.target

--- a/app/services/path_template_service.rb
+++ b/app/services/path_template_service.rb
@@ -246,7 +246,10 @@ class PathTemplateService
         },
         "series" => {
           value: book.series,
-          path: "Unknown Series",
+          # Empty path fallback: omit the series segment entirely when a book
+          # has no series (no "Unknown Series" folder). Empty path segments are
+          # collapsed by sanitize_path_segments.
+          path: "",
           filename: ""
         },
         "narrator" => {

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -7,15 +7,16 @@
   <nav class="mb-6" aria-label="Request filters">
     <div class="flex flex-wrap gap-2">
       <%
+        query_params = @request_query.present? ? { q: @request_query } : {}
         current_filter = params[:attention] == "true" ? "attention" : (params[:status].presence || "all")
         filters = [
-          { key: "all", label: "All", path: requests_path },
-          { key: "attention", label: "Need Attention", path: requests_path(attention: "true"), count: @attention_count, alert: true },
-          { key: "active", label: "Active", path: requests_path(status: "active"), count: @active_count },
-          { key: "awaiting_purchase", label: "Store Offers", path: requests_path(status: "awaiting_purchase") },
-          { key: "completed", label: "Completed", path: requests_path(status: "completed") },
-          { key: "not_found", label: "Not Found", path: requests_path(status: "not_found") },
-          { key: "failed", label: "Cancelled", path: requests_path(status: "failed") }
+          { key: "all", label: "All", path: requests_path(query_params) },
+          { key: "attention", label: "Need Attention", path: requests_path(query_params.merge(attention: "true")), count: @attention_count, alert: true },
+          { key: "active", label: "Active", path: requests_path(query_params.merge(status: "active")), count: @active_count },
+          { key: "awaiting_purchase", label: "Store Offers", path: requests_path(query_params.merge(status: "awaiting_purchase")) },
+          { key: "completed", label: "Completed", path: requests_path(query_params.merge(status: "completed")) },
+          { key: "not_found", label: "Not Found", path: requests_path(query_params.merge(status: "not_found")) },
+          { key: "failed", label: "Cancelled", path: requests_path(query_params.merge(status: "failed")) }
         ]
       %>
       <% filters.each do |filter| %>
@@ -37,8 +38,33 @@
     </div>
   </nav>
 
+  <div class="mb-6">
+    <%= form_with url: requests_path, method: :get, local: true, class: "flex flex-col sm:flex-row gap-2" do %>
+      <% if params[:status].present? %>
+        <%= hidden_field_tag :status, params[:status] %>
+      <% end %>
+      <% if params[:attention].present? %>
+        <%= hidden_field_tag :attention, params[:attention] %>
+      <% end %>
+      <label for="request-query" class="sr-only">Search requests by title or author</label>
+      <%= text_field_tag :q, @request_query,
+            id: "request-query",
+            placeholder: "Search requests by title or author…",
+            autocomplete: "off",
+            class: "flex-1 rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" %>
+      <div class="flex gap-2">
+        <%= submit_tag "Search", class: "rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 cursor-pointer" %>
+        <% if @request_query.present? %>
+          <%= link_to "Clear",
+                requests_path(params.permit(:status, :attention).to_h.symbolize_keys),
+                class: "inline-flex items-center rounded-lg bg-gray-800 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700" %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
   <%
-    has_filters = params[:status].present? || params[:attention].present?
+    has_filters = params[:status].present? || params[:attention].present? || @request_query.present?
   %>
   <% if @requests.empty? %>
     <div class="bg-gray-900 border border-gray-800 rounded-lg p-12 text-center">
@@ -47,14 +73,18 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <h3 class="text-lg font-medium text-white mb-2">
-          <% if params[:attention] == "true" %>
+          <% if @request_query.present? %>
+            No matching requests
+          <% elsif params[:attention] == "true" %>
             No requests need attention
           <% else %>
             No matching requests
           <% end %>
         </h3>
         <p class="text-gray-500 mb-4">
-          <% if params[:attention] == "true" %>
+          <% if @request_query.present? %>
+            No requests match “<%= @request_query %>”.
+          <% elsif params[:attention] == "true" %>
             All requests are processing normally.
           <% else %>
             No requests match your current filter.
@@ -228,14 +258,15 @@
       <div class="mt-6 flex flex-wrap items-center justify-between gap-3 text-sm text-gray-400">
         <p><%= @requests_total_count %> <%= "request".pluralize(@requests_total_count) %> &middot; Page <%= @requests_page %> of <%= @requests_total_pages %></p>
         <div class="flex gap-2">
+          <% pagination_params = { status: params[:status], attention: params[:attention], q: @request_query.presence }.compact %>
           <% if @requests_page > 1 %>
             <%= link_to "Previous",
-              requests_path(status: params[:status], attention: params[:attention], page: @requests_page - 1),
+              requests_path(pagination_params.merge(page: @requests_page - 1)),
               class: "rounded-md bg-gray-800 px-3 py-2 text-white hover:bg-gray-700" %>
           <% end %>
           <% if @requests_page < @requests_total_pages %>
             <%= link_to "Next",
-              requests_path(status: params[:status], attention: params[:attention], page: @requests_page + 1),
+              requests_path(pagination_params.merge(page: @requests_page + 1)),
               class: "rounded-md bg-gray-800 px-3 py-2 text-white hover:bg-gray-700" %>
           <% end %>
         </div>

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -152,6 +152,26 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h3", match.book.title
   end
 
+  test "index search is Unicode case-insensitive" do
+    sign_out
+    sign_in_as(@admin)
+
+    match = Request.create!(
+      book: Book.create!(
+        title: "Émile Zola Collected Works",
+        author: "Émile Zola",
+        book_type: :ebook,
+        open_library_work_id: "OL_REQ_SEARCH_UNICODE"
+      ),
+      user: @user,
+      status: :pending
+    )
+
+    get requests_path(q: "émile")
+    assert_response :success
+    assert_select "h3", match.book.title
+  end
+
   test "index shows attention count and active count" do
     sign_out
     sign_in_as(@admin)

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -126,6 +126,32 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h3", attention_request.book.title
   end
 
+  test "index searches requests by title or author" do
+    sign_out
+    sign_in_as(@admin)
+
+    match = Request.create!(
+      book: Book.create!(title: "Unique Hobbit Quest", author: "Tolkien Search", book_type: :ebook, open_library_work_id: "OL_REQ_SEARCH_1"),
+      user: @user,
+      status: :pending
+    )
+    Request.create!(
+      book: Book.create!(title: "Unrelated Title", author: "Someone Else", book_type: :ebook, open_library_work_id: "OL_REQ_SEARCH_2"),
+      user: @user,
+      status: :pending
+    )
+
+    get requests_path(q: "hobbit")
+    assert_response :success
+    assert_select "h3", match.book.title
+    assert_select "h3", text: "Unrelated Title", count: 0
+    assert_select "input#request-query[value='hobbit']"
+
+    get requests_path(q: "tolkien")
+    assert_response :success
+    assert_select "h3", match.book.title
+  end
+
   test "index shows attention count and active count" do
     sign_out
     sign_in_as(@admin)

--- a/test/services/path_template_service_test.rb
+++ b/test/services/path_template_service_test.rb
@@ -56,7 +56,7 @@ class PathTemplateServiceTest < ActiveSupport::TestCase
   test "handles missing series" do
     @book.update!(series: nil)
     result = PathTemplateService.build_path(@book, "{author}/{series}/{title}")
-    assert_equal "Stephen King/Unknown Series/The Shining", result
+    assert_equal "Stephen King/The Shining", result
   end
 
   test "supports optional suffixes for missing path variables" do


### PR DESCRIPTION
## Summary
Implements two high-value slices from #407:

1. **Request list search** — filter by title/author via `q`, with form UI, filter-tab and pagination preservation, LIKE escaping, and a 200-char cap.
2. **No “Unknown Series” folder** — missing series path tokens collapse instead of inserting a placeholder folder.

Intentionally deferred (already exist or larger work): cancel anytime (already available for non-completed requests), Search in top nav (already desktop + mobile), multi-select catalog search, typeahead → enter-to-search.

Closes #407

## Proof
- `PathTemplateService.build_path` with `{author}/{series}/{title}` and nil series → `Author/Title` (was `Author/Unknown Series/Title`).
- Requests index with `q=hobbit` returns matching title only.

## Test plan
- [x] path template missing-series test
- [x] requests controller search test

## Adversarial review
**APPROVE** (optional ESCAPE/length nits applied before merge).