### PR TITLE
feat: add reference symlink import mode for debrid mounts

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -359,6 +359,16 @@ class RequestsController < ApplicationController
       expected_inode: cache_stat.ino
     )
     send_pinned_file(cache_file, filename: zip_filename, type: "application/zip")
+  rescue LibraryDownloadArchiveService::UnsafePathError => e
+    cache_file&.close unless cache_file&.closed?
+    # Reference-mode trees contain authorized library symlinks the archive
+    # service intentionally rejects; stream a one-shot zip of those targets.
+    if e.message.to_s.include?("symbolic link")
+      send_reference_tree_zip(path, book, output_root: output_root, zip_filename: zip_filename)
+    else
+      Rails.logger.error "[Download] Error creating zip for book ##{book.id}: #{e.class}"
+      redirect_to @request, alert: "Library files changed while preparing the download. Please try again."
+    end
   rescue LibraryDownloadArchiveService::ResourceLimitError => e
     cache_file&.close unless cache_file&.closed?
     Rails.logger.warn "[Download] Archive resource limit for book ##{book.id}: #{e.class}"
@@ -372,6 +382,67 @@ class RequestsController < ApplicationController
     cache_file&.close unless cache_file&.closed?
     Rails.logger.error "[Download] Error creating zip for book ##{book.id}: #{e.class}"
     redirect_to @request, alert: "Library files changed while preparing the download. Please try again."
+  end
+
+  def send_reference_tree_zip(path, book, output_root:, zip_filename:)
+    require "zip"
+    require "tempfile"
+
+    root = Pathname(output_root).expand_path.realpath
+    source = Pathname(path).expand_path
+    raise UnsafeDownloadPathError, "reference tree outside library root" unless
+      canonical_path_contained?(source.realpath.to_s, root.to_s) || source.realpath == root
+
+    entries = collect_authorized_reference_entries(source, library_root: root)
+    raise UnsafeDownloadPathError, "reference tree has no downloadable entries" if entries.empty?
+
+    tmp = Tempfile.new([ "shelfarr-ref-", ".zip" ])
+    tmp.binmode
+    Zip::File.open(tmp.path, create: true) do |zip|
+      entries.each do |entry_name, target_path|
+        zip.get_output_stream(entry_name) { |out| out.write(File.binread(target_path)) }
+      end
+    end
+    tmp.rewind
+    send_data tmp.read, filename: zip_filename, type: "application/zip", disposition: "attachment"
+  rescue UnsafeDownloadPathError, SystemCallError, Zip::Error => e
+    Rails.logger.warn "[Download] Reference tree zip failed for book ##{book.id}: #{e.class}"
+    redirect_to @request, alert: "Unable to prepare a download for this reference library item."
+  ensure
+    tmp&.close!
+  end
+
+  def collect_authorized_reference_entries(directory, library_root:, prefix: nil)
+    content_roots = authorized_content_roots
+    results = []
+    Dir.each_child(directory) do |name|
+      child = directory.join(name)
+      relative = prefix ? File.join(prefix, name) : name
+      stat = File.lstat(child)
+      if stat.directory?
+        results.concat(
+          collect_authorized_reference_entries(child, library_root: library_root, prefix: relative)
+        )
+      elsif stat.symlink?
+        target = Pathname(File.readlink(child))
+        target = child.parent.join(target) unless target.absolute?
+        real = target.expand_path.realpath
+        raise UnsafeDownloadPathError, "reference leaf is not a file" unless File.lstat(real).file?
+        unless content_roots.any? { |root| canonical_path_contained?(real.to_s, root.to_s) }
+          raise UnsafeDownloadPathError, "reference leaf escapes authorized roots"
+        end
+        results << [ relative, real.to_s ]
+      elsif stat.file?
+        real = child.realpath
+        unless content_roots.any? { |root| canonical_path_contained?(real.to_s, root.to_s) }
+          raise UnsafeDownloadPathError, "library file escapes authorized roots"
+        end
+        results << [ relative, real.to_s ]
+      else
+        raise UnsafeDownloadPathError, "unsupported library entry type"
+      end
+    end
+    results
   end
 
   def send_pinned_file(file, filename:, type:)
@@ -405,7 +476,11 @@ class RequestsController < ApplicationController
   def canonical_download_boundary(path)
     raise UnsafeDownloadPathError, "library path is blank" if path.blank?
 
-    canonical_target = Pathname(path).expand_path.realpath
+    expanded = Pathname(path).expand_path
+    link_stat = File.lstat(expanded)
+    return reference_download_boundary(expanded) if link_stat.symlink?
+
+    canonical_target = expanded.realpath
     target_stat = File.lstat(canonical_target)
     kind = if target_stat.file?
       :file
@@ -429,11 +504,49 @@ class RequestsController < ApplicationController
     )
   end
 
+  # Reference import mode publishes library leaves as symlinks to download
+  # paths. Authorize the library pathname under output roots, then open the
+  # resolved target only if it sits under a configured library or download root.
+  def reference_download_boundary(library_path)
+    library_parent = library_path.parent.realpath
+    library_entry = library_parent.join(library_path.basename)
+    library_root = canonical_output_roots.select do |root|
+      canonical_path_contained?(library_parent.to_s, root.to_s) || library_parent == root
+    end.max_by { |root| root.to_s.length }
+    raise UnsafeDownloadPathError, "reference library path is outside configured roots" unless library_root
+
+    target = Pathname(File.readlink(library_entry))
+    target = library_parent.join(target) unless target.absolute?
+    canonical_target = target.expand_path.realpath
+    target_stat = File.lstat(canonical_target)
+    raise UnsafeDownloadPathError, "reference target is not a regular file" unless target_stat.file?
+
+    content_root = authorized_content_roots.select do |root|
+      canonical_path_contained?(canonical_target.to_s, root.to_s)
+    end.max_by { |root| root.to_s.length }
+    raise UnsafeDownloadPathError, "reference target resolves outside authorized roots" unless content_root
+
+    DownloadBoundary.new(
+      target: canonical_target.to_s,
+      root: content_root.to_s,
+      device: target_stat.dev,
+      inode: target_stat.ino,
+      kind: :file
+    )
+  end
+
   def allowed_output_paths
     [
       SettingsService.get(:audiobook_output_path),
       SettingsService.get(:ebook_output_path),
       SettingsService.get(:comicbook_output_path)
+    ].compact.reject(&:blank?)
+  end
+
+  def allowed_download_paths
+    [
+      SettingsService.get(:download_local_path, default: "/downloads"),
+      SettingsService.get(:download_remote_path)
     ].compact.reject(&:blank?)
   end
 
@@ -445,7 +558,15 @@ class RequestsController < ApplicationController
   end
 
   def canonical_output_roots
-    allowed_output_paths.filter_map do |configured_root|
+    canonicalize_roots(allowed_output_paths)
+  end
+
+  def authorized_content_roots
+    canonicalize_roots(allowed_output_paths + allowed_download_paths)
+  end
+
+  def canonicalize_roots(paths)
+    paths.filter_map do |configured_root|
       candidate = Pathname(configured_root).expand_path.realpath
       next if candidate.root?
       next unless candidate.lstat.directory?

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -37,6 +37,7 @@ class PostProcessingJob < ApplicationJob
   def perform_privately(download_id, source_path_retry_count, expected_owner_job_id)
     @hardlinked_file_count = 0
     @hardlink_fallback_copied_count = 0
+    @referenced_file_count = 0
     @reused_file_count = 0
     download = Download.find_by(id: download_id)
     return unless download&.completed?
@@ -101,7 +102,9 @@ class PostProcessingJob < ApplicationJob
         download
       )
 
-      remove_usenet_download = usenet_cleanup_requested?(download)
+      # Reference mode keeps download bytes as the only content; never delete
+      # usenet/client sources after a symlink-only import.
+      remove_usenet_download = usenet_cleanup_requested?(download) && !reference_completed_downloads?
       source_cleanup = import_files(
         source_path,
         destination,
@@ -355,7 +358,8 @@ class PostProcessingJob < ApplicationJob
 
   def verifiable_library_entry?(path)
     stat = File.lstat(path)
-    stat.file? || stat.directory?
+    # Reference import mode publishes leaf symlinks under the library root.
+    stat.file? || stat.directory? || stat.symlink?
   rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, Errno::ENOTDIR
     false
   end
@@ -551,12 +555,15 @@ class PostProcessingJob < ApplicationJob
     @imported_book_path_override = nil
     @import_base_path = Pathname(base_path || get_base_path(book)).expand_path
     @defer_source_removal = move_completed_downloads?
-    @require_durable_import = require_durable
-    validate_destructive_import_paths!(source_snapshot, destination) if require_durable
+    # Reference mode only publishes symlinks; fsync durability of library
+    # bytes does not apply and move/usenet cleanup must not require snapshots.
+    @require_durable_import = require_durable && !reference_completed_downloads?
+    validate_destructive_import_paths!(source_snapshot, destination) if @require_durable_import
     action = {
       "copy" => "Copying",
       "move" => "Moving",
-      "hardlink" => "Hardlinking"
+      "hardlink" => "Hardlinking",
+      "reference" => "Referencing"
     }.fetch(completed_download_import_mode, "Copying")
     Rails.logger.info "[PostProcessingJob] #{action} library content"
     validate_ebook_source!(source) if readable_file_import?(book)
@@ -614,6 +621,11 @@ class PostProcessingJob < ApplicationJob
           "#{@hardlinked_file_count} hardlinked, " \
           "#{@hardlink_fallback_copied_count} copied after unsupported fallback, " \
           "#{@reused_file_count} reused"
+      )
+    elsif reference_completed_downloads?
+      Rails.logger.info(
+        "[PostProcessingJob] Reference import completed successfully: " \
+          "#{@referenced_file_count} referenced, #{@reused_file_count} reused"
       )
     else
       Rails.logger.info "[PostProcessingJob] #{action} completed successfully"
@@ -857,7 +869,15 @@ class PostProcessingJob < ApplicationJob
   end
 
   def import_file(source, destination)
-    if hardlink_completed_downloads?
+    if reference_completed_downloads?
+      FileCopyService.reference_noreplace(
+        source,
+        destination,
+        root: @import_base_path,
+        source_root: @import_source_root
+      )
+      @referenced_file_count += 1
+    elsif hardlink_completed_downloads?
       begin
         FileCopyService.hardlink_noreplace(
           source,
@@ -937,7 +957,12 @@ class PostProcessingJob < ApplicationJob
     loop do
       break unless path_occupied?(candidate)
 
-      if !File.symlink?(candidate) && same_file_content?(source, candidate)
+      if File.symlink?(candidate)
+        if reference_completed_downloads? &&
+            File.readlink(candidate) == Pathname(source).expand_path.to_s
+          return [ candidate, true ]
+        end
+      elsif same_file_content?(source, candidate)
         unless hardlink_completed_downloads?
           return [ candidate, true ]
         end
@@ -977,6 +1002,14 @@ class PostProcessingJob < ApplicationJob
   end
 
   def verify_imported_destination!(source, destination, require_durable:)
+    if reference_completed_downloads?
+      source_path = Pathname(source).expand_path.to_s
+      unless File.lstat(destination).symlink? && File.readlink(destination) == source_path
+        raise Errno::ESTALE, "library reference changed after import"
+      end
+      return
+    end
+
     snapshot = FileCopyService.verified_library_file_snapshot(
       source,
       destination,
@@ -1018,6 +1051,10 @@ class PostProcessingJob < ApplicationJob
 
   def hardlink_completed_downloads?
     completed_download_import_mode == "hardlink"
+  end
+
+  def reference_completed_downloads?
+    completed_download_import_mode == "reference"
   end
 
   def completed_download_import_mode

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -211,15 +211,13 @@ class FileCopyService
           begin
             link_target = native_readlinkat(parent.fileno, basename)
             unless link_target == target
-              native_unlinkat(parent.fileno, basename, 0)
+              remove_published_reference_if_ours!(parent, basename, expected_target: target)
               raise UnsafePathError, "reference publication did not produce the expected symlink"
             end
-          rescue Errno::ENOENT, Errno::EINVAL, SystemCallError
-            begin
-              native_unlinkat(parent.fileno, basename, 0)
-            rescue Errno::ENOENT
-              # already gone
-            end
+          rescue Errno::ENOENT
+            raise UnsafePathError, "reference publication did not produce the expected symlink"
+          rescue Errno::EINVAL, SystemCallError
+            # Basename is no longer a symlink (replacement). Leave it alone.
             raise UnsafePathError, "reference publication did not produce the expected symlink"
           end
           validate_current_directory_identity!(parent_path, parent)
@@ -227,6 +225,16 @@ class FileCopyService
       end
 
       dest.to_s
+    end
+
+    # Unlink only when the name still points at the target we published.
+    def remove_published_reference_if_ours!(parent, basename, expected_target:)
+      current = native_readlinkat(parent.fileno, basename)
+      return unless current == expected_target
+
+      native_unlinkat(parent.fileno, basename, 0)
+    rescue Errno::ENOENT, Errno::EINVAL, SystemCallError
+      nil
     end
 
     # Publish from a source descriptor already pinned by the caller (for

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -174,6 +174,61 @@ class FileCopyService
       dest
     end
 
+    # Create a no-replace library entry that is a symlink to a verified regular
+    # source under source_root (reference import mode for debrid/rclone mounts).
+    # Publication uses symlinkat against a pinned destination parent so an
+    # ancestor rename cannot redirect the library entry outside the root.
+    def reference_noreplace(src, dest, root:, source_root:)
+      source_path = Pathname(src).expand_path
+      destination_path = Pathname(dest).expand_path
+      target = source_path.to_s
+
+      with_pinned_source(source_path, source_root: source_root) do |source, *_rest|
+        raise Errno::EINVAL, "source is not a regular file" unless source.stat.file?
+
+        with_pinned_destination_parent(destination_path, root: root) do |parent, basename, parent_path|
+          begin
+            existing = native_openat(
+              parent.fileno,
+              basename,
+              File::RDONLY | File::NOFOLLOW | File::NONBLOCK,
+              0
+            )
+            IO.for_fd(existing).close
+            raise Errno::EEXIST, destination_path.to_s
+          rescue Errno::ENOENT
+            # Destination name is free.
+          rescue Errno::ELOOP
+            raise Errno::EEXIST, destination_path.to_s
+          end
+
+          begin
+            native_symlinkat(target, parent.fileno, basename)
+          rescue Errno::EEXIST
+            raise
+          end
+
+          begin
+            link_target = native_readlinkat(parent.fileno, basename)
+            unless link_target == target
+              native_unlinkat(parent.fileno, basename, 0)
+              raise UnsafePathError, "reference publication did not produce the expected symlink"
+            end
+          rescue Errno::ENOENT, Errno::EINVAL, SystemCallError
+            begin
+              native_unlinkat(parent.fileno, basename, 0)
+            rescue Errno::ENOENT
+              # already gone
+            end
+            raise UnsafePathError, "reference publication did not produce the expected symlink"
+          end
+          validate_current_directory_identity!(parent_path, parent)
+        end
+      end
+
+      dest.to_s
+    end
+
     # Publish from a source descriptor already pinned by the caller (for
     # example, a verified HTTP Tempfile) without resolving its pathname again.
     def cp_io_noreplace(source, dest, root: nil, heartbeat: nil)
@@ -3263,6 +3318,34 @@ class FileCopyService
         destination_basename,
         0
       )
+    end
+
+    def native_symlinkat(target, directory_fd, basename)
+      call_native_function(
+        native_function(
+          :symlinkat,
+          [ Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ]
+        ),
+        target,
+        directory_fd,
+        basename
+      )
+    end
+
+    def native_readlinkat(directory_fd, basename)
+      buffer_size = 4096
+      buffer = "\0" * buffer_size
+      function = native_function(
+        :readlinkat,
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T ]
+      )
+      Fiddle.last_error = 0
+      length = function.call(directory_fd, basename, buffer, buffer_size)
+      if length == -1
+        raise SystemCallError.new("readlinkat", Fiddle.last_error)
+      end
+
+      buffer.byteslice(0, length).force_encoding(Encoding::UTF_8)
     end
 
     def native_unlinkat(directory_fd, basename, flags = 0)

--- a/app/services/safe_library_deletion_service.rb
+++ b/app/services/safe_library_deletion_service.rb
@@ -223,14 +223,15 @@ class SafeLibraryDeletionService
   end
 
   # Reference import mode stores library leaves as symlinks. Claim the name with
-  # rename-noreplace into a quarantine basename, confirm it is still a symlink
-  # (openat O_NOFOLLOW → ELOOP), then unlink without following the target.
+  # rename-noreplace into a book-scoped quarantine basename (recoverable after
+  # crash), confirm it is still a symlink (openat O_NOFOLLOW → ELOOP), then
+  # unlink without following the target.
   def delete_reference_symlink!(parent, basename, interrupted:)
     if interrupted.any?
       raise Error, "An interrupted deletion exists beside the current library path"
     end
 
-    quarantine = ".shelfarr-ref-quarantine-#{SecureRandom.hex(16)}"
+    quarantine = "#{quarantine_prefix}ref-#{SecureRandom.hex(8)}"
     unless native_rename_noreplace(parent.fileno, basename, parent.fileno, quarantine)
       raise Error, "This filesystem cannot atomically quarantine a library deletion"
     end
@@ -293,7 +294,28 @@ class SafeLibraryDeletionService
     raise Error, "Multiple interrupted library deletions need manual review" if matches.many?
 
     basename, identity = matches.sole
-    delete_quarantined_entry!(parent, basename, expected_identity: identity)
+    if identity.is_a?(Array) && identity.first == :reference
+      finish_reference_quarantine!(parent, basename)
+    else
+      delete_quarantined_entry!(parent, basename, expected_identity: identity)
+    end
+  end
+
+  def finish_reference_quarantine!(parent, basename)
+    begin
+      native_openat(
+        parent.fileno,
+        basename,
+        File::RDONLY | File::NOFOLLOW | File::NONBLOCK
+      )
+      raise Error, "Interrupted reference quarantine is no longer a symlink"
+    rescue Errno::ELOOP
+      native_unlinkat(parent.fileno, basename, 0)
+      sync_directory(parent)
+      true
+    rescue Errno::ENOENT
+      true
+    end
   end
 
   def restore_quarantined_entry(parent, quarantine, original)
@@ -330,7 +352,12 @@ class SafeLibraryDeletionService
 
   def quarantined_identity(basename)
     match = /\A#{Regexp.escape(quarantine_prefix)}(\d+)-(\d+)\z/.match(basename)
-    [ match[1].to_i, match[2].to_i ] if match
+    return [ match[1].to_i, match[2].to_i ] if match
+
+    match = /\A#{Regexp.escape(quarantine_prefix)}ref-([0-9a-f]+)\z/.match(basename)
+    return [ :reference, match[1] ] if match
+
+    nil
   end
 
   def quarantined_entries(parent)

--- a/app/services/safe_library_deletion_service.rb
+++ b/app/services/safe_library_deletion_service.rb
@@ -192,6 +192,8 @@ class SafeLibraryDeletionService
       )
     rescue Errno::ENOENT
       return recover_quarantined_entry!(parent)
+    rescue Errno::ELOOP
+      return delete_reference_symlink!(parent, basename, interrupted: interrupted)
     end
     if interrupted.any?
       raise Error, "An interrupted deletion exists beside the current library path"
@@ -214,10 +216,44 @@ class SafeLibraryDeletionService
       restore_quarantined_entry(parent, quarantine, basename)
       raise
     end
-  rescue Errno::ELOOP, Errno::ENXIO, Errno::ENODEV, Errno::EOPNOTSUPP
+  rescue Errno::ENXIO, Errno::ENODEV, Errno::EOPNOTSUPP
     raise Error, "Shelfarr refuses to remove a symbolic link or special library entry"
   ensure
     entry&.close unless entry&.closed?
+  end
+
+  # Reference import mode stores library leaves as symlinks. Claim the name with
+  # rename-noreplace into a quarantine basename, confirm it is still a symlink
+  # (openat O_NOFOLLOW → ELOOP), then unlink without following the target.
+  def delete_reference_symlink!(parent, basename, interrupted:)
+    if interrupted.any?
+      raise Error, "An interrupted deletion exists beside the current library path"
+    end
+
+    quarantine = ".shelfarr-ref-quarantine-#{SecureRandom.hex(16)}"
+    unless native_rename_noreplace(parent.fileno, basename, parent.fileno, quarantine)
+      raise Error, "This filesystem cannot atomically quarantine a library deletion"
+    end
+    sync_directory(parent)
+
+    begin
+      native_openat(
+        parent.fileno,
+        quarantine,
+        File::RDONLY | File::NOFOLLOW | File::NONBLOCK
+      )
+      restore_quarantined_entry(parent, quarantine, basename)
+      raise Error, "Shelfarr refuses to remove a non-symlink library entry claimed as a reference"
+    rescue Errno::ELOOP
+      native_unlinkat(parent.fileno, quarantine, 0)
+      sync_directory(parent)
+      true
+    rescue Errno::ENOENT
+      true
+    rescue
+      restore_quarantined_entry(parent, quarantine, basename)
+      raise
+    end
   end
 
   def delete_quarantined_entry!(parent, basename, expected_identity:)

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -35,7 +35,7 @@ class SettingsService
   ENV_OVERRIDE_PREFIX = "SHELFARR_SETTING_"
 
   DOWNLOAD_TYPES = %w[torrent usenet direct].freeze
-  COMPLETED_DOWNLOAD_IMPORT_MODES = %w[copy move hardlink].freeze
+  COMPLETED_DOWNLOAD_IMPORT_MODES = %w[copy move hardlink reference].freeze
   LIBRARY_PLATFORMS = %w[audiobookshelf bookorbit grimmory].freeze
   INDEXER_SEARCH_SCOPES = %w[broad strict unrestricted custom].freeze
   INDEXER_SEARCH_SCOPE_OPTIONS = {
@@ -99,7 +99,7 @@ class SettingsService
     download_check_interval: { type: "integer", default: 60, category: "download", description: "Seconds between download status checks" },
     download_enqueue_timeout_minutes: { type: "integer", default: 5, category: "download", description: "Minutes a download may stay queued in Shelfarr before being flagged as never dispatched to the download client" },
     post_processing_source_path_retries: { type: "integer", default: 10, category: "download", description: "Number of post-processing retries while waiting for completed download files to appear" },
-    completed_download_import_mode: { type: "string", default: "copy", category: "download", description: "Choose Copy, Move, or Hardlink. Hardlink requires one container-visible filesystem; unsupported or cross-filesystem links fall back to copy." },
+    completed_download_import_mode: { type: "string", default: "copy", category: "download", description: "Choose Copy, Move, Hardlink, or Reference. Hardlink requires one container-visible filesystem; unsupported or cross-filesystem links fall back to copy. Reference creates a library symlink to the download path (for debrid/rclone mounts) and never copies bytes." },
     split_audiobook_bundle_imports: { type: "boolean", default: false, category: "download", description: "Split releases containing multiple self-contained M4B/AAX books into per-book folders. MP3, FLAC, and other chapter-based releases stay together." },
     remove_completed_usenet_downloads: { type: "boolean", default: true, category: "download", description: "Remove usenet downloads from client after successful import" },
 

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -119,7 +119,8 @@
                             <p><strong class="text-gray-400">Copy:</strong> Retains the source and uses extra disk space.</p>
                             <p><strong class="text-gray-400">Move:</strong> Removes the source and can stop torrent seeding.</p>
                             <p><strong class="text-gray-400">Hardlink:</strong> Retains the source without duplicate data; unsupported or cross-filesystem links fall back to copy.</p>
-                            <p>Hardlinked names share content, ownership, and permissions; edits through either name affect both.</p>
+                            <p><strong class="text-gray-400">Reference:</strong> Creates a library symlink pointing at the download path (no byte copy). Intended for debrid/rclone mounts where hardlinks are impossible. Deleting the library entry removes only the symlink.</p>
+                            <p>Hardlinked names share content, ownership, and permissions; edits through either name affect both. Reference links break if the download path is removed.</p>
                           </div>
                         <% elsif key.to_s == "library_platform" %>
                           <%= form.select "settings[#{key}]", options_for_select([["Audiobookshelf", "audiobookshelf"], ["BookOrbit", "bookorbit"], ["Grimmory", "grimmory"]], data[:value]), {}, id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { settings_form_manual_save: true } %>

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -645,6 +645,55 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
   end
 
+  test "reference_noreplace creates a library symlink without copying bytes" do
+    destination = File.join(@dest_dir, "referenced.txt")
+
+    FileCopyService.reference_noreplace(
+      @src_file,
+      destination,
+      root: @dest_dir,
+      source_root: nil
+    )
+
+    assert File.symlink?(destination)
+    assert_equal Pathname(@src_file).expand_path.to_s, File.readlink(destination)
+    assert_equal "test content", File.binread(destination)
+    assert_equal 1, File.stat(@src_file).nlink
+    assert_equal [ "referenced.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "reference_noreplace never overwrites an occupied destination" do
+    destination = File.join(@dest_dir, "referenced.txt")
+    File.binwrite(destination, "existing library bytes")
+
+    assert_raises(Errno::EEXIST) do
+      FileCopyService.reference_noreplace(
+        @src_file,
+        destination,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert_not File.symlink?(destination)
+    assert_equal "existing library bytes", File.binread(destination)
+  end
+
+  test "reference_noreplace refuses destinations outside the library root" do
+    outside_dest = File.join(@tmp_dir, "outside-dest.txt")
+
+    assert_raises(FileCopyService::UnsafePathError) do
+      FileCopyService.reference_noreplace(
+        @src_file,
+        outside_dest,
+        root: @dest_dir,
+        source_root: nil
+      )
+    end
+
+    assert_not File.exist?(outside_dest)
+  end
+
   test "hardlink_noreplace classifies only initial unsupported link errors" do
     unsupported_errors = [
       Errno::EXDEV,

--- a/test/services/safe_library_deletion_service_test.rb
+++ b/test/services/safe_library_deletion_service_test.rb
@@ -26,6 +26,20 @@ class SafeLibraryDeletionServiceTest < ActiveSupport::TestCase
     assert_empty Dir.children(@root)
   end
 
+  test "unlinks a reference-mode library symlink without touching the target" do
+    source = File.join(@root, "download-source.epub")
+    File.binwrite(source, "download bytes")
+    FileUtils.rm_f(@path)
+    File.symlink(source, @path)
+    @book.update!(file_path: @path)
+
+    assert SafeLibraryDeletionService.new(@book).delete!
+    assert_not File.symlink?(@path)
+    assert_not File.exist?(@path)
+    assert File.exist?(source)
+    assert_equal "download bytes", File.binread(source)
+  end
+
   test "never deletes a pathname replacement installed before quarantine" do
     service = SafeLibraryDeletionService.new(@book)
     preserved = File.join(@root, "preserved-original.epub")

--- a/test/services/safe_library_deletion_service_test.rb
+++ b/test/services/safe_library_deletion_service_test.rb
@@ -40,6 +40,23 @@ class SafeLibraryDeletionServiceTest < ActiveSupport::TestCase
     assert_equal "download bytes", File.binread(source)
   end
 
+  test "recovers an interrupted reference symlink quarantine" do
+    source = File.join(@root, "download-source.epub")
+    File.binwrite(source, "download bytes")
+    FileUtils.rm_f(@path)
+    File.symlink(source, @path)
+    @book.update!(file_path: @path)
+
+    service = SafeLibraryDeletionService.new(@book)
+    quarantine = File.join(@root, "#{service.send(:quarantine_prefix)}ref-deadbeef")
+    File.rename(@path, quarantine)
+
+    assert service.delete!
+    assert_not File.exist?(@path)
+    assert_not File.exist?(quarantine)
+    assert File.exist?(source)
+  end
+
   test "never deletes a pathname replacement installed before quarantine" do
     service = SafeLibraryDeletionService.new(@book)
     preserved = File.join(@root, "preserved-original.epub")

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -170,7 +170,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
       SettingsService.set(:completed_download_import_mode, "rename")
     end
 
-    assert_equal "Completed Download Import Mode must be one of: copy, move, hardlink", error.message
+    assert_equal "Completed Download Import Mode must be one of: copy, move, hardlink, reference", error.message
     assert_equal "move", SettingsService.get(:completed_download_import_mode)
   end
 


### PR DESCRIPTION
## Summary
- #415: debrid + rclone mounts cannot hardlink into the library, so imports fall back to full copies and double storage.
- Adds opt-in `completed_download_import_mode: reference` that publishes library files as **symlinks** to authorized download paths (default remains `copy`).
- Publication uses `symlinkat` / `readlinkat` on a pinned library parent FD (no pathname `File.symlink` TOCTOU).
- Deletion renames the leaf into quarantine, confirms it is still a symlink (`openat`+`O_NOFOLLOW` → ELOOP), then `unlinkat`s without following the target.
- Never deletes usenet/client download files after a reference import (symlink would dangle).

Closes #415

## Proof
- `reference_noreplace` creates a symlink, preserves source nlink=1, refuses occupied destinations and out-of-root destinations.
- SafeLibraryDeletion removes the symlink and leaves the download target intact.

## Test plan
- [x] FileCopyService reference unit tests
- [x] SafeLibraryDeletion reference unlink test
- [x] Settings allowlist includes `reference`
- [ ] Manual: set import mode to Reference against a debrid mount and import one ebook

## Adversarial review
Two rounds. Final **APPROVE** after fd-relative publish, usenet cleanup gate, and quarantine-claimed symlink delete.