### PR TITLE
feat: add search pagination and resolve reported issues

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -10,12 +10,12 @@ class SearchController < ApplicationController
     @search_page = SearchResultSnapshot.normalize_page(params[:page])
     @results = []
     @error = nil
-    @search_loading = @query.present?
+    @search_loading = @query.length >= 2
     @search_total_results = 0
     @search_page_count = 0
     @search_has_next = false
-    @search_complete = false
-    @search_initial_search = @query.present?
+    @search_complete = !@search_loading
+    @search_initial_search = @search_loading
     @search_provider_failure_names = []
     @audiobookshelf_matches = []
     @existing_books_lookup = {}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,39 +4,64 @@ class SearchController < ApplicationController
   include ActionController::Live
 
   def index
-    @query = params[:q]
+    @live_script_name = request.script_name.presence
+    @query = params[:q].to_s.strip
     @content_kind = normalized_content_kind(params[:content_kind])
+    @search_page = SearchResultSnapshot.normalize_page(params[:page])
+    @results = []
+    @error = nil
+    @search_loading = @query.present?
+    @search_total_results = 0
+    @search_page_count = 0
+    @search_has_next = false
+    @search_complete = false
+    @search_initial_search = @query.present?
+    @search_provider_failure_names = []
+    @audiobookshelf_matches = []
+    @existing_books_lookup = {}
   end
 
   def results
+    @live_script_name = request.script_name.presence
     @query = params[:q].to_s.strip
     @content_kind = normalized_content_kind(params[:content_kind])
+    return head :not_found if request.format.symbol == :html && invalid_explicit_search_page?
 
+    @search_page = SearchResultSnapshot.normalize_page(params[:page])
+    requested_page = @search_page
+    @search_initial_search = false
+    private_search_response!
+
+    aggregate_results = []
+    error = nil
     if @query.blank?
-      @results = []
-      @error = nil
-      @audiobookshelf_matches = []
-      @existing_books_lookup = {}
+      aggregate_results = []
     else
       begin
-        @results = search_metadata(@query)
-        @audiobookshelf_matches = audiobookshelf_matches_for(@results)
-        @existing_books_lookup = existing_books_lookup_for(@results)
-        @error = nil
+        aggregate_results = search_metadata(@query)
       rescue HardcoverClient::ConnectionError, GoogleBooksClient::ConnectionError, OpenLibraryClient::ConnectionError, ComicVineClient::ConnectionError => e
-        @results = []
-        @audiobookshelf_matches = []
-        @existing_books_lookup = {}
-        @error = "Unable to connect to metadata service. Please try again later."
+        error = "Unable to connect to metadata service. Please try again later."
         Rails.logger.error("Metadata service connection error: #{e.message}")
       rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, ComicVineClient::Error, MetadataService::Error => e
-        @results = []
-        @audiobookshelf_matches = []
-        @existing_books_lookup = {}
-        @error = "Search failed. Please try again."
+        error = "Search failed. Please try again."
         Rails.logger.error("Metadata service error: #{e.message}")
       end
     end
+
+    assign_search_results(
+      results: aggregate_results,
+      loading: false,
+      pending_providers: [],
+      completed_providers: [],
+      failed_providers: [],
+      provider_count: nil,
+      page: @search_page,
+      snapshot_id: nil,
+      snapshot_expires_at: nil,
+      error: error
+    )
+
+    return head :not_found if request.format.symbol == :html && error.nil? && @search_page != requested_page
 
     respond_to do |format|
       format.turbo_stream
@@ -50,60 +75,148 @@ class SearchController < ApplicationController
     @live_script_name = request.script_name.presence
     @query = params[:q].to_s.strip
     @content_kind = normalized_content_kind(params[:content_kind])
+    @search_page = SearchResultSnapshot.normalize_page(params[:page])
 
     response.headers["Content-Type"] = "text/vnd.turbo-stream.html; charset=utf-8"
-    response.headers["Cache-Control"] = "no-cache"
+    private_search_response!
     response.headers["X-Accel-Buffering"] = "no"
 
     if @query.blank?
-      write_search_results_stream(results: [], loading: false)
+      write_search_results_stream(results: [], loading: false, page: @search_page)
       return
     end
 
     providers = MetadataService.enabled_metadata_providers(content_kind: @content_kind)
     if providers.empty?
-      write_search_results_stream(results: [], loading: false)
+      write_search_results_stream(results: [], loading: false, page: @search_page)
       return
     end
 
     query = @query
     results_by_provider = {}
     completed_providers = []
+    failed_providers = []
+    snapshot_id = SearchResultSnapshot.create(
+      user: Current.user,
+      query: query,
+      content_kind: @content_kind,
+      provider_count: providers.size
+    )
+    snapshot_expires_at = nil
 
     write_search_results_stream(
       results: [],
       loading: true,
       pending_providers: providers,
-      completed_providers: completed_providers
+      completed_providers: completed_providers,
+      page: @search_page,
+      snapshot_id: snapshot_id,
+      snapshot_expires_at: snapshot_expires_at,
+      provider_count: providers.size
     )
 
-    each_provider_search(query) do |provider, results|
+    each_provider_search(query) do |provider, results, failed|
       completed_providers << provider
+      failed_providers << provider if failed
       results_by_provider[provider] = results
 
       candidates = MetadataService.aggregate_provider_results(
         MetadataService.merge_provider_results(results_by_provider),
+        limit: SearchResultSnapshot::MAX_RESULTS,
         content_kind: @content_kind
       )
       pending_providers = providers - completed_providers
+      complete = pending_providers.empty?
+      error = provider_failure_error(candidates, failed_providers, providers, complete: complete)
+
+      if snapshot_id
+        snapshot = SearchResultSnapshot.write(
+          user: Current.user,
+          id: snapshot_id,
+          query: query,
+          content_kind: @content_kind,
+          results: candidates,
+          complete: complete,
+          failed_providers: failed_providers,
+          provider_count: providers.size
+        )
+        if snapshot
+          candidates = snapshot.results
+          snapshot_expires_at = snapshot.expires_at
+        else
+          snapshot_id = nil
+          snapshot_expires_at = nil
+        end
+      end
 
       write_search_results_stream(
         results: candidates,
-        loading: pending_providers.any?,
+        loading: !complete,
         pending_providers: pending_providers,
-        completed_providers: completed_providers
+        completed_providers: completed_providers,
+        failed_providers: failed_providers,
+        provider_count: providers.size,
+        page: @search_page,
+        snapshot_id: snapshot_id,
+        snapshot_expires_at: snapshot_expires_at,
+        error: error
       )
     end
   rescue IOError, ActionController::Live::ClientDisconnected
     Rails.logger.info("Search results stream disconnected")
   rescue HardcoverClient::ConnectionError, GoogleBooksClient::ConnectionError, OpenLibraryClient::ConnectionError, ComicVineClient::ConnectionError => e
     Rails.logger.error("Metadata service connection error: #{e.message}")
-    write_search_results_stream(results: [], error: "Unable to connect to metadata service. Please try again later.", loading: false)
+    write_search_results_stream(
+      results: [],
+      error: "Unable to connect to metadata service. Please try again later.",
+      loading: false,
+      page: @search_page
+    )
   rescue HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, ComicVineClient::Error, MetadataService::Error => e
     Rails.logger.error("Metadata service error: #{e.message}")
-    write_search_results_stream(results: [], error: "Search failed. Please try again.", loading: false)
+    write_search_results_stream(results: [], error: "Search failed. Please try again.", loading: false, page: @search_page)
+  rescue StandardError => e
+    Rails.logger.error("Search stream failed: #{e.class}: #{e.message}")
+    write_search_results_stream(results: [], error: "Search failed. Please try again.", loading: false, page: @search_page)
   ensure
     response.stream.close
+  end
+
+  def snapshot_results
+    @live_script_name = request.script_name.presence
+    @query = params[:q].to_s.strip
+    @content_kind = normalized_content_kind(params[:content_kind])
+    @search_page = SearchResultSnapshot.normalize_page(params[:page])
+    private_search_response!
+
+    snapshot = SearchResultSnapshot.fetch(
+      user: Current.user,
+      id: params[:snapshot_id],
+      query: @query,
+      content_kind: @content_kind
+    )
+    return head :not_found unless snapshot&.complete
+
+    error = provider_failure_error(
+      snapshot.results,
+      snapshot.failed_providers,
+      Array.new(snapshot.provider_count),
+      complete: true
+    )
+    assign_search_results(
+      results: snapshot.results,
+      loading: false,
+      pending_providers: [],
+      completed_providers: [],
+      failed_providers: snapshot.failed_providers,
+      provider_count: snapshot.provider_count,
+      page: @search_page,
+      snapshot_id: snapshot.id,
+      snapshot_expires_at: snapshot.expires_at,
+      error: error
+    )
+
+    render template: "search/results", formats: [ :turbo_stream ], layout: false
   end
 
   def details
@@ -183,33 +296,81 @@ class SearchController < ApplicationController
     true
   end
 
-  def write_search_results_stream(results:, loading:, pending_providers: [], completed_providers: [], error: nil)
+  def write_search_results_stream(results:, loading:, pending_providers: [], completed_providers: [],
+    failed_providers: [], provider_count: nil, page: 1, snapshot_id: nil, snapshot_expires_at: nil, error: nil)
     response.stream.write(
       render_search_results_stream(
         results: results,
         loading: loading,
         pending_providers: pending_providers,
         completed_providers: completed_providers,
+        failed_providers: failed_providers,
+        provider_count: provider_count,
+        page: page,
+        snapshot_id: snapshot_id,
+        snapshot_expires_at: snapshot_expires_at,
         error: error
       )
     )
   end
 
-  def render_search_results_stream(results:, loading:, pending_providers:, completed_providers:, error:)
-    @results = results
-    @error = error
-    @search_loading = loading
-    @search_pending_provider_names = provider_names(pending_providers)
-    @search_completed_provider_names = provider_names(completed_providers)
-    enrichment = stream_enrichment_for(results, loading: loading)
-    @audiobookshelf_matches = enrichment[:audiobookshelf_matches]
-    @existing_books_lookup = enrichment[:existing_books_lookup]
+  def render_search_results_stream(results:, loading:, pending_providers:, completed_providers:,
+    failed_providers: [], provider_count: nil, page: 1, snapshot_id: nil, snapshot_expires_at: nil, error:)
+    assign_search_results(
+      results: results,
+      loading: loading,
+      pending_providers: pending_providers,
+      completed_providers: completed_providers,
+      failed_providers: failed_providers,
+      provider_count: provider_count,
+      page: page,
+      snapshot_id: snapshot_id,
+      snapshot_expires_at: snapshot_expires_at,
+      error: error
+    )
 
     render_to_string(
       template: "search/results",
       formats: [ :turbo_stream ],
       layout: false
     )
+  end
+
+  def assign_search_results(results:, loading:, pending_providers:, completed_providers:,
+    failed_providers:, provider_count:, page:, snapshot_id:, snapshot_expires_at:, error:)
+    requested_page = SearchResultSnapshot.normalize_page(page)
+    @search_total_results = results.size
+    @search_page_count = (@search_total_results.to_f / SearchResultSnapshot::PAGE_SIZE).ceil
+    @search_page = if !loading && error.blank?
+      @search_page_count.positive? ? [ requested_page, @search_page_count ].min : 1
+    else
+      requested_page
+    end
+    @search_has_next = @search_page < @search_page_count
+    @results = results.slice((@search_page - 1) * SearchResultSnapshot::PAGE_SIZE, SearchResultSnapshot::PAGE_SIZE) || []
+    @error = error
+    @search_loading = loading
+    @search_complete = !loading
+    @search_snapshot_id = snapshot_id
+    @search_snapshot_expires_at = snapshot_expires_at
+    @search_provider_count = provider_count.to_i
+    @search_pending_provider_names = provider_names(pending_providers)
+    @search_completed_provider_names = provider_names(completed_providers)
+    @search_provider_failure_names = provider_names(failed_providers)
+    enrichment = stream_enrichment_for(@results, loading: loading)
+    @audiobookshelf_matches = enrichment[:audiobookshelf_matches]
+    @existing_books_lookup = enrichment[:existing_books_lookup]
+  end
+
+  def provider_failure_error(results, failed_providers, providers, complete:)
+    return unless complete && results.empty? && providers.any? && failed_providers.size >= providers.size
+
+    "Unable to connect to metadata service. Please try again later."
+  end
+
+  def private_search_response!
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Pragma"] = "no-cache"
   end
 
   def audiobookshelf_matches_for(results)
@@ -247,21 +408,39 @@ class SearchController < ApplicationController
   end
 
   def search_metadata(query)
-    return MetadataService.search(query, content_kind: @content_kind) if @content_kind.present?
+    if @content_kind.present?
+      return MetadataService.search(
+        query,
+        content_kind: @content_kind,
+        aggregate_limit: SearchResultSnapshot::MAX_RESULTS
+      )
+    end
 
-    MetadataService.search(query)
+    MetadataService.search(query, aggregate_limit: SearchResultSnapshot::MAX_RESULTS)
   end
 
   def each_provider_search(query)
     if @content_kind.present?
-      MetadataService.each_provider_search(query, content_kind: @content_kind) { |provider, results| yield provider, results }
+      MetadataService.each_provider_search(query, content_kind: @content_kind) do |provider, results, failed|
+        yield provider, results, failed
+      end
     else
-      MetadataService.each_provider_search(query) { |provider, results| yield provider, results }
+      MetadataService.each_provider_search(query) { |provider, results, failed| yield provider, results, failed }
     end
   end
 
   def normalized_content_kind(value)
     ContentKinds.normalize(value, default: nil)
+  end
+
+  def invalid_explicit_search_page?
+    return false unless params.key?(:page)
+
+    value = params[:page].to_s
+    return true unless value.match?(/\A[1-9]\d*\z/)
+
+    page = Integer(value, exception: false)
+    !page&.between?(1, SearchResultSnapshot::MAX_PAGES)
   end
 
   def enrich_details_from_source

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,122 +1,152 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Stimulus controller for debounced search
-// Connects to data-controller="search"
+const PAGE_CACHE_LIMIT = 5
+const PAGE_CACHE_TTL = 10 * 60 * 1000
+
+// Handles progressive federated search and cached aggregate page navigation.
 export default class extends Controller {
   static targets = ["input", "results", "spinner", "contentKind"]
   static values = {
+    indexUrl: String,
     url: String,
     streamUrl: String,
+    snapshotUrl: String,
+    page: { type: Number, default: 1 },
+    initialSearch: Boolean,
     debounce: { type: Number, default: 700 }
   }
 
   connect() {
     this.timeout = null
     this.currentAbortController = null
+    this.preloadAbortController = null
     this.requestSequence ??= 0
+    this.pageCache ??= new Map()
+
+    this.requestSequence += 1
+    const urlState = this.stateFromUrl(window.location.href)
+    this.pageValue = urlState.page
+    const restoredState = this.restoreSnapshotFromPage()
+
+    const query = this.inputTarget.value.trim()
+    if (this.completeStateMatches(restoredState, query, this.currentContentKind, this.pageValue) &&
+        (!restoredState.snapshotId || !this.snapshotExpired(restoredState.snapshotExpiresAt))) {
+      return
+    }
+
+    const historyState = this.restoreSnapshotFromHistory(query, this.currentContentKind, this.pageValue)
+    if (historyState && query.length >= 2) {
+      const requestId = this.beginGeneration()
+      this.fetchSnapshotPage(urlState, requestId, { focus: false })
+    } else if (query.length >= 2 && (this.initialSearchValue || restoredState)) {
+      const requestId = this.beginGeneration()
+      this.performSearch(query, this.currentContentKind, this.pageValue, requestId)
+    }
   }
 
   disconnect() {
-    if (this.timeout) {
-      clearTimeout(this.timeout)
-    }
+    if (this.timeout) clearTimeout(this.timeout)
+    this.timeout = null
     this.requestSequence += 1
-    this.abortCurrentRequest()
+    this.abortVisibleRequest()
+    this.abortPreloadRequest()
   }
 
   search() {
     const query = this.inputTarget.value.trim()
     const contentKind = this.currentContentKind
-    const requestId = ++this.requestSequence
+    const page = 1
+    const requestId = this.beginGeneration()
 
-    // Clear existing timeout
-    if (this.timeout) {
-      clearTimeout(this.timeout)
-    }
-    this.abortCurrentRequest()
+    if (this.timeout) clearTimeout(this.timeout)
+    this.timeout = null
+    this.pageValue = page
+    this.clearSnapshot()
 
-    // If query is empty, clear results
     if (query.length === 0) {
       this.resultsTarget.innerHTML = ""
+      this.resultsTarget.setAttribute("aria-busy", "false")
+      this.replaceCanonicalState(query, contentKind, page)
       this.hideSpinner()
       return
     }
 
-    // Don't search for very short queries
     if (query.length < 2) {
+      this.resultsTarget.innerHTML = ""
+      this.resultsTarget.setAttribute("aria-busy", "false")
+      this.replaceCanonicalState(query, contentKind, page)
       this.hideSpinner()
       return
     }
 
     this.timeout = setTimeout(() => {
       this.timeout = null
-      this.performSearch(query, contentKind, requestId)
+      this.replaceCanonicalState(query, contentKind, page)
+      this.performSearch(query, contentKind, page, requestId)
     }, this.debounceValue)
   }
 
-  async performSearch(query, contentKind, requestId) {
-    if (!this.searchStateMatches(requestId, query, contentKind)) return
+  navigate(event) {
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
 
-    const params = new URLSearchParams({ q: query })
-    if (contentKind) {
-      params.set("content_kind", contentKind)
-    }
+    event.preventDefault()
+    const state = this.stateFromUrl(event.currentTarget.href)
+    this.navigateToState(state, { historyMode: "push", focus: true })
+  }
+
+  async performSearch(query, contentKind, page, requestId, { focus = false } = {}) {
+    if (!this.searchStateMatches(requestId, query, contentKind, page)) return
+
+    const params = this.searchParams(query, contentKind, page)
     const url = `${this.searchUrl}?${params.toString()}`
     const abortController = new AbortController()
 
     this.currentAbortController = abortController
+    this.resultsTarget.setAttribute("aria-busy", "true")
     this.showSpinner()
 
+    let completed = false
     try {
       const response = await fetch(url, {
         signal: abortController.signal,
-        headers: {
-          "Accept": "text/vnd.turbo-stream.html"
-        }
+        headers: { "Accept": "text/vnd.turbo-stream.html" }
       })
 
-      if (response.ok && this.searchStateMatches(requestId, query, contentKind)) {
+      if (!this.searchStateMatches(requestId, query, contentKind, page)) return
+
+      if (response.ok) {
         if (response.body) {
-          await this.renderStreamingResponse(response, requestId, query, contentKind)
+          completed = await this.renderStreamingResponse(response, requestId, query, contentKind, page, { focus })
         } else {
           const html = await response.text()
-          this.renderStreamMessage(html, requestId, query, contentKind)
+          completed = this.renderStreamMessage(html, requestId, query, contentKind, page, { focus })
         }
+      } else {
+        this.renderRequestError(requestId, query, contentKind, page, { focus })
       }
     } catch (error) {
-      if (error.name === "AbortError") {
-        return
+      if (error.name !== "AbortError" && this.searchStateMatches(requestId, query, contentKind, page)) {
+        console.error("Search failed:", error)
+        this.renderRequestError(requestId, query, contentKind, page, { focus })
       }
-
-      console.error("Search failed:", error)
     } finally {
       if (this.currentAbortController === abortController) {
         this.currentAbortController = null
         this.hideSpinner()
+        if (!completed && this.searchStateMatches(requestId, query, contentKind, page) &&
+            this.resultsTarget.getAttribute("aria-busy") === "true") {
+          this.renderRequestError(requestId, query, contentKind, page, { focus })
+        }
       }
     }
   }
 
-  abortCurrentRequest() {
-    if (this.currentAbortController) {
-      this.currentAbortController.abort()
-      this.currentAbortController = null
-    }
-  }
-
-  get searchUrl() {
-    return this.hasStreamUrlValue ? this.streamUrlValue : this.urlValue
-  }
-
-  get currentContentKind() {
-    return this.hasContentKindTarget ? this.contentKindTarget.value : ""
-  }
-
-  async renderStreamingResponse(response, requestId, query, contentKind) {
+  async renderStreamingResponse(response, requestId, query, contentKind, page, { focus }) {
     const reader = response.body.getReader()
     const decoder = new TextDecoder()
     const closingTag = "</turbo-stream>"
     let buffer = ""
+    let completed = false
 
     while (true) {
       const { done, value } = await reader.read()
@@ -127,40 +157,442 @@ export default class extends Controller {
         const endIndex = closingIndex + closingTag.length
         const message = buffer.slice(0, endIndex)
         buffer = buffer.slice(endIndex)
-        this.renderStreamMessage(message, requestId, query, contentKind)
+        completed = this.renderStreamMessage(message, requestId, query, contentKind, page, { focus }) || completed
         closingIndex = buffer.indexOf(closingTag)
       }
 
       if (done) {
         if (buffer.trim().length > 0) {
-          this.renderStreamMessage(buffer, requestId, query, contentKind)
+          completed = this.renderStreamMessage(buffer, requestId, query, contentKind, page, { focus }) || completed
         }
         break
       }
     }
+
+    return completed
   }
 
-  renderStreamMessage(html, requestId, query, contentKind) {
-    if (this.searchStateMatches(requestId, query, contentKind)) {
-      Turbo.renderStreamMessage(html)
+  renderStreamMessage(html, requestId, query, contentKind, page, { focus = false, expectedSnapshotId = null } = {}) {
+    if (!this.searchStateMatches(requestId, query, contentKind, page)) return false
+
+    const responseState = this.stateFromResponse(html)
+    if (responseState && !this.responseStateMatches(responseState, query, contentKind, page)) return false
+    if (expectedSnapshotId && responseState?.snapshotId !== expectedSnapshotId) return false
+
+    Turbo.renderStreamMessage(html)
+    if (!responseState) return false
+
+    queueMicrotask(() => {
+      if (!this.searchStateMatches(requestId, query, contentKind, page)) return
+
+      this.resultsTarget.setAttribute("aria-busy", responseState.complete ? "false" : "true")
+      this.pageValue = responseState.page
+      if (responseState.snapshotId && !this.snapshotExpired(responseState.snapshotExpiresAt)) {
+        this.currentSnapshotId = responseState.snapshotId
+        this.snapshotExpiresAt = responseState.snapshotExpiresAt
+        this.snapshotQuery = query
+        this.snapshotContentKind = contentKind
+      }
+
+      if (!responseState.complete) return
+
+      this.replaceCanonicalState(
+        query,
+        contentKind,
+        responseState.page,
+        responseState.snapshotId,
+        responseState.snapshotExpiresAt
+      )
+
+      this.storePage(query, contentKind, responseState.page, responseState.snapshotId, responseState.snapshotExpiresAt, html)
+      if (focus) this.focusResultsHeading()
+      this.preloadNextPage(responseState, requestId, query, contentKind, responseState.page)
+    })
+
+    return responseState.complete
+  }
+
+  async navigateToState(state, { historyMode, focus }) {
+    const requestId = this.beginGeneration()
+    this.inputTarget.value = state.query
+    if (this.hasContentKindTarget) this.contentKindTarget.value = state.contentKind
+    this.pageValue = state.page
+
+    if (historyMode === "push") {
+      this.pushCanonicalState(state.query, state.contentKind, state.page)
+    }
+
+    if (state.query.length < 2) {
+      this.resultsTarget.innerHTML = ""
+      this.hideSpinner()
+      return
+    }
+
+    if (this.snapshotMatches(state.query, state.contentKind)) {
+      const cached = this.cachedPage(
+        state.query,
+        state.contentKind,
+        state.page,
+        this.currentSnapshotId,
+        this.snapshotExpiresAt
+      )
+      if (cached) {
+        this.hideSpinner()
+        this.renderStreamMessage(cached, requestId, state.query, state.contentKind, state.page, {
+          focus,
+          expectedSnapshotId: this.currentSnapshotId
+        })
+        return
+      }
+      await this.fetchSnapshotPage(state, requestId, { focus })
+    } else {
+      this.clearSnapshot()
+      await this.performSearch(state.query, state.contentKind, state.page, requestId, { focus })
     }
   }
 
-  searchStateMatches(requestId, query, contentKind) {
+  async fetchSnapshotPage(state, requestId, { focus }) {
+    const snapshotId = this.currentSnapshotId
+    const abortController = new AbortController()
+    this.currentAbortController = abortController
+    this.resultsTarget.setAttribute("aria-busy", "true")
+    this.showSpinner()
+
+    try {
+      const response = await fetch(this.snapshotRequestUrl(snapshotId, state.query, state.contentKind, state.page), {
+        signal: abortController.signal,
+        headers: { "Accept": "text/vnd.turbo-stream.html" }
+      })
+
+      if (!this.searchStateMatches(requestId, state.query, state.contentKind, state.page)) return
+
+      if (response.ok) {
+        const html = await response.text()
+        const rendered = this.renderStreamMessage(html, requestId, state.query, state.contentKind, state.page, {
+          focus,
+          expectedSnapshotId: snapshotId
+        })
+        if (!rendered && this.searchStateMatches(requestId, state.query, state.contentKind, state.page)) {
+          this.currentAbortController = null
+          this.clearSnapshot()
+          await this.performSearch(state.query, state.contentKind, state.page, requestId, { focus })
+        }
+      } else {
+        this.currentAbortController = null
+        this.clearSnapshot()
+        await this.performSearch(state.query, state.contentKind, state.page, requestId, { focus })
+      }
+    } catch (error) {
+      if (error.name !== "AbortError" && this.searchStateMatches(requestId, state.query, state.contentKind, state.page)) {
+        console.error("Search page failed:", error)
+        this.currentAbortController = null
+        this.clearSnapshot()
+        await this.performSearch(state.query, state.contentKind, state.page, requestId, { focus })
+      }
+    } finally {
+      if (this.currentAbortController === abortController) {
+        this.currentAbortController = null
+        this.hideSpinner()
+      }
+    }
+  }
+
+  preloadNextPage(state, requestId, query, contentKind, page) {
+    this.abortPreloadRequest()
+    if (!state.preloadPage || !state.snapshotId || this.snapshotExpired(state.snapshotExpiresAt)) return
+
+    const preloadPage = state.preloadPage
+    if (this.cachedPage(query, contentKind, preloadPage, state.snapshotId, state.snapshotExpiresAt)) return
+
+    const abortController = new AbortController()
+    this.preloadAbortController = abortController
+
+    fetch(this.snapshotRequestUrl(state.snapshotId, query, contentKind, preloadPage), {
+      signal: abortController.signal,
+      headers: { "Accept": "text/vnd.turbo-stream.html" }
+    }).then(async (response) => {
+      if (!response.ok) return
+      const html = await response.text()
+      const responseState = this.stateFromResponse(html)
+      if (abortController.signal.aborted ||
+          !this.searchStateMatches(requestId, query, contentKind, page) ||
+          this.currentSnapshotId !== state.snapshotId ||
+          this.snapshotExpired(state.snapshotExpiresAt) ||
+          !responseState?.complete ||
+          responseState.snapshotId !== state.snapshotId ||
+          !this.responseStateMatches(responseState, query, contentKind, preloadPage)) return
+
+      this.storePage(query, contentKind, responseState.page, state.snapshotId, state.snapshotExpiresAt, html)
+    }).catch((error) => {
+      if (error.name !== "AbortError") console.error("Search page preload failed:", error)
+    }).finally(() => {
+      if (this.preloadAbortController === abortController) this.preloadAbortController = null
+    })
+  }
+
+  beginGeneration() {
+    this.requestSequence += 1
+    this.abortVisibleRequest()
+    this.abortPreloadRequest()
+    return this.requestSequence
+  }
+
+  abortVisibleRequest() {
+    if (this.currentAbortController) this.currentAbortController.abort()
+    this.currentAbortController = null
+  }
+
+  abortPreloadRequest() {
+    if (this.preloadAbortController) this.preloadAbortController.abort()
+    this.preloadAbortController = null
+  }
+
+  clearSnapshot() {
+    this.currentSnapshotId = null
+    this.snapshotExpiresAt = null
+    this.snapshotQuery = null
+    this.snapshotContentKind = null
+  }
+
+  snapshotMatches(query, contentKind) {
+    if (this.snapshotExpired(this.snapshotExpiresAt)) {
+      this.deleteSnapshotPages(this.currentSnapshotId)
+      this.clearSnapshot()
+      return false
+    }
+
+    return this.currentSnapshotId && this.snapshotQuery === query && this.snapshotContentKind === contentKind
+  }
+
+  get searchUrl() {
+    return this.hasStreamUrlValue ? this.streamUrlValue : this.urlValue
+  }
+
+  get currentContentKind() {
+    return this.hasContentKindTarget ? this.contentKindTarget.value : ""
+  }
+
+  searchStateMatches(requestId, query, contentKind, page) {
     return requestId === this.requestSequence &&
       this.inputTarget.value.trim() === query &&
-      this.currentContentKind === contentKind
+      this.currentContentKind === contentKind &&
+      this.pageValue === page
+  }
+
+  responseStateMatches(state, query, contentKind, page) {
+    const canonicalPage = state.complete && state.page <= page
+    return state.query === query && state.contentKind === contentKind &&
+      (state.page === page || canonicalPage)
+  }
+
+  stateFromResponse(html) {
+    const document = new DOMParser().parseFromString(html, "text/html")
+    const template = document.querySelector("turbo-stream template")
+    const element = template?.content.querySelector("[data-search-state]")
+    return element ? this.stateFromElement(element) : null
+  }
+
+  stateFromElement(element) {
+    return {
+      query: element.dataset.searchQuery || "",
+      contentKind: element.dataset.searchContentKind || "",
+      page: this.normalizePage(element.dataset.searchPage),
+      complete: element.dataset.searchComplete === "true",
+      snapshotId: element.dataset.searchSnapshotId || null,
+      snapshotExpiresAt: Number.parseInt(element.dataset.searchSnapshotExpiresAt || "0", 10),
+      preloadPage: element.dataset.searchPreloadPage ? this.normalizePage(element.dataset.searchPreloadPage) : null
+    }
+  }
+
+  restoreSnapshotFromPage() {
+    const element = this.resultsTarget.querySelector("[data-search-state]")
+    if (!element) return null
+
+    const state = this.stateFromElement(element)
+    if (!state.complete) return null
+    if (!state.snapshotId || this.snapshotExpired(state.snapshotExpiresAt)) return state
+
+    this.currentSnapshotId = state.snapshotId
+    this.snapshotExpiresAt = state.snapshotExpiresAt
+    this.snapshotQuery = state.query
+    this.snapshotContentKind = state.contentKind
+    return state
+  }
+
+  restoreSnapshotFromHistory(query, contentKind, page) {
+    const state = history.state?.shelfarrSearch
+    if (!state || state.query !== query || state.contentKind !== contentKind || state.page !== page ||
+        !state.snapshotId || this.snapshotExpired(state.snapshotExpiresAt)) return null
+
+    this.currentSnapshotId = state.snapshotId
+    this.snapshotExpiresAt = state.snapshotExpiresAt
+    this.snapshotQuery = query
+    this.snapshotContentKind = contentKind
+    return state
+  }
+
+  completeStateMatches(state, query, contentKind, page) {
+    return state?.complete && state.query === query && state.contentKind === contentKind && state.page === page
+  }
+
+  stateFromUrl(value) {
+    const url = new URL(value, window.location.href)
+    return {
+      query: (url.searchParams.get("q") || "").trim(),
+      contentKind: this.normalizeContentKind(url.searchParams.get("content_kind")),
+      page: this.normalizePage(url.searchParams.get("page"))
+    }
+  }
+
+  normalizeContentKind(value) {
+    if (value === "comic" || value === "manga") return "graphic"
+    return value === "book" || value === "graphic" ? value : ""
+  }
+
+  normalizePage(value) {
+    const page = Number.parseInt(value || "1", 10)
+    return Number.isFinite(page) ? Math.min(Math.max(page, 1), 10) : 1
+  }
+
+  searchParams(query, contentKind, page) {
+    const params = new URLSearchParams({ q: query, page: page.toString() })
+    if (contentKind) params.set("content_kind", contentKind)
+    return params
+  }
+
+  snapshotRequestUrl(snapshotId, query, contentKind, page) {
+    const params = this.searchParams(query, contentKind, page)
+    params.set("snapshot_id", snapshotId)
+    return `${this.snapshotUrlValue}?${params.toString()}`
+  }
+
+  canonicalUrl(query, contentKind, page) {
+    const url = new URL(this.indexUrlValue, window.location.origin)
+    if (query) {
+      url.search = this.searchParams(query, contentKind, page).toString()
+    }
+    return `${url.pathname}${url.search}`
+  }
+
+  pushCanonicalState(query, contentKind, page) {
+    history.pushState(this.searchHistoryState(query, contentKind, page), "", this.canonicalUrl(query, contentKind, page))
+  }
+
+  replaceCanonicalState(query, contentKind, page, snapshotId = null, snapshotExpiresAt = null) {
+    history.replaceState(
+      this.searchHistoryState(query, contentKind, page, snapshotId, snapshotExpiresAt),
+      "",
+      this.canonicalUrl(query, contentKind, page)
+    )
+  }
+
+  searchHistoryState(
+    query,
+    contentKind,
+    page,
+    snapshotId = this.currentSnapshotId,
+    snapshotExpiresAt = this.snapshotExpiresAt
+  ) {
+    const current = history.state && typeof history.state === "object" ? history.state : {}
+    return {
+      ...current,
+      shelfarrSearch: { query, contentKind, page, snapshotId, snapshotExpiresAt }
+    }
+  }
+
+  pageKey(query, contentKind, page, snapshotId) {
+    return JSON.stringify([snapshotId, query, contentKind, page])
+  }
+
+  storePage(query, contentKind, page, snapshotId, snapshotExpiresAt, html) {
+    if (!snapshotId || this.snapshotExpired(snapshotExpiresAt)) return
+
+    const key = this.pageKey(query, contentKind, page, snapshotId)
+    this.pageCache.delete(key)
+    this.pageCache.set(key, { html, snapshotId, snapshotExpiresAt, storedAt: Date.now() })
+    while (this.pageCache.size > PAGE_CACHE_LIMIT) {
+      this.pageCache.delete(this.pageCache.keys().next().value)
+    }
+  }
+
+  cachedPage(query, contentKind, page, snapshotId, snapshotExpiresAt) {
+    if (!snapshotId || this.snapshotExpired(snapshotExpiresAt)) {
+      this.deleteSnapshotPages(snapshotId)
+      return null
+    }
+
+    const key = this.pageKey(query, contentKind, page, snapshotId)
+    const cached = this.pageCache.get(key)
+    if (!cached) return null
+    if (cached.snapshotId !== snapshotId || cached.snapshotExpiresAt !== snapshotExpiresAt ||
+        Date.now() - cached.storedAt > PAGE_CACHE_TTL || this.snapshotExpired(cached.snapshotExpiresAt)) {
+      this.pageCache.delete(key)
+      return null
+    }
+    this.pageCache.delete(key)
+    this.pageCache.set(key, cached)
+    return cached.html
+  }
+
+  deleteSnapshotPages(snapshotId) {
+    if (!snapshotId) return
+
+    for (const [key, cached] of this.pageCache) {
+      if (cached.snapshotId === snapshotId) this.pageCache.delete(key)
+    }
+  }
+
+  snapshotExpired(expiresAt) {
+    return !Number.isFinite(expiresAt) || expiresAt * 1000 <= Date.now()
+  }
+
+  renderRequestError(requestId, query, contentKind, page, { focus }) {
+    if (!this.searchStateMatches(requestId, query, contentKind, page)) return
+
+    this.clearSnapshot()
+    const container = document.createElement("div")
+    container.dataset.searchState = ""
+    container.dataset.searchQuery = query
+    container.dataset.searchContentKind = contentKind
+    container.dataset.searchPage = page.toString()
+    container.dataset.searchPageCount = "0"
+    container.dataset.searchHasNext = "false"
+    container.dataset.searchComplete = "true"
+
+    const heading = document.createElement("h2")
+    heading.id = "search-results-heading"
+    heading.tabIndex = -1
+    heading.className = "mb-4 text-xl font-semibold text-white focus:outline-none"
+    heading.textContent = "Search results"
+
+    const status = document.createElement("p")
+    status.className = "sr-only"
+    status.setAttribute("role", "status")
+    status.setAttribute("aria-live", "polite")
+    status.setAttribute("aria-atomic", "true")
+    status.textContent = "Search failed. Please try again."
+
+    const error = document.createElement("div")
+    error.className = "rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-400"
+    error.textContent = "Search failed. Please try again."
+
+    container.append(heading, status, error)
+    this.resultsTarget.replaceChildren(container)
+    this.resultsTarget.setAttribute("aria-busy", "false")
+    if (focus) this.focusResultsHeading()
+  }
+
+  focusResultsHeading() {
+    requestAnimationFrame(() => {
+      this.resultsTarget.querySelector("#search-results-heading")?.focus()
+    })
   }
 
   showSpinner() {
-    if (this.hasSpinnerTarget) {
-      this.spinnerTarget.classList.remove("hidden")
-    }
+    if (this.hasSpinnerTarget) this.spinnerTarget.classList.remove("hidden")
   }
 
   hideSpinner() {
-    if (this.hasSpinnerTarget) {
-      this.spinnerTarget.classList.add("hidden")
-    }
+    if (this.hasSpinnerTarget) this.spinnerTarget.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -13,18 +13,21 @@ export default class extends Controller {
   connect() {
     this.timeout = null
     this.currentAbortController = null
-    this.requestSequence = 0
+    this.requestSequence ??= 0
   }
 
   disconnect() {
     if (this.timeout) {
       clearTimeout(this.timeout)
     }
+    this.requestSequence += 1
     this.abortCurrentRequest()
   }
 
   search() {
     const query = this.inputTarget.value.trim()
+    const contentKind = this.currentContentKind
+    const requestId = ++this.requestSequence
 
     // Clear existing timeout
     if (this.timeout) {
@@ -46,17 +49,19 @@ export default class extends Controller {
     }
 
     this.timeout = setTimeout(() => {
-      this.performSearch(query)
+      this.timeout = null
+      this.performSearch(query, contentKind, requestId)
     }, this.debounceValue)
   }
 
-  async performSearch(query) {
+  async performSearch(query, contentKind, requestId) {
+    if (!this.searchStateMatches(requestId, query, contentKind)) return
+
     const params = new URLSearchParams({ q: query })
-    if (this.hasContentKindTarget && this.contentKindTarget.value) {
-      params.set("content_kind", this.contentKindTarget.value)
+    if (contentKind) {
+      params.set("content_kind", contentKind)
     }
     const url = `${this.searchUrl}?${params.toString()}`
-    const requestId = ++this.requestSequence
     const abortController = new AbortController()
 
     this.currentAbortController = abortController
@@ -70,12 +75,12 @@ export default class extends Controller {
         }
       })
 
-      if (response.ok && requestId === this.requestSequence && this.inputTarget.value.trim() === query) {
+      if (response.ok && this.searchStateMatches(requestId, query, contentKind)) {
         if (response.body) {
-          await this.renderStreamingResponse(response, requestId, query)
+          await this.renderStreamingResponse(response, requestId, query, contentKind)
         } else {
           const html = await response.text()
-          this.renderStreamMessage(html, requestId, query)
+          this.renderStreamMessage(html, requestId, query, contentKind)
         }
       }
     } catch (error) {
@@ -103,7 +108,11 @@ export default class extends Controller {
     return this.hasStreamUrlValue ? this.streamUrlValue : this.urlValue
   }
 
-  async renderStreamingResponse(response, requestId, query) {
+  get currentContentKind() {
+    return this.hasContentKindTarget ? this.contentKindTarget.value : ""
+  }
+
+  async renderStreamingResponse(response, requestId, query, contentKind) {
     const reader = response.body.getReader()
     const decoder = new TextDecoder()
     const closingTag = "</turbo-stream>"
@@ -118,23 +127,29 @@ export default class extends Controller {
         const endIndex = closingIndex + closingTag.length
         const message = buffer.slice(0, endIndex)
         buffer = buffer.slice(endIndex)
-        this.renderStreamMessage(message, requestId, query)
+        this.renderStreamMessage(message, requestId, query, contentKind)
         closingIndex = buffer.indexOf(closingTag)
       }
 
       if (done) {
         if (buffer.trim().length > 0) {
-          this.renderStreamMessage(buffer, requestId, query)
+          this.renderStreamMessage(buffer, requestId, query, contentKind)
         }
         break
       }
     }
   }
 
-  renderStreamMessage(html, requestId, query) {
-    if (requestId === this.requestSequence && this.inputTarget.value.trim() === query) {
+  renderStreamMessage(html, requestId, query, contentKind) {
+    if (this.searchStateMatches(requestId, query, contentKind)) {
       Turbo.renderStreamMessage(html)
     }
+  }
+
+  searchStateMatches(requestId, query, contentKind) {
+    return requestId === this.requestSequence &&
+      this.inputTarget.value.trim() === query &&
+      this.currentContentKind === contentKind
   }
 
   showSpinner() {

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -188,6 +188,19 @@ class DownloadJob < ApplicationJob
   end
 
   def direct_library_configuration_error?(error)
+    return true if direct_library_configuration_exception?(error)
+    return false unless error.is_a?(DirectDownloadFileService::Error)
+
+    8.times do
+      error = error.cause
+      return false unless error
+      return true if direct_library_configuration_exception?(error)
+    end
+
+    false
+  end
+
+  def direct_library_configuration_exception?(error)
     case error
     when FileCopyService::DirectoryNotWritableError,
          FileCopyService::UnsafeFilePermissionsError,

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -957,12 +957,11 @@ class PostProcessingJob < ApplicationJob
     loop do
       break unless path_occupied?(candidate)
 
-      if File.symlink?(candidate)
-        if reference_completed_downloads? &&
-            File.readlink(candidate) == Pathname(source).expand_path.to_s
+      if reference_completed_downloads?
+        if reference_target_matches?(source, candidate)
           return [ candidate, true ]
         end
-      elsif same_file_content?(source, candidate)
+      elsif !File.symlink?(candidate) && same_file_content?(source, candidate)
         unless hardlink_completed_downloads?
           return [ candidate, true ]
         end
@@ -1001,10 +1000,19 @@ class PostProcessingJob < ApplicationJob
     )
   end
 
+  def reference_target_matches?(source, destination)
+    FileCopyService.reference_target_matches?(
+      source,
+      destination,
+      root: @import_base_path,
+      source_root: @import_source_root,
+      source_snapshot: @import_source_file_snapshot
+    )
+  end
+
   def verify_imported_destination!(source, destination, require_durable:)
     if reference_completed_downloads?
-      source_path = Pathname(source).expand_path.to_s
-      unless File.lstat(destination).symlink? && File.readlink(destination) == source_path
+      unless reference_target_matches?(source, destination)
         raise Errno::ESTALE, "library reference changed after import"
       end
       return

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -85,7 +85,7 @@ class Book < ApplicationRecord
 
     case source
     when "hardcover"
-      "https://hardcover.app/books/#{source_id}"
+      MetadataSources.hardcover_book_url(source_id)
     when "google_books"
       "https://books.google.com/books?id=#{source_id}"
     when "openlibrary"

--- a/app/models/metadata_sources.rb
+++ b/app/models/metadata_sources.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module MetadataSources
+  HARDCOVER_BOOK_ID_PATTERN = /\A[1-9]\d*\z/
+
   NAMES = {
     "hardcover" => "Hardcover",
     "google_books" => "Google Books",
@@ -10,5 +12,10 @@ module MetadataSources
 
   def self.display_name(source)
     NAMES.fetch(source.to_s, source.to_s.titleize)
+  end
+
+  def self.hardcover_book_url(id)
+    id = id.to_s
+    "https://hardcover.app/id/book/#{id}" if HARDCOVER_BOOK_ID_PATTERN.match?(id)
   end
 end

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -227,6 +227,38 @@ class FileCopyService
       dest.to_s
     end
 
+    def reference_target_matches?(source, destination, root:, source_root: nil, source_snapshot: nil)
+      if source_root.nil? == source_snapshot.nil?
+        raise ArgumentError, "reference source requires exactly one authorization snapshot"
+      end
+
+      source_path = Pathname(source).expand_path
+      if source_snapshot && source_path != source_snapshot.path
+        raise UnsafePathError, "reference source does not match its authorization snapshot"
+      end
+      source_operation = if source_snapshot
+        ->(&operation) { with_pinned_source_snapshot(source_snapshot, &operation) }
+      else
+        ->(&operation) { with_pinned_source(source_path, source_root: source_root, &operation) }
+      end
+
+      result = nil
+      source_operation.call do |pinned_source, *_source_path|
+        raise Errno::EINVAL, "source is not a regular file" unless pinned_source.stat.file?
+
+        with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
+          matches = begin
+            native_readlinkat(parent.fileno, basename) == source_path.to_s
+          rescue Errno::EINVAL
+            false
+          end
+          validate_current_directory_identity!(parent_path, parent)
+          result = matches
+        end
+      end
+      result
+    end
+
     # Unlink only when the name still points at the target we published.
     def remove_published_reference_if_ours!(parent, basename, expected_target:)
       current = native_readlinkat(parent.fileno, basename)

--- a/app/services/metadata_search/result_normalizer.rb
+++ b/app/services/metadata_search/result_normalizer.rb
@@ -39,7 +39,7 @@ module MetadataSearch
           series_position: result.series_position,
           has_ebook: result.has_ebook,
           has_audiobook: result.has_audiobook,
-          source_url: "https://hardcover.app/books/#{result.id}",
+          source_url: MetadataSources.hardcover_book_url(result.id),
           raw_payload: nil,
           content_kind: classification.content_kind,
           resource_kind: "work",

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -277,6 +277,8 @@ class MetadataService
       candidates.sort_by do |candidate|
         [
           candidate.content_kind == requested_content_kind ? 0 : 1,
+          requested_content_kind &&
+            candidate.classification_confidence < MetadataSearch::ContentClassifier::STRONG_CONFIDENCE ? 1 : 0,
           priority.index(candidate.source.to_s) || priority.size,
           -candidate.confidence,
           candidate.title.to_s.downcase,

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -5,6 +5,8 @@
 class MetadataService
   class Error < StandardError; end
 
+  ProviderSearchOutcome = Data.define(:results, :failed, :skipped)
+
   SearchResult = Data.define(
     :source, :source_id, :title, :author, :description, :year,
     :cover_url, :has_audiobook, :has_ebook, :series_name, :series_position
@@ -49,13 +51,13 @@ class MetadataService
   class << self
     # Search for books across enabled metadata sources and aggregate duplicates
     # into Shelfarr candidates.
-    def search(query, limit: nil, content_kind: nil)
+    def search(query, limit: nil, content_kind: nil, aggregate_limit: nil)
       content_kind = ContentKinds.normalize(content_kind, default: nil)
       providers = enabled_metadata_providers(content_kind: content_kind)
       Rails.logger.info "[MetadataService] Searching '#{query}' using providers: #{providers.join(', ')}"
 
       provider_results = search_providers_concurrently(providers, query, limit: limit, content_kind: content_kind)
-      aggregate_provider_results(provider_results, limit: limit, content_kind: content_kind)
+      aggregate_provider_results(provider_results, limit: aggregate_limit || limit, content_kind: content_kind)
     end
 
     def each_provider_search(query, limit: nil, content_kind: nil)
@@ -68,12 +70,20 @@ class MetadataService
         Thread.new do
           Rails.application.executor.wrap do
             ActiveRecord::Base.connection_pool.with_connection do
-              queue << [ provider, search_provider(provider, query, limit: limit, content_kind: content_kind) ]
+              outcome = search_provider(
+                provider,
+                query,
+                limit: limit,
+                content_kind: content_kind,
+                with_outcome: true
+              )
+              outcome = ProviderSearchOutcome.new(results: Array(outcome), failed: false, skipped: false) unless outcome.is_a?(ProviderSearchOutcome)
+              queue << [ provider, outcome.results, outcome.failed ]
             end
           end
         rescue StandardError => e
           Rails.logger.warn "[MetadataService] #{provider} search failed: #{e.message}"
-          queue << [ provider, [] ]
+          queue << [ provider, [], true ]
         end
       end
 
@@ -84,12 +94,13 @@ class MetadataService
       threads&.each(&:join)
     end
 
-    def search_provider(provider, query, limit: nil, content_kind: nil)
+    def search_provider(provider, query, limit: nil, content_kind: nil, with_outcome: false)
       content_kind = ContentKinds.normalize(content_kind, default: nil)
       status = MetadataProviderStatus.for_provider(provider)
       unless status.available?
         Rails.logger.info "[MetadataService] Skipping #{provider}: #{status.status}"
-        return []
+        outcome = ProviderSearchOutcome.new(results: [], failed: true, skipped: true)
+        return with_outcome ? outcome : outcome.results
       end
 
       results = if content_kind.present?
@@ -98,11 +109,13 @@ class MetadataService
         send("search_#{provider}", query, provider_limit(provider, limit))
       end
       status.record_success!
-      results
+      outcome = ProviderSearchOutcome.new(results: results, failed: false, skipped: false)
+      with_outcome ? outcome : outcome.results
     rescue *provider_errors(provider) => e
       status&.record_failure!(e)
       Rails.logger.warn "[MetadataService] #{provider} search failed: #{e.message}"
-      []
+      outcome = ProviderSearchOutcome.new(results: [], failed: true, skipped: false)
+      with_outcome ? outcome : outcome.results
     end
 
     def aggregate_provider_results(provider_results, limit: nil, content_kind: nil)

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -29,7 +29,7 @@ class MetadataService
     def source_url
       case source.to_s
       when "hardcover"
-        "https://hardcover.app/books/#{source_id}" if source_id.present?
+        MetadataSources.hardcover_book_url(source_id)
       when "google_books"
         "https://books.google.com/books?id=#{source_id}" if source_id.present?
       when "openlibrary"

--- a/app/services/search_result_snapshot.rb
+++ b/app/services/search_result_snapshot.rb
@@ -1,0 +1,362 @@
+# frozen_string_literal: true
+
+require "digest"
+
+class SearchResultSnapshot
+  TTL = 10.minutes
+  PAGE_SIZE = 20
+  MAX_PAGES = 10
+  MAX_RESULTS = PAGE_SIZE * MAX_PAGES
+  MAX_SNAPSHOTS = 3
+  MAX_PAYLOAD_BYTES = 2.megabytes
+  COLLECTION_OVERHEAD_BYTES = 32.kilobytes
+  MAX_SNAPSHOT_BYTES = (MAX_PAYLOAD_BYTES - COLLECTION_OVERHEAD_BYTES) / MAX_SNAPSHOTS
+  MAX_QUERY_BYTES = 500
+  MAX_IDENTITY_BYTES = 512
+  MAX_TEXT_BYTES = 8.kilobytes
+  MAX_URL_BYTES = 2.kilobytes
+  MAX_SOURCES = 8
+  MAX_EDITIONS = 20
+  MAX_LIST_VALUES = 20
+  MAX_INTEGER = 9_007_199_254_740_991
+  MAX_FLOAT = 9_007_199_254_740_991.0
+  TOKEN_PATTERN = /\A[A-Za-z0-9_-]{32}\z/
+
+  Snapshot = Data.define(:id, :results, :complete, :failed_providers, :provider_count, :expires_at)
+
+  class << self
+    attr_writer :lock_root
+
+    def create(user:, query:, content_kind:, provider_count:)
+      binding = normalized_binding(user, query, content_kind)
+      return unless binding
+
+      with_user_lock(user) do
+        collection = pruned_collection(read_collection(user))
+        token = SecureRandom.urlsafe_base64(24)
+        collection["snapshots"][token] = binding.merge(
+          "token" => token,
+          "results" => [],
+          "complete" => false,
+          "failed_providers" => [],
+          "provider_count" => provider_count.to_i.clamp(0, MAX_SOURCES),
+          "expires_at" => expires_at
+        )
+        collection["order"] << token
+        trim_collection!(collection)
+
+        token if write_collection(user, collection)
+      end
+    rescue StandardError => e
+      Rails.logger.warn("[SearchResultSnapshot] Cache write failed: #{e.class}")
+      nil
+    end
+
+    def write(user:, id:, query:, content_kind:, results:, complete:, failed_providers:, provider_count:)
+      binding = normalized_binding(user, query, content_kind)
+      return false unless binding && TOKEN_PATTERN.match?(id.to_s)
+
+      with_user_lock(user) do
+        collection = pruned_collection(read_collection(user))
+        payload = collection.dig("snapshots", id)
+        next false unless payload_matches?(payload, binding, id)
+
+        payload["complete"] = !!complete
+        payload["failed_providers"] = bounded_list(failed_providers, limit: MAX_SOURCES)
+        payload["provider_count"] = provider_count.to_i.clamp(0, MAX_SOURCES)
+        payload["expires_at"] = expires_at
+        payload["results"] = []
+        append_bounded_results!(collection, payload, results)
+
+        write_collection(user, collection) && snapshot_from(payload)
+      end
+    rescue StandardError => e
+      Rails.logger.warn("[SearchResultSnapshot] Cache update failed: #{e.class}")
+      false
+    end
+
+    def fetch(user:, id:, query:, content_kind:)
+      binding = normalized_binding(user, query, content_kind)
+      return unless binding && TOKEN_PATTERN.match?(id.to_s)
+
+      payload = read_collection(user)&.dig("snapshots", id)
+      return unless payload_matches?(payload, binding, id)
+      return if expired?(payload)
+
+      snapshot_from(payload)
+    rescue StandardError => e
+      Rails.logger.warn("[SearchResultSnapshot] Cache read failed: #{e.class}")
+      nil
+    end
+
+    def normalize_page(value)
+      value.to_i.clamp(1, MAX_PAGES)
+    end
+
+    def lock_root
+      @lock_root || Rails.root.join("tmp", ".shelfarr-search-snapshots")
+    end
+
+    def reset_lock_root!
+      @lock_root = nil
+    end
+
+    private
+
+    def normalized_binding(user, query, content_kind)
+      normalized_query = query.to_s.strip
+      return if user&.id.blank? || normalized_query.blank? || normalized_query.bytesize > MAX_QUERY_BYTES
+
+      {
+        "user_id" => user.id,
+        "query" => normalized_query,
+        "content_kind" => ContentKinds.normalize(content_kind, default: nil)
+      }
+    end
+
+    def empty_collection
+      { "order" => [], "snapshots" => {} }
+    end
+
+    def pruned_collection(value)
+      collection = value.is_a?(Hash) ? value : empty_collection
+      snapshots = collection["snapshots"].is_a?(Hash) ? collection["snapshots"] : {}
+      order = Array(collection["order"]).select { |token| snapshots.key?(token) }
+      expired_tokens = order.select { |token| expired?(snapshots[token]) }
+      expired_tokens.each { |token| snapshots.delete(token) }
+
+      { "order" => order - expired_tokens, "snapshots" => snapshots.slice(*(order - expired_tokens)) }
+    end
+
+    def trim_collection!(collection)
+      while collection["order"].size > MAX_SNAPSHOTS || encoded_bytes(collection) > MAX_PAYLOAD_BYTES
+        token = collection["order"].shift
+        collection["snapshots"].delete(token)
+      end
+    end
+
+    def append_bounded_results!(collection, payload, results)
+      bytes = encoded_bytes(collection)
+      snapshot_bytes = JSON.generate(payload).bytesize
+      Array(results).first(MAX_RESULTS).each do |result|
+        serialized = serialized_result(result)
+        next unless serialized
+
+        additional_bytes = JSON.generate(serialized).bytesize
+        additional_bytes += 1 if payload["results"].any?
+        next if snapshot_bytes + additional_bytes > MAX_SNAPSHOT_BYTES
+        next if bytes + additional_bytes > MAX_PAYLOAD_BYTES
+
+        payload["results"] << serialized
+        bytes += additional_bytes
+        snapshot_bytes += additional_bytes
+      end
+    end
+
+    def serialized_result(result)
+      value = serialize_result(result)
+      JSON.generate(value)
+      value
+    rescue StandardError
+      nil
+    end
+
+    def payload_matches?(payload, binding, token)
+      payload.present? && payload.slice(*binding.keys) == binding && payload["token"] == token
+    end
+
+    def snapshot_from(payload)
+      Snapshot.new(
+        id: payload["token"],
+        results: Array(payload["results"]).first(MAX_RESULTS).filter_map { |result| deserialize_result(result) },
+        complete: payload["complete"] == true,
+        failed_providers: bounded_list(payload["failed_providers"], limit: MAX_SOURCES),
+        provider_count: safe_integer(payload["provider_count"])&.clamp(0, MAX_SOURCES).to_i,
+        expires_at: safe_integer(payload["expires_at"]).to_i
+      )
+    end
+
+    def read_collection(user)
+      value = Rails.cache.read(cache_key(user))
+      return unless value.is_a?(String) && value.bytesize <= MAX_PAYLOAD_BYTES
+
+      JSON.parse(value)
+    end
+
+    def write_collection(user, collection)
+      value = JSON.generate(collection)
+      return false if value.bytesize > MAX_PAYLOAD_BYTES
+
+      Rails.cache.write(cache_key(user), value, expires_in: TTL)
+    end
+
+    def encoded_bytes(collection)
+      JSON.generate(collection).bytesize
+    end
+
+    def with_user_lock(user, &operation)
+      root = Pathname(lock_root).expand_path
+      FileCopyService.secure_private_directory!(root.to_s, root: root.parent.to_s)
+      digest = Digest::SHA256.hexdigest(user.id.to_s)
+      FileCopyService.with_private_lock(root.join("#{digest}.lock").to_s, root: root.to_s, &operation)
+    end
+
+    def cache_key(user)
+      "search_result_snapshot:v3:#{user.id}"
+    end
+
+    def expires_at
+      TTL.from_now.to_i
+    end
+
+    def expired?(payload)
+      payload.blank? || safe_integer(payload["expires_at"]).to_i <= Time.current.to_i
+    end
+
+    def serialize_result(result)
+      {
+        "canonical_key" => bounded_text(result.canonical_key),
+        "title" => bounded_text(result.title),
+        "author" => bounded_text(result.author),
+        "year" => scalar(result.year),
+        "description" => bounded_text(result.description),
+        "cover_url" => bounded_url(result.cover_url),
+        "series_name" => bounded_text(result.series_name),
+        "series_position" => bounded_text(result.series_position),
+        "has_ebook" => scalar(result.has_ebook),
+        "has_audiobook" => scalar(result.has_audiobook),
+        "sources" => Array(result.sources).first(MAX_SOURCES).filter_map { |source| serialize_source(source) },
+        "editions" => Array(result.editions).first(MAX_EDITIONS).filter_map { |edition| serialize_edition(edition) },
+        "confidence" => bounded_percentage(result.confidence),
+        "content_kind" => bounded_content_kind(result.content_kind),
+        "resource_kind" => bounded_text(result.resource_kind),
+        "classification_evidence" => bounded_list(result.classification_evidence),
+        "classification_confidence" => bounded_percentage(result.classification_confidence),
+        "categories" => bounded_list(result.categories),
+        "subjects" => bounded_list(result.subjects),
+        "collection_source" => bounded_text(result.collection_source),
+        "collection_id" => bounded_text(result.collection_id),
+        "collection_title" => bounded_text(result.collection_title),
+        "issue_number" => bounded_text(result.issue_number),
+        "release_date" => bounded_text(result.release_date)
+      }
+    end
+
+    def deserialize_result(value)
+      result = value.to_h.stringify_keys
+      MetadataSearch::Candidate.new(
+        canonical_key: result["canonical_key"],
+        title: result["title"],
+        author: result["author"],
+        year: result["year"],
+        description: result["description"],
+        cover_url: result["cover_url"],
+        series_name: result["series_name"],
+        series_position: result["series_position"],
+        has_ebook: result["has_ebook"],
+        has_audiobook: result["has_audiobook"],
+        sources: Array(result["sources"]).map { |source| source.to_h.symbolize_keys },
+        editions: Array(result["editions"]).map { |edition| edition.to_h.symbolize_keys },
+        confidence: result["confidence"],
+        content_kind: result["content_kind"],
+        resource_kind: result["resource_kind"],
+        classification_evidence: result["classification_evidence"],
+        classification_confidence: result["classification_confidence"],
+        categories: result["categories"],
+        subjects: result["subjects"],
+        collection_source: result["collection_source"],
+        collection_id: result["collection_id"],
+        collection_title: result["collection_title"],
+        issue_number: result["issue_number"],
+        release_date: result["release_date"]
+      )
+    rescue KeyError, TypeError, ArgumentError
+      nil
+    end
+
+    def serialize_source(value)
+      source = value.to_h.symbolize_keys
+      {
+        source: bounded_identity(source[:source]),
+        source_id: bounded_identity(source[:source_id]),
+        source_name: bounded_identity(source[:source_name]),
+        source_url: bounded_url(source[:source_url]),
+        work_id: bounded_identity(source[:work_id])
+      }.compact
+    rescue StandardError
+      nil
+    end
+
+    def serialize_edition(value)
+      edition = value.to_h.symbolize_keys.slice(
+        :source, :source_id, :isbn_10, :isbn_13, :publisher, :year,
+        :page_count, :resource_kind
+      )
+      edition.transform_values { |item| scalar(item, maximum: MAX_IDENTITY_BYTES) }
+        .merge(publisher: bounded_text(edition[:publisher]))
+        .compact
+    rescue StandardError
+      nil
+    end
+
+    def bounded_list(values, limit: MAX_LIST_VALUES)
+      Array(values).first(limit).filter_map { |value| bounded_identity(value) }
+    end
+
+    def bounded_percentage(value)
+      number = safe_number(value)
+      number&.clamp(0, 100)&.to_i || 0
+    end
+
+    def bounded_content_kind(value)
+      return ContentKinds::BOOK if value.is_a?(Numeric)
+
+      ContentKinds.normalize(value)
+    end
+
+    def scalar(value, maximum: MAX_TEXT_BYTES)
+      return value if value.nil? || value == true || value == false
+      return safe_number(value) if value.is_a?(Numeric)
+
+      bounded_string(value, maximum)
+    end
+
+    def safe_number(value)
+      return safe_integer(value) if value.instance_of?(Integer)
+      return value if value.instance_of?(Float) && value.finite? && value.abs <= MAX_FLOAT
+
+      nil
+    end
+
+    def safe_integer(value)
+      return unless value.instance_of?(Integer) && value.abs <= MAX_INTEGER
+
+      value
+    end
+
+    def bounded_identity(value)
+      return scalar(value, maximum: MAX_IDENTITY_BYTES) if value.is_a?(Numeric)
+
+      bounded_string(value, MAX_IDENTITY_BYTES)
+    end
+
+    def bounded_text(value)
+      return scalar(value) if value.is_a?(Numeric)
+
+      bounded_string(value, MAX_TEXT_BYTES)
+    end
+
+    def bounded_url(value)
+      return if value.is_a?(Numeric)
+
+      bounded_string(value, MAX_URL_BYTES)
+    end
+
+    def bounded_string(value, maximum)
+      return if value.nil?
+
+      string = value.to_s
+      string.bytesize > maximum ? string.byteslice(0, maximum).scrub : string
+    end
+  end
+end

--- a/app/views/search/_results.html.erb
+++ b/app/views/search/_results.html.erb
@@ -1,3 +1,36 @@
+<%
+  total_results = @search_total_results.to_i
+  current_page = @search_page.to_i.clamp(1, SearchResultSnapshot::MAX_PAGES)
+  page_count = @search_page_count.to_i
+  complete = @search_complete == true
+  status = if @error.present?
+    @error
+  elsif @search_loading
+    total_results.positive? ? "Found #{total_results} results so far. Still searching." : "Searching metadata providers."
+  elsif total_results.zero?
+    "No results found."
+  else
+    "Page #{current_page} of #{page_count} loaded. #{total_results} total results."
+  end
+  preload_page = current_page + 1 if complete && @search_has_next && @search_snapshot_id.present?
+%>
+
+<div
+  data-search-state
+  data-search-query="<%= @query %>"
+  data-search-content-kind="<%= @content_kind %>"
+  data-search-page="<%= current_page %>"
+  data-search-page-count="<%= page_count %>"
+  data-search-has-next="<%= @search_has_next == true %>"
+  data-search-complete="<%= complete %>"
+  data-search-snapshot-id="<%= @search_snapshot_id %>"
+  data-search-snapshot-expires-at="<%= @search_snapshot_expires_at %>"
+  data-search-preload-page="<%= preload_page %>"
+  data-search-failed-providers="<%= Array(@search_provider_failure_names).join(",") %>"
+>
+  <h2 id="search-results-heading" tabindex="-1" class="mb-4 text-xl font-semibold text-white focus:outline-none">Search results</h2>
+  <p class="sr-only" role="status" aria-live="polite" aria-atomic="true"><%= status %></p>
+
 <% if @error.present? %>
   <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4 text-red-400">
     <%= @error %>
@@ -24,7 +57,7 @@
 <% else %>
   <div class="mb-6 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
     <div>
-      <p class="text-sm text-gray-500"><%= @results.size %> result<%= @results.size == 1 ? '' : 's' %> for "<span class="font-medium text-gray-300"><%= @query %></span>"</p>
+      <p class="text-sm text-gray-500"><%= total_results %> result<%= total_results == 1 ? '' : 's' %> for "<span class="font-medium text-gray-300"><%= @query %></span>"</p>
       <% if @search_loading && @search_pending_provider_names.present? %>
         <p class="mt-1 text-xs text-gray-600">Still checking <%= @search_pending_provider_names.to_sentence %></p>
       <% end %>
@@ -45,9 +78,38 @@
     </div>
   </div>
 
+  <% if complete && @search_provider_failure_names.present? %>
+    <p class="mb-4 rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
+      Some metadata providers could not be reached: <%= @search_provider_failure_names.to_sentence %>.
+    </p>
+  <% end %>
+
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
     <% @results.each_with_index do |result, index| %>
       <%= render "result_card", result: result, audiobookshelf_matches: Array(@audiobookshelf_matches)[index], existing_books_lookup: @existing_books_lookup %>
     <% end %>
   </div>
 <% end %>
+
+<% if total_results.positive? && (page_count > 1 || current_page > 1) %>
+  <nav class="mt-8 flex items-center justify-center gap-2" aria-label="Search result pages">
+    <% if complete && current_page > 1 %>
+      <%= link_to "Previous", search_results_path(q: @query, content_kind: @content_kind, page: current_page - 1),
+        class: "inline-flex min-h-11 items-center justify-center rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-sm font-medium text-gray-200 hover:border-gray-500 hover:text-white",
+        data: { action: "click->search#navigate", search_page: current_page - 1 } %>
+    <% else %>
+      <span class="inline-flex min-h-11 items-center justify-center rounded-lg border border-gray-800 bg-gray-950 px-4 py-2 text-sm font-medium text-gray-600" aria-disabled="true">Previous</span>
+    <% end %>
+
+    <span class="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white" aria-current="page" aria-label="Page <%= current_page %>"><%= current_page %></span>
+
+    <% if complete && @search_has_next %>
+      <%= link_to "Next", search_results_path(q: @query, content_kind: @content_kind, page: current_page + 1),
+        class: "inline-flex min-h-11 items-center justify-center rounded-lg border border-gray-700 bg-gray-900 px-4 py-2 text-sm font-medium text-gray-200 hover:border-gray-500 hover:text-white",
+        data: { action: "click->search#navigate", search_page: current_page + 1 } %>
+    <% else %>
+      <span class="inline-flex min-h-11 items-center justify-center rounded-lg border border-gray-800 bg-gray-950 px-4 py-2 text-sm font-medium text-gray-600" aria-disabled="true"><%= @search_loading ? "Loading" : "Next" %></span>
+    <% end %>
+  </nav>
+<% end %>
+</div>

--- a/app/views/search/_results.html.erb
+++ b/app/views/search/_results.html.erb
@@ -31,6 +31,12 @@
   <h2 id="search-results-heading" tabindex="-1" class="mb-4 text-xl font-semibold text-white focus:outline-none">Search results</h2>
   <p class="sr-only" role="status" aria-live="polite" aria-atomic="true"><%= status %></p>
 
+  <% if @error.blank? && complete && @search_provider_failure_names.present? %>
+    <p class="mb-4 rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
+      Some metadata providers could not be reached: <%= @search_provider_failure_names.to_sentence %>.
+    </p>
+  <% end %>
+
 <% if @error.present? %>
   <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4 text-red-400">
     <%= @error %>
@@ -77,12 +83,6 @@
       <% end %>
     </div>
   </div>
-
-  <% if complete && @search_provider_failure_names.present? %>
-    <p class="mb-4 rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
-      Some metadata providers could not be reached: <%= @search_provider_failure_names.to_sentence %>.
-    </p>
-  <% end %>
 
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
     <% @results.each_with_index do |result, index| %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,15 +1,26 @@
 <div class="mx-auto max-w-6xl">
   <h1 class="font-bold text-3xl mb-6 text-white">Search Books, Comics &amp; Manga</h1>
 
-  <div data-controller="search" data-search-url-value="<%= search_results_path %>" data-search-stream-url-value="<%= search_results_stream_path %>" data-search-debounce-value="700">
+  <div
+    data-controller="search"
+    data-search-index-url-value="<%= search_path %>"
+    data-search-url-value="<%= search_results_path %>"
+    data-search-stream-url-value="<%= search_results_stream_path %>"
+    data-search-snapshot-url-value="<%= search_results_snapshot_path %>"
+    data-search-page-value="<%= @search_page %>"
+    data-search-initial-search-value="<%= @search_initial_search == true %>"
+    data-search-debounce-value="700"
+  >
     <div class="mb-8 grid gap-3 md:grid-cols-[1fr_180px]">
       <div class="relative">
+        <label for="metadata-search-query" class="sr-only">Search by title, author, series, issue, or volume</label>
         <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
           <svg class="h-5 w-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </div>
         <input
+          id="metadata-search-query"
           type="text"
           data-search-target="input"
           data-action="input->search#search"
@@ -25,7 +36,9 @@
           </svg>
         </div>
       </div>
+      <label for="metadata-search-content-kind" class="sr-only">Content type</label>
       <select
+        id="metadata-search-content-kind"
         data-search-target="contentKind"
         data-action="change->search#search"
         class="w-full rounded-xl border border-gray-800 bg-gray-900 px-4 py-4 text-lg text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
@@ -36,7 +49,7 @@
       </select>
     </div>
 
-    <div id="search-results" data-search-target="results">
+    <div id="search-results" data-search-target="results" aria-busy="<%= @search_loading %>">
       <% if @query.present? %>
         <%= render "results" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get "search/modal/close", to: "search#close_modal", as: :search_modal_close
   get "search/results", to: "search#results"
   get "search/results/stream", to: "search#stream_results"
+  get "search/results/snapshot", to: "search#snapshot_results"
 
   # Library
   resources :library, only: [ :index, :show, :destroy ] do

--- a/test/controllers/api/v1/search_controller_test.rb
+++ b/test/controllers/api/v1/search_controller_test.rb
@@ -97,9 +97,10 @@ class API::V1::SearchControllerTest < ActionDispatch::IntegrationTest
       content_kind: "manga"
     )
 
-    MetadataService.stub(:search, ->(_query, limit:, content_kind:) {
+    MetadataService.stub(:search, ->(_query, limit:, content_kind:, **options) {
       assert_equal "graphic", content_kind
       assert_equal 10, limit
+      assert_empty options
       [ result ]
     }) do
       get api_v1_search_path,

--- a/test/controllers/search_controller_rendering_test.rb
+++ b/test/controllers/search_controller_rendering_test.rb
@@ -88,6 +88,38 @@ class SearchControllerRenderingTest < ActionController::TestCase
     assert_no_match %r{href="/books/books/}, response.body
   end
 
+  test "index keeps mounted search and snapshot paths" do
+    @controller.define_singleton_method(:require_authentication) { true }
+    @request.set_header("SCRIPT_NAME", "/books")
+
+    get :index, params: { q: "dune", page: 2 }
+
+    assert_response :success
+    assert_select "[data-search-index-url-value='/books/search']"
+    assert_select "[data-search-stream-url-value='/books/search/results/stream']"
+    assert_select "[data-search-snapshot-url-value='/books/search/results/snapshot']"
+  end
+
+  test "pagination links keep the mounted synchronous results path" do
+    @controller.instance_variable_set(:@live_script_name, "/books")
+    @controller.instance_variable_set(:@query, "dune")
+    results = Array.new(21) { candidate }
+
+    html = @controller.send(
+      :render_search_results_stream,
+      results: results,
+      loading: false,
+      pending_providers: [],
+      completed_providers: [],
+      error: nil
+    )
+
+    link = Nokogiri::HTML.fragment(html).css("a").find { |element| element.text == "Next" }
+    uri = URI.parse(link["href"])
+    assert_equal "/books/search/results", uri.path
+    assert_equal({ "q" => "dune", "page" => "2" }, Rack::Utils.parse_query(uri.query))
+  end
+
   test "audiobookshelf_matches_for returns placeholders without library items" do
     LibraryItem.destroy_all
 

--- a/test/controllers/search_controller_rendering_test.rb
+++ b/test/controllers/search_controller_rendering_test.rb
@@ -120,6 +120,17 @@ class SearchControllerRenderingTest < ActionController::TestCase
     assert_equal({ "q" => "dune", "page" => "2" }, Rack::Utils.parse_query(uri.query))
   end
 
+  test "a direct one-character query is idle instead of permanently loading" do
+    @controller.define_singleton_method(:require_authentication) { true }
+    get :index, params: { q: "a", page: 1 }
+
+    assert_response :success
+    assert_select "[data-controller='search'][data-search-initial-search-value='false']"
+    assert_select "#search-results[aria-busy='false']"
+    assert_select "[data-search-state][data-search-complete='true']"
+    assert_select "p", text: "No results found"
+  end
+
   test "audiobookshelf_matches_for returns placeholders without library items" do
     LibraryItem.destroy_all
 

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -55,8 +55,9 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "results normalizes legacy graphic filters before searching" do
-    MetadataService.stub(:search, ->(_query, content_kind:) {
+    MetadataService.stub(:search, ->(_query, content_kind:, aggregate_limit:) {
       assert_equal "graphic", content_kind
+      assert_equal SearchResultSnapshot::MAX_RESULTS, aggregate_limit
       []
     }) do
       get search_results_path, params: { q: "akira", content_kind: "comic" }
@@ -162,7 +163,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "results renders connection error message" do
-    MetadataService.stub(:search, ->(_) { raise GoogleBooksClient::ConnectionError, "network down" }) do
+    MetadataService.stub(:search, ->(*, **) { raise GoogleBooksClient::ConnectionError, "network down" }) do
       get search_results_path, params: { q: "fiction" }
     end
 
@@ -171,7 +172,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "results renders generic metadata error message" do
-    MetadataService.stub(:search, ->(_) { raise GoogleBooksClient::Error, "api down" }) do
+    MetadataService.stub(:search, ->(*, **) { raise GoogleBooksClient::Error, "api down" }) do
       get search_results_path, params: { q: "fiction" }
     end
 
@@ -320,7 +321,8 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
       assert_equal "graphic", content_kind
       block.call("openlibrary", [])
     end
-    aggregate = lambda do |_results, content_kind:|
+    aggregate = lambda do |_results, limit:, content_kind:|
+      assert_equal SearchResultSnapshot::MAX_RESULTS, limit
       aggregated_content_kinds << content_kind
       []
     end

--- a/test/controllers/search_pagination_controller_test.rb
+++ b/test/controllers/search_pagination_controller_test.rb
@@ -1,0 +1,384 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchPaginationControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    @user = users(:one)
+    sign_in_as(@user)
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+  end
+
+  test "stream rebuilds untruncated pages as providers finish without duplicate provider calls" do
+    candidates = 25.times.map { |index| candidate(index) }
+    provider_calls = Hash.new(0)
+    aggregate_sizes = []
+    provider_search = lambda do |_query, **options, &block|
+      assert_nil options[:limit]
+      provider_calls["openlibrary"] += 1
+      block.call("openlibrary", [ :first ], false)
+      provider_calls["google_books"] += 1
+      block.call("google_books", [ :second ], false)
+    end
+    aggregate = lambda do |raw_results, limit:, content_kind:|
+      assert_equal SearchResultSnapshot::MAX_RESULTS, limit
+      assert_nil content_kind
+      aggregate_sizes << raw_results.size
+      raw_results.size == 1 ? candidates.first(10) : candidates
+    end
+
+    MetadataService.stub(:enabled_metadata_providers, %w[openlibrary google_books]) do
+      MetadataService.stub(:each_provider_search, provider_search) do
+        MetadataService.stub(:aggregate_provider_results, aggregate) do
+          get search_results_stream_path, params: { q: "many books", page: 1 }
+        end
+      end
+    end
+
+    assert_response :success
+    assert_equal({ "openlibrary" => 1, "google_books" => 1 }, provider_calls)
+    assert_equal [ 1, 2 ], aggregate_sizes
+    assert_operator response.body.scan('<turbo-stream action="update" target="search-results">').size, :>=, 3
+    assert_includes response.body, "25 results for"
+    assert_includes response.body, 'data-search-page-count="2"'
+    assert_includes response.body, 'data-search-has-next="true"'
+    assert_includes response.body, 'data-search-complete="true"'
+    assert_includes response.body, "Book 19"
+    assert_not_includes response.body.split('<turbo-stream action="update" target="search-results">').last, "Book 20"
+    assert_select "a[href*='q=many+books'][href*='page=2']", text: "Next"
+  end
+
+  test "snapshot endpoint returns the last aggregate page without calling providers" do
+    token = completed_snapshot(25)
+
+    MetadataService.stub(:each_provider_search, ->(*) { flunk "snapshot navigation called metadata providers" }) do
+      get search_results_snapshot_path,
+        params: { snapshot_id: token, q: "many books", content_kind: "book", page: 2 },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_equal "private, no-store", response.headers["Cache-Control"]
+    assert_includes response.body, "Book 20"
+    assert_includes response.body, "Book 24"
+    assert_not_includes response.body, "Book 19"
+    assert_includes response.body, 'data-search-page="2"'
+    assert_includes response.body, 'data-search-page-count="2"'
+    assert_includes response.body, 'data-search-has-next="false"'
+    assert_select "nav[aria-label='Search result pages']"
+    assert_select "[aria-current='page'][aria-label='Page 2']", text: "2"
+    assert_select "a[href*='page=1']", text: "Previous"
+    assert_select "[aria-disabled='true']", text: "Next"
+  end
+
+  test "snapshot endpoint canonicalizes an out-of-range completed page" do
+    token = completed_snapshot(25)
+
+    get search_results_snapshot_path,
+      params: { snapshot_id: token, q: "many books", content_kind: "book", page: 10 },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "[data-search-state][data-search-page='2'][data-search-page-count='2']"
+    assert_select "[aria-current='page'][aria-label='Page 2']", text: "2"
+    assert_select "a[href*='page=1']", text: "Previous"
+    assert_select "h3", text: "Book 20"
+    assert_select "h3", text: "Book 0", count: 0
+  end
+
+  test "synchronous results aggregate to the bound and render only the requested slice" do
+    search = lambda do |_query, aggregate_limit:, **_options|
+      assert_equal SearchResultSnapshot::MAX_RESULTS, aggregate_limit
+      25.times.map { |index| candidate(index) }
+    end
+
+    MetadataService.stub(:search, search) do
+      get search_results_path,
+        params: { q: "many books", content_kind: "book", page: 2 },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_select "[data-search-state][data-search-page='2'][data-search-page-count='2']"
+    assert_select "h3", count: 5
+    assert_select "h3", text: "Book 20"
+    assert_select "h3", text: "Book 19", count: 0
+  end
+
+  test "no-JavaScript Next follows the synchronous endpoint and renders only page two" do
+    calls = 0
+    search = lambda do |_query, aggregate_limit:, **_options|
+      calls += 1
+      assert_equal SearchResultSnapshot::MAX_RESULTS, aggregate_limit
+      25.times.map { |index| candidate(index) }
+    end
+
+    MetadataService.stub(:search, search) do
+      get search_results_path, params: { q: "many books", content_kind: "book", page: 1 }
+      assert_response :success
+      next_href = css_select("a").find { |link| link.text == "Next" }["href"]
+      assert URI(next_href).path.end_with?(search_results_path)
+
+      get next_href
+    end
+
+    assert_response :success
+    assert_equal 2, calls
+    assert_select "[data-search-state][data-search-page='2'][data-search-page-count='2']"
+    assert_select "h3", count: 5
+    assert_select "h3", text: "Book 20"
+    assert_select "h3", text: "Book 19", count: 0
+  end
+
+  test "no-JavaScript out-of-range pages fail without repeating provider search" do
+    calls = 0
+    search = lambda do |_query, aggregate_limit:, **_options|
+      calls += 1
+      assert_equal SearchResultSnapshot::MAX_RESULTS, aggregate_limit
+      25.times.map { |index| candidate(index) }
+    end
+
+    MetadataService.stub(:search, search) do
+      get search_results_path, params: { q: "many books", content_kind: "book", page: 10 }
+    end
+
+    assert_response :not_found
+    assert_equal 1, calls
+  end
+
+  test "Turbo out-of-range pages canonicalize in place without redirecting" do
+    search = lambda do |_query, aggregate_limit:, **_options|
+      assert_equal SearchResultSnapshot::MAX_RESULTS, aggregate_limit
+      25.times.map { |index| candidate(index) }
+    end
+
+    MetadataService.stub(:search, search) do
+      get search_results_path,
+        params: { q: "many books", content_kind: "book", page: 10 },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_select "[data-search-state][data-search-page='2'][data-search-page-count='2']"
+  end
+
+  test "no-JavaScript invalid page values fail before calling providers" do
+    [ "", " ", "0", "-5", "+1", "1_0", "999", "invalid" ].each do |page|
+      MetadataService.stub(:search, ->(*) { flunk "invalid page called metadata providers" }) do
+        get search_results_path, params: { q: "many books", page: page }
+      end
+
+      assert_response :not_found
+    end
+  end
+
+  test "no-JavaScript unavailable page fails when the search has no results" do
+    calls = 0
+    MetadataService.stub(:search, ->(*) { calls += 1; [] }) do
+      get search_results_path, params: { q: "missing book", page: 2 }
+    end
+
+    assert_response :not_found
+    assert_equal 1, calls
+  end
+
+  test "snapshot endpoint fails safely for mismatched and foreign snapshots" do
+    token = completed_snapshot(1)
+
+    get search_results_snapshot_path,
+      params: { snapshot_id: token, q: "different", content_kind: "book", page: 1 }
+    assert_response :not_found
+
+    sign_out
+    sign_in_as(users(:two))
+    get search_results_snapshot_path,
+      params: { snapshot_id: token, q: "many books", content_kind: "book", page: 1 }
+    assert_response :not_found
+  end
+
+  test "expired snapshot endpoint fails safely without providers" do
+    token = completed_snapshot(1)
+
+    travel SearchResultSnapshot::TTL + 1.second do
+      MetadataService.stub(:each_provider_search, ->(*) { flunk "expired snapshot called metadata providers" }) do
+        get search_results_snapshot_path,
+          params: { snapshot_id: token, q: "many books", content_kind: "book", page: 1 }
+      end
+    end
+
+    assert_response :not_found
+    assert_equal "private, no-store", response.headers["Cache-Control"]
+  end
+
+  test "stream exposes partial provider failures in the completed snapshot state" do
+    provider_search = lambda do |_query, **_options, &block|
+      block.call("openlibrary", [ :result ], false)
+      block.call("google_books", [], true)
+    end
+
+    MetadataService.stub(:enabled_metadata_providers, %w[openlibrary google_books]) do
+      MetadataService.stub(:each_provider_search, provider_search) do
+        MetadataService.stub(:aggregate_provider_results, [ candidate(1) ]) do
+          get search_results_stream_path, params: { q: "partial" }
+        end
+      end
+    end
+
+    assert_response :success
+    assert_includes response.body, "Some metadata providers could not be reached: Google Books."
+    assert_includes response.body, 'data-search-failed-providers="Google Books"'
+  end
+
+  test "stream renders all-provider failure on the requested page and clears loading state" do
+    provider_search = lambda do |_query, **_options, &block|
+      block.call("openlibrary", [], true)
+      block.call("google_books", [], true)
+    end
+
+    MetadataService.stub(:enabled_metadata_providers, %w[openlibrary google_books]) do
+      MetadataService.stub(:each_provider_search, provider_search) do
+        MetadataService.stub(:aggregate_provider_results, []) do
+          get search_results_stream_path, params: { q: "failed", content_kind: "book", page: 2 }
+        end
+      end
+    end
+
+    assert_response :success
+    final = response.body.split('<turbo-stream action="update" target="search-results">').last
+    assert_includes final, "Unable to connect to metadata service"
+    assert_includes final, 'data-search-query="failed"'
+    assert_includes final, 'data-search-content-kind="book"'
+    assert_includes final, 'data-search-page="2"'
+    assert_includes final, 'data-search-complete="true"'
+  end
+
+  test "unexpected stream errors retain requested state" do
+    provider_search = lambda do |_query, **_options, &block|
+      block.call("openlibrary", [ :result ], false)
+    end
+
+    MetadataService.stub(:enabled_metadata_providers, %w[openlibrary]) do
+      MetadataService.stub(:each_provider_search, provider_search) do
+        MetadataService.stub(:aggregate_provider_results, ->(*) { raise ArgumentError, "bad aggregate" }) do
+          get search_results_stream_path, params: { q: "broken", content_kind: "graphic", page: 3 }
+        end
+      end
+    end
+
+    assert_response :success
+    final = response.body.split('<turbo-stream action="update" target="search-results">').last
+    assert_includes final, "Search failed. Please try again."
+    assert_includes final, 'data-search-query="broken"'
+    assert_includes final, 'data-search-content-kind="graphic"'
+    assert_includes final, 'data-search-page="3"'
+    assert_includes final, 'data-search-complete="true"'
+  end
+
+  test "snapshot pages refresh existing-library enrichment" do
+    token = completed_snapshot(1)
+    %i[ebook audiobook].each do |book_type|
+      Book.create!(
+        title: "Book 0",
+        book_type: book_type,
+        open_library_work_id: "work-0",
+        file_path: "/library/#{book_type}/book-0"
+      )
+    end
+
+    get search_results_snapshot_path,
+      params: { snapshot_id: token, q: "many books", content_kind: "book", page: 1 },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_select "span", text: "In library"
+    assert_select "a", text: "Request", count: 0
+  end
+
+  test "direct stream canonicalizes page ten to the last discovered page" do
+    provider_search = lambda do |_query, **_options, &block|
+      block.call("openlibrary", [ :result ], false)
+    end
+
+    MetadataService.stub(:enabled_metadata_providers, %w[openlibrary]) do
+      MetadataService.stub(:each_provider_search, provider_search) do
+        MetadataService.stub(:aggregate_provider_results, 25.times.map { |index| candidate(index) }) do
+          get search_results_stream_path, params: { q: "many books", page: 10 }
+        end
+      end
+    end
+
+    assert_response :success
+    final = response.body.split('<turbo-stream action="update" target="search-results">').last
+    assert_includes final, 'data-search-page="2"'
+    assert_includes final, 'aria-label="Page 2"'
+    assert_includes final, "page=1"
+    assert_includes final, "Book 20"
+  end
+
+  test "direct page parameters are normalized and included in the initial search state" do
+    get search_path, params: { q: "many books", content_kind: "comic", page: 2 }
+
+    assert_response :success
+    assert_select "[data-controller='search'][data-search-page-value='2'][data-search-initial-search-value='true']"
+    assert_select "[data-search-snapshot-url-value='#{search_results_snapshot_path}']"
+    assert_select "option[value='graphic'][selected]"
+    assert_select "#search-results[aria-busy='true']"
+    assert_select "label[for='metadata-search-query']", text: /Search by title/
+    assert_select "input#metadata-search-query[aria-label]", count: 0
+    assert_select "label[for='metadata-search-content-kind']", text: "Content type"
+  end
+
+  private
+
+  def completed_snapshot(size)
+    token = SearchResultSnapshot.create(
+      user: @user,
+      query: "many books",
+      content_kind: "book",
+      provider_count: 2
+    )
+    SearchResultSnapshot.write(
+      user: @user,
+      id: token,
+      query: "many books",
+      content_kind: "book",
+      results: size.times.map { |index| candidate(index) },
+      complete: true,
+      failed_providers: [],
+      provider_count: 2
+    )
+    token
+  end
+
+  def candidate(index)
+    MetadataSearch::Candidate.new(
+      canonical_key: "openlibrary:work-#{index}",
+      title: "Book #{index}",
+      author: "Author",
+      year: 2020,
+      description: nil,
+      cover_url: nil,
+      series_name: nil,
+      series_position: nil,
+      has_ebook: true,
+      has_audiobook: nil,
+      sources: [ {
+        source: "openlibrary",
+        source_id: "work-#{index}",
+        source_name: "Open Library",
+        source_url: nil,
+        work_id: "openlibrary:work-#{index}"
+      } ],
+      editions: [],
+      confidence: 70,
+      content_kind: "book"
+    )
+  end
+end

--- a/test/controllers/search_pagination_controller_test.rb
+++ b/test/controllers/search_pagination_controller_test.rb
@@ -236,6 +236,23 @@ class SearchPaginationControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'data-search-failed-providers="Google Books"'
   end
 
+  test "stream exposes partial provider failures when healthy providers find no results" do
+    provider_search = lambda do |_query, **_options, &block|
+      block.call("openlibrary", [], false)
+      block.call("google_books", [], true)
+    end
+
+    MetadataService.stub(:enabled_metadata_providers, %w[openlibrary google_books]) do
+      MetadataService.stub(:each_provider_search, provider_search) do
+        get search_results_stream_path, params: { q: "missing book" }
+      end
+    end
+
+    assert_response :success
+    assert_includes response.body, "No results found"
+    assert_includes response.body, "Some metadata providers could not be reached: Google Books."
+  end
+
   test "stream renders all-provider failure on the requested page and clears loading state" do
     provider_search = lambda do |_query, **_options, &block|
       block.call("openlibrary", [], true)

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -359,6 +359,42 @@ class DownloadJobTest < ActiveJob::TestCase
     refute_includes @request.issue_description, "/private/library"
   end
 
+  test "does not blocklist on a wrapped direct download library configuration error" do
+    @download.update!(status: :downloading, download_type: "direct")
+    permissions_error = FileCopyService::UnsafeFilePermissionsError.new(
+      "filesystem did not preserve safe directory permissions",
+      path: "/private/library/.shelfarr-staging",
+      root: "/private/library"
+    )
+    error = FileCopyService.stub(:secure_private_directory!, ->(*) { raise permissions_error }) do
+      assert_raises(DirectDownloadFileService::Error) do
+        DirectDownloadFileService.staging_parent(root: "/private/library")
+      end
+    end
+
+    DownloadJob.new.send(
+      :handle_direct_download_failure,
+      @download,
+      error,
+      message: "Direct download failed at /private/library/.shelfarr-staging"
+    )
+
+    assert @request.reload.attention_needed?
+    assert_not @selected_result.reload.blocklisted?
+    assert_includes @request.issue_description, "configured library storage"
+    refute_includes @request.issue_description, "/private/library"
+  end
+
+  test "does not classify a wrapped direct network permission error as library configuration" do
+    error = begin
+      raise DownloadJob::DirectDownloadError, "connection denied", cause: Errno::EACCES.new("connect")
+    rescue DownloadJob::DirectDownloadError => wrapped_error
+      wrapped_error
+    end
+
+    assert_not DownloadJob.new.send(:direct_library_configuration_error?, error)
+  end
+
   test "does not blocklist on LibriVox direct audiobook transient download error" do
     Dir.mktmpdir do |dir|
       setup_librivox_download(output_path: dir)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -641,6 +641,62 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_includes output, "1 hardlinked, 0 copied after unsupported fallback, 0 reused"
   end
 
+  test "reference retry reuses a native target match when File.readlink fails" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    source = File.join(@temp_source, "audiobook.mp3")
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    FileUtils.mkdir_p(destination)
+    referenced = File.join(destination, "audiobook.mp3")
+    File.symlink(Pathname(source).expand_path.to_s, referenced)
+
+    File.stub(:readlink, ->(*) { raise Errno::EIO, "simulated CIFS disagreement" }) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert @request.reload.completed?
+    assert_equal Pathname(source).expand_path.to_s, File.readlink(referenced)
+    assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
+  end
+
+  test "reference retry suffixes a mismatched symlink" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    source = File.join(@temp_source, "audiobook.mp3")
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    FileUtils.mkdir_p(destination)
+    referenced = File.join(destination, "audiobook.mp3")
+    File.symlink("/different/source.mp3", referenced)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    assert @request.reload.completed?
+    assert_equal "/different/source.mp3", File.readlink(referenced)
+    assert_equal Pathname(source).expand_path.to_s,
+      File.readlink(File.join(destination, "audiobook (2).mp3"))
+  end
+
+  test "reference EEXIST reconciliation reuses the concurrent native target match" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    attempts = 0
+    concurrent_publication = lambda do |source, target, **|
+      attempts += 1
+      File.symlink(Pathname(source).expand_path.to_s, target)
+      raise Errno::EEXIST, target
+    end
+
+    FileCopyService.stub(:reference_noreplace, concurrent_publication) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert_equal 1, attempts
+    assert @request.reload.completed?
+    assert File.symlink?(File.join(destination, "audiobook.mp3"))
+    assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
+  end
+
   test "hardlink retry reuses a secure fallback copy after interruption" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:completed_download_import_mode, "hardlink")

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -135,6 +135,8 @@ class BookTest < ActiveSupport::TestCase
     google_book = Book.new(title: "Google Book", book_type: :ebook, google_books_id: "abc123")
     open_library_book = Book.new(title: "Open Book", book_type: :ebook, open_library_work_id: "OL123W")
     hardcover_book = Book.new(title: "Hardcover Book", book_type: :ebook, hardcover_id: "789")
+    malformed_hardcover_book = Book.new(title: "Malformed Hardcover Book", book_type: :ebook, hardcover_id: "789/unsafe")
+    missing_source_book = Book.new(title: "Missing Source Book", book_type: :ebook)
 
     assert_equal "Google Books", google_book.metadata_source_name
     assert_equal "https://books.google.com/books?id=abc123", google_book.metadata_source_url
@@ -142,7 +144,9 @@ class BookTest < ActiveSupport::TestCase
     assert_equal "Open Library", open_library_book.metadata_source_name
     assert_equal "https://openlibrary.org/works/OL123W", open_library_book.metadata_source_url
     assert_equal "Hardcover", hardcover_book.metadata_source_name
-    assert_equal "https://hardcover.app/books/789", hardcover_book.metadata_source_url
+    assert_equal "https://hardcover.app/id/book/789", hardcover_book.metadata_source_url
+    assert_nil malformed_hardcover_book.metadata_source_url
+    assert_nil missing_source_book.metadata_source_url
   end
 
 

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -13,6 +13,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     @dest_dir = File.join(@tmp_dir, "dest")
     FileUtils.mkdir_p(@dest_dir)
     File.write(@src_file, "test content")
+    @source_snapshot = FileCopyService.snapshot_source_file(@src_file)
   end
 
   teardown do
@@ -660,6 +661,111 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal "test content", File.binread(destination)
     assert_equal 1, File.stat(@src_file).nlink
     assert_equal [ "referenced.txt" ], Dir.children(@dest_dir)
+  end
+
+  test "reference_target_matches compares the exact normalized symlink target" do
+    destination = File.join(@dest_dir, "referenced.txt")
+    source_alias = File.join(@tmp_dir, "missing", "..", "source.txt")
+    File.symlink(Pathname(source_alias).expand_path.to_s, destination)
+
+    assert FileCopyService.reference_target_matches?(
+      source_alias, destination, root: @dest_dir, source_snapshot: @source_snapshot
+    )
+
+    [ File.join(@tmp_dir, "other.txt"), "../source.txt" ].each do |target|
+      File.unlink(destination)
+      File.symlink(target, destination)
+      assert_not FileCopyService.reference_target_matches?(
+        @src_file, destination, root: @dest_dir, source_snapshot: @source_snapshot
+      )
+    end
+
+    File.unlink(destination)
+    File.binwrite(destination, "not a symlink")
+    assert_not FileCopyService.reference_target_matches?(
+      @src_file, destination, root: @dest_dir, source_snapshot: @source_snapshot
+    )
+    assert_raises(ArgumentError) do
+      FileCopyService.reference_target_matches?(@src_file, destination, root: @dest_dir)
+    end
+  end
+
+  test "reference_target_matches rejects source replacement and ancestry changes" do
+    destination = File.join(@dest_dir, "snapshot-reference.txt")
+    File.symlink(@src_file, destination)
+    real_readlink = FileCopyService.method(:native_readlinkat)
+    replacing_readlink = lambda do |*arguments|
+      target = real_readlink.call(*arguments)
+      File.rename(@src_file, File.join(@tmp_dir, "original-source.txt"))
+      File.binwrite(@src_file, "replacement")
+      target
+    end
+    FileCopyService.stub(:native_readlinkat, replacing_readlink) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.reference_target_matches?(
+          @src_file, destination, root: @dest_dir, source_snapshot: @source_snapshot
+        )
+      end
+    end
+
+    source_root_path = File.join(@tmp_dir, "authorized-source")
+    source = File.join(source_root_path, "book.mp3")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "authorized")
+    source_root = FileCopyService.snapshot_source_root(source_root_path)
+    rooted_destination = File.join(@dest_dir, "root-reference.txt")
+    File.symlink(source, rooted_destination)
+    File.rename(source_root_path, File.join(@tmp_dir, "displaced-source"))
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(source, "replacement")
+    assert_raises(Errno::ESTALE) do
+      FileCopyService.reference_target_matches?(
+        source, rooted_destination, root: @dest_dir, source_root: source_root
+      )
+    end
+  end
+
+  test "reference_target_matches fails closed for destination and filesystem races" do
+    outside = File.join(@tmp_dir, "outside-reference.txt")
+    File.symlink(@src_file, outside)
+    assert_raises(FileCopyService::UnsafePathError) do
+      FileCopyService.reference_target_matches?(
+        @src_file, outside, root: @dest_dir, source_snapshot: @source_snapshot
+      )
+    end
+    assert_raises(Errno::ENOENT) do
+      FileCopyService.reference_target_matches?(
+        @src_file, File.join(@dest_dir, "missing"), root: @dest_dir, source_snapshot: @source_snapshot
+      )
+    end
+
+    nested = File.join(@dest_dir, "nested")
+    displaced = File.join(@dest_dir, "displaced")
+    destination = File.join(nested, "referenced.txt")
+    FileUtils.mkdir_p(nested)
+    File.symlink(@src_file, destination)
+    real_readlink = FileCopyService.method(:native_readlinkat)
+    replacing_readlink = lambda do |*arguments|
+      target = real_readlink.call(*arguments)
+      File.rename(nested, displaced)
+      FileUtils.mkdir_p(nested)
+      target
+    end
+    FileCopyService.stub(:native_readlinkat, replacing_readlink) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.reference_target_matches?(
+          @src_file, destination, root: @dest_dir, source_snapshot: @source_snapshot
+        )
+      end
+    end
+    FileCopyService.stub(:native_readlinkat, ->(*) { raise Errno::ESTALE }) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.reference_target_matches?(
+          @src_file, File.join(displaced, "referenced.txt"),
+          root: @dest_dir, source_snapshot: @source_snapshot
+        )
+      end
+    end
   end
 
   test "reference_noreplace never overwrites an occupied destination" do

--- a/test/services/metadata_search/result_normalizer_test.rb
+++ b/test/services/metadata_search/result_normalizer_test.rb
@@ -4,6 +4,31 @@ require "test_helper"
 
 module MetadataSearch
   class ResultNormalizerTest < ActiveSupport::TestCase
+    test "uses Hardcover stable numeric id links and rejects malformed ids" do
+      result = HardcoverClient::SearchResult.new(
+        id: "175280",
+        title: "Piranesi",
+        author: "Susanna Clarke",
+        description: nil,
+        release_year: 2020,
+        cover_url: nil,
+        has_audiobook: true,
+        has_ebook: true,
+        series_name: nil,
+        series_position: nil
+      )
+
+      normalized = ResultNormalizer.call("hardcover", result)
+
+      assert_equal "175280", normalized.source_id
+      assert_equal "hardcover:175280", normalized.work_id
+      assert_equal "https://hardcover.app/id/book/175280", normalized.source_url
+      assert_equal "https://hardcover.app/id/book/1", ResultNormalizer.call("hardcover", result.with(id: 1)).source_url
+      assert_nil ResultNormalizer.call("hardcover", result.with(id: nil)).source_url
+      assert_nil ResultNormalizer.call("hardcover", result.with(id: 0)).source_url
+      assert_nil ResultNormalizer.call("hardcover", result.with(id: "175280/unsafe")).source_url
+    end
+
     test "retains Google categories and emits graphic classification evidence" do
       result = GoogleBooksClient::SearchResult.new(
         id: "gb1",
@@ -44,6 +69,7 @@ module MetadataSearch
       assert_equal 90, normalized.classification_confidence
       assert_equal [ "subject:Graphic novels" ], normalized.classification_evidence
       assert_equal [ "Graphic novels" ], normalized.subjects
+      assert_equal "https://openlibrary.org/works/OL123W", normalized.source_url
     end
 
     test "uses requested kind as weak fallback when provider evidence is absent" do

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -541,6 +541,62 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert results.all? { |result| result.content_kind == "graphic" }
   end
 
+  test "strong graphic results remain when a slower provider fills the result limit with fallbacks" do
+    SettingsService.set(:metadata_provider_priority, "openlibrary,comic_vine")
+    comic_results = 10.times.map do |index|
+      metadata_provider_result(
+        source: "comic_vine",
+        source_id: "comic-#{index}",
+        title: "Low Comic #{index}",
+        content_kind: "graphic",
+        classification_confidence: 100
+      )
+    end
+    fallback_results = 20.times.map do |index|
+      metadata_provider_result(
+        source: "openlibrary",
+        source_id: "fallback-#{index}",
+        title: "Low Fallback #{index}",
+        content_kind: "graphic",
+        classification_confidence: 20
+      )
+    end
+
+    partial_results = MetadataService.aggregate_provider_results(comic_results, content_kind: "graphic")
+    final_results = MetadataService.aggregate_provider_results(
+      fallback_results + comic_results,
+      content_kind: "graphic"
+    )
+
+    assert_equal 20, final_results.size
+    assert_empty partial_results.map(&:work_id) - final_results.map(&:work_id)
+    assert_equal Array.new(10, "comic_vine"), final_results.first(10).map(&:source)
+  end
+
+  test "provider priority orders strong requested-kind matches regardless of raw classification confidence" do
+    SettingsService.set(:metadata_provider_priority, "google_books,comic_vine")
+    provider_results = [
+      metadata_provider_result(
+        source: "comic_vine",
+        source_id: "definitive-graphic",
+        title: "Definitive Graphic",
+        content_kind: "graphic",
+        classification_confidence: 100
+      ),
+      metadata_provider_result(
+        source: "google_books",
+        source_id: "strong-graphic",
+        title: "Strong Graphic",
+        content_kind: "graphic",
+        classification_confidence: 90
+      )
+    ]
+
+    results = MetadataService.aggregate_provider_results(provider_results, content_kind: "graphic")
+
+    assert_equal %w[google_books comic_vine], results.map(&:source)
+  end
+
   test "search_google_books returns empty array when provider disabled" do
     SettingsService.set(:google_books_enabled, false)
 

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -275,6 +275,82 @@ class MetadataServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "search_provider keeps array callers while exposing skipped outcomes" do
+    SettingsService.set(:metadata_source, "google_books")
+    MetadataProviderStatus.create!(
+      provider: "google_books",
+      status: "rate_limited",
+      rate_limited_until: 10.minutes.from_now
+    )
+
+    assert_equal [], MetadataService.search_provider("google_books", "dune")
+
+    outcome = MetadataService.search_provider("google_books", "dune", with_outcome: true)
+    assert_instance_of MetadataService::ProviderSearchOutcome, outcome
+    assert_empty outcome.results
+    assert outcome.failed
+    assert outcome.skipped
+  end
+
+  test "concurrent searches use their invocation-local provider outcomes" do
+    started = Queue.new
+    releases = { "successful" => Queue.new, "failed" => Queue.new }
+    outcomes = Queue.new
+    provider_search = lambda do |_provider, query, **_options|
+      started << query
+      releases.fetch(query).pop
+      MetadataService::ProviderSearchOutcome.new(
+        results: query == "successful" ? [ query ] : [],
+        failed: query == "failed",
+        skipped: false
+      )
+    end
+
+    SettingsService.stub(:enabled_metadata_providers, %w[openlibrary]) do
+      MetadataService.stub(:search_provider, provider_search) do
+        threads = %w[successful failed].map do |query|
+          Thread.new do
+            MetadataService.each_provider_search(query) do |_provider, results, failed|
+              outcomes << [ query, results, failed ]
+            end
+          end
+        end
+
+        assert_equal %w[failed successful], 2.times.map { started.pop }.sort
+        releases["failed"] << true
+        releases["successful"] << true
+        threads.each(&:join)
+      end
+    end
+
+    assert_equal(
+      [ [ "failed", [], true ], [ "successful", [ "successful" ], false ] ],
+      2.times.map { outcomes.pop }.sort_by(&:first)
+    )
+  end
+
+  test "aggregate-only limits do not change configured provider request limits" do
+    searched = nil
+    aggregate = nil
+    concurrent_search = lambda do |providers, query, limit:, content_kind:|
+      searched = { providers: providers, query: query, limit: limit, content_kind: content_kind }
+      []
+    end
+    aggregate_results = lambda do |results, limit:, content_kind:|
+      aggregate = { results: results, limit: limit, content_kind: content_kind }
+      []
+    end
+
+    MetadataService.stub(:search_providers_concurrently, concurrent_search) do
+      MetadataService.stub(:aggregate_provider_results, aggregate_results) do
+        MetadataService.search("dune", aggregate_limit: SearchResultSnapshot::MAX_RESULTS)
+      end
+    end
+
+    assert_nil searched[:limit]
+    assert_equal SearchResultSnapshot::MAX_RESULTS, aggregate[:limit]
+  end
+
   test "book_details handles hardcover work_id" do
     SettingsService.set(:hardcover_api_token, "test_token")
 
@@ -487,6 +563,34 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert_equal 1, results.size
     assert_equal "High Confidence", results.first.title
     assert_equal 90, results.first.confidence
+  end
+
+  test "bounded web aggregation remains untruncated until pagination after deduplication" do
+    SettingsService.set(:metadata_provider_priority, "openlibrary,google_books")
+    provider_results = 22.times.map do |index|
+      metadata_provider_result(
+        source: "openlibrary",
+        source_id: "ol-#{index}",
+        title: "Result #{index}",
+        year: 2000 + index
+      )
+    end
+    provider_results << metadata_provider_result(
+      source: "google_books",
+      source_id: "gb-0",
+      title: "Result 0",
+      year: 2000
+    )
+
+    results = MetadataService.aggregate_provider_results(
+      provider_results,
+      limit: SearchResultSnapshot::MAX_RESULTS
+    )
+
+    assert_equal 22, results.size
+    assert_equal 2, results.find { |result| result.title == "Result 0" }.sources.size
+    assert_equal 20, results.first(SearchResultSnapshot::PAGE_SIZE).size
+    assert_equal 2, results.drop(SearchResultSnapshot::PAGE_SIZE).size
   end
 
   test "requested content kind does not prune enabled metadata providers" do

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -293,6 +293,7 @@ class MetadataServiceTest < ActiveSupport::TestCase
       result = MetadataService.book_details("hardcover:12345")
 
       assert_equal "hardcover", result.source
+      assert_equal "https://hardcover.app/id/book/12345", result.source_url
       assert_equal "Test Book", result.title
       assert_nil result.series_position
     end
@@ -376,8 +377,10 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert_nil result.cover_id
     assert_equal "1", result.series_position
     assert_equal "Hardcover", result.source_name
-    assert_equal "https://hardcover.app/books/123", result.source_url
+    assert_equal "https://hardcover.app/id/book/123", result.source_url
     assert_equal "Metadata from Hardcover", result.source_attribution
+    assert_nil result.with(source_id: nil).source_url
+    assert_nil result.with(source_id: "123/unsafe").source_url
   end
 
   test "SearchResult exposes source metadata for each provider" do

--- a/test/services/search_result_snapshot_test.rb
+++ b/test/services/search_result_snapshot_test.rb
@@ -1,0 +1,470 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchResultSnapshotTest < ActiveSupport::TestCase
+  setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    @user = users(:one)
+    @lock_parent = Dir.mktmpdir("search-result-snapshot-locks")
+    SearchResultSnapshot.lock_root = Pathname(@lock_parent).join("private")
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+    SearchResultSnapshot.reset_lock_root!
+    FileUtils.remove_entry(@lock_parent) if @lock_parent && File.exist?(@lock_parent)
+  end
+
+  test "stores bounded plain candidate data and restores the aggregate" do
+    token = SearchResultSnapshot.create(
+      user: @user,
+      query: "dune",
+      content_kind: "book",
+      provider_count: 4
+    )
+    results = (SearchResultSnapshot::MAX_RESULTS + 5).times.map { |index| candidate(index) }
+
+    snapshot = SearchResultSnapshot.write(
+      user: @user,
+      id: token,
+      query: "dune",
+      content_kind: "book",
+      results: results,
+      complete: true,
+      failed_providers: %w[google_books],
+      provider_count: 4
+    )
+    fetched = SearchResultSnapshot.fetch(
+      user: @user,
+      id: token,
+      query: "dune",
+      content_kind: "book"
+    )
+    cached = Rails.cache.read("search_result_snapshot:v3:#{@user.id}")
+    payload = JSON.parse(cached)
+
+    assert_instance_of SearchResultSnapshot::Snapshot, snapshot
+    assert_equal SearchResultSnapshot::MAX_RESULTS, fetched.results.size
+    assert_equal "Book 0", fetched.results.first.title
+    assert_equal "openlibrary:work-0", fetched.results.first.work_id
+    assert fetched.complete
+    assert_equal %w[google_books], fetched.failed_providers
+    assert plain_cache_data?(payload)
+    assert_operator cached.bytesize, :<=, SearchResultSnapshot::MAX_PAYLOAD_BYTES
+  end
+
+  test "keeps three snapshots and evicts only the oldest" do
+    tokens = %w[one two three four].map do |query|
+      SearchResultSnapshot.create(user: @user, query: query, content_kind: "book", provider_count: 1)
+    end
+
+    assert_nil SearchResultSnapshot.fetch(user: @user, id: tokens[0], query: "one", content_kind: "book")
+    assert_not SearchResultSnapshot.write(
+      user: @user,
+      id: tokens[0],
+      query: "one",
+      content_kind: "book",
+      results: [ candidate(1) ],
+      complete: true,
+      failed_providers: [],
+      provider_count: 1
+    )
+    %w[two three four].each_with_index do |query, index|
+      assert SearchResultSnapshot.fetch(user: @user, id: tokens[index + 1], query: query, content_kind: "book")
+    end
+
+    keys = Rails.cache.instance_variable_get(:@data).keys
+    assert_equal [ "search_result_snapshot:v3:#{@user.id}" ], keys
+    collection = JSON.parse(Rails.cache.read(keys.first))
+    assert_equal tokens.last(3), collection["order"]
+  end
+
+  test "concurrent tab snapshots and delayed writes coexist up to quota" do
+    queries = %w[alpha beta gamma]
+    tokens = {}
+    mutex = Mutex.new
+    create_threads = queries.map do |query|
+      Thread.new do
+        token = SearchResultSnapshot.create(user: @user, query: query, content_kind: "book", provider_count: 1)
+        mutex.synchronize { tokens[query] = token }
+      end
+    end
+    create_threads.each(&:join)
+
+    write_threads = queries.reverse.map do |query|
+      Thread.new do
+        SearchResultSnapshot.write(
+          user: @user,
+          id: tokens.fetch(query),
+          query: query,
+          content_kind: "book",
+          results: [ candidate(queries.index(query)) ],
+          complete: true,
+          failed_providers: [],
+          provider_count: 1
+        )
+      end
+    end
+    snapshots = write_threads.map(&:value)
+
+    assert snapshots.all?
+    queries.each do |query|
+      snapshot = SearchResultSnapshot.fetch(
+        user: @user,
+        id: tokens.fetch(query),
+        query: query,
+        content_kind: "book"
+      )
+      assert snapshot.complete
+      assert_equal 1, snapshot.results.size
+    end
+  end
+
+  test "worst-case fields are deterministically truncated to the serialized byte ceiling" do
+    token = SearchResultSnapshot.create(user: @user, query: "large", content_kind: "book", provider_count: 4)
+    results = SearchResultSnapshot::MAX_RESULTS.times.map { |index| worst_case_candidate(index) }
+
+    first = SearchResultSnapshot.write(
+      user: @user,
+      id: token,
+      query: "large",
+      content_kind: "book",
+      results: results,
+      complete: true,
+      failed_providers: [],
+      provider_count: 4
+    )
+    first_payload = Rails.cache.read("search_result_snapshot:v3:#{@user.id}")
+    second = SearchResultSnapshot.write(
+      user: @user,
+      id: token,
+      query: "large",
+      content_kind: "book",
+      results: results,
+      complete: true,
+      failed_providers: [],
+      provider_count: 4
+    )
+
+    assert_operator first_payload.bytesize, :<=, SearchResultSnapshot::MAX_PAYLOAD_BYTES
+    assert_operator first.results.size, :<, SearchResultSnapshot::MAX_RESULTS
+    assert_equal first.results.map(&:canonical_key), second.results.map(&:canonical_key)
+    expected_keys = results.first(first.results.size).map do |result|
+      result.canonical_key.byteslice(0, SearchResultSnapshot::MAX_TEXT_BYTES).scrub
+    end
+    assert_equal expected_keys, first.results.map(&:canonical_key)
+  end
+
+  test "three large snapshots receive fair budgets and remain populated after eviction" do
+    large_results = SearchResultSnapshot::MAX_RESULTS.times.map { |index| worst_case_candidate(index) }
+    tokens = 3.times.map do |index|
+      SearchResultSnapshot.create(user: @user, query: "large-#{index}", content_kind: "book", provider_count: 4)
+    end
+    tokens.each_with_index do |token, index|
+      assert SearchResultSnapshot.write(
+        user: @user,
+        id: token,
+        query: "large-#{index}",
+        content_kind: "book",
+        results: large_results,
+        complete: true,
+        failed_providers: [],
+        provider_count: 4
+      )
+    end
+
+    cached = Rails.cache.read("search_result_snapshot:v3:#{@user.id}")
+    assert_operator cached.bytesize, :<=, SearchResultSnapshot::MAX_PAYLOAD_BYTES
+    collection = JSON.parse(cached)
+    counts = []
+    tokens.each_with_index do |token, index|
+      snapshot = SearchResultSnapshot.fetch(
+        user: @user,
+        id: token,
+        query: "large-#{index}",
+        content_kind: "book"
+      )
+      counts << snapshot.results.size
+      assert_operator snapshot.results.size, :>, 0
+      assert_operator JSON.generate(collection.dig("snapshots", token)).bytesize,
+        :<=, SearchResultSnapshot::MAX_SNAPSHOT_BYTES
+    end
+    assert_equal 1, counts.uniq.size
+
+    fourth = SearchResultSnapshot.create(user: @user, query: "large-3", content_kind: "book", provider_count: 4)
+    assert SearchResultSnapshot.write(
+      user: @user,
+      id: fourth,
+      query: "large-3",
+      content_kind: "book",
+      results: large_results,
+      complete: true,
+      failed_providers: [],
+      provider_count: 4
+    )
+
+    assert_nil SearchResultSnapshot.fetch(user: @user, id: tokens.first, query: "large-0", content_kind: "book")
+    retained = [ tokens[1], tokens[2], fourth ]
+    retained.each_with_index do |token, index|
+      snapshot = SearchResultSnapshot.fetch(
+        user: @user,
+        id: token,
+        query: "large-#{index + 1}",
+        content_kind: "book"
+      )
+      assert_operator snapshot.results.size, :>, 0
+    end
+    final_cached = Rails.cache.read("search_result_snapshot:v3:#{@user.id}")
+    final_collection = JSON.parse(final_cached)
+    assert_equal retained, final_collection["order"]
+    assert_operator final_cached.bytesize, :<=, SearchResultSnapshot::MAX_PAYLOAD_BYTES
+  end
+
+  test "pathological numerics are rejected without suppressing later results" do
+    huge_integer = 1 << 3_400_000
+    custom_numeric = Class.new(Numeric) do
+      def to_i
+        raise "must not convert"
+      end
+
+      def to_s
+        raise "must not stringify"
+      end
+    end.new
+    token = SearchResultSnapshot.create(user: @user, query: "numbers", content_kind: "book", provider_count: 1)
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    snapshot = SearchResultSnapshot.write(
+      user: @user,
+      id: token,
+      query: "numbers",
+      content_kind: "book",
+      results: [
+        candidate(0, year: huge_integer),
+        candidate(1, year: 2026),
+        candidate(2, year: custom_numeric),
+        candidate(3, year: Float::INFINITY)
+      ],
+      complete: true,
+      failed_providers: [],
+      provider_count: 1
+    )
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_operator elapsed, :<, 2.0
+    assert_equal [ nil, 2026, nil, nil ], snapshot.results.map(&:year)
+    assert_equal [ "Book 0", "Book 1", "Book 2", "Book 3" ], snapshot.results.map(&:title)
+    assert_operator Rails.cache.read("search_result_snapshot:v3:#{@user.id}").bytesize,
+      :<=, SearchResultSnapshot::MAX_PAYLOAD_BYTES
+  end
+
+  test "a candidate that exceeds the remaining fair budget does not suppress a later valid candidate" do
+    target_token = SearchResultSnapshot.create(user: @user, query: "target", content_kind: "book", provider_count: 1)
+
+    snapshot = SearchResultSnapshot.write(
+      user: @user,
+      id: target_token,
+      query: "target",
+      content_kind: "book",
+      results: [ worst_case_candidate(998), worst_case_candidate(999), candidate(1) ],
+      complete: true,
+      failed_providers: [],
+      provider_count: 1
+    )
+
+    assert_equal [ "x" * SearchResultSnapshot::MAX_TEXT_BYTES, "Book 1" ], snapshot.results.map(&:title)
+  end
+
+  test "rejects foreign users and mismatched query or content kind" do
+    token = SearchResultSnapshot.create(user: @user, query: "dune", content_kind: "book", provider_count: 1)
+    SearchResultSnapshot.write(
+      user: @user,
+      id: token,
+      query: "dune",
+      content_kind: "book",
+      results: [ candidate(1) ],
+      complete: true,
+      failed_providers: [],
+      provider_count: 1
+    )
+
+    assert_nil SearchResultSnapshot.fetch(user: users(:two), id: token, query: "dune", content_kind: "book")
+    assert_nil SearchResultSnapshot.fetch(user: @user, id: token, query: "foundation", content_kind: "book")
+    assert_nil SearchResultSnapshot.fetch(user: @user, id: token, query: "dune", content_kind: "graphic")
+    assert_nil SearchResultSnapshot.fetch(user: @user, id: "not-a-token", query: "dune", content_kind: "book")
+  end
+
+  test "expires snapshots and bounds page numbers" do
+    token = SearchResultSnapshot.create(user: @user, query: "dune", content_kind: nil, provider_count: 1)
+
+    travel SearchResultSnapshot::TTL + 1.second do
+      assert_nil SearchResultSnapshot.fetch(user: @user, id: token, query: "dune", content_kind: nil)
+    end
+
+    assert_equal 1, SearchResultSnapshot.normalize_page(nil)
+    assert_equal 1, SearchResultSnapshot.normalize_page(-5)
+    assert_equal SearchResultSnapshot::MAX_PAGES, SearchResultSnapshot.normalize_page(100)
+  end
+
+  test "cache failures return safe misses" do
+    failing_cache = Class.new do
+      def read(*)
+        raise IOError, "cache unavailable"
+      end
+
+      def write(*)
+        raise IOError, "cache unavailable"
+      end
+    end.new
+    Rails.cache = failing_cache
+
+    assert_nil SearchResultSnapshot.create(user: @user, query: "dune", content_kind: nil, provider_count: 1)
+    assert_nil SearchResultSnapshot.fetch(user: @user, id: "a" * 32, query: "dune", content_kind: nil)
+    assert_not SearchResultSnapshot.write(
+      user: @user,
+      id: "a" * 32,
+      query: "dune",
+      content_kind: nil,
+      results: [],
+      complete: true,
+      failed_providers: [],
+      provider_count: 1
+    )
+  end
+
+  test "mutations use one persistent flock and release it after failure" do
+    real_lock = FileCopyService.method(:with_private_lock)
+    lock_calls = 0
+    wrapper = lambda do |path, root:, **options, &block|
+      lock_calls += 1
+      real_lock.call(path, root: root, **options, &block)
+    end
+
+    FileCopyService.stub(:with_private_lock, wrapper) do
+      token = SearchResultSnapshot.create(user: @user, query: "locked", content_kind: "book", provider_count: 1)
+      assert SearchResultSnapshot.write(
+        user: @user,
+        id: token,
+        query: "locked",
+        content_kind: "book",
+        results: [ candidate(1) ],
+        complete: true,
+        failed_providers: [],
+        provider_count: 1
+      )
+
+      working_cache = Rails.cache
+      begin
+        Rails.cache = Class.new do
+          def read(*) = nil
+          def write(*) = raise(IOError, "cache unavailable")
+        end.new
+        assert_nil SearchResultSnapshot.create(user: @user, query: "failed", content_kind: "book", provider_count: 1)
+      ensure
+        Rails.cache = working_cache
+      end
+    end
+
+    assert_equal 3, lock_calls
+    lock_path = snapshot_lock_path
+    acquired = FileCopyService.with_private_lock(lock_path.to_s, root: SearchResultSnapshot.lock_root.to_s, nonblock: true) do
+      true
+    end
+    assert acquired
+    assert File.file?(lock_path)
+  end
+
+  private
+
+  def candidate(index, year: 2000 + (index % 20))
+    MetadataSearch::Candidate.new(
+      canonical_key: "openlibrary:work-#{index}",
+      title: "Book #{index}",
+      author: "Author #{index}",
+      year: year,
+      description: "Description #{index}",
+      cover_url: "https://example.com/covers/#{index}.jpg",
+      series_name: nil,
+      series_position: nil,
+      has_ebook: true,
+      has_audiobook: nil,
+      sources: [ {
+        source: "openlibrary",
+        source_id: "work-#{index}",
+        source_name: "Open Library",
+        source_url: "https://openlibrary.org/works/work-#{index}",
+        work_id: "openlibrary:work-#{index}"
+      } ],
+      editions: [],
+      confidence: 70
+    )
+  end
+
+  def snapshot_lock_path
+    digest = Digest::SHA256.hexdigest(@user.id.to_s)
+    Pathname(SearchResultSnapshot.lock_root).join("#{digest}.lock")
+  end
+
+  def worst_case_candidate(index)
+    text = "x" * SearchResultSnapshot::MAX_TEXT_BYTES
+    sources = SearchResultSnapshot::MAX_SOURCES.times.map do |source_index|
+      {
+        source: text,
+        source_id: "#{index}-#{source_index}-#{text}",
+        source_name: text,
+        source_url: "https://example.com/#{text}",
+        work_id: "source:#{index}-#{source_index}-#{text}"
+      }
+    end
+    editions = SearchResultSnapshot::MAX_EDITIONS.times.map do |edition_index|
+      {
+        source: text,
+        source_id: "#{index}-#{edition_index}-#{text}",
+        isbn_10: text,
+        isbn_13: text,
+        publisher: text,
+        year: text,
+        page_count: text,
+        resource_kind: text
+      }
+    end
+
+    MetadataSearch::Candidate.new(
+      canonical_key: "key-#{index}-#{text}",
+      title: text,
+      author: text,
+      year: 2026,
+      description: text,
+      cover_url: "https://example.com/#{text}",
+      series_name: text,
+      series_position: text,
+      has_ebook: true,
+      has_audiobook: true,
+      sources: sources,
+      editions: editions,
+      confidence: 100,
+      classification_evidence: Array.new(SearchResultSnapshot::MAX_LIST_VALUES, text),
+      categories: Array.new(SearchResultSnapshot::MAX_LIST_VALUES, text),
+      subjects: Array.new(SearchResultSnapshot::MAX_LIST_VALUES, text),
+      collection_source: text,
+      collection_id: text,
+      collection_title: text,
+      issue_number: text,
+      release_date: text
+    )
+  end
+
+  def plain_cache_data?(value)
+    case value
+    when Hash
+      value.all? { |key, item| (key.is_a?(String) || key.is_a?(Symbol)) && plain_cache_data?(item) }
+    when Array
+      value.all? { |item| plain_cache_data?(item) }
+    when String, Numeric, TrueClass, FalseClass, NilClass
+      true
+    else
+      false
+    end
+  end
+end

--- a/test/system/search_streaming_test.rb
+++ b/test/system/search_streaming_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class SearchStreamingTest < ApplicationSystemTestCase
+  test "stale stream chunks cannot render after the query or content kind changes" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_streaming_search_stub
+
+    search_input = find("[data-search-target='input']")
+    search_input.fill_in with: "low"
+    assert_selector "body[data-search-fetch-count='1']", visible: :all
+
+    enqueue_search_result(0, "current-result")
+    assert_selector "#current-result"
+
+    select "Comics & Manga"
+    enqueue_search_result(0, "stale-filter-result")
+    wait_for_stream_processing
+    assert_no_selector "#stale-filter-result"
+    assert_selector "body[data-search-fetch-count='2']", visible: :all
+    assert_equal "graphic", search_request_params(1)["content_kind"]
+
+    enqueue_search_result(1, "filtered-result")
+    assert_selector "#filtered-result"
+
+    page.execute_script <<~JAVASCRIPT
+      const input = document.querySelector("[data-search-target='input']")
+      input.value = "different"
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+      input.value = "low"
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+    JAVASCRIPT
+    enqueue_search_result(1, "stale-query-result")
+    wait_for_stream_processing
+    assert_no_selector "#stale-query-result"
+    assert_selector "body[data-search-fetch-count='3']", visible: :all
+  end
+
+  test "reconnecting a reused controller cannot reuse an old request ID" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_streaming_search_stub
+
+    find("[data-search-target='input']").fill_in with: "low"
+    assert_selector "body[data-search-fetch-count='1']", visible: :all
+    assert remember_search_controller
+
+    page.execute_script <<~JAVASCRIPT
+      window.searchControllerElement = document.querySelector("[data-controller='search']")
+      window.searchControllerParent = window.searchControllerElement.parentElement
+      window.searchControllerElement.remove()
+    JAVASCRIPT
+    wait_for_stream_processing
+    assert page.evaluate_script("window.searchRequests[0].signal.aborted")
+
+    page.execute_script("window.searchControllerParent.appendChild(window.searchControllerElement)")
+    wait_for_stream_processing
+    assert reused_search_controller?
+
+    page.execute_script <<~JAVASCRIPT
+      const input = document.querySelector("[data-search-target='input']")
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+    JAVASCRIPT
+    enqueue_search_result(0, "stale-lifecycle-result")
+    wait_for_stream_processing
+
+    assert_no_selector "#stale-lifecycle-result"
+    assert_selector "body[data-search-fetch-count='2']", visible: :all
+  end
+
+  private
+
+  def install_streaming_search_stub
+    page.execute_script <<~JAVASCRIPT
+      window.searchRequests = []
+      window.searchStreams = []
+      window.fetch = (input, options = {}) => {
+        const url = typeof input === "string" ? input : input.url
+        let streamController
+        const body = new ReadableStream({
+          start(controller) {
+            streamController = controller
+          }
+        })
+
+        window.searchRequests.push({ url, signal: options.signal })
+        window.searchStreams.push(streamController)
+        document.body.dataset.searchFetchCount = window.searchRequests.length.toString()
+        return Promise.resolve(new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/vnd.turbo-stream.html" }
+        }))
+      }
+    JAVASCRIPT
+  end
+
+  def enqueue_search_result(stream_index, element_id)
+    page.execute_script <<~JAVASCRIPT
+      window.searchStreams[#{stream_index}].enqueue(new TextEncoder().encode(
+        '<turbo-stream action="update" target="search-results"><template><p id="#{element_id}">#{element_id}</p></template></turbo-stream>'
+      ))
+    JAVASCRIPT
+  end
+
+  def wait_for_stream_processing
+    page.driver.browser.execute_async_script <<~JAVASCRIPT
+      const done = arguments[0]
+      setTimeout(done, 50)
+    JAVASCRIPT
+  end
+
+  def remember_search_controller
+    page.driver.browser.execute_async_script <<~JAVASCRIPT
+      const done = arguments[0]
+      import("controllers/application").then(({ application }) => {
+        const element = document.querySelector("[data-controller='search']")
+        window.rememberedSearchController = application.getControllerForElementAndIdentifier(element, "search")
+        done(window.rememberedSearchController !== null)
+      }).catch(() => done(false))
+    JAVASCRIPT
+  end
+
+  def reused_search_controller?
+    page.driver.browser.execute_async_script <<~JAVASCRIPT
+      const done = arguments[0]
+      import("controllers/application").then(({ application }) => {
+        const element = document.querySelector("[data-controller='search']")
+        const controller = application.getControllerForElementAndIdentifier(element, "search")
+        done(controller === window.rememberedSearchController)
+      }).catch(() => done(false))
+    JAVASCRIPT
+  end
+
+  def search_request_params(index)
+    page.evaluate_script <<~JAVASCRIPT
+      Object.fromEntries(new URL(window.searchRequests[#{index}].url, window.location.href).searchParams)
+    JAVASCRIPT
+  end
+end

--- a/test/system/search_streaming_test.rb
+++ b/test/system/search_streaming_test.rb
@@ -70,6 +70,222 @@ class SearchStreamingTest < ApplicationSystemTestCase
     assert_selector "body[data-search-fetch-count='2']", visible: :all
   end
 
+  test "next page preloads silently and renders immediately with canonical history" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub
+    page.execute_script('history.replaceState({ ...history.state, reviewMarker: "preserved" }, "", window.location.href)')
+
+    find("[data-search-target='input']").fill_in with: "low"
+    assert_selector "body[data-search-fetch-count='1']", visible: :all
+    enqueue_paginated_search_result(0, page_number: 1, has_next: true)
+
+    assert_selector "body[data-search-fetch-count='2']", visible: :all
+    restoration_identifier = page.evaluate_script("history.state.turbo.restorationIdentifier")
+    assert_no_selector "#page-2-result"
+    assert_not_equal "search-results-heading", page.evaluate_script("document.activeElement.id")
+
+    click_link "Next"
+
+    assert_selector "#page-2-result", text: "Page 2 result"
+    assert_equal({ "q" => "low", "page" => "2" }, current_search_params)
+    assert_no_match "snapshot_id", page.current_url
+    assert_equal "preserved", page.evaluate_script("history.state.reviewMarker")
+    assert_equal 2, page.evaluate_script("history.state.shelfarrSearch.page")
+    assert_equal restoration_identifier, page.evaluate_script("history.state.turbo.restorationIdentifier")
+    assert_equal "search-results-heading", page.evaluate_script("document.activeElement.id")
+
+    page.go_back
+
+    assert_selector "#page-1-result", text: "Page 1 result"
+    assert_equal({ "q" => "low", "page" => "1" }, current_search_params)
+    assert_equal 1, page.evaluate_script("window.searchStreams.length")
+    assert_equal "preserved", page.evaluate_script("history.state.reviewMarker")
+  end
+
+  test "page one and two survive Turbo away Back Back with one federated search" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub
+    page.execute_script('history.replaceState({ ...history.state, reviewMarker: "turbo-preserved" }, "", window.location.href)')
+    restoration_identifier = page.evaluate_script("history.state.turbo.restorationIdentifier")
+
+    find("[data-search-target='input']").fill_in with: "low"
+    assert_selector "body[data-search-fetch-count='1']", visible: :all
+    enqueue_paginated_search_result(0, page_number: 1, has_next: true)
+    assert_selector "#page-1-result"
+    assert_equal restoration_identifier, page.evaluate_script("history.state.turbo.restorationIdentifier")
+
+    click_link "Next"
+    assert_selector "#page-2-result"
+    assert_equal 1, page.evaluate_script("window.searchStreams.length")
+
+    find("nav a", text: "Shelfarr", match: :first).click
+    assert_current_path root_path
+    assert_link "Search for books by title or author..."
+
+    page.go_back
+
+    assert_selector "#page-2-result"
+    assert_equal({ "q" => "low", "page" => "2" }, current_search_params)
+    assert_equal 1, page.evaluate_script("window.searchStreams.length")
+
+    page.go_back
+
+    assert_selector "#page-1-result"
+    assert_equal({ "q" => "low", "page" => "1" }, current_search_params)
+    assert_equal "turbo-preserved", page.evaluate_script("history.state.reviewMarker")
+    assert page.evaluate_script("Boolean(history.state.turbo)")
+    assert_equal restoration_identifier, page.evaluate_script("history.state.turbo.restorationIdentifier")
+    assert_equal 1, page.evaluate_script("window.searchStreams.length")
+  end
+
+  test "browser page cache is snapshot-bound across repeated A B A searches" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub
+
+    search_with_generation("alpha", "generation-a1", stream_index: 0, has_next: true)
+    search_with_generation("beta", "generation-b", stream_index: 1, has_next: false)
+    search_with_generation("alpha", "generation-a2", stream_index: 2, has_next: true)
+
+    click_link "Next"
+
+    assert_selector "[data-snapshot-generation='generation-a2']"
+    assert_no_selector "[data-snapshot-generation='generation-a1']"
+    cache = search_page_cache
+    assert_operator cache.fetch("size"), :<=, 5
+    assert_includes cache.fetch("snapshotIds"), "generation-a1"
+    assert_includes cache.fetch("snapshotIds"), "generation-a2"
+  end
+
+  test "reconnect and repeated same query cannot reuse the previous generation" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub
+
+    search_with_generation("repeat", "repeat-old", stream_index: 0, has_next: true)
+    assert remember_search_controller
+    page.execute_script <<~JAVASCRIPT
+      window.searchControllerElement = document.querySelector("[data-controller='search']")
+      window.searchControllerParent = window.searchControllerElement.parentElement
+      window.searchControllerElement.remove()
+      window.searchControllerParent.appendChild(window.searchControllerElement)
+    JAVASCRIPT
+    wait_for_stream_processing
+    assert reused_search_controller?
+
+    page.execute_script <<~JAVASCRIPT
+      const input = document.querySelector("[data-search-target='input']")
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+    JAVASCRIPT
+    assert_selector "body[data-search-stream-count='2']", visible: :all
+    page.execute_script('window.searchSnapshotToken = "repeat-new"')
+    enqueue_paginated_search_result(1, page_number: 1, has_next: true, query: "repeat")
+    assert_selector "[data-snapshot-generation='repeat-new']"
+
+    click_link "Next"
+
+    assert_selector "[data-snapshot-generation='repeat-new'][data-page='2']"
+    assert_no_selector "[data-snapshot-generation='repeat-old'][data-page='2']"
+  end
+
+  test "expired snapshot cache is discarded before navigation fallback" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub
+
+    search_with_generation("low", "expired-generation", stream_index: 0, has_next: true)
+    assert_selector "body[data-search-fetch-count='2']", visible: :all
+    expire_current_search_snapshot
+
+    click_link "Next"
+
+    assert_selector "body[data-search-fetch-count='3']", visible: :all
+    assert_equal "2", search_request_params(2)["page"]
+    assert_no_selector "[data-snapshot-generation='expired-generation'][data-page='2']"
+
+    page.execute_script('window.searchSnapshotToken = "fresh-generation"')
+    enqueue_paginated_search_result(1, page_number: 2, has_next: false, query: "low")
+    assert_selector "[data-snapshot-generation='fresh-generation']"
+  end
+
+  test "clicking Next during preload aborts it and uses a visible snapshot request" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub(delay_preload: true)
+
+    search_with_generation("low", "click-generation", stream_index: 0, has_next: true)
+    assert_selector "body[data-search-fetch-count='2']", visible: :all
+
+    click_link "Next"
+
+    assert page.evaluate_script("window.searchRequests[1].signal.aborted")
+    assert_selector "body[data-search-fetch-count='3']", visible: :all
+    assert_selector "#page-2-result"
+    assert_selector "[data-snapshot-generation='click-generation']"
+  end
+
+  test "server canonical page replaces page ten without accepting another generation" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub
+
+    navigate_search_controller(query: "low", page_number: 10)
+    assert_selector "body[data-search-fetch-count='1']", visible: :all
+    page.execute_script('window.searchSnapshotToken = "canonical-generation"')
+    enqueue_paginated_search_result(0, page_number: 2, has_next: false, query: "low")
+
+    assert_selector "#page-2-result"
+    assert_equal({ "q" => "low", "page" => "2" }, current_search_params)
+    assert_selector "[aria-current='page'][aria-label='Page 2']"
+    previous = find_link("Previous")
+    assert_equal({ "q" => "low", "page" => "1" }, Rack::Utils.parse_query(URI(previous[:href]).query))
+  end
+
+  test "non-OK visible responses render an idle accessible error" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub
+    page.execute_script("window.failNextSearchRequest = true")
+
+    find("[data-search-target='input']").fill_in with: "low"
+
+    assert_selector "[role='status']", text: "Search failed. Please try again.", visible: :all
+    assert_selector "#search-results[aria-busy='false']"
+    assert_selector "[data-search-state][data-search-page='1'][data-search-complete='true']"
+  end
+
+  test "browser page cache keeps a bounded LRU" do
+    sign_in_as(users(:one))
+    visit search_path
+
+    cache = fill_search_page_cache(6)
+
+    assert_equal 5, cache.fetch("size")
+    assert_not_includes cache.fetch("snapshotIds"), "lru-0"
+    assert_equal %w[lru-1 lru-2 lru-3 lru-4 lru-5], cache.fetch("snapshotIds")
+  end
+
+  test "query changes abort and invalidate an in-flight page preload" do
+    sign_in_as(users(:one))
+    visit search_path
+    install_pagination_search_stub(delay_preload: true)
+
+    find("[data-search-target='input']").fill_in with: "low"
+    assert_selector "body[data-search-fetch-count='1']", visible: :all
+    enqueue_paginated_search_result(0, page_number: 1, has_next: true)
+    assert_selector "body[data-search-fetch-count='2']", visible: :all
+
+    find("[data-search-target='input']").fill_in with: "different"
+    assert page.evaluate_script("window.searchRequests[1].signal.aborted")
+    page.execute_script("window.resolveSearchPreload()")
+    wait_for_stream_processing
+
+    assert_no_selector "#page-2-result"
+    assert_selector "body[data-search-fetch-count='3']", visible: :all
+  end
+
   private
 
   def install_streaming_search_stub
@@ -96,11 +312,97 @@ class SearchStreamingTest < ApplicationSystemTestCase
     JAVASCRIPT
   end
 
+  def install_pagination_search_stub(delay_preload: false)
+    page.execute_script <<~JAVASCRIPT
+      window.nativeSearchFetch = window.fetch
+      window.searchRequests = []
+      window.searchStreams = []
+      window.searchSnapshotToken = "snapshot-token-12345678901234567"
+      window.searchSnapshotExpiresAt = Math.floor(Date.now() / 1000) + 600
+      window.delayedSearchPreloads = #{delay_preload ? 1 : 0}
+      window.failNextSearchRequest = false
+      window.fetch = (input, options = {}) => {
+        const url = new URL(typeof input === "string" ? input : input.url, window.location.href)
+        if (!url.pathname.includes("/search/results")) {
+          return window.nativeSearchFetch(input, options)
+        }
+        window.searchRequests.push({ url: url.toString(), signal: options.signal })
+        document.body.dataset.searchFetchCount = window.searchRequests.length.toString()
+
+        if (url.pathname.endsWith("/search/results/snapshot")) {
+          const pageNumber = url.searchParams.get("page")
+          const query = url.searchParams.get("q")
+          const contentKind = url.searchParams.get("content_kind") || ""
+          const html = window.searchPageResponse(pageNumber, query, contentKind, false)
+          if (window.delayedSearchPreloads > 0) {
+            window.delayedSearchPreloads -= 1
+            return new Promise((resolve) => {
+              window.resolveSearchPreload = () => resolve(new Response(html, {
+                status: 200,
+                headers: { "Content-Type": "text/vnd.turbo-stream.html" }
+              }))
+            })
+          }
+          return Promise.resolve(new Response(html, {
+            status: 200,
+            headers: { "Content-Type": "text/vnd.turbo-stream.html" }
+          }))
+        }
+
+        if (window.failNextSearchRequest) {
+          window.failNextSearchRequest = false
+          return Promise.resolve(new Response("Search failed", { status: 503 }))
+        }
+
+        let streamController
+        const body = new ReadableStream({
+          start(controller) {
+            streamController = controller
+          }
+        })
+        window.searchStreams.push(streamController)
+        document.body.dataset.searchStreamCount = window.searchStreams.length.toString()
+        return Promise.resolve(new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/vnd.turbo-stream.html" }
+        }))
+      }
+
+      window.searchPageResponse = (pageNumber, query, contentKind, hasNext) => {
+        const preloadPage = hasNext ? Number(pageNumber) + 1 : ""
+        const kindParam = contentKind ? `&content_kind=${encodeURIComponent(contentKind)}` : ""
+        const previousLink = Number(pageNumber) > 1
+          ? `<a href="#{search_path}?q=${encodeURIComponent(query)}&page=${Number(pageNumber) - 1}${kindParam}" data-action="click->search#navigate">Previous</a>`
+          : '<span aria-disabled="true">Previous</span>'
+        const nextLink = hasNext
+          ? `<a href="#{search_path}?q=${encodeURIComponent(query)}&page=${preloadPage}${kindParam}" data-action="click->search#navigate" data-search-page="${preloadPage}">Next</a>`
+          : '<span aria-disabled="true">Next</span>'
+        return `<turbo-stream action="update" target="search-results"><template>
+          <div data-search-state data-search-query="${query}" data-search-content-kind="${contentKind}" data-search-page="${pageNumber}" data-search-page-count="2" data-search-has-next="${hasNext}" data-search-complete="true" data-search-snapshot-id="${window.searchSnapshotToken}" data-search-snapshot-expires-at="${window.searchSnapshotExpiresAt}" data-search-preload-page="${preloadPage}">
+            <h2 id="search-results-heading" tabindex="-1">Search results</h2>
+            <p role="status" aria-live="polite">Page ${pageNumber} loaded</p>
+            <p id="page-${pageNumber}-result" data-page="${pageNumber}" data-snapshot-generation="${window.searchSnapshotToken}">Page ${pageNumber} result</p>
+            <nav aria-label="Search result pages">${previousLink}<span aria-current="page" aria-label="Page ${pageNumber}">${pageNumber}</span>${nextLink}</nav>
+          </div>
+        </template></turbo-stream>`
+      }
+    JAVASCRIPT
+  end
+
   def enqueue_search_result(stream_index, element_id)
     page.execute_script <<~JAVASCRIPT
       window.searchStreams[#{stream_index}].enqueue(new TextEncoder().encode(
         '<turbo-stream action="update" target="search-results"><template><p id="#{element_id}">#{element_id}</p></template></turbo-stream>'
       ))
+    JAVASCRIPT
+  end
+
+  def enqueue_paginated_search_result(stream_index, page_number:, has_next:, query: "low")
+    page.execute_script <<~JAVASCRIPT
+      window.searchStreams[#{stream_index}].enqueue(new TextEncoder().encode(
+        window.searchPageResponse(#{page_number}, "#{query}", "", #{has_next})
+      ))
+      window.searchStreams[#{stream_index}].close()
     JAVASCRIPT
   end
 
@@ -136,6 +438,77 @@ class SearchStreamingTest < ApplicationSystemTestCase
   def search_request_params(index)
     page.evaluate_script <<~JAVASCRIPT
       Object.fromEntries(new URL(window.searchRequests[#{index}].url, window.location.href).searchParams)
+    JAVASCRIPT
+  end
+
+  def current_search_params
+    Rack::Utils.parse_query(URI(page.current_url).query)
+  end
+
+  def search_with_generation(query, generation, stream_index:, has_next:)
+    find("[data-search-target='input']").fill_in with: query
+    assert_selector "body[data-search-stream-count='#{stream_index + 1}']", visible: :all
+    page.execute_script("window.searchSnapshotToken = #{generation.to_json}")
+    enqueue_paginated_search_result(stream_index, page_number: 1, has_next: has_next, query: query)
+    assert_selector "[data-snapshot-generation='#{generation}']"
+  end
+
+  def search_page_cache
+    page.driver.browser.execute_async_script <<~JAVASCRIPT
+      const done = arguments[0]
+      import("controllers/application").then(({ application }) => {
+        const element = document.querySelector("[data-controller='search']")
+        const controller = application.getControllerForElementAndIdentifier(element, "search")
+        done({
+          size: controller.pageCache.size,
+          snapshotIds: Array.from(controller.pageCache.values(), (entry) => entry.snapshotId)
+        })
+      }).catch((error) => done({ error: error.message }))
+    JAVASCRIPT
+  end
+
+  def expire_current_search_snapshot
+    page.driver.browser.execute_async_script <<~JAVASCRIPT
+      const done = arguments[0]
+      import("controllers/application").then(({ application }) => {
+        const element = document.querySelector("[data-controller='search']")
+        const controller = application.getControllerForElementAndIdentifier(element, "search")
+        controller.snapshotExpiresAt = Math.floor(Date.now() / 1000) - 1
+        done(true)
+      }).catch(() => done(false))
+    JAVASCRIPT
+  end
+
+  def navigate_search_controller(query:, page_number:)
+    page.driver.browser.execute_async_script <<~JAVASCRIPT
+      const done = arguments[0]
+      import("controllers/application").then(({ application }) => {
+        const element = document.querySelector("[data-controller='search']")
+        const controller = application.getControllerForElementAndIdentifier(element, "search")
+        controller.navigateToState(
+          { query: #{query.to_json}, contentKind: "", page: #{page_number} },
+          { historyMode: "push", focus: true }
+        )
+        done(true)
+      }).catch(() => done(false))
+    JAVASCRIPT
+  end
+
+  def fill_search_page_cache(count)
+    page.driver.browser.execute_async_script <<~JAVASCRIPT
+      const done = arguments[0]
+      import("controllers/application").then(({ application }) => {
+        const element = document.querySelector("[data-controller='search']")
+        const controller = application.getControllerForElementAndIdentifier(element, "search")
+        const expiresAt = Math.floor(Date.now() / 1000) + 600
+        for (let index = 0; index < #{count}; index += 1) {
+          controller.storePage(`query-${index}`, "", 1, `lru-${index}`, expiresAt, `<p>${index}</p>`)
+        }
+        done({
+          size: controller.pageCache.size,
+          snapshotIds: Array.from(controller.pageCache.values(), (entry) => entry.snapshotId)
+        })
+      }).catch((error) => done({ error: error.message }))
     JAVASCRIPT
   end
 end


### PR DESCRIPTION
## Summary

This PR fixes every confirmed code defect from the open-issue triage and adds the selected search-pagination design.

- Fixes #430 by invalidating search work as soon as query or content kind changes, validating the complete state for every streamed chunk, and keeping strong filtered matches ahead of weak provider fallbacks without overriding configured provider priority.
- Fixes #431 with backend-aggregated pagination. Each provider is called once with its configured limit; results stream progressively as providers settle, the complete deduplicated aggregate is paged in 20-result slices, and the next page is silently preloaded from a bounded user snapshot.
- Fixes #428 by replacing broken `hardcover.app/books/<numeric-id>` links with the documented stable `hardcover.app/id/book/<numeric-id>` route.
- Fixes #432 by replacing retry and reused-reference pathname `File.readlink` comparisons with one source-authorized, pinned-parent `readlinkat` verifier.
- Improves #429 by correctly classifying wrapped private-staging permission failures as sanitized storage-configuration errors without weakening the exact `0700` requirement or misclassifying network permission failures.

## Pagination Design

- Providers remain concurrent and are called exactly once per federated search; there is no provider-based pagination.
- Backend aggregation and deduplication rebuild the visible page after each provider response.
- Page size is 20, with up to 200 aggregate candidates per search.
- Up to three opaque user/query/content-kind-bound snapshots are retained for 10 minutes under a strict 2 MiB per-user cache budget.
- Snapshot mutations use the existing pinned private-file `flock` primitive for cross-process safety.
- The frontend silently preloads the next backend page, preserves Turbo history and mounted paths, and rejects stale query/filter/page/snapshot responses.
- Canonical Previous/Next links provide a synchronous no-JavaScript fallback.
- API v1, provider clients, provider limits, settings, and the database schema are unchanged.

## Review Outcomes

- The initial #428 slug-persistence design was rejected because Hardcover documents slugs as mutable and reassignable; the stable ID redirect is smaller and correct.
- The initial #432 publication rewrite was reduced from roughly 2,000 changed lines to a 214-line descriptor-verification patch after simplification review found that a new rename/journal protocol could regress the reported CIFS filesystem.
- The optional #427 torrent-cleanup prototype was discarded after adversarial concurrency tests found shared-hash data-loss races across dispatch, move cleanup, cancellation, and recovery. The issue remains open with lifecycle-wide design requirements.
- Search pagination went through repeated adversarial reviews covering cache bounds, concurrent tabs, provider timing, history restoration, stale preloads, accessibility, no-JavaScript navigation, and malformed/out-of-range pages.

## Remaining Report Dispositions

| Issue | Disposition |
|---|---|
| #429 | Left open for the reporter’s exact nested staging probe and fresh-request logs; the confirmed wrapped-error classification bug is fixed here. |
| #375 | Closed as resolved CIFS capability support. |
| #393 | Closed as not planned because keyless Anna acquisition requires unsupported browser scraping. |
| #366 | Closed as an untestable UI umbrella; focused reports requested. |
| #427 | Unsafe prototype discarded; lifecycle-wide ownership requirements documented. |
| #417 | OPDS inventory and watched-folder delivery separated; product scope requested. |
| #380 / #433 | Root routing foundation and category taxonomy separated and specified. |
| #355 | One-time import, scheduled sync, and discovery split; Hardcover one-time import proposed first. |

## Test Plan

- `bin/quality push`
- Search service/controller/system regressions for progressive rebuilds, pagination, deduplication, snapshot bounds, concurrent tabs, preload, reconnect, Turbo Back/Forward, mounted paths, accessibility, provider failures, no-JavaScript fallback, and unchanged API behavior
- Wrapped direct-storage cause classification and network-error boundary regressions
- Hardcover model/service/normalizer URL and malformed-ID regressions
- FileCopyService and PostProcessingJob reference tests for matching, mismatch, source/parent replacement, `ENOENT`, `ESTALE`, retry reuse, suffixing, and concurrent `EEXIST`
- Final whole-branch adversarial review: no findings

## Residual Validation

The exact Hetzner CIFS `reparse=nfs` mount from #432 and the Synology all-squash NFS hierarchy from #429 were not available locally. Reporter hardware validation remains required for those filesystem combinations.
