### PR TITLE
fix: harden filesystem publication across CIFS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,33 @@ jobs:
         working-directory: services/libation_companion
         run: ./tests/container-smoke.sh
 
+  filesystem-contracts:
+    needs: [quality]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y cifs-utils libvips
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          bundler-cache: true
+
+      - name: Prepare test database
+        env:
+          RAILS_ENV: test
+        run: bin/rails db:test:prepare
+
+      - name: Run CIFS filesystem contracts
+        run: test/filesystem_contracts/cifs-smoke.sh
+
   container:
-    needs: [quality, companion]
+    needs: [quality, companion, filesystem-contracts]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,11 @@ jobs:
 
   filesystem-contracts:
     needs: [quality]
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,7 +81,11 @@ jobs:
   validate:
     needs: [plan]
     if: needs.plan.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,7 @@ jobs:
     needs: [plan]
     if: needs.plan.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -92,7 +93,7 @@ jobs:
           ref: ${{ needs.plan.outputs.head_sha }}
 
       - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y cifs-utils libvips
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
@@ -109,6 +110,9 @@ jobs:
         env:
           RAILS_ENV: test
         run: bin/quality push
+
+      - name: Run CIFS filesystem contracts
+        run: test/filesystem_contracts/cifs-smoke.sh
 
       - name: Audit Shelfarr gems
         run: bin/bundler-audit --update

--- a/app/jobs/cleanup_temp_files_job.rb
+++ b/app/jobs/cleanup_temp_files_job.rb
@@ -106,6 +106,7 @@ class CleanupTempFilesJob < ApplicationJob
       Upload.where.not(cleanup_source_path: nil).pluck(:cleanup_source_path).compact
     )
     directories = [ Rails.root.join("tmp", "uploads") ]
+    ordinary_directories = ordinary_upload_staging_directories
     owned_staging_roots.each do |root|
       # Each Shelfarr database owns only its fingerprinted subdirectory. Two
       # instances may intentionally share one audiobook filesystem and must
@@ -116,10 +117,38 @@ class CleanupTempFilesJob < ApplicationJob
     deleted_count = directories.uniq.sum do |directory|
       cleanup_upload_directory(directory, max_age: max_age, protected_paths: protected_paths)
     end
+    deleted_count += ordinary_directories.sum do |directory, root|
+      cleanup_ordinary_upload_directory(
+        directory,
+        root: root,
+        max_age: max_age,
+        protected_paths: protected_paths
+      )
+    end
 
     Rails.logger.info "[CleanupTempFilesJob] Deleted #{deleted_count} orphaned upload files" if deleted_count > 0
   rescue Errno::ENOENT, Errno::EACCES => e
     Rails.logger.warn "[CleanupTempFilesJob] Could not inspect upload staging: #{e.class}"
+  end
+
+  def ordinary_upload_staging_directories
+    configured_roots = [
+      SettingsService.get(:audiobook_output_path),
+      SettingsService.get(:ebook_output_path),
+      SettingsService.get(:comicbook_output_path)
+    ]
+    historical_roots = Upload.where.not(destination_root: [ nil, "" ]).distinct.pluck(:destination_root)
+    fingerprint = UploadImportFileService.send(:database_fingerprint)
+
+    (configured_roots + historical_roots).compact_blank.filter_map do |root|
+      root = Pathname(root).expand_path
+      next unless root.directory?
+
+      canonical_root = root.realpath
+      [ canonical_root.join(UploadImportFileService::PRIVATE_DIRECTORY, fingerprint), canonical_root ]
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
+      nil
+    end.uniq
   end
 
   def owned_staging_roots
@@ -148,6 +177,7 @@ class CleanupTempFilesJob < ApplicationJob
     return 0 unless File.directory?(directory)
 
     directory = Pathname(directory).expand_path
+    FileCopyService.cleanup_interrupted_copies(directory, root: directory.to_s)
     protected_directories = protected_paths.each_with_object(Set.new) do |raw_path, paths|
       path = Pathname(raw_path).expand_path
       next unless path.to_s.start_with?("#{directory}#{File::SEPARATOR}")
@@ -184,20 +214,72 @@ class CleanupTempFilesJob < ApplicationJob
       next
     end
     deleted_count
+  rescue FileCopyService::AtomicPublicationUnsupportedError, FileCopyService::UnsafePathError,
+    SystemCallError => error
+    Rails.logger.warn "[CleanupTempFilesJob] Could not safely inspect upload staging: #{error.class}"
+    0
   end
 
-  def delete_upload_file_unless_active(path, max_age:)
+  def cleanup_ordinary_upload_directory(directory, root:, max_age:, protected_paths:)
+    directory = Pathname(directory).expand_path
+    root = Pathname(root).expand_path
+    FileCopyService.cleanup_interrupted_copies(directory, root: root.to_s)
+    parent_identity = FileCopyService.directory_identity(directory, root: root.to_s)
+    children = FileCopyService.directory_children(directory, root: root.to_s)
+    attempt_pattern = UploadImportFileService.send(:private_attempt_pattern)
+
+    children.sum do |child|
+      next 0 unless child.type == :file
+      next 0 unless attempt_pattern.match?(child.name)
+      next 0 if child.mtime > max_age
+
+      path = directory.join(child.name)
+      next 0 if protected_paths.include?(path.to_s)
+
+      removed = delete_upload_file_unless_active(
+        path,
+        max_age: max_age,
+        root: root,
+        expected_identity: [ child.device, child.inode ],
+        expected_parent_identity: parent_identity
+      )
+      removed ? 1 : 0
+    end
+  rescue Errno::ENOENT
+    0
+  rescue FileCopyService::AtomicPublicationUnsupportedError, FileCopyService::UnsafePathError,
+    SystemCallError => error
+    Rails.logger.warn "[CleanupTempFilesJob] Could not safely inspect ordinary upload staging: #{error.class}"
+    0
+  end
+
+  def delete_upload_file_unless_active(
+    path,
+    max_age:,
+    root: Pathname(path).parent,
+    expected_identity: nil,
+    expected_parent_identity: nil
+  )
     # Referenced files are not orphans. Preserve every Upload status so failed
     # Audible backups remain retryable and a failed->pending transition cannot
     # race cleanup on SQLite (where SELECT ... FOR UPDATE is not a row lock).
-    return false if Upload.where(file_path: path).exists?
+    return false if Upload.where(file_path: path.to_s).exists?
 
     stat = File.lstat(path)
     return false unless stat.file? && stat.mtime <= max_age
 
-    File.unlink(path)
-    true
+    FileCopyService.remove_regular_file_safely(
+      path,
+      root: root.to_s,
+      expected_identity: expected_identity,
+      expected_parent_identity: expected_parent_identity,
+      maximum_mtime: max_age
+    )
   rescue Errno::ENOENT
+    false
+  rescue FileCopyService::UnsafePathError, FileCopyService::AtomicPublicationUnsupportedError,
+    SystemCallError => error
+    Rails.logger.warn "[CleanupTempFilesJob] Could not safely clean an upload file: #{error.class}"
     false
   end
 

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -897,7 +897,6 @@ class PostProcessingJob < ApplicationJob
           root: @import_base_path,
           source_root: @import_source_root,
           hardlink_mode: true,
-          allow_compatibility_fallback: true,
           require_durable: @require_durable_import
         )
         @hardlink_fallback_copied_count += 1
@@ -909,7 +908,6 @@ class PostProcessingJob < ApplicationJob
         root: @import_base_path,
         source_root: @import_source_root,
         source_snapshot: @import_source_file_snapshot,
-        allow_compatibility_fallback: true,
         require_durable: @require_durable_import
       )
     end

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -1863,11 +1863,9 @@ class FileCopyService
         temporary_basename = ".shelfarr-copy-#{token}.tmp"
         lock_basename = ".shelfarr-copy-#{token}.lock"
         temporary_identity = nil
-        lock_identity = nil
 
         begin
           with_created_regular_child(parent, lock_basename, 0o600) do |lock|
-            lock_identity = file_identity(lock.stat)
             raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
 
             apply_file_mode!(
@@ -1887,7 +1885,7 @@ class FileCopyService
               source_manifest
             )
             persist_copy_lock_identity!(lock, token, source_identity)
-            lock_identity = verify_hardlink_identity_support!(
+            verify_hardlink_identity_support!(
               parent,
               lock,
               lock_basename,
@@ -1972,15 +1970,22 @@ class FileCopyService
             end
           end
         ensure
-          temporary_cleanup = remove_pinned_child_if_identity(
-            parent,
-            temporary_basename,
-            temporary_identity
-          )
-          if temporary_cleanup.in?([ :removed, :missing ])
-            remove_pinned_child_if_identity(parent, lock_basename, lock_identity)
+          # The lock descriptor can retain a provisional CIFS inode after the
+          # hardlink probe gives the path its server identity. Once its flock
+          # is released, reopen the journal and clean probe, temp, then lock
+          # using their current pinned path identities.
+          in_flight_error = $!
+          begin
+            cleanup_interrupted_copy(parent, token)
+            sync_io(parent)
+          rescue => cleanup_error
+            raise unless in_flight_error
+
+            Rails.logger.warn(
+              "[FileCopyService] Hardlink teardown was deferred after capability failure: " \
+                "#{cleanup_error.class}"
+            )
           end
-          sync_io(parent)
         end
       end
     end

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -3,6 +3,7 @@
 require "fiddle"
 require "pathname"
 require "digest"
+require "set"
 
 # NFS-safe file copy operations.
 #
@@ -36,9 +37,8 @@ class FileCopyService
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   SOURCE_QUARANTINE_PATTERN = /\A\.shelfarr-source-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   COPY_QUARANTINE_ENTRY = "entry"
+  HARDLINK_PROBE_ENTRY = "entry"
   COPY_QUARANTINE_STALE_AGE = 24 * 60 * 60
-  LINUX_RENAME_NOREPLACE = 0x1
-  DARWIN_RENAME_EXCL = 0x4
   AT_REMOVEDIR = RUBY_PLATFORM.include?("darwin") ? 0x80 : 0x200
 
   class UnsafePathError < StandardError
@@ -680,12 +680,10 @@ class FileCopyService
             raise Errno::ESTALE, "private publication source changed"
           end
 
-          publish_private_child_noreplace!(
+          publish_private_child_atomically_noreplace!(
             parent,
             source.basename.to_s,
-            basename,
-            [ private_file.device, private_file.inode ],
-            mode: mode
+            basename
           )
         end
         validate_published_child!(
@@ -1728,22 +1726,11 @@ class FileCopyService
               source_validator&.call
 
               begin
-                if published_mode == LIBRARY_FILE_MODE
-                  publish_private_child_noreplace!(
-                    parent,
-                    temporary_basename,
-                    basename,
-                    temporary_identity
-                  )
-                else
-                  publish_private_child_noreplace!(
-                    parent,
-                    temporary_basename,
-                    basename,
-                    temporary_identity,
-                    mode: published_mode
-                  )
-                end
+                publish_private_child_atomically_noreplace!(
+                  parent,
+                  temporary_basename,
+                  basename
+                )
                 published_identity = temporary_identity
               rescue AtomicPublicationUnsupportedError
                 raise unless allow_compatibility_fallback
@@ -1752,7 +1739,7 @@ class FileCopyService
                   "[FileCopyService] Atomic publication unsupported; using exclusive-copy compatibility mode"
                 )
                 published_identity, published_mode, published_file_durable =
-                  publish_private_child_by_copy_noreplace!(
+                  publish_private_child_by_exclusive_copy_noreplace!(
                     parent,
                     temporary_basename,
                     basename,
@@ -1813,6 +1800,11 @@ class FileCopyService
 
       cleanup_interrupted_copies(File.dirname(destination), root: root)
       with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
+        if hardlink_identity_unreliable?(source_parent_path, parent_path)
+          raise HardlinkUnsupportedError,
+            "The source or destination filesystem does not expose stable hardlink identities"
+        end
+
         token = SecureRandom.hex(16)
         temporary_basename = ".shelfarr-copy-#{token}.tmp"
         lock_basename = ".shelfarr-copy-#{token}.lock"
@@ -1841,6 +1833,11 @@ class FileCopyService
               source_manifest
             )
             persist_copy_lock_identity!(lock, token, source_identity)
+            verify_hardlink_identity_support!(
+              parent,
+              lock_basename,
+              ".shelfarr-hardlink-probe-#{token}"
+            )
             begin
               native_linkat(
                 source_parent.fileno,
@@ -1881,13 +1878,17 @@ class FileCopyService
             )
             validate_current_directory_identity!(parent_path, parent)
 
-            publish_private_child_noreplace!(
-              parent,
-              temporary_basename,
-              basename,
-              temporary_identity,
-              mode: source_mode
-            )
+            begin
+              publish_private_child_atomically_noreplace!(
+                parent,
+                temporary_basename,
+                basename
+              )
+            rescue AtomicPublicationUnsupportedError => error
+              raise HardlinkUnsupportedError,
+                "The destination filesystem cannot safely publish the requested hardlink",
+                cause: error
+            end
             validate_published_child!(
               parent,
               basename,
@@ -1942,6 +1943,51 @@ class FileCopyService
       end
     end
 
+    def verify_hardlink_identity_support!(parent, lock_basename, probe_directory_basename)
+      probe_directory = nil
+      native_mkdirat(parent.fileno, probe_directory_basename, 0o700)
+      probe_directory = open_pinned_directory_child(parent, probe_directory_basename)
+      unless secure_cleanup_quarantine?(probe_directory, parent)
+        raise UnsafePathError, "hardlink identity probe directory is not private"
+      end
+
+      native_hardlink_probe(
+        parent.fileno,
+        lock_basename,
+        probe_directory.fileno,
+        HARDLINK_PROBE_ENTRY
+      )
+      with_pinned_regular_child(parent, lock_basename) do |reopened_lock|
+        lock_identity = file_identity(reopened_lock.stat)
+        with_pinned_regular_child(probe_directory, HARDLINK_PROBE_ENTRY) do |probe|
+          unless file_identity(probe.stat) == lock_identity
+            raise HardlinkUnsupportedError,
+              "The destination filesystem does not expose stable hardlink identities"
+          end
+        end
+      end
+    rescue Errno::EXDEV, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS, Errno::EMLINK,
+        Errno::EINVAL, Fiddle::DLError, NotImplementedError => error
+      raise HardlinkUnsupportedError,
+        "The destination filesystem cannot verify hardlink identity",
+        cause: error
+    ensure
+      if probe_directory
+        begin
+          cleanup = remove_hardlink_probe_directory(
+            parent,
+            probe_directory_basename,
+            directory: probe_directory
+          )
+          unless cleanup.in?([ :removed, :missing ])
+            raise UnsafePathError, "hardlink identity probe could not be removed safely"
+          end
+        ensure
+          probe_directory.close unless probe_directory.closed?
+        end
+      end
+    end
+
     def copy_source_io(source, target, heartbeat: nil)
       source.rewind
       if heartbeat
@@ -1966,33 +2012,29 @@ class FileCopyService
       end
     end
 
-    def publish_private_child_noreplace!(parent, temporary_basename, destination_basename, identity, mode: LIBRARY_FILE_MODE)
+    def publish_private_child_atomically_noreplace!(parent, temporary_basename, destination_basename)
+      published = native_rename_noreplace(
+        parent.fileno,
+        temporary_basename,
+        parent.fileno,
+        destination_basename
+      )
+      return if published
+
       native_linkat(
         parent.fileno,
         temporary_basename,
         parent.fileno,
         destination_basename
       )
-    # CIFS/SMB often returns EINVAL rather than EOPNOTSUPP/ENOTSUP when
-    # hardlinks are unsupported. Treat it as "link unsupported" so the
-    # rename-based atomic publish path still runs (same as native_rename_noreplace).
-    rescue Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS, Errno::EMLINK,
-        Errno::EINVAL, Fiddle::DLError, NotImplementedError
-      result = native_rename_noreplace(
-        parent.fileno,
-        temporary_basename,
-        parent.fileno,
-        destination_basename
-      )
-      unless result
-        raise AtomicPublicationUnsupportedError,
-          "The destination filesystem cannot atomically publish library files"
-      end
-
-      validate_published_child!(parent, destination_basename, identity, expected_mode: mode)
+    rescue Errno::EXDEV, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS, Errno::EMLINK,
+        Errno::EINVAL, Fiddle::DLError, NotImplementedError => error
+      raise AtomicPublicationUnsupportedError,
+        "The destination filesystem cannot atomically publish library files",
+        cause: error
     end
 
-    def publish_private_child_by_copy_noreplace!(
+    def publish_private_child_by_exclusive_copy_noreplace!(
       parent,
       temporary_basename,
       destination_basename,
@@ -2121,6 +2163,11 @@ class FileCopyService
       with_pinned_regular_child(parent, lock_basename, writable: true) do |lock|
         return unless lock.flock(File::LOCK_EX | File::LOCK_NB)
         return unless secure_copy_lock?(lock, parent)
+        probe_cleanup = remove_hardlink_probe_directory(
+          parent,
+          ".shelfarr-hardlink-probe-#{token}"
+        )
+        return unless probe_cleanup.in?([ :removed, :missing ])
 
         lock_identity = file_identity(lock.stat)
         lock.rewind
@@ -2223,6 +2270,43 @@ class FileCopyService
       )
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, IOError, UnsafePathError
       nil
+    end
+
+    def remove_hardlink_probe_directory(
+      parent,
+      basename,
+      directory: nil
+    )
+      opened_here = directory.nil?
+      directory ||= open_pinned_directory_child(parent, basename)
+      return :retained unless secure_cleanup_quarantine?(directory, parent)
+
+      children = pinned_directory_children(directory)
+      return :retained unless children.empty? || children == [ HARDLINK_PROBE_ENTRY ]
+
+      if children == [ HARDLINK_PROBE_ENTRY ]
+        begin
+          with_pinned_regular_child(directory, HARDLINK_PROBE_ENTRY) do
+            native_unlinkat(directory.fileno, HARDLINK_PROBE_ENTRY)
+          end
+        rescue Errno::ENOENT
+          nil
+        end
+        sync_io(directory)
+      end
+
+      # CIFS may retain a stale directory listing and replace a freshly created
+      # directory's provisional inode after its first child operation. rmdir
+      # still asks the server to prove this random private directory is empty.
+      native_unlinkat(parent.fileno, basename, AT_REMOVEDIR)
+      sync_io(parent)
+      :removed
+    rescue Errno::ENOENT
+      :missing
+    rescue Errno::EEXIST, Errno::ENOTEMPTY, Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+      :retained
+    ensure
+      directory.close if opened_here && directory && !directory.closed?
     end
 
     def cleanup_interrupted_quarantine(parent, basename, expected_identity)
@@ -2812,6 +2896,55 @@ class FileCopyService
       [ *manifest.first(5), manifest.fetch(6) ]
     end
 
+    def hardlink_identity_unreliable?(*paths)
+      return false unless RUBY_PLATFORM.include?("linux")
+
+      mounts = File.binread("/proc/self/mountinfo").lines(chomp: true).filter_map do |line|
+        mount_fields, separator, filesystem_fields = line.partition(" - ")
+        next if separator.empty?
+
+        fields = mount_fields.split
+        filesystem = filesystem_fields.split
+        next if fields.size < 6 || filesystem.size < 3
+
+        mount_id = Integer(fields.fetch(0), exception: false)
+        parent_id = Integer(fields.fetch(1), exception: false)
+        next unless mount_id && parent_id
+
+        mountpoint = fields.fetch(4).gsub(/\\([0-7]{3})/) do
+          [ Regexp.last_match(1).to_i(8) ].pack("C")
+        end
+        [ mount_id, parent_id, fields.fetch(2), mountpoint, filesystem.fetch(0), fields.fetch(5), filesystem.fetch(2) ]
+      end
+      mount_parents = mounts.to_h { |mount_id, parent_id, *| [ mount_id, parent_id ] }
+
+      paths.any? do |path|
+        expanded = Pathname(path).expand_path.realpath.to_s.b
+        stat = File.stat(expanded)
+        device = "#{stat.dev_major}:#{stat.dev_minor}"
+        mount = mounts.select do |_mount_id, _parent_id, mount_device, mountpoint, *|
+          mount_device == device &&
+            (expanded == mountpoint || expanded.start_with?("#{mountpoint.delete_suffix("/")}/"))
+        end.max_by do |mount_id, _parent_id, _mount_device, mountpoint, *|
+          depth = 0
+          seen = Set.new
+          current = mount_id
+          while (parent = mount_parents[current]) && seen.add?(current)
+            depth += 1
+            current = parent
+          end
+          [ mountpoint.bytesize, depth ]
+        end
+        next true unless mount
+        next false unless mount.fetch(4).in?([ "cifs", "smb3" ])
+
+        options = "#{mount.fetch(5)},#{mount.fetch(6)}".split(",")
+        !options.include?("serverino")
+      end
+    rescue ArgumentError, Encoding::CompatibilityError, Errno::ENOENT, Errno::EACCES
+      true
+    end
+
     def pinned_child_identity(parent, basename, directory: false)
       descriptor = native_openat(
         parent.fileno,
@@ -3320,154 +3453,47 @@ class FileCopyService
     end
 
     def native_openat(directory_fd, basename, flags, mode)
-      Fiddle.last_error = 0
-      descriptor = if (flags & File::CREAT).positive?
-        # openat is variadic when O_CREAT is present. On arm64 Darwin, treating
-        # mode_t as a fixed fourth argument silently creates mode-000 files.
-        function = native_function(
-          :openat_create,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VARIADIC ],
-          symbol: :openat
-        )
-        function.call(directory_fd, basename, flags, Fiddle::TYPE_INT, mode)
-      else
-        function = native_function(
-          :openat,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]
-        )
-        function.call(directory_fd, basename, flags)
-      end
-      return descriptor unless descriptor == -1
-
-      raise SystemCallError.new("openat", Fiddle.last_error)
+      FilesystemSyscalls.openat(directory_fd, basename, flags: flags, mode: mode)
     end
 
     def native_mkdirat(directory_fd, basename, mode)
-      call_native_function(
-        native_function(:mkdirat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-        directory_fd,
-        basename,
-        mode
-      )
+      FilesystemSyscalls.mkdirat(directory_fd, basename, mode)
     end
 
     def native_linkat(source_fd, source_basename, destination_fd, destination_basename)
-      call_native_function(
-        native_function(
-          :linkat,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]
-        ),
-        source_fd,
-        source_basename,
-        destination_fd,
-        destination_basename,
-        0
-      )
+      FilesystemSyscalls.linkat(source_fd, source_basename, destination_fd, destination_basename)
+    end
+
+    def native_hardlink_probe(source_fd, source_basename, destination_fd, destination_basename)
+      FilesystemSyscalls.linkat(source_fd, source_basename, destination_fd, destination_basename)
     end
 
     def native_symlinkat(target, directory_fd, basename)
-      call_native_function(
-        native_function(
-          :symlinkat,
-          [ Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ]
-        ),
-        target,
-        directory_fd,
-        basename
-      )
+      FilesystemSyscalls.symlinkat(target, directory_fd, basename)
     end
 
     def native_readlinkat(directory_fd, basename)
-      buffer_size = 4096
-      buffer = "\0" * buffer_size
-      function = native_function(
-        :readlinkat,
-        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T ]
-      )
-      Fiddle.last_error = 0
-      length = function.call(directory_fd, basename, buffer, buffer_size)
-      if length == -1
-        raise SystemCallError.new("readlinkat", Fiddle.last_error)
-      end
-
-      buffer.byteslice(0, length).force_encoding(Encoding::UTF_8)
+      FilesystemSyscalls.readlinkat(directory_fd, basename)
     end
 
     def native_unlinkat(directory_fd, basename, flags = 0)
-      call_native_function(
-        native_function(:unlinkat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-        directory_fd,
-        basename,
-        flags
-      )
+      FilesystemSyscalls.unlinkat(directory_fd, basename, flags)
     end
 
     def native_fchmod(descriptor, mode)
-      call_native_function(
-        native_function(:fchmod, [ Fiddle::TYPE_INT, Fiddle::TYPE_INT ]),
-        descriptor,
-        mode
-      )
+      FilesystemSyscalls.fchmod(descriptor, mode)
     end
 
     def native_futimes_now(descriptor)
-      call_native_function(
-        native_function(:futimes, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ]),
-        descriptor,
-        nil
-      )
+      FilesystemSyscalls.futimes_now(descriptor)
     end
 
     def native_renameat(source_fd, source_basename, destination_fd, destination_basename)
-      call_native_function(
-        native_function(
-          :renameat,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ]
-        ),
-        source_fd,
-        source_basename,
-        destination_fd,
-        destination_basename
-      )
+      FilesystemSyscalls.renameat(source_fd, source_basename, destination_fd, destination_basename)
     end
 
     def native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
-      function, arguments = if RUBY_PLATFORM.include?("darwin")
-        [
-          :renameatx_np,
-          [ source_fd, source_basename, destination_fd, destination_basename, DARWIN_RENAME_EXCL ]
-        ]
-      elsif RUBY_PLATFORM.include?("linux")
-        [
-          :renameat2,
-          [ source_fd, source_basename, destination_fd, destination_basename, LINUX_RENAME_NOREPLACE ]
-        ]
-      else
-        return false
-      end
-
-      signature = [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT ]
-      call_native_function(native_function(function, signature), *arguments)
-      true
-    rescue Fiddle::DLError, Errno::ENOSYS, Errno::EINVAL, Errno::EOPNOTSUPP, Errno::ENOTSUP
-      false
-    end
-
-    def native_function(name, arguments, symbol: name)
-      @native_functions ||= {}
-      @native_functions[[ name, arguments ]] ||= Fiddle::Function.new(
-        Fiddle::Handle::DEFAULT[symbol.to_s],
-        arguments,
-        Fiddle::TYPE_INT
-      )
-    end
-
-    def call_native_function(function, *arguments)
-      Fiddle.last_error = 0
-      result = function.call(*arguments)
-      return result if result.zero?
-
-      raise SystemCallError.new("filesystem operation", Fiddle.last_error)
+      FilesystemSyscalls.rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
     end
 
     def file_identity(stat)

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -1854,9 +1854,9 @@ class FileCopyService
 
       cleanup_interrupted_copies(File.dirname(destination), root: root)
       with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
-        if hardlink_identity_unreliable?(source_parent, parent)
+        if hardlink_identity_unreliable?(source_parent, parent, reject_cifs: true)
           raise HardlinkUnsupportedError,
-            "The source or destination filesystem does not expose stable hardlink identities"
+            "The source or destination filesystem cannot safely verify hardlink identities"
         end
 
         token = SecureRandom.hex(16)
@@ -2832,7 +2832,7 @@ class FileCopyService
       [ *manifest.first(5), manifest.fetch(6) ]
     end
 
-    def hardlink_identity_unreliable?(*filesystem_entries)
+    def hardlink_identity_unreliable?(*filesystem_entries, reject_cifs: false)
       return false unless RUBY_PLATFORM.include?("linux")
 
       mounts = File.binread("/proc/self/mountinfo").lines(chomp: true).filter_map do |line|
@@ -2878,6 +2878,7 @@ class FileCopyService
         end
         next true unless mount
         next false unless mount.fetch(4).in?([ "cifs", "smb3" ])
+        next true if reject_cifs
 
         options = "#{mount.fetch(5)},#{mount.fetch(6)}".split(",")
         !options.include?("serverino")

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -35,9 +35,9 @@ class FileCopyService
   COPY_LOCK_COMPATIBILITY_PREPARED_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:prepared:([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_LOCK_COMPATIBILITY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:(copying|complete):([0-9]+):([0-9]+):([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
+  DISCARD_PATTERN = /\A\.shelfarr-discard-([0-9a-f]+)-([0-9a-f]+)-[0-9a-f]{32}\.tmp\z/
   SOURCE_QUARANTINE_PATTERN = /\A\.shelfarr-source-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   COPY_QUARANTINE_ENTRY = "entry"
-  HARDLINK_PROBE_ENTRY = "entry"
   COPY_QUARANTINE_STALE_AGE = 24 * 60 * 60
   AT_REMOVEDIR = RUBY_PLATFORM.include?("darwin") ? 0x80 : 0x200
 
@@ -54,6 +54,7 @@ class FileCopyService
   class DirectoryNotWritableError < UnsafePathError; end
   class UnsafeFilePermissionsError < UnsafePathError; end
   class AtomicPublicationUnsupportedError < StandardError; end
+  class AmbiguousPublicationError < StandardError; end
   class DurabilityUnsupportedError < StandardError; end
   class HardlinkUnsupportedError < StandardError; end
   SourceFileSnapshot = Struct.new(
@@ -103,10 +104,10 @@ class FileCopyService
     end
 
     # Copy a regular file through a complete private file in the destination
-    # directory. Publication uses an atomic no-replace operation when the
-    # filesystem supports one, or an exclusive descriptor-backed copy with
-    # crash recovery on compatibility filesystems. Every destination component
-    # is opened from a pinned root descriptor with O_NOFOLLOW.
+    # directory. Publication uses an atomic no-replace operation and fails
+    # closed when the destination filesystem cannot provide one. Every
+    # destination component is opened from a pinned root descriptor with
+    # O_NOFOLLOW.
     def cp_noreplace(
       src,
       dest,
@@ -115,7 +116,6 @@ class FileCopyService
       source_snapshot: nil,
       heartbeat: nil,
       hardlink_mode: false,
-      allow_compatibility_fallback: false,
       require_durable: false
     )
       if hardlink_mode
@@ -126,7 +126,6 @@ class FileCopyService
             dest,
             root: root,
             heartbeat: heartbeat,
-            allow_compatibility_fallback: allow_compatibility_fallback,
             source_validator: validator,
             accepted_modes: LIBRARY_FILE_MODES,
             require_durable: require_durable
@@ -144,7 +143,6 @@ class FileCopyService
             dest,
             root: root,
             heartbeat: heartbeat,
-            allow_compatibility_fallback: allow_compatibility_fallback,
             source_validator: validator,
             accepted_modes: LIBRARY_FILE_MODES,
             require_durable: require_durable
@@ -172,6 +170,10 @@ class FileCopyService
         )
       end
       dest
+    end
+
+    def stable_hardlink_identity?(*filesystem_entries)
+      !hardlink_identity_unreliable?(*filesystem_entries)
     end
 
     # Create a no-replace library entry that is a symlink to a verified regular
@@ -211,7 +213,8 @@ class FileCopyService
           begin
             link_target = native_readlinkat(parent.fileno, basename)
             unless link_target == target
-              remove_published_reference_if_ours!(parent, basename, expected_target: target)
+              # The name may have been replaced after symlinkat. Retain it;
+              # there is no descriptor-based unlink primitive for symlinks.
               raise UnsafePathError, "reference publication did not produce the expected symlink"
             end
           rescue Errno::ENOENT
@@ -259,16 +262,6 @@ class FileCopyService
       result
     end
 
-    # Unlink only when the name still points at the target we published.
-    def remove_published_reference_if_ours!(parent, basename, expected_target:)
-      current = native_readlinkat(parent.fileno, basename)
-      return unless current == expected_target
-
-      native_unlinkat(parent.fileno, basename, 0)
-    rescue Errno::ENOENT, Errno::EINVAL, SystemCallError
-      nil
-    end
-
     # Publish from a source descriptor already pinned by the caller (for
     # example, a verified HTTP Tempfile) without resolving its pathname again.
     def cp_io_noreplace(source, dest, root: nil, heartbeat: nil)
@@ -286,8 +279,7 @@ class FileCopyService
       dest,
       root: nil,
       source_root: nil,
-      heartbeat: nil,
-      allow_compatibility_fallback: false
+      heartbeat: nil
     )
       source_snapshot = snapshot_source_file(src, source_root: source_root)
       cp_noreplace(
@@ -297,7 +289,6 @@ class FileCopyService
         source_root: source_root,
         source_snapshot: source_snapshot,
         heartbeat: heartbeat,
-        allow_compatibility_fallback: allow_compatibility_fallback,
         require_durable: true
       )
       destination_snapshot = verified_library_file_snapshot(
@@ -322,6 +313,9 @@ class FileCopyService
       source_root ||= snapshot_source_root(source, heartbeat: heartbeat)
       source_path = Pathname(source).expand_path
       destination_path = Pathname(destination).expand_path
+      if destination_path == source_path || destination_path.to_s.start_with?("#{source_path}#{File::SEPARATOR}")
+        raise Errno::EINVAL, "destination directory is inside the source tree"
+      end
 
       with_pinned_absolute_directory(source_root.canonical_parent_path) do |source_parent|
         unless file_identity(source_parent.stat) == [ source_root.parent_device, source_root.parent_inode ]
@@ -680,18 +674,34 @@ class FileCopyService
             raise Errno::ESTALE, "private publication source changed"
           end
 
-          publish_private_child_atomically_noreplace!(
-            parent,
-            source.basename.to_s,
-            basename
-          )
+          publication_method = if hardlink_identity_unreliable?(parent)
+            publish_private_child_atomically_noreplace!(
+              parent,
+              source.basename.to_s,
+              basename,
+              allow_link_fallback: false
+            )
+          else
+            publish_private_child_atomically_noreplace!(
+              parent,
+              source.basename.to_s,
+              basename
+            )
+          end
         end
-        validate_published_child!(
-          parent,
-          basename,
-          [ private_file.device, private_file.inode ],
-          expected_mode: mode
-        )
+        begin
+          validate_published_child!(
+            parent,
+            basename,
+            [ private_file.device, private_file.inode ],
+            expected_mode: mode
+          )
+        rescue Errno::EINVAL => error
+          raise unless publication_method == :link
+
+          raise AmbiguousPublicationError,
+            "The linked destination could not be verified after publication: #{error.message}"
+        end
         validate_current_directory_identity!(parent_path, parent)
         sync_io(parent)
       end
@@ -704,6 +714,8 @@ class FileCopyService
       source = Pathname(private_file.name).expand_path
       removed = false
       with_pinned_destination_parent(source, root: root) do |parent, basename, parent_path|
+        return false if hardlink_identity_unreliable?(parent)
+
         with_pinned_regular_child(parent, basename) do |current|
           next unless file_identity(current.stat) == [ private_file.device, private_file.inode ]
 
@@ -721,16 +733,35 @@ class FileCopyService
     # Remove a regular file only after atomically moving it to a unique name
     # inside the same pinned private directory and verifying that the moved
     # entry is the inode inspected by this process.
-    def remove_regular_file_safely(path, root:)
+    def remove_regular_file_safely(
+      path,
+      root:,
+      expected_identity: nil,
+      expected_parent_identity: nil,
+      maximum_mtime: nil
+    )
       path = Pathname(path).expand_path
       with_pinned_destination_parent(path, root: root) do |parent, basename, parent_path|
-        expected_identity = nil
-        with_pinned_regular_child(parent, basename) do |current|
-          expected_identity = file_identity(current.stat)
+        if hardlink_identity_unreliable?(parent)
+          raise UnsafePathError, "cleanup requires stable filesystem identities"
+        end
+        if expected_parent_identity && file_identity(parent.stat) != expected_parent_identity
+          raise Errno::ESTALE, "cleanup directory changed before file removal"
         end
 
-        quarantine = ".shelfarr-discard-#{SecureRandom.hex(16)}.tmp"
-        renamed = native_rename_noreplace(
+        inspected_identity = nil
+        with_pinned_regular_child(parent, basename) do |current|
+          stat = current.stat
+          inspected_identity = file_identity(stat)
+          if expected_identity && inspected_identity != expected_identity
+            raise Errno::ESTALE, "cleanup file changed before removal"
+          end
+          return false if maximum_mtime && stat.mtime > maximum_mtime
+        end
+
+        quarantine = ".shelfarr-discard-#{inspected_identity.first.to_s(16)}-" \
+          "#{inspected_identity.last.to_s(16)}-#{SecureRandom.hex(16)}.tmp"
+        renamed = native_rename_noreplace_compatibility(
           parent.fileno,
           basename,
           parent.fileno,
@@ -745,8 +776,8 @@ class FileCopyService
         with_pinned_regular_child(parent, quarantine) do |current|
           actual_identity = file_identity(current.stat)
         end
-        unless actual_identity == expected_identity
-          restored = native_rename_noreplace(
+        unless actual_identity == inspected_identity
+          restored = native_rename_noreplace_compatibility(
             parent.fileno,
             quarantine,
             parent.fileno,
@@ -875,6 +906,8 @@ class FileCopyService
       parent_path = Pathname(parent_path).expand_path
       snapshot = nil
       with_pinned_directory(parent_path, root: root, create: false, mode: 0o700) do |parent|
+        return false if hardlink_identity_unreliable?(parent)
+
         child = open_pinned_directory_child(parent, child_name)
         begin
           stat = child.stat
@@ -1109,6 +1142,8 @@ class FileCopyService
       end
 
       with_pinned_absolute_directory(source_snapshot.canonical_parent_path) do |parent|
+        return false if hardlink_identity_unreliable?(parent)
+
         unless file_identity(parent.stat) == [ source_snapshot.parent_device, source_snapshot.parent_inode ]
           raise Errno::ESTALE, "source parent identity changed during cleanup"
         end
@@ -1161,11 +1196,13 @@ class FileCopyService
       quarantine_basename = ".shelfarr-remove-#{SecureRandom.hex(16)}"
 
       with_pinned_absolute_directory(canonical_parent) do |parent|
+        return false if hardlink_identity_unreliable?(parent)
+
         unless file_identity(parent.stat) == [ source_root.parent_device, source_root.parent_inode ]
           raise Errno::ESTALE, "source parent identity changed during cleanup"
         end
         validate_current_directory_identity!(parent_path, parent)
-        renamed = native_rename_noreplace(
+        renamed = native_rename_noreplace_compatibility(
           parent.fileno,
           expanded.basename.to_s,
           parent.fileno,
@@ -1405,16 +1442,38 @@ class FileCopyService
       destination = File.join(directory, ".shelfarr-cleanup-probe")
       with_pinned_destination_parent(destination, root: root) do |parent, _basename, parent_path|
         validate_current_directory_identity!(parent_path, parent)
-        Dir.children(parent_path).each do |entry|
+        identity_reliable = !hardlink_identity_unreliable?(parent)
+        entries = Dir.children(parent_path)
+        unless identity_reliable
+          retained = entries.any? do |entry|
+            COPY_LOCK_PATTERN.match?(entry) || COPY_QUARANTINE_PATTERN.match?(entry) ||
+              DISCARD_PATTERN.match?(entry) || OWNER_PROBE_PATTERN.match?(entry)
+          end
+          if retained
+            Rails.logger.warn(
+              "[FileCopyService] Interrupted publication artifacts require manual cleanup because " \
+                "the filesystem does not expose stable identities"
+            )
+            raise AtomicPublicationUnsupportedError,
+              "Interrupted publication artifacts require manual cleanup before another import"
+          end
+        end
+        entries.each do |entry|
           if (match = COPY_LOCK_PATTERN.match(entry))
-            cleanup_interrupted_copy(parent, match[1])
-          elsif (match = COPY_QUARANTINE_PATTERN.match(entry))
+            cleanup_interrupted_copy(parent, match[1]) if identity_reliable
+          elsif identity_reliable && (match = COPY_QUARANTINE_PATTERN.match(entry))
             cleanup_interrupted_quarantine(
               parent,
               entry,
               [ match[1].to_i(16), match[2].to_i(16) ]
             )
-          elsif OWNER_PROBE_PATTERN.match?(entry)
+          elsif identity_reliable && (match = DISCARD_PATTERN.match(entry))
+            remove_pinned_child_if_identity(
+              parent,
+              entry,
+              [ match[1].to_i(16), match[2].to_i(16) ]
+            )
+          elsif identity_reliable && OWNER_PROBE_PATTERN.match?(entry)
             cleanup_interrupted_owner_probe(parent, entry)
           end
         end
@@ -1663,7 +1722,6 @@ class FileCopyService
       destination,
       root:,
       heartbeat: nil,
-      allow_compatibility_fallback: false,
       source_validator: nil,
       accepted_modes: LIBRARY_FILE_MODES,
       require_durable: false
@@ -1724,40 +1782,36 @@ class FileCopyService
                 raise DurabilityUnsupportedError, "destination file fsync is unsupported"
               end
               source_validator&.call
+              identity_reliable = !hardlink_identity_unreliable?(parent)
 
-              begin
+              publication_method = if identity_reliable
                 publish_private_child_atomically_noreplace!(
                   parent,
                   temporary_basename,
                   basename
                 )
-                published_identity = temporary_identity
-              rescue AtomicPublicationUnsupportedError
-                raise unless allow_compatibility_fallback
-
-                Rails.logger.warn(
-                  "[FileCopyService] Atomic publication unsupported; using exclusive-copy compatibility mode"
+              else
+                publish_private_child_atomically_noreplace!(
+                  parent,
+                  temporary_basename,
+                  basename,
+                  allow_link_fallback: false
                 )
-                published_identity, published_mode, published_file_durable =
-                  publish_private_child_by_exclusive_copy_noreplace!(
-                    parent,
-                    temporary_basename,
-                    basename,
-                    temporary_identity,
-                    lock: lock,
-                    token: token,
-                    heartbeat: heartbeat,
-                    accepted_modes: accepted_modes,
-                    path: destination,
-                    root: root
-                  )
               end
-              validate_published_child!(
-                parent,
-                basename,
-                published_identity,
-                expected_mode: published_mode
-              )
+              published_identity = temporary_identity
+              begin
+                validate_published_child!(
+                  parent,
+                  basename,
+                  published_identity,
+                  expected_mode: published_mode
+                )
+              rescue Errno::EINVAL => error
+                raise unless publication_method == :link
+
+                raise AmbiguousPublicationError,
+                  "The linked destination could not be verified after publication: #{error.message}"
+              end
               validate_current_directory_identity!(parent_path, parent)
               parent_durable = sync_io(parent)
               if require_durable && !(published_file_durable && parent_durable)
@@ -1800,7 +1854,7 @@ class FileCopyService
 
       cleanup_interrupted_copies(File.dirname(destination), root: root)
       with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
-        if hardlink_identity_unreliable?(source_parent_path, parent_path)
+        if hardlink_identity_unreliable?(source_parent, parent)
           raise HardlinkUnsupportedError,
             "The source or destination filesystem does not expose stable hardlink identities"
         end
@@ -1833,10 +1887,11 @@ class FileCopyService
               source_manifest
             )
             persist_copy_lock_identity!(lock, token, source_identity)
-            verify_hardlink_identity_support!(
+            lock_identity = verify_hardlink_identity_support!(
               parent,
+              lock,
               lock_basename,
-              ".shelfarr-hardlink-probe-#{token}"
+              ".shelfarr-hardlink-probe-#{token}.tmp"
             )
             begin
               native_linkat(
@@ -1879,7 +1934,7 @@ class FileCopyService
             validate_current_directory_identity!(parent_path, parent)
 
             begin
-              publish_private_child_atomically_noreplace!(
+              publication_method = publish_private_child_atomically_noreplace!(
                 parent,
                 temporary_basename,
                 basename
@@ -1889,13 +1944,20 @@ class FileCopyService
                 "The destination filesystem cannot safely publish the requested hardlink",
                 cause: error
             end
-            validate_published_child!(
-              parent,
-              basename,
-              source_identity,
-              expected_mode: source_mode,
-              expected_manifest: source_manifest
-            )
+            begin
+              validate_published_child!(
+                parent,
+                basename,
+                source_identity,
+                expected_mode: source_mode,
+                expected_manifest: source_manifest
+              )
+            rescue Errno::EINVAL => error
+              raise unless publication_method == :link
+
+              raise AmbiguousPublicationError,
+                "The linked destination could not be verified after publication: #{error.message}"
+            end
             validate_hardlink_source!(
               source,
               source_parent,
@@ -1943,47 +2005,52 @@ class FileCopyService
       end
     end
 
-    def verify_hardlink_identity_support!(parent, lock_basename, probe_directory_basename)
-      probe_directory = nil
-      native_mkdirat(parent.fileno, probe_directory_basename, 0o700)
-      probe_directory = open_pinned_directory_child(parent, probe_directory_basename)
-      unless secure_cleanup_quarantine?(probe_directory, parent)
-        raise UnsafePathError, "hardlink identity probe directory is not private"
-      end
-
+    def verify_hardlink_identity_support!(parent, lock, lock_basename, probe_basename)
+      lock_path_identity = nil
+      probe_identity = nil
       native_hardlink_probe(
         parent.fileno,
         lock_basename,
-        probe_directory.fileno,
-        HARDLINK_PROBE_ENTRY
+        parent.fileno,
+        probe_basename
       )
       with_pinned_regular_child(parent, lock_basename) do |reopened_lock|
-        lock_identity = file_identity(reopened_lock.stat)
-        with_pinned_regular_child(probe_directory, HARDLINK_PROBE_ENTRY) do |probe|
-          unless file_identity(probe.stat) == lock_identity
+        lock_path_identity = file_identity(reopened_lock.stat)
+        unless file_identity(lock.stat) == lock_path_identity
+          raise HardlinkUnsupportedError,
+            "The destination filesystem does not expose stable hardlink identities"
+        end
+        with_pinned_regular_child(parent, probe_basename) do |probe|
+          probe_identity = file_identity(probe.stat)
+          unless probe_identity == lock_path_identity
             raise HardlinkUnsupportedError,
               "The destination filesystem does not expose stable hardlink identities"
           end
         end
       end
+      lock_path_identity
     rescue Errno::EXDEV, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS, Errno::EMLINK,
         Errno::EINVAL, Fiddle::DLError, NotImplementedError => error
       raise HardlinkUnsupportedError,
         "The destination filesystem cannot verify hardlink identity",
         cause: error
     ensure
-      if probe_directory
+      if probe_identity && probe_identity == lock_path_identity
+        in_flight_error = $!
+        cleanup_error = nil
         begin
-          cleanup = remove_hardlink_probe_directory(
-            parent,
-            probe_directory_basename,
-            directory: probe_directory
-          )
-          unless cleanup.in?([ :removed, :missing ])
-            raise UnsafePathError, "hardlink identity probe could not be removed safely"
+          cleanup = remove_pinned_child_if_identity(parent, probe_basename, probe_identity)
+        rescue => error
+          cleanup_error = error
+          cleanup = :retained
+        end
+        unless cleanup.in?([ :removed, :missing ])
+          if in_flight_error
+            Rails.logger.warn("[FileCopyService] Retained a hardlink identity probe after capability failure")
+          else
+            raise cleanup_error || UnsafePathError,
+              "hardlink identity probe could not be removed safely"
           end
-        ensure
-          probe_directory.close unless probe_directory.closed?
         end
       end
     end
@@ -2012,14 +2079,27 @@ class FileCopyService
       end
     end
 
-    def publish_private_child_atomically_noreplace!(parent, temporary_basename, destination_basename)
-      published = native_rename_noreplace(
-        parent.fileno,
-        temporary_basename,
-        parent.fileno,
-        destination_basename
-      )
-      return if published
+    def publish_private_child_atomically_noreplace!(
+      parent,
+      temporary_basename,
+      destination_basename,
+      allow_link_fallback: true
+    )
+      published = begin
+        native_rename_noreplace(
+          parent.fileno,
+          temporary_basename,
+          parent.fileno,
+          destination_basename
+        )
+      rescue Errno::EINVAL
+        false
+      end
+      return :rename if published
+      unless allow_link_fallback
+        raise AtomicPublicationUnsupportedError,
+          "The destination filesystem cannot atomically publish library files"
+      end
 
       native_linkat(
         parent.fileno,
@@ -2027,111 +2107,12 @@ class FileCopyService
         parent.fileno,
         destination_basename
       )
+      :link
     rescue Errno::EXDEV, Errno::EPERM, Errno::EOPNOTSUPP, Errno::ENOTSUP, Errno::ENOSYS, Errno::EMLINK,
         Errno::EINVAL, Fiddle::DLError, NotImplementedError => error
       raise AtomicPublicationUnsupportedError,
         "The destination filesystem cannot atomically publish library files",
         cause: error
-    end
-
-    def publish_private_child_by_exclusive_copy_noreplace!(
-      parent,
-      temporary_basename,
-      destination_basename,
-      temporary_identity,
-      lock:,
-      token:,
-      heartbeat:,
-      accepted_modes:,
-      path:,
-      root:,
-      mode: LIBRARY_FILE_MODE
-    )
-      destination_identity = nil
-      destination_mode = nil
-      destination_durable = false
-      source_size = nil
-
-      begin
-        with_pinned_regular_child(parent, temporary_basename) do |source|
-          source_stat = source.stat
-          unless file_identity(source_stat) == temporary_identity
-            raise Errno::ESTALE, "private publication source changed"
-          end
-          source_size = source_stat.size
-
-          persist_copy_lock_compatibility!(
-            lock,
-            token,
-            :prepared,
-            temporary_identity,
-            destination_basename
-          )
-          with_created_regular_child(parent, destination_basename, 0o600) do |destination|
-            destination_identity = file_identity(destination.stat)
-            apply_file_mode!(
-              destination,
-              0o600,
-              accepted_modes: accepted_modes,
-              path: path,
-              root: root
-            )
-            persist_copy_lock_compatibility!(
-              lock,
-              token,
-              :copying,
-              temporary_identity,
-              destination_basename,
-              destination_identity
-            )
-            sync_io(parent)
-
-            if heartbeat
-              copy_source_io(source, destination, heartbeat: heartbeat)
-            else
-              copy_source_io(source, destination)
-            end
-            destination_mode = apply_file_mode!(
-              destination,
-              mode,
-              accepted_modes: accepted_modes,
-              path: path,
-              root: root
-            )
-            destination_durable = flush_and_sync(destination)
-            unless file_identity(source.stat) == temporary_identity &&
-                source.stat.size == source_size && destination.stat.size == source_size
-              raise Errno::ESTALE, "file changed during compatibility publication"
-            end
-          end
-        end
-
-        with_pinned_regular_child(parent, temporary_basename) do |source|
-          unless file_identity(source.stat) == temporary_identity && source.stat.size == source_size
-            raise Errno::ESTALE, "private publication source changed"
-          end
-        end
-        validate_published_child!(
-          parent,
-          destination_basename,
-          destination_identity,
-          expected_mode: destination_mode
-        )
-        sync_io(parent)
-        persist_copy_lock_compatibility!(
-          lock,
-          token,
-          :complete,
-          temporary_identity,
-          destination_basename,
-          destination_identity
-        )
-        [ destination_identity, destination_mode, destination_durable ]
-      rescue
-        remove_pinned_child_if_identity(parent, destination_basename, destination_identity)
-        sync_io(parent)
-        raise
-      end
     end
 
     def validate_published_child!(
@@ -2163,16 +2144,25 @@ class FileCopyService
       with_pinned_regular_child(parent, lock_basename, writable: true) do |lock|
         return unless lock.flock(File::LOCK_EX | File::LOCK_NB)
         return unless secure_copy_lock?(lock, parent)
-        probe_cleanup = remove_hardlink_probe_directory(
-          parent,
-          ".shelfarr-hardlink-probe-#{token}"
-        )
-        return unless probe_cleanup.in?([ :removed, :missing ])
 
         lock_identity = file_identity(lock.stat)
         lock.rewind
         state, expected_temporary_identity, destination_basename,
           expected_destination_identity = copy_lock_cleanup_state(lock.read, token)
+        probe_basename = ".shelfarr-hardlink-probe-#{token}.tmp"
+        probe_cleanup = if state == :full
+          begin
+            remove_pinned_child_if_identity(parent, probe_basename, lock_identity)
+          rescue Errno::EINVAL
+            :retained
+          end
+        elsif pinned_child_missing?(parent, probe_basename)
+          :missing
+        else
+          :retained
+        end
+        return unless probe_cleanup.in?([ :removed, :missing ])
+
         cleanup_result = case state
         when :full
           remove_pinned_child_if_identity(
@@ -2226,7 +2216,7 @@ class FileCopyService
             destination_status
           end
         when :pending, :legacy
-          remove_pinned_regular_child(parent, temporary_basename)
+          pinned_child_missing?(parent, temporary_basename) ? :missing : :retained
         else
           pinned_child_missing?(parent, temporary_basename) ? :missing : :retained
         end
@@ -2270,43 +2260,6 @@ class FileCopyService
       )
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, IOError, UnsafePathError
       nil
-    end
-
-    def remove_hardlink_probe_directory(
-      parent,
-      basename,
-      directory: nil
-    )
-      opened_here = directory.nil?
-      directory ||= open_pinned_directory_child(parent, basename)
-      return :retained unless secure_cleanup_quarantine?(directory, parent)
-
-      children = pinned_directory_children(directory)
-      return :retained unless children.empty? || children == [ HARDLINK_PROBE_ENTRY ]
-
-      if children == [ HARDLINK_PROBE_ENTRY ]
-        begin
-          with_pinned_regular_child(directory, HARDLINK_PROBE_ENTRY) do
-            native_unlinkat(directory.fileno, HARDLINK_PROBE_ENTRY)
-          end
-        rescue Errno::ENOENT
-          nil
-        end
-        sync_io(directory)
-      end
-
-      # CIFS may retain a stale directory listing and replace a freshly created
-      # directory's provisional inode after its first child operation. rmdir
-      # still asks the server to prove this random private directory is empty.
-      native_unlinkat(parent.fileno, basename, AT_REMOVEDIR)
-      sync_io(parent)
-      :removed
-    rescue Errno::ENOENT
-      :missing
-    rescue Errno::EEXIST, Errno::ENOTEMPTY, Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
-      :retained
-    ensure
-      directory.close if opened_here && directory && !directory.closed?
     end
 
     def cleanup_interrupted_quarantine(parent, basename, expected_identity)
@@ -2377,28 +2330,6 @@ class FileCopyService
         lock,
         "#{COPY_LOCK_MAGIC}:#{token}:full:#{identity.first}:#{identity.last}"
       )
-    end
-
-    def persist_copy_lock_compatibility!(
-      lock,
-      token,
-      state,
-      temporary_identity,
-      destination_basename,
-      destination_identity = nil
-    )
-      encoded_basename = destination_basename.b.unpack1("H*")
-      record = "#{COPY_LOCK_MAGIC}:#{token}:compatibility:#{state}:" \
-        "#{temporary_identity.first}:#{temporary_identity.last}:"
-      if destination_identity
-        record << "#{destination_identity.first}:#{destination_identity.last}:"
-      end
-      record << encoded_basename
-
-      checksum = Digest::SHA256.hexdigest(record)
-      lock.seek(0, IO::SEEK_END)
-      lock.write("\n#{record}:#{checksum}\n")
-      flush_and_sync(lock)
     end
 
     def persist_copy_lock_record!(lock, record)
@@ -2805,7 +2736,7 @@ class FileCopyService
         relative = prefix ? prefix.join(entry) : Pathname(entry)
         expected = expected_entries.fetch(relative.to_s)
         quarantine = ".shelfarr-remove-child-#{SecureRandom.hex(16)}"
-        renamed = native_rename_noreplace(
+        renamed = native_rename_noreplace_compatibility(
           directory.fileno,
           entry,
           directory.fileno,
@@ -2896,7 +2827,7 @@ class FileCopyService
       [ *manifest.first(5), manifest.fetch(6) ]
     end
 
-    def hardlink_identity_unreliable?(*paths)
+    def hardlink_identity_unreliable?(*filesystem_entries)
       return false unless RUBY_PLATFORM.include?("linux")
 
       mounts = File.binread("/proc/self/mountinfo").lines(chomp: true).filter_map do |line|
@@ -2918,9 +2849,14 @@ class FileCopyService
       end
       mount_parents = mounts.to_h { |mount_id, parent_id, *| [ mount_id, parent_id ] }
 
-      paths.any? do |path|
-        expanded = Pathname(path).expand_path.realpath.to_s.b
-        stat = File.stat(expanded)
+      filesystem_entries.any? do |entry|
+        expanded, stat = if entry.respond_to?(:fileno) && entry.respond_to?(:stat)
+          descriptor_path = File.readlink("/proc/self/fd/#{entry.fileno}").delete_suffix(" (deleted)")
+          [ Pathname(descriptor_path).expand_path.to_s.b, entry.stat ]
+        else
+          path = Pathname(entry).expand_path.realpath
+          [ path.to_s.b, File.stat(path) ]
+        end
         device = "#{stat.dev_major}:#{stat.dev_minor}"
         mount = mounts.select do |_mount_id, _parent_id, mount_device, mountpoint, *|
           mount_device == device &&
@@ -2941,7 +2877,7 @@ class FileCopyService
         options = "#{mount.fetch(5)},#{mount.fetch(6)}".split(",")
         !options.include?("serverino")
       end
-    rescue ArgumentError, Encoding::CompatibilityError, Errno::ENOENT, Errno::EACCES
+    rescue ArgumentError, Encoding::CompatibilityError, IOError, SystemCallError
       true
     end
 
@@ -2965,7 +2901,7 @@ class FileCopyService
     end
 
     def restore_quarantined_replacement(parent, quarantine_basename, original_basename)
-      restored = native_rename_noreplace(
+      restored = native_rename_noreplace_compatibility(
         parent.fileno,
         quarantine_basename,
         parent.fileno,
@@ -3340,7 +3276,7 @@ class FileCopyService
     end
 
     def restore_quarantined_child!(quarantine, parent, basename)
-      restored = native_rename_noreplace(
+      restored = native_rename_noreplace_compatibility(
         quarantine.fileno,
         COPY_QUARANTINE_ENTRY,
         parent.fileno,
@@ -3494,6 +3430,17 @@ class FileCopyService
 
     def native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
       FilesystemSyscalls.rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
+    end
+
+    def native_rename_noreplace_compatibility(
+      source_fd,
+      source_basename,
+      destination_fd,
+      destination_basename
+    )
+      native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
+    rescue Errno::EINVAL
+      false
     end
 
     def file_identity(stat)

--- a/app/services/owned_media_import_file_service.rb
+++ b/app/services/owned_media_import_file_service.rb
@@ -67,11 +67,15 @@ class OwnedMediaImportFileService
     def copy_io_to_staging!(media_import, source, extension, root: output_root)
       destination = staging_path_for(media_import, extension, root: root)
       basename = destination.basename.to_s
-      temporary = ".#{basename}.#{SecureRandom.hex(16)}.tmp"
+      owner_token = UploadImportFileService.send(:filesystem_owner_token)
+      attempt_pattern = /\A\.#{Regexp.escape(basename)}\.#{Regexp.escape(owner_token)}\.[0-9a-f]{32}\.tmp\z/
+      temporary = ".#{basename}.#{owner_token}.#{SecureRandom.hex(16)}.tmp"
       size = nil
       copying = false
 
+      FileCopyService.cleanup_interrupted_copies(destination.dirname, root: root)
       secure_directory!(destination.dirname) do |directory|
+        reclaim_interrupted_copy_attempts!(directory, attempt_pattern)
         descriptor = class_native_openat(
           directory.fileno,
           temporary,
@@ -113,6 +117,35 @@ class OwnedMediaImportFileService
       raise if copying
 
       raise Error, "Shelfarr could not stage the Libation audiobook safely: #{error.message}"
+    end
+
+    def reclaim_interrupted_copy_attempts!(directory, pattern)
+      attempts = FileCopyService.send(:pinned_directory_children, directory).grep(pattern)
+      return if attempts.empty?
+
+      unless FileCopyService.stable_hardlink_identity?(directory)
+        raise Error, "An interrupted Libation staging attempt requires manual cleanup before retrying"
+      end
+
+      attempts.each do |basename|
+        identity = nil
+        with_class_pinned_regular_child(directory, basename) do |attempt|
+          stat = attempt.stat
+          identity = [ stat.dev, stat.ino ]
+        end
+        removed = FileCopyService.send(
+          :remove_pinned_child_if_identity,
+          directory,
+          basename,
+          identity
+        )
+        unless removed.in?([ :removed, :missing ])
+          raise Error, "An interrupted Libation staging attempt could not be cleaned safely"
+        end
+      end
+      directory.fsync
+    rescue Errno::ELOOP, Errno::ENOTDIR, FileCopyService::UnsafePathError => error
+      raise Error, "An interrupted Libation staging attempt could not be cleaned safely: #{error.message}"
     end
 
     # Imports staged by an earlier Shelfarr beta lived below Rails tmp. Move
@@ -900,14 +933,24 @@ class OwnedMediaImportFileService
 
   def publish_pinned_hard_link!(source_parent:, source_stat:, destination_parent:, destination:)
     basename = destination.basename.to_s
+    published = false
+    unless FileCopyService.stable_hardlink_identity?(source_parent, destination_parent)
+      raise Error, "The audiobook filesystem does not expose stable hardlink identities"
+    end
+
     native_linkat(
       source_parent.fileno,
       source_path.basename.to_s,
       destination_parent.fileno,
       basename
     )
+    published = true
     destination_parent.fsync
     validate_pinned_destination!(destination_parent, destination, source_stat: source_stat)
+  rescue Errno::EINVAL => error
+    raise unless published
+
+    raise Error, "The audiobook destination could not be verified after publication: #{error.message}"
   end
 
   def validate_pinned_destination!(directory, destination, source_stat: nil)

--- a/app/services/owned_media_import_file_service.rb
+++ b/app/services/owned_media_import_file_service.rb
@@ -435,90 +435,27 @@ class OwnedMediaImportFileService
     end
 
     def class_native_openat(directory_fd, basename, flags:, mode: 0)
-      Fiddle.last_error = 0
-      descriptor = if (flags & File::CREAT).positive?
-        function = class_native_function(
-          :openat_create,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VARIADIC ],
-          symbol: :openat
-        )
-        function.call(directory_fd, basename, flags, Fiddle::TYPE_INT, mode)
-      else
-        function = class_native_function(
-          :openat,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]
-        )
-        function.call(directory_fd, basename, flags)
-      end
-      return descriptor unless descriptor == -1
-
-      raise SystemCallError.new("openat", Fiddle.last_error)
+      FilesystemSyscalls.openat(directory_fd, basename, flags: flags, mode: mode)
     end
 
     def class_native_mkdirat(directory_fd, basename, mode)
-      call_class_native_path_function(
-        class_native_function(:mkdirat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-        directory_fd,
-        basename,
-        mode
-      )
+      FilesystemSyscalls.mkdirat(directory_fd, basename, mode)
     rescue Errno::EEXIST
       nil
     end
 
     def class_native_fchmod(descriptor, mode)
-      Fiddle.last_error = 0
-      result = class_native_function(
-        :fchmod,
-        [ Fiddle::TYPE_INT, Fiddle::TYPE_INT ]
-      ).call(descriptor, mode)
-      return if result.zero?
-
-      raise SystemCallError.new("fchmod", Fiddle.last_error)
+      FilesystemSyscalls.fchmod(descriptor, mode)
     end
 
     def class_native_renameat(source_fd, source_basename, destination_fd, destination_basename)
-      call_class_native_path_function(
-        class_native_function(
-          :renameat,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ]
-        ),
-        source_fd,
-        source_basename,
-        destination_fd,
-        destination_basename
-      )
+      FilesystemSyscalls.renameat(source_fd, source_basename, destination_fd, destination_basename)
     end
 
     def class_native_unlinkat(directory_fd, basename)
-      call_class_native_path_function(
-        class_native_function(:unlinkat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-        directory_fd,
-        basename,
-        0
-      )
+      FilesystemSyscalls.unlinkat(directory_fd, basename)
     rescue Errno::ENOENT
       nil
-    end
-
-    def call_class_native_path_function(function, *arguments)
-      pointers = arguments.map do |argument|
-        argument.is_a?(String) ? Fiddle::Pointer[argument + "\0"] : argument
-      end
-      Fiddle.last_error = 0
-      result = function.call(*pointers)
-      return result unless result == -1
-
-      raise SystemCallError.new("filesystem operation", Fiddle.last_error)
-    end
-
-    def class_native_function(name, arguments, symbol: name)
-      @class_native_functions ||= {}
-      @class_native_functions[[ name, arguments ]] ||= Fiddle::Function.new(
-        Fiddle::Handle::DEFAULT[symbol.to_s],
-        arguments,
-        Fiddle::TYPE_INT
-      )
     end
 
     def same_class_file_identity?(left, right)
@@ -1108,79 +1045,46 @@ class OwnedMediaImportFileService
   end
 
   def native_linkat(source_directory_fd, source_basename, destination_directory_fd, destination_basename)
-    call_native_path_function(
-      native_function(
-        :linkat,
-        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]
-      ),
-      source_directory_fd,
-      source_basename,
-      destination_directory_fd,
-      destination_basename,
-      0
-    )
+    with_audiobook_filesystem_syscall do
+      FilesystemSyscalls.linkat(
+        source_directory_fd,
+        source_basename,
+        destination_directory_fd,
+        destination_basename
+      )
+    end
   end
 
-
   def native_mkdirat(directory_fd, basename, mode)
-    call_native_path_function(
-      native_function(:mkdirat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-      directory_fd,
-      basename,
-      mode
-    )
+    with_audiobook_filesystem_syscall do
+      FilesystemSyscalls.mkdirat(directory_fd, basename, mode)
+    end
   rescue Errno::EEXIST
     nil
   end
 
   def native_openat(directory_fd, basename, flags: File::RDONLY | File::NOFOLLOW)
-    function = native_function(
-      :openat,
-      [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_INT ]
-    )
-    Fiddle.last_error = 0
-    descriptor = function.call(directory_fd, basename, flags, 0)
-    return descriptor unless descriptor == -1
-
-    raise SystemCallError.new("openat", Fiddle.last_error)
+    with_audiobook_filesystem_syscall do
+      FilesystemSyscalls.openat(directory_fd, basename, flags: flags)
+    end
   end
 
   def native_unlinkat(directory_fd, basename)
     return if basename.blank?
 
-    call_native_path_function(
-      native_function(:unlinkat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-      directory_fd,
-      basename,
-      0
-    )
+    with_audiobook_filesystem_syscall do
+      FilesystemSyscalls.unlinkat(directory_fd, basename)
+    end
   rescue Errno::ENOENT
     nil
   end
 
   def native_fchmod(descriptor, mode)
-    call_native_path_function(
-      native_function(:fchmod, [ Fiddle::TYPE_INT, Fiddle::TYPE_INT ]),
-      descriptor,
-      mode
-    )
+    with_audiobook_filesystem_syscall { FilesystemSyscalls.fchmod(descriptor, mode) }
   end
 
-  def call_native_path_function(function, *arguments)
-    Fiddle.last_error = 0
-    result = function.call(*arguments)
-    return result if result.zero?
-
-    raise SystemCallError.new("filesystem operation", Fiddle.last_error)
-  end
-
-  def native_function(name, arguments)
-    @native_functions ||= {}
-    @native_functions[name] ||= Fiddle::Function.new(
-      Fiddle::Handle::DEFAULT[name.to_s],
-      arguments,
-      Fiddle::TYPE_INT
-    )
+  def with_audiobook_filesystem_syscall
+    yield
   rescue Fiddle::DLError => e
     raise Error, "The audiobook filesystem cannot safely pin destinations: #{e.message}"
   end

--- a/app/services/safe_library_deletion_service.rb
+++ b/app/services/safe_library_deletion_service.rb
@@ -395,5 +395,7 @@ class SafeLibraryDeletionService
 
   def native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
     FilesystemSyscalls.rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
+  rescue Errno::EINVAL
+    false
   end
 end

--- a/app/services/safe_library_deletion_service.rb
+++ b/app/services/safe_library_deletion_service.rb
@@ -11,8 +11,6 @@ class SafeLibraryDeletionService
   class Error < StandardError; end
 
   AT_REMOVEDIR = RbConfig::CONFIG.fetch("host_os").match?(/darwin/i) ? 0x80 : 0x200
-  LINUX_RENAME_NOREPLACE = 0x1
-  DARWIN_RENAME_EXCL = 0x4
   INTERNAL_DIRECTORIES = [
     OwnedMediaImportFileService::STAGING_DIRECTORY,
     UploadImportFileService::PRIVATE_DIRECTORY
@@ -388,74 +386,14 @@ class SafeLibraryDeletionService
   end
 
   def native_openat(directory_fd, basename, flags)
-    call_native(
-      native_function(
-        :openat,
-        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_INT ]
-      ),
-      directory_fd,
-      basename,
-      flags,
-      0
-    )
+    FilesystemSyscalls.openat(directory_fd, basename, flags: flags)
   end
 
   def native_unlinkat(directory_fd, basename, flags)
-    call_native(
-      native_function(
-        :unlinkat,
-        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]
-      ),
-      directory_fd,
-      basename,
-      flags
-    )
+    FilesystemSyscalls.unlinkat(directory_fd, basename, flags)
   end
 
   def native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
-    function, arguments = if RUBY_PLATFORM.include?("darwin")
-      [
-        :renameatx_np,
-        [ source_fd, source_basename, destination_fd, destination_basename, DARWIN_RENAME_EXCL ]
-      ]
-    elsif RUBY_PLATFORM.include?("linux")
-      [
-        :renameat2,
-        [ source_fd, source_basename, destination_fd, destination_basename, LINUX_RENAME_NOREPLACE ]
-      ]
-    else
-      return false
-    end
-    signature = [
-      Fiddle::TYPE_INT,
-      Fiddle::TYPE_VOIDP,
-      Fiddle::TYPE_INT,
-      Fiddle::TYPE_VOIDP,
-      Fiddle::TYPE_UINT
-    ]
-    call_native(native_function(function, signature), *arguments)
-    true
-  rescue Fiddle::DLError, Errno::ENOSYS, Errno::EINVAL, Errno::EOPNOTSUPP, Errno::ENOTSUP
-    false
-  end
-
-  def call_native(function, *arguments)
-    pointers = arguments.map do |argument|
-      argument.is_a?(String) ? Fiddle::Pointer[argument + "\0"] : argument
-    end
-    Fiddle.last_error = 0
-    result = function.call(*pointers)
-    return result unless result == -1
-
-    raise SystemCallError.new("filesystem operation", Fiddle.last_error)
-  end
-
-  def native_function(name, arguments)
-    @native_functions ||= {}
-    @native_functions[name] ||= Fiddle::Function.new(
-      Fiddle::Handle::DEFAULT[name.to_s],
-      arguments,
-      Fiddle::TYPE_INT
-    )
+    FilesystemSyscalls.rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
   end
 end

--- a/app/services/upload_import_file_service.rb
+++ b/app/services/upload_import_file_service.rb
@@ -23,9 +23,6 @@ class UploadImportFileService
   FILE_MODE = 0o640
   SHA256_PATTERN = /\A[0-9a-f]{64}\z/
   MAX_CANDIDATES = 10_000
-  LINUX_RENAME_NOREPLACE = 0x1
-  DARWIN_RENAME_EXCL = 0x4
-
   attr_reader :upload, :source_path
 
   class << self
@@ -631,81 +628,42 @@ class UploadImportFileService
     end
 
     def native_linkat(source_directory_fd, source_basename, destination_directory_fd, destination_basename)
-      call_native_path_function(
-        native_function(
-          :linkat,
-          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]
-        ),
-        source_directory_fd,
-        source_basename,
-        destination_directory_fd,
-        destination_basename,
-        0
-      )
+      with_upload_filesystem_syscall do
+        FilesystemSyscalls.linkat(
+          source_directory_fd,
+          source_basename,
+          destination_directory_fd,
+          destination_basename
+        )
+      end
     end
 
     def native_mkdirat(directory_fd, basename, mode)
-      call_native_path_function(
-        native_function(:mkdirat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-        directory_fd,
-        basename,
-        mode
-      )
+      with_upload_filesystem_syscall do
+        FilesystemSyscalls.mkdirat(directory_fd, basename, mode)
+      end
     rescue Errno::EEXIST
       nil
     end
 
     def native_openat(directory_fd, basename, flags: File::RDONLY | File::NOFOLLOW, mode: 0)
-      function = native_function(
-        :openat,
-        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_INT ]
-      )
-      Fiddle.last_error = 0
-      descriptor = function.call(directory_fd, basename, flags, mode)
-      return descriptor unless descriptor == -1
-
-      raise SystemCallError.new("openat", Fiddle.last_error)
+      with_upload_filesystem_syscall do
+        FilesystemSyscalls.openat(directory_fd, basename, flags: flags, mode: mode)
+      end
     end
 
     def native_unlinkat(directory_fd, basename)
       return if basename.blank?
 
-      call_native_path_function(
-        native_function(:unlinkat, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]),
-        directory_fd,
-        basename,
-        0
-      )
+      with_upload_filesystem_syscall do
+        FilesystemSyscalls.unlinkat(directory_fd, basename)
+      end
     rescue Errno::ENOENT
       nil
     end
 
     def native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
-      function, arguments = if RUBY_PLATFORM.include?("darwin")
-        [
-          :renameatx_np,
-          [ source_fd, source_basename, destination_fd, destination_basename, DARWIN_RENAME_EXCL ]
-        ]
-      elsif RUBY_PLATFORM.include?("linux")
-        [
-          :renameat2,
-          [ source_fd, source_basename, destination_fd, destination_basename, LINUX_RENAME_NOREPLACE ]
-        ]
-      else
-        return false
-      end
-
-      signature = [
-        Fiddle::TYPE_INT,
-        Fiddle::TYPE_VOIDP,
-        Fiddle::TYPE_INT,
-        Fiddle::TYPE_VOIDP,
-        Fiddle::TYPE_UINT
-      ]
-      call_native_path_function(native_function(function, signature), *arguments)
-      true
-    rescue Fiddle::DLError, Errno::ENOSYS, Errno::EINVAL, Errno::EOPNOTSUPP, Errno::ENOTSUP
-      false
+      FilesystemSyscalls.rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
     end
 
     def restore_ingress_quarantine(directory, quarantine, original)
@@ -724,36 +682,15 @@ class UploadImportFileService
     end
 
     def native_fchmod(descriptor, mode)
-      call_native_path_function(
-        native_function(:fchmod, [ Fiddle::TYPE_INT, Fiddle::TYPE_INT ]),
-        descriptor,
-        mode
-      )
+      with_upload_filesystem_syscall { FilesystemSyscalls.fchmod(descriptor, mode) }
     end
 
     def native_ftruncate(descriptor, length)
-      call_native_path_function(
-        native_function(:ftruncate, [ Fiddle::TYPE_INT, Fiddle::TYPE_LONG ]),
-        descriptor,
-        length
-      )
+      with_upload_filesystem_syscall { FilesystemSyscalls.ftruncate(descriptor, length) }
     end
 
-    def call_native_path_function(function, *arguments)
-      Fiddle.last_error = 0
-      result = function.call(*arguments)
-      return result if result.zero?
-
-      raise SystemCallError.new("filesystem operation", Fiddle.last_error)
-    end
-
-    def native_function(name, arguments)
-      @native_functions ||= {}
-      @native_functions[name] ||= Fiddle::Function.new(
-        Fiddle::Handle::DEFAULT[name.to_s],
-        arguments,
-        Fiddle::TYPE_INT
-      )
+    def with_upload_filesystem_syscall
+      yield
     rescue Fiddle::DLError => error
       raise Error, "The library filesystem cannot safely pin upload paths: #{error.message}"
     end

--- a/app/services/upload_import_file_service.rb
+++ b/app/services/upload_import_file_service.rb
@@ -22,6 +22,8 @@ class UploadImportFileService
   LOCK_SHARDS = 1_024
   FILE_MODE = 0o640
   SHA256_PATTERN = /\A[0-9a-f]{64}\z/
+  FILESYSTEM_OWNER_SETTING_KEY = "internal_filesystem_owner_token"
+  FILESYSTEM_OWNER_TOKEN_PATTERN = /\A[0-9a-f]{32}\z/
   MAX_CANDIDATES = 10_000
   attr_reader :upload, :source_path
 
@@ -127,7 +129,8 @@ class UploadImportFileService
         ) do |upload_directory|
           with_pinned_child(upload_directory, candidate.basename.to_s) do |file|
             identity = file.stat
-            quarantine = ".shelfarr-discard-#{SecureRandom.hex(16)}"
+            quarantine = ".shelfarr-discard-#{identity.dev.to_s(16)}-" \
+              "#{identity.ino.to_s(16)}-#{SecureRandom.hex(16)}.tmp"
             renamed = native_rename_noreplace(
               upload_directory.fileno,
               candidate.basename.to_s,
@@ -240,7 +243,6 @@ class UploadImportFileService
             return false
           end
 
-          remove_private_copy(upload, root)
           clear_reservation!(upload)
           remove_empty_library_directories(library_path, destination, root)
           true
@@ -441,16 +443,6 @@ class UploadImportFileService
       upload.reload
     end
 
-    def remove_private_copy(upload, root)
-      with_pinned_absolute_directory(root) do |root_directory|
-        relative = Pathname(PRIVATE_DIRECTORY).join(database_fingerprint)
-        with_pinned_relative_directory(root_directory, relative, create: true, mode: 0o700) do |private_dir|
-          native_unlinkat(private_dir.fileno, "upload_#{upload.id}.tmp")
-          private_dir.fsync
-        end
-      end
-    end
-
     def remove_verified_destination!(destination, expected_size:, digest:)
       quarantine = ".shelfarr-upload-rollback-#{SecureRandom.hex(16)}"
       with_pinned_absolute_directory(destination.parent) do |parent|
@@ -536,6 +528,42 @@ class UploadImportFileService
       Digest::SHA256.hexdigest(
         ActiveRecord::Base.connection_db_config.database.to_s
       ).first(12)
+    end
+
+    def private_attempt_basename(upload_id)
+      "upload_#{upload_id}-#{filesystem_owner_token}-#{SecureRandom.hex(16)}.tmp"
+    end
+
+    def private_attempt_pattern(upload_id = nil)
+      id_pattern = upload_id ? Regexp.escape(upload_id.to_s) : "\\d+"
+      /\Aupload_#{id_pattern}-#{Regexp.escape(filesystem_owner_token)}-[0-9a-f]{32}\.tmp\z/
+    end
+
+    def filesystem_owner_token
+      setting = Setting.find_by(key: FILESYSTEM_OWNER_SETTING_KEY)
+      if setting
+        token = setting.value.to_s
+        unless FILESYSTEM_OWNER_TOKEN_PATTERN.match?(token)
+          raise Error, "Shelfarr's filesystem owner token is invalid"
+        end
+        return token
+      end
+
+      token = SecureRandom.hex(16)
+      now = Time.current
+      Setting.insert_all(
+        [ {
+          key: FILESYSTEM_OWNER_SETTING_KEY,
+          value: token,
+          value_type: "string",
+          category: "internal",
+          description: "Private filesystem staging owner",
+          created_at: now,
+          updated_at: now
+        } ],
+        unique_by: :index_settings_on_key
+      )
+      Setting.find_by!(key: FILESYSTEM_OWNER_SETTING_KEY).value
     end
 
     def with_pinned_file(path, flags: File::RDONLY | File::NOFOLLOW | File::NONBLOCK)
@@ -664,6 +692,8 @@ class UploadImportFileService
 
     def native_rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
       FilesystemSyscalls.rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
+    rescue Errno::EINVAL
+      false
     end
 
     def restore_ingress_quarantine(directory, quarantine, original)
@@ -818,6 +848,7 @@ class UploadImportFileService
         private_relative = Pathname(PRIVATE_DIRECTORY).join(
           self.class.send(:database_fingerprint)
         )
+        FileCopyService.cleanup_interrupted_copies(root.join(private_relative), root: root)
 
         self.class.send(:with_pinned_absolute_directory, root) do |root_directory|
           self.class.send(
@@ -837,7 +868,6 @@ class UploadImportFileService
                   :validate_open_file!, existing, upload.file_size, upload.content_sha256
                 )
                 validate_published_parent!(destination.parent, destination_parent)
-                self.class.send(:remove_private_copy, upload, root)
                 return book_library_path
               end
             rescue Errno::ENOENT
@@ -935,8 +965,11 @@ class UploadImportFileService
     destination_basename:,
     private_directory:
   )
-    temporary_basename = "upload_#{upload.id}.tmp"
-    self.class.send(:native_unlinkat, private_directory.fileno, temporary_basename)
+    reclaim_interrupted_private_attempts!(private_directory)
+    temporary_basename = self.class.send(:private_attempt_basename, upload.id)
+    temporary_identity = nil
+    source_consumed = false
+    destination_published = false
 
     self.class.send(:with_pinned_absolute_directory, source_path.parent) do |source_parent|
       self.class.send(:with_pinned_child, source_parent, source_path.basename.to_s) do |source|
@@ -952,6 +985,8 @@ class UploadImportFileService
         )
         private_copy = IO.new(descriptor, "wb", autoclose: true)
         begin
+          private_stat = private_copy.stat
+          temporary_identity = [ private_stat.dev, private_stat.ino ]
           source.rewind
           IO.copy_stream(source, private_copy)
           private_copy.flush
@@ -971,13 +1006,29 @@ class UploadImportFileService
       )
       temporary_stat = private_copy.stat
     end
-    self.class.send(
-      :native_linkat,
+    published_by_rename = self.class.send(
+      :native_rename_noreplace,
       private_directory.fileno,
       temporary_basename,
       destination_parent.fileno,
       destination_basename
     )
+    source_consumed = published_by_rename
+    destination_published = published_by_rename
+    unless published_by_rename
+      unless FileCopyService.stable_hardlink_identity?(destination_parent)
+        raise Error, "The library filesystem does not expose stable hardlink identities"
+      end
+
+      self.class.send(
+        :native_linkat,
+        private_directory.fileno,
+        temporary_basename,
+        destination_parent.fileno,
+        destination_basename
+      )
+      destination_published = true
+    end
     destination_parent.fsync
     self.class.send(:with_pinned_child, destination_parent, destination_basename) do |published|
       self.class.send(
@@ -988,11 +1039,61 @@ class UploadImportFileService
       end
     end
     validate_published_parent!(destination_parent_path, destination_parent)
+  rescue Errno::EINVAL => error
+    raise unless destination_published
+
+    raise AmbiguousPublicationError,
+      "The upload destination could not be verified after publication: #{error.message}"
   ensure
-    if private_directory && temporary_basename
-      self.class.send(:native_unlinkat, private_directory.fileno, temporary_basename)
-      private_directory.fsync
+    if private_directory && temporary_basename && temporary_identity && !source_consumed
+      begin
+        cleanup = FileCopyService.send(
+          :remove_pinned_child_if_identity,
+          private_directory,
+          temporary_basename,
+          temporary_identity
+        )
+        private_directory.fsync if cleanup.in?([ :removed, :missing ])
+        unless cleanup.in?([ :removed, :missing ])
+          Rails.logger.warn("[UploadImportFileService] Retained an unverified private upload copy")
+        end
+      rescue => cleanup_error
+        Rails.logger.warn(
+          "[UploadImportFileService] Could not clean the private upload copy: " \
+            "#{cleanup_error.class}: #{cleanup_error.message}"
+        )
+      end
     end
+  end
+
+  def reclaim_interrupted_private_attempts!(private_directory)
+    pattern = self.class.send(:private_attempt_pattern, upload.id)
+    attempts = FileCopyService.send(:pinned_directory_children, private_directory).grep(pattern)
+    return if attempts.empty?
+
+    unless FileCopyService.stable_hardlink_identity?(private_directory)
+      raise Error, "An interrupted private upload attempt requires manual cleanup before retrying"
+    end
+
+    attempts.each do |basename|
+      identity = nil
+      self.class.send(:with_pinned_child, private_directory, basename) do |attempt|
+        stat = attempt.stat
+        identity = [ stat.dev, stat.ino ]
+      end
+      removed = FileCopyService.send(
+        :remove_pinned_child_if_identity,
+        private_directory,
+        basename,
+        identity
+      )
+      unless removed.in?([ :removed, :missing ])
+        raise Error, "An interrupted private upload attempt could not be cleaned safely"
+      end
+    end
+    private_directory.fsync
+  rescue Errno::ELOOP, Errno::ENOTDIR, FileCopyService::UnsafePathError => error
+    raise Error, "An interrupted private upload attempt could not be cleaned safely: #{error.message}"
   end
 
   def validate_published_parent!(path, pinned_parent)

--- a/app/services/upload_zip_import_file_service.rb
+++ b/app/services/upload_zip_import_file_service.rb
@@ -471,7 +471,7 @@ class UploadZipImportFileService
   rescue OwnedMediaImportFileService::Error,
     FileCopyService::UnsafePathError,
     FileCopyService::AtomicPublicationUnsupportedError,
-    Errno::EXDEV, Errno::EPERM, Errno::ENOTSUP, Errno::ELOOP, Errno::ENOTDIR => error
+    Errno::EXDEV, Errno::EINVAL, Errno::EPERM, Errno::ENOTSUP, Errno::ELOOP, Errno::ENOTDIR => error
     raise Error, "The library filesystem cannot safely publish ZIP uploads: #{error.message}"
   end
 

--- a/lib/filesystem_syscalls.rb
+++ b/lib/filesystem_syscalls.rb
@@ -10,13 +10,14 @@ module FilesystemSyscalls
   class << self
     def openat(directory_fd, basename, flags:, mode: 0)
       Fiddle.last_error = 0
-      descriptor = if (flags & File::CREAT).positive?
+      descriptor = if open_requires_mode?(flags)
         # openat is variadic when O_CREAT is present. On arm64 Darwin, treating
         # mode_t as a fixed fourth argument silently creates mode-000 files.
         native_function(
           :openat_create,
           [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VARIADIC ],
-          symbol: :openat
+          symbol: :openat,
+          cache: false
         ).call(directory_fd, path_pointer(basename), flags, Fiddle::TYPE_INT, mode)
       else
         native_function(
@@ -63,15 +64,16 @@ module FilesystemSyscalls
 
     def readlinkat(directory_fd, basename)
       buffer_size = 4096
-      buffer = Fiddle::Pointer.malloc(buffer_size)
+      buffer = "\0".b * buffer_size
       Fiddle.last_error = 0
       length = native_function(
         :readlinkat,
-        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T ]
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T ],
+        return_type: Fiddle::TYPE_SSIZE_T
       ).call(directory_fd, path_pointer(basename), buffer, buffer_size)
       raise SystemCallError.new("readlinkat", Fiddle.last_error) if length == -1
 
-      buffer.to_s(length).force_encoding(Encoding::UTF_8)
+      buffer.byteslice(0, length).force_encoding(Encoding::UTF_8)
     end
 
     def unlinkat(directory_fd, basename, flags = 0)
@@ -126,7 +128,7 @@ module FilesystemSyscalls
         flag
       )
       true
-    rescue Fiddle::DLError, Errno::ENOSYS, Errno::EINVAL, Errno::EOPNOTSUPP, Errno::ENOTSUP
+    rescue Fiddle::DLError, Errno::ENOSYS, Errno::EOPNOTSUPP, Errno::ENOTSUP
       false
     end
 
@@ -140,17 +142,35 @@ module FilesystemSyscalls
       raise SystemCallError.new(name.to_s, Fiddle.last_error)
     end
 
-    def native_function(name, arguments, symbol: name)
+    def native_function(name, arguments, symbol: name, return_type: Fiddle::TYPE_INT, cache: true)
+      return build_native_function(symbol, arguments, return_type) unless cache
+
       @native_functions ||= {}
-      @native_functions[[ name, arguments ]] ||= Fiddle::Function.new(
+      @native_functions[[ name, arguments, return_type ]] ||= build_native_function(
+        symbol,
+        arguments,
+        return_type
+      )
+    end
+
+    def build_native_function(symbol, arguments, return_type)
+      Fiddle::Function.new(
         Fiddle::Handle::DEFAULT[symbol.to_s],
         arguments,
-        Fiddle::TYPE_INT
+        return_type
       )
     end
 
     def path_pointer(path)
-      Fiddle::Pointer[path.to_s.b + "\0"]
+      path = path.to_s.b
+      raise ArgumentError, "path contains null byte" if path.include?("\0")
+
+      Fiddle::Pointer[path + "\0"]
+    end
+
+    def open_requires_mode?(flags)
+      (flags & File::CREAT).positive? ||
+        (File.const_defined?(:TMPFILE) && (flags & File::TMPFILE) == File::TMPFILE)
     end
   end
 end

--- a/lib/filesystem_syscalls.rb
+++ b/lib/filesystem_syscalls.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "fiddle"
+
+# Descriptor-relative libc filesystem operations used by publication services.
+module FilesystemSyscalls
+  LINUX_RENAME_NOREPLACE = 0x1
+  DARWIN_RENAME_EXCL = 0x4
+
+  class << self
+    def openat(directory_fd, basename, flags:, mode: 0)
+      Fiddle.last_error = 0
+      descriptor = if (flags & File::CREAT).positive?
+        # openat is variadic when O_CREAT is present. On arm64 Darwin, treating
+        # mode_t as a fixed fourth argument silently creates mode-000 files.
+        native_function(
+          :openat_create,
+          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VARIADIC ],
+          symbol: :openat
+        ).call(directory_fd, path_pointer(basename), flags, Fiddle::TYPE_INT, mode)
+      else
+        native_function(
+          :openat,
+          [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ]
+        ).call(directory_fd, path_pointer(basename), flags)
+      end
+      return descriptor unless descriptor == -1
+
+      raise SystemCallError.new("openat", Fiddle.last_error)
+    end
+
+    def mkdirat(directory_fd, basename, mode)
+      call_zero(
+        :mkdirat,
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ],
+        directory_fd,
+        path_pointer(basename),
+        mode
+      )
+    end
+
+    def linkat(source_fd, source_basename, destination_fd, destination_basename)
+      call_zero(
+        :linkat,
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ],
+        source_fd,
+        path_pointer(source_basename),
+        destination_fd,
+        path_pointer(destination_basename),
+        0
+      )
+    end
+
+    def symlinkat(target, directory_fd, basename)
+      call_zero(
+        :symlinkat,
+        [ Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ],
+        path_pointer(target),
+        directory_fd,
+        path_pointer(basename)
+      )
+    end
+
+    def readlinkat(directory_fd, basename)
+      buffer_size = 4096
+      buffer = Fiddle::Pointer.malloc(buffer_size)
+      Fiddle.last_error = 0
+      length = native_function(
+        :readlinkat,
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T ]
+      ).call(directory_fd, path_pointer(basename), buffer, buffer_size)
+      raise SystemCallError.new("readlinkat", Fiddle.last_error) if length == -1
+
+      buffer.to_s(length).force_encoding(Encoding::UTF_8)
+    end
+
+    def unlinkat(directory_fd, basename, flags = 0)
+      call_zero(
+        :unlinkat,
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT ],
+        directory_fd,
+        path_pointer(basename),
+        flags
+      )
+    end
+
+    def fchmod(descriptor, mode)
+      call_zero(:fchmod, [ Fiddle::TYPE_INT, Fiddle::TYPE_INT ], descriptor, mode)
+    end
+
+    def ftruncate(descriptor, length)
+      call_zero(:ftruncate, [ Fiddle::TYPE_INT, Fiddle::TYPE_LONG ], descriptor, length)
+    end
+
+    def futimes_now(descriptor)
+      call_zero(:futimes, [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ], descriptor, nil)
+    end
+
+    def renameat(source_fd, source_basename, destination_fd, destination_basename)
+      call_zero(
+        :renameat,
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP ],
+        source_fd,
+        path_pointer(source_basename),
+        destination_fd,
+        path_pointer(destination_basename)
+      )
+    end
+
+    def rename_noreplace(source_fd, source_basename, destination_fd, destination_basename)
+      function, flag = if RUBY_PLATFORM.include?("darwin")
+        [ :renameatx_np, DARWIN_RENAME_EXCL ]
+      elsif RUBY_PLATFORM.include?("linux")
+        [ :renameat2, LINUX_RENAME_NOREPLACE ]
+      else
+        return false
+      end
+
+      call_zero(
+        function,
+        [ Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT ],
+        source_fd,
+        path_pointer(source_basename),
+        destination_fd,
+        path_pointer(destination_basename),
+        flag
+      )
+      true
+    rescue Fiddle::DLError, Errno::ENOSYS, Errno::EINVAL, Errno::EOPNOTSUPP, Errno::ENOTSUP
+      false
+    end
+
+    private
+
+    def call_zero(name, arguments, *values)
+      Fiddle.last_error = 0
+      result = native_function(name, arguments).call(*values)
+      return result if result.zero?
+
+      raise SystemCallError.new(name.to_s, Fiddle.last_error)
+    end
+
+    def native_function(name, arguments, symbol: name)
+      @native_functions ||= {}
+      @native_functions[[ name, arguments ]] ||= Fiddle::Function.new(
+        Fiddle::Handle::DEFAULT[symbol.to_s],
+        arguments,
+        Fiddle::TYPE_INT
+      )
+    end
+
+    def path_pointer(path)
+      Fiddle::Pointer[path.to_s.b + "\0"]
+    end
+  end
+end

--- a/test/config/docker_workflow_test.rb
+++ b/test/config/docker_workflow_test.rb
@@ -54,6 +54,7 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert validation_commands.any? { |command| command.include?("bin/quality push") }
     assert validation_commands.any? { |command| command.include?("cifs-smoke.sh") }
     assert validation_commands.any? { |command| command.include?("bin/bundler-audit --update") }
+    assert_includes @jobs.dig("validate", "strategy", "matrix", "runner"), "ubuntu-24.04-arm"
 
     docker_job = @jobs.fetch("docker")
     assert_equal %w[plan validate], docker_job.fetch("needs")
@@ -155,6 +156,7 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert filesystem_commands.any? { |command| command.include?("cifs-utils") }
     assert filesystem_commands.any? { |command| command.include?("cifs-smoke.sh") }
     assert_equal [ "quality" ], jobs.fetch("filesystem-contracts").fetch("needs")
+    assert_includes jobs.dig("filesystem-contracts", "strategy", "matrix", "runner"), "ubuntu-24.04-arm"
     assert_includes jobs.fetch("container").fetch("needs"), "filesystem-contracts"
     assert_equal false, container_build.dig("with", "push")
   end

--- a/test/config/docker_workflow_test.rb
+++ b/test/config/docker_workflow_test.rb
@@ -52,6 +52,7 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     validation_commands = @jobs.fetch("validate").fetch("steps").filter_map { |step| step["run"] }
 
     assert validation_commands.any? { |command| command.include?("bin/quality push") }
+    assert validation_commands.any? { |command| command.include?("cifs-smoke.sh") }
     assert validation_commands.any? { |command| command.include?("bin/bundler-audit --update") }
 
     docker_job = @jobs.fetch("docker")
@@ -142,6 +143,7 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     )
     jobs = workflow.fetch("jobs")
     companion_commands = jobs.fetch("companion").fetch("steps").filter_map { |step| step["run"] }
+    filesystem_commands = jobs.fetch("filesystem-contracts").fetch("steps").filter_map { |step| step["run"] }
     container_build = jobs.fetch("container").fetch("steps").find do |step|
       step["name"] == "Build Shelfarr image"
     end
@@ -150,6 +152,10 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert companion_commands.any? { |command| command.include?("dotnet format") && command.include?("--verify-no-changes") }
     assert companion_commands.any? { |command| command.include?("dotnet test") && command.include?("--no-restore") }
     assert companion_commands.any? { |command| command.include?("container-smoke.sh") }
+    assert filesystem_commands.any? { |command| command.include?("cifs-utils") }
+    assert filesystem_commands.any? { |command| command.include?("cifs-smoke.sh") }
+    assert_equal [ "quality" ], jobs.fetch("filesystem-contracts").fetch("needs")
+    assert_includes jobs.fetch("container").fetch("needs"), "filesystem-contracts"
     assert_equal false, container_build.dig("with", "push")
   end
 

--- a/test/filesystem_contracts/README.md
+++ b/test/filesystem_contracts/README.md
@@ -1,0 +1,43 @@
+# Filesystem Contract Tests
+
+These tests exercise Shelfarr's file-publication guarantees against real
+mounted filesystems. Unit tests still inject individual syscall failures, but
+they cannot reproduce combined client/server behavior such as a successful
+`linkat()` followed by an unusable destination pathname.
+
+The contract suite verifies application behavior rather than requiring every
+filesystem to expose identical Unix metadata. It covers nested directory
+creation, complete no-clobber copies, concurrent publication, hardlink
+fallback, durable move behavior, cross-process locking, and cleanup artifacts.
+
+Run the local-filesystem control:
+
+```bash
+PARALLEL_WORKERS=1 \
+  bin/rails test test/filesystem_contracts/file_copy_service_contract_test.rb
+```
+
+Run the same suite against an existing mount:
+
+```bash
+SHELFARR_FILESYSTEM_CONTRACT_ROOT=/absolute/path/to/mount \
+SHELFARR_FILESYSTEM_CONTRACT_PROFILE=my-filesystem \
+PARALLEL_WORKERS=1 \
+  bin/rails test test/filesystem_contracts/file_copy_service_contract_test.rb
+```
+
+Run the containerized Samba/CIFS matrix:
+
+```bash
+test/filesystem_contracts/cifs-smoke.sh
+```
+
+The CIFS harness requires Docker, the host CIFS kernel module, `mount.cifs`,
+and permission to mount and unmount filesystems. It builds a disposable Samba
+server and runs both `serverino` and `noserverino` profiles with the fixed
+`0775` modes reported in production issues.
+
+When adding another filesystem, mount it in a disposable harness and pass its
+root to the same Rails contract file. Add a new assertion only when it
+represents a Shelfarr guarantee; filesystem capabilities should result in a
+safe typed fallback rather than filesystem-specific expectations in the test.

--- a/test/filesystem_contracts/cifs-smoke.sh
+++ b/test/filesystem_contracts/cifs-smoke.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+suffix="$$"
+image="shelfarr-filesystem-contract-samba:${suffix}"
+container="shelfarr-filesystem-contract-samba-${suffix}"
+mount_root="$(mktemp -d "${TMPDIR:-/tmp}/shelfarr-cifs-contract-XXXXXX")"
+mounted=false
+
+if [[ "${EUID}" -eq 0 ]]; then
+  root_command=()
+else
+  root_command=(sudo)
+fi
+
+cleanup() {
+  status="$1"
+  if [[ "${mounted}" = true ]]; then
+    if ! timeout 30s "${root_command[@]}" umount "${mount_root}" >/dev/null 2>&1; then
+      echo "Normal CIFS unmount failed; attempting a lazy detach." >&2
+      timeout 30s "${root_command[@]}" umount --lazy "${mount_root}" >/dev/null 2>&1 || true
+    fi
+    if mountpoint -q "${mount_root}"; then
+      echo "CIFS cleanup could not detach ${mount_root}; retaining container ${container}." >&2
+      return
+    fi
+    mounted=false
+  fi
+  if [[ "${status}" -ne 0 ]] && docker inspect "${container}" >/dev/null 2>&1; then
+    docker logs "${container}" >&2 || true
+  fi
+  docker rm -f "${container}" >/dev/null 2>&1 || true
+  docker image rm -f "${image}" >/dev/null 2>&1 || true
+  rmdir "${mount_root}" >/dev/null 2>&1 || true
+}
+
+on_exit() {
+  cleanup "$?"
+}
+
+on_signal() {
+  status="$1"
+  trap - EXIT INT TERM
+  cleanup "${status}"
+  exit "${status}"
+}
+
+trap on_exit EXIT
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
+
+if ! command -v mount.cifs >/dev/null 2>&1; then
+  echo "mount.cifs is required; install cifs-utils before running this test." >&2
+  exit 1
+fi
+
+cd "${root}"
+docker build --quiet -f test/filesystem_contracts/samba.Dockerfile -t "${image}" . >/dev/null
+docker run -d \
+  --name "${container}" \
+  --publish 127.0.0.1::445 \
+  "${image}" >/dev/null
+
+attempt=0
+until docker exec "${container}" \
+  smbclient -L 127.0.0.1 -m SMB3 -U 'shelfarr%shelfarr-test' >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [[ "${attempt}" -ge 30 ]]; then
+    echo "Samba did not become ready." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+endpoint="$(docker port "${container}" 445/tcp)"
+port="${endpoint##*:}"
+common_options="username=shelfarr,password=shelfarr-test,vers=3.1.1,nounix,noperm,uid=$(id -u),gid=$(id -g),forceuid,forcegid,file_mode=0775,dir_mode=0775,cache=strict,actimeo=1,port=${port}"
+
+run_profile() {
+  profile="$1"
+  inode_option="$2"
+  options="${common_options},${inode_option}"
+  profile_status=0
+
+  echo "Running filesystem contracts against CIFS profile ${profile}."
+  if ! timeout 30s "${root_command[@]}" mount \
+    -t cifs //127.0.0.1/contracts "${mount_root}" -o "${options}"; then
+    echo "Failed to mount CIFS profile ${profile}." >&2
+    return 1
+  fi
+  mounted=true
+  findmnt --noheadings --output FSTYPE,OPTIONS --target "${mount_root}"
+
+  if ! env SHELFARR_FILESYSTEM_CONTRACT_ROOT="${mount_root}" \
+    SHELFARR_FILESYSTEM_CONTRACT_PROFILE="cifs-${profile}" \
+    SHELFARR_FILESYSTEM_CONTRACT_OPTIONS="${options//password=shelfarr-test/password=[FILTERED]}" \
+    PARALLEL_WORKERS=1 \
+    timeout 10m bin/rails test test/filesystem_contracts/file_copy_service_contract_test.rb; then
+    profile_status=1
+  fi
+
+  if timeout 30s "${root_command[@]}" umount "${mount_root}"; then
+    mounted=false
+  else
+    echo "Failed to unmount CIFS profile ${profile}." >&2
+    profile_status=1
+  fi
+  return "${profile_status}"
+}
+
+status=0
+run_profile serverino serverino || status=1
+if [[ "${mounted}" = true ]]; then
+  exit "${status}"
+fi
+run_profile noserverino noserverino || status=1
+exit "${status}"

--- a/test/filesystem_contracts/cifs-smoke.sh
+++ b/test/filesystem_contracts/cifs-smoke.sh
@@ -14,33 +14,78 @@ else
   root_command=(sudo)
 fi
 
+mount_state() {
+  local result
+  timeout --kill-after=2s 5s mountpoint -q "${mount_root}"
+  result="$?"
+  [[ "${result}" -eq 0 ]] && return 0
+  [[ "${result}" -eq 1 || "${result}" -eq 32 ]] && return 1
+  return 2
+}
+
 cleanup() {
-  status="$1"
-  if [[ "${mounted}" = true ]]; then
-    if ! timeout 30s "${root_command[@]}" umount "${mount_root}" >/dev/null 2>&1; then
+  local exit_status="$1"
+  local mount_status
+  local detach_status
+  local cleanup_status=0
+  local resource_ids
+  if mount_state; then
+    mount_status=0
+  else
+    mount_status="$?"
+  fi
+  if [[ "${mounted}" = true || "${mount_status}" -eq 0 ]]; then
+    if ! timeout --kill-after=5s 30s "${root_command[@]}" umount "${mount_root}" >/dev/null 2>&1; then
       echo "Normal CIFS unmount failed; attempting a lazy detach." >&2
-      timeout 30s "${root_command[@]}" umount --lazy "${mount_root}" >/dev/null 2>&1 || true
+      timeout --kill-after=5s 30s "${root_command[@]}" umount --lazy "${mount_root}" >/dev/null 2>&1 || true
     fi
-    if mountpoint -q "${mount_root}"; then
+    if mount_state; then
       echo "CIFS cleanup could not detach ${mount_root}; retaining container ${container}." >&2
-      return
+      return 1
+    else
+      detach_status="$?"
+      if [[ "${detach_status}" -ne 1 ]]; then
+        echo "CIFS cleanup could not determine whether ${mount_root} is still mounted; retaining container ${container}." >&2
+        return 1
+      fi
     fi
     mounted=false
+  elif [[ "${mount_status}" -ne 1 ]]; then
+    echo "CIFS cleanup could not determine whether ${mount_root} is mounted; retaining container ${container}." >&2
+    return 1
   fi
-  if [[ "${status}" -ne 0 ]] && docker inspect "${container}" >/dev/null 2>&1; then
-    docker logs "${container}" >&2 || true
+  if [[ "${exit_status}" -ne 0 ]] && timeout --kill-after=2s 10s docker inspect "${container}" >/dev/null 2>&1; then
+    timeout --kill-after=2s 10s docker logs "${container}" >&2 || true
   fi
-  docker rm -f "${container}" >/dev/null 2>&1 || true
-  docker image rm -f "${image}" >/dev/null 2>&1 || true
-  rmdir "${mount_root}" >/dev/null 2>&1 || true
+  if resource_ids="$(timeout --kill-after=2s 10s docker container ls -a \
+    --filter "name=^/${container}$" --format '{{.ID}}')"; then
+    if [[ -n "${resource_ids}" ]]; then
+      timeout --kill-after=2s 15s docker rm -f "${container}" >/dev/null 2>&1 || cleanup_status=1
+    fi
+  else
+    cleanup_status=1
+  fi
+  if resource_ids="$(timeout --kill-after=2s 10s docker image ls \
+    --filter "reference=${image}" --format '{{.ID}}')"; then
+    if [[ -n "${resource_ids}" ]]; then
+      timeout --kill-after=2s 15s docker image rm -f "${image}" >/dev/null 2>&1 || cleanup_status=1
+    fi
+  else
+    cleanup_status=1
+  fi
+  rmdir "${mount_root}" >/dev/null 2>&1 || cleanup_status=1
+  return "${cleanup_status}"
 }
 
 on_exit() {
-  cleanup "$?"
+  local status="$?"
+  trap - EXIT
+  cleanup "${status}" || status=1
+  exit "${status}"
 }
 
 on_signal() {
-  status="$1"
+  local status="$1"
   trap - EXIT INT TERM
   cleanup "${status}"
   exit "${status}"
@@ -56,14 +101,15 @@ if ! command -v mount.cifs >/dev/null 2>&1; then
 fi
 
 cd "${root}"
-docker build --quiet -f test/filesystem_contracts/samba.Dockerfile -t "${image}" . >/dev/null
-docker run -d \
+timeout --kill-after=10s 5m docker build --quiet \
+  -f test/filesystem_contracts/samba.Dockerfile -t "${image}" . >/dev/null
+timeout --kill-after=5s 30s docker run -d \
   --name "${container}" \
   --publish 127.0.0.1::445 \
   "${image}" >/dev/null
 
 attempt=0
-until docker exec "${container}" \
+until timeout --kill-after=2s 5s docker exec "${container}" \
   smbclient -L 127.0.0.1 -m SMB3 -U 'shelfarr%shelfarr-test' >/dev/null 2>&1; do
   attempt=$((attempt + 1))
   if [[ "${attempt}" -ge 30 ]]; then
@@ -73,7 +119,7 @@ until docker exec "${container}" \
   sleep 1
 done
 
-endpoint="$(docker port "${container}" 445/tcp)"
+endpoint="$(timeout --kill-after=2s 10s docker port "${container}" 445/tcp)"
 port="${endpoint##*:}"
 common_options="username=shelfarr,password=shelfarr-test,vers=3.1.1,nounix,noperm,uid=$(id -u),gid=$(id -g),forceuid,forcegid,file_mode=0775,dir_mode=0775,cache=strict,actimeo=1,port=${port}"
 
@@ -84,23 +130,23 @@ run_profile() {
   profile_status=0
 
   echo "Running filesystem contracts against CIFS profile ${profile}."
-  if ! timeout 30s "${root_command[@]}" mount \
+  if ! timeout --kill-after=5s 30s "${root_command[@]}" mount \
     -t cifs //127.0.0.1/contracts "${mount_root}" -o "${options}"; then
     echo "Failed to mount CIFS profile ${profile}." >&2
     return 1
   fi
   mounted=true
-  findmnt --noheadings --output FSTYPE,OPTIONS --target "${mount_root}"
+  timeout --kill-after=2s 10s findmnt --noheadings --output FSTYPE,OPTIONS --target "${mount_root}"
 
   if ! env SHELFARR_FILESYSTEM_CONTRACT_ROOT="${mount_root}" \
     SHELFARR_FILESYSTEM_CONTRACT_PROFILE="cifs-${profile}" \
     SHELFARR_FILESYSTEM_CONTRACT_OPTIONS="${options//password=shelfarr-test/password=[FILTERED]}" \
     PARALLEL_WORKERS=1 \
-    timeout 10m bin/rails test test/filesystem_contracts/file_copy_service_contract_test.rb; then
+    timeout --kill-after=30s 5m bin/rails test test/filesystem_contracts/file_copy_service_contract_test.rb; then
     profile_status=1
   fi
 
-  if timeout 30s "${root_command[@]}" umount "${mount_root}"; then
+  if timeout --kill-after=5s 30s "${root_command[@]}" umount "${mount_root}"; then
     mounted=false
   else
     echo "Failed to unmount CIFS profile ${profile}." >&2

--- a/test/filesystem_contracts/file_copy_service_contract_test.rb
+++ b/test/filesystem_contracts/file_copy_service_contract_test.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "set"
+require "tmpdir"
+
+class FileCopyServiceContractTest < ActiveSupport::TestCase
+  setup do
+    parent = Pathname(
+      ENV.fetch("SHELFARR_FILESYSTEM_CONTRACT_ROOT", Dir.tmpdir)
+    ).expand_path
+    raise "Filesystem contract root must be an existing directory" unless parent.directory?
+
+    @contract_root = Pathname(Dir.mktmpdir("shelfarr-filesystem-contract-", parent.to_s))
+    @source_root = @contract_root.join("downloads")
+    @library_root = @contract_root.join("library")
+    FileUtils.mkdir_p([ @source_root, @library_root ])
+
+    report_contract_profile_once
+  end
+
+  teardown do
+    FileUtils.rm_rf(@contract_root) if @contract_root
+  end
+
+  test "creates writable nested library directories" do
+    destination = @library_root.join("Author", "Book")
+
+    FileCopyService.ensure_directory(
+      destination.to_s,
+      root: @library_root.to_s
+    )
+
+    assert destination.directory?
+    assert File.writable?(destination)
+    assert File.executable?(destination)
+
+    probe = destination.join("write-probe")
+    probe.binwrite("writable")
+    assert_equal "writable", probe.binread
+    probe.delete
+    assert_not probe.exist?
+  end
+
+  test "publishes consecutive complete copies" do
+    files = {
+      "AIW.jpg" => "\xFF\xD8\xFF".b + SecureRandom.random_bytes(16_381),
+      "AIW.txt" => SecureRandom.random_bytes(80_864)
+    }
+
+    files.each do |basename, content|
+      source = @source_root.join(basename)
+      destination = @library_root.join(basename)
+      source.binwrite(content)
+
+      FileCopyService.cp_noreplace(
+        source.to_s,
+        destination.to_s,
+        root: @library_root.to_s,
+        allow_compatibility_fallback: true
+      )
+
+      assert_equal content, destination.binread
+      assert_equal content, source.binread
+      assert_includes FileCopyService::LIBRARY_FILE_MODES,
+        destination.stat.mode & 0o7777
+    end
+
+    assert_no_publication_artifacts
+  end
+
+  test "never replaces an occupied destination" do
+    source = @source_root.join("source.txt")
+    destination = @library_root.join("occupied.txt")
+    source.binwrite("new bytes")
+    destination.binwrite("existing bytes")
+
+    assert_raises(Errno::EEXIST) do
+      FileCopyService.cp_noreplace(
+        source.to_s,
+        destination.to_s,
+        root: @library_root.to_s,
+        allow_compatibility_fallback: true
+      )
+    end
+
+    assert_equal "existing bytes", destination.binread
+    assert_equal "new bytes", source.binread
+    assert_no_publication_artifacts
+  end
+
+  test "concurrent publications retain exactly one complete winner" do
+    destination = @library_root.join("winner.txt")
+    sources = [ "first complete bytes", "second complete bytes" ].map.with_index do |content, index|
+      @source_root.join("source-#{index}.txt").tap { |path| path.binwrite(content) }
+    end
+    ready = Queue.new
+    release = Queue.new
+
+    workers = sources.map do |source|
+      Thread.new do
+        ready << true
+        release.pop
+        FileCopyService.cp_noreplace(
+          source.to_s,
+          destination.to_s,
+          root: @library_root.to_s,
+          allow_compatibility_fallback: true
+        )
+        :published
+      rescue Errno::EEXIST
+        :occupied
+      end
+    end
+    sources.size.times { ready.pop }
+    sources.size.times { release << true }
+    outcomes = workers.map(&:value)
+
+    assert_equal [ :occupied, :published ], outcomes.sort
+    assert_includes sources.map(&:binread), destination.binread
+    assert_no_publication_artifacts
+  ensure
+    workers&.each { |worker| worker.join if worker.alive? }
+  end
+
+  test "hardlink import either succeeds or uses its typed copy fallback" do
+    source = @source_root.join("chapter.mp3")
+    destination = @library_root.join("chapter.mp3")
+    source.binwrite(SecureRandom.random_bytes(32_768))
+
+    hardlinked = begin
+      FileCopyService.hardlink_noreplace(
+        source.to_s,
+        destination.to_s,
+        root: @library_root.to_s,
+        source_root: nil
+      )
+      true
+    rescue FileCopyService::HardlinkUnsupportedError
+      FileCopyService.cp_noreplace(
+        source.to_s,
+        destination.to_s,
+        root: @library_root.to_s,
+        hardlink_mode: true,
+        allow_compatibility_fallback: true
+      )
+      false
+    end
+
+    assert_equal source.binread, destination.binread
+    assert source.file?
+    profile = ENV["SHELFARR_FILESYSTEM_CONTRACT_PROFILE"]
+    assert hardlinked if profile == "cifs-serverino"
+    assert_not hardlinked if profile == "cifs-noserverino"
+
+    if hardlinked
+      source.open("ab") do |file|
+        file.write("shared mutation")
+        file.flush
+        begin
+          file.fsync
+        rescue Errno::EINVAL, Errno::EOPNOTSUPP
+          nil
+        end
+      end
+      assert_equal source.binread, destination.binread
+    else
+      copied_content = destination.binread
+      source.open("ab") { |file| file.write("independent mutation") }
+      assert_equal copied_content, destination.binread
+    end
+    assert_no_publication_artifacts
+  end
+
+  test "destructive import removes only a source it can still prove" do
+    source = @source_root.join("move.epub")
+    destination = @library_root.join("move.epub")
+    content = SecureRandom.random_bytes(24_576)
+    source.binwrite(content)
+    source_snapshot = FileCopyService.snapshot_source_file(source.to_s)
+
+    FileCopyService.cp_noreplace(
+      source.to_s,
+      destination.to_s,
+      root: @library_root.to_s,
+      source_snapshot: source_snapshot,
+      allow_compatibility_fallback: true,
+      require_durable: true
+    )
+    destination_snapshot = FileCopyService.verified_library_file_snapshot(
+      source.to_s,
+      destination.to_s,
+      root: @library_root.to_s,
+      source_snapshot: source_snapshot,
+      require_durable: true
+    )
+    assert destination_snapshot
+
+    removed = FileCopyService.remove_source_file(
+      source_snapshot,
+      destination_snapshot: destination_snapshot
+    )
+    if removed
+      assert_not source.exist?
+    else
+      assert_equal content, source.binread
+    end
+
+    assert_equal content, destination.binread
+    assert_no_publication_artifacts
+    assert_empty Dir.children(@source_root).grep(/\A\.shelfarr-/)
+  end
+
+  test "private file locks exclude a second process" do
+    skip "fork is required for the cross-process lock contract" unless Process.respond_to?(:fork)
+
+    lock = @library_root.join("contract.lock")
+    enter_reader, enter_writer = IO.pipe
+    result_reader, result_writer = IO.pipe
+    child = fork do
+      enter_writer.close
+      result_reader.close
+      enter_reader.read(1)
+      acquired = FileCopyService.with_private_lock(
+        lock.to_s,
+        root: @library_root.to_s,
+        nonblock: true
+      ) { true }
+      result_writer.write(acquired ? "acquired" : "blocked")
+      result_writer.close
+      exit! 0
+    end
+    enter_reader.close
+    result_writer.close
+
+    result = FileCopyService.with_private_lock(
+      lock.to_s,
+      root: @library_root.to_s
+    ) do
+      enter_writer.write("1")
+      enter_writer.close
+      result_reader.read
+    end
+
+    child_status = Process.wait2(child).last
+    child = nil
+    assert_equal "blocked", result
+    assert_predicate child_status, :success?
+  ensure
+    enter_reader&.close unless enter_reader&.closed?
+    enter_writer&.close unless enter_writer&.closed?
+    result_reader&.close unless result_reader&.closed?
+    result_writer&.close unless result_writer&.closed?
+    if child
+      begin
+        Process.wait(child)
+      rescue Errno::ECHILD
+        nil
+      end
+    end
+  end
+
+  private
+
+  def assert_no_publication_artifacts
+    artifacts = Dir.children(@library_root).grep(/\A\.shelfarr-/)
+    assert_empty artifacts
+  end
+
+  def report_contract_profile_once
+    profile = ENV["SHELFARR_FILESYSTEM_CONTRACT_PROFILE"]
+    return if profile.blank?
+
+    self.class.instance_variable_get(:@reported_profiles) ||
+      self.class.instance_variable_set(:@reported_profiles, Set.new)
+    reported = self.class.instance_variable_get(:@reported_profiles)
+    return if reported.include?(profile)
+
+    reported << profile
+    warn "[filesystem-contract] profile=#{profile} root=#{@contract_root.parent} " \
+      "options=#{ENV.fetch('SHELFARR_FILESYSTEM_CONTRACT_OPTIONS', 'unknown')}"
+  end
+end

--- a/test/filesystem_contracts/file_copy_service_contract_test.rb
+++ b/test/filesystem_contracts/file_copy_service_contract_test.rb
@@ -169,7 +169,7 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
 
     assert_equal source.binread, destination.binread
     assert source.file?
-    assert_not hardlinked if cifs_noserverino_profile?
+    assert_not hardlinked if cifs_profile?
 
     if hardlinked
       source.open("ab") do |file|

--- a/test/filesystem_contracts/file_copy_service_contract_test.rb
+++ b/test/filesystem_contracts/file_copy_service_contract_test.rb
@@ -169,9 +169,7 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
 
     assert_equal source.binread, destination.binread
     assert source.file?
-    profile = ENV["SHELFARR_FILESYSTEM_CONTRACT_PROFILE"]
-    assert hardlinked if profile == "cifs-serverino"
-    assert_not hardlinked if profile == "cifs-noserverino"
+    assert_not hardlinked if cifs_noserverino_profile?
 
     if hardlinked
       source.open("ab") do |file|

--- a/test/filesystem_contracts/file_copy_service_contract_test.rb
+++ b/test/filesystem_contracts/file_copy_service_contract_test.rb
@@ -187,6 +187,7 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
       source.open("ab") { |file| file.write("independent mutation") }
       assert_equal copied_content, destination.binread
     end
+    reclaim_deferred_empty_quarantines if cifs_profile?
     assert_no_publication_artifacts
   end
 
@@ -388,6 +389,22 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
   end
 
   private
+
+  def reclaim_deferred_empty_quarantines
+    artifacts = Dir.children(@library_root).grep(/\A\.shelfarr-/)
+    quarantines, unexpected = artifacts.partition do |entry|
+      FileCopyService::COPY_QUARANTINE_PATTERN.match?(entry)
+    end
+    assert_empty unexpected
+    quarantines.each do |entry|
+      path = @library_root.join(entry)
+      assert path.directory?
+      assert_empty Dir.children(path)
+      stale_time = Time.now - FileCopyService::COPY_QUARANTINE_STALE_AGE - 60
+      File.utime(stale_time, stale_time, path)
+    end
+    FileCopyService.cleanup_interrupted_copies(@library_root.to_s, root: @library_root.to_s)
+  end
 
   def assert_no_publication_artifacts
     artifacts = Dir.glob(

--- a/test/filesystem_contracts/file_copy_service_contract_test.rb
+++ b/test/filesystem_contracts/file_copy_service_contract_test.rb
@@ -34,6 +34,7 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
     assert destination.directory?
     assert File.writable?(destination)
     assert File.executable?(destination)
+    assert_equal 0o775, destination.stat.mode & 0o777 if cifs_profile?
 
     probe = destination.join("write-probe")
     probe.binwrite("writable")
@@ -56,14 +57,17 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
       FileCopyService.cp_noreplace(
         source.to_s,
         destination.to_s,
-        root: @library_root.to_s,
-        allow_compatibility_fallback: true
+        root: @library_root.to_s
       )
 
       assert_equal content, destination.binread
       assert_equal content, source.binread
-      assert_includes FileCopyService::LIBRARY_FILE_MODES,
-        destination.stat.mode & 0o7777
+      if cifs_profile?
+        assert_equal 0o775, destination.stat.mode & 0o777
+      else
+        assert_includes FileCopyService::LIBRARY_FILE_MODES,
+          destination.stat.mode & 0o7777
+      end
     end
 
     assert_no_publication_artifacts
@@ -79,8 +83,7 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
       FileCopyService.cp_noreplace(
         source.to_s,
         destination.to_s,
-        root: @library_root.to_s,
-        allow_compatibility_fallback: true
+        root: @library_root.to_s
       )
     end
 
@@ -90,36 +93,54 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
   end
 
   test "concurrent publications retain exactly one complete winner" do
+    skip "noserverino cannot prove concurrent source or artifact identities" if cifs_noserverino_profile?
+
     destination = @library_root.join("winner.txt")
     sources = [ "first complete bytes", "second complete bytes" ].map.with_index do |content, index|
       @source_root.join("source-#{index}.txt").tap { |path| path.binwrite(content) }
     end
     ready = Queue.new
     release = Queue.new
-
-    workers = sources.map do |source|
-      Thread.new do
-        ready << true
-        release.pop
-        FileCopyService.cp_noreplace(
-          source.to_s,
-          destination.to_s,
-          root: @library_root.to_s,
-          allow_compatibility_fallback: true
-        )
-        :published
-      rescue Errno::EEXIST
-        :occupied
-      end
+    publishing = Queue.new
+    publish = Queue.new
+    workers = nil
+    real_publish = FileCopyService.method(:publish_private_child_atomically_noreplace!)
+    synchronized_publish = lambda do |*arguments, **options|
+      publishing << true
+      publish.pop
+      real_publish.call(*arguments, **options)
     end
-    sources.size.times { ready.pop }
-    sources.size.times { release << true }
-    outcomes = workers.map(&:value)
+
+    outcomes = FileCopyService.stub(:publish_private_child_atomically_noreplace!, synchronized_publish) do
+      workers = sources.map do |source|
+        Thread.new do
+          ready << true
+          release.pop
+          FileCopyService.cp_noreplace(
+            source.to_s,
+            destination.to_s,
+            root: @library_root.to_s
+          )
+          :published
+        rescue Errno::EEXIST
+          :occupied
+        end
+      end
+      sources.size.times { ready.pop }
+      sources.size.times { release << true }
+      sources.size.times { publishing.pop }
+      sources.size.times { publish << true }
+      workers.map(&:value)
+    end
 
     assert_equal [ :occupied, :published ], outcomes.sort
     assert_includes sources.map(&:binread), destination.binread
     assert_no_publication_artifacts
   ensure
+    workers&.size&.times do
+      release << true
+      publish << true
+    end
     workers&.each { |worker| worker.join if worker.alive? }
   end
 
@@ -141,8 +162,7 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
         source.to_s,
         destination.to_s,
         root: @library_root.to_s,
-        hardlink_mode: true,
-        allow_compatibility_fallback: true
+        hardlink_mode: true
       )
       false
     end
@@ -177,38 +197,100 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
     destination = @library_root.join("move.epub")
     content = SecureRandom.random_bytes(24_576)
     source.binwrite(content)
-    source_snapshot = FileCopyService.snapshot_source_file(source.to_s)
 
-    FileCopyService.cp_noreplace(
-      source.to_s,
-      destination.to_s,
-      root: @library_root.to_s,
-      source_snapshot: source_snapshot,
-      allow_compatibility_fallback: true,
-      require_durable: true
-    )
-    destination_snapshot = FileCopyService.verified_library_file_snapshot(
-      source.to_s,
-      destination.to_s,
-      root: @library_root.to_s,
-      source_snapshot: source_snapshot,
-      require_durable: true
-    )
-    assert destination_snapshot
-
-    removed = FileCopyService.remove_source_file(
-      source_snapshot,
-      destination_snapshot: destination_snapshot
-    )
-    if removed
-      assert_not source.exist?
-    else
+    if cifs_profile?
+      error = assert_raises(Errno::ESTALE) do
+        FileCopyService.mv_noreplace(
+          source.to_s,
+          destination.to_s,
+          root: @library_root.to_s
+        )
+      end
+      assert_match(/source changed after no-clobber move/, error.message)
       assert_equal content, source.binread
+    else
+      FileCopyService.mv_noreplace(
+        source.to_s,
+        destination.to_s,
+        root: @library_root.to_s
+      )
+      assert_not source.exist?
     end
 
     assert_equal content, destination.binread
     assert_no_publication_artifacts
     assert_empty Dir.children(@source_root).grep(/\A\.shelfarr-/)
+  end
+
+  test "moves a local source into the mounted library and removes the source" do
+    local_root = Pathname(Dir.mktmpdir("shelfarr-local-source-"))
+    source = local_root.join("local.epub")
+    destination = @library_root.join("local.epub")
+    content = SecureRandom.random_bytes(24_576)
+    source.binwrite(content)
+
+    FileCopyService.mv_noreplace(
+      source.to_s,
+      destination.to_s,
+      root: @library_root.to_s
+    )
+
+    assert_not source.exist?
+    assert_equal content, destination.binread
+    assert_no_publication_artifacts
+  ensure
+    FileUtils.rm_rf(local_root) if local_root
+  end
+
+  test "recovers interrupted publication artifacts in a nested library directory" do
+    nested = @library_root.join("Author", "Book")
+    FileUtils.mkdir_p(nested)
+    token = SecureRandom.hex(16)
+    temporary = nested.join(".shelfarr-copy-#{token}.tmp")
+    lock = nested.join(".shelfarr-copy-#{token}.lock")
+    temporary.binwrite("partial publication")
+    temporary_stat = temporary.stat
+    lock.binwrite(
+      "#{FileCopyService::COPY_LOCK_MAGIC}:#{token}:full:" \
+        "#{temporary_stat.dev}:#{temporary_stat.ino}"
+    )
+
+    if cifs_noserverino_profile?
+      error = assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+        FileCopyService.cleanup_interrupted_copies(nested.to_s, root: @library_root.to_s)
+      end
+      assert_match(/manual cleanup/, error.message)
+      assert temporary.exist?
+      assert lock.exist?
+      assert_equal "partial publication", temporary.binread
+      retry_source = @source_root.join("retry.txt")
+      retry_source.binwrite("retry bytes")
+      entries = Dir.children(nested)
+      assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+        FileCopyService.cp_noreplace(
+          retry_source.to_s,
+          nested.join("retry.txt").to_s,
+          root: @library_root.to_s
+        )
+      end
+      assert_equal entries.sort, Dir.children(nested).sort
+    elsif cifs_profile?
+      FileCopyService.cleanup_interrupted_copies(nested.to_s, root: @library_root.to_s)
+      assert_not temporary.exist?
+      assert_not lock.exist?
+      quarantines = Dir.glob(nested.join(".shelfarr-copy-quarantine-*").to_s)
+      assert_equal 1, quarantines.size
+      assert_empty Dir.children(quarantines.sole)
+      stale_time = Time.now - FileCopyService::COPY_QUARANTINE_STALE_AGE - 60
+      File.utime(stale_time, stale_time, quarantines.sole)
+      FileCopyService.cleanup_interrupted_copies(nested.to_s, root: @library_root.to_s)
+      assert_no_publication_artifacts
+    else
+      FileCopyService.cleanup_interrupted_copies(nested.to_s, root: @library_root.to_s)
+      assert_not temporary.exist?
+      assert_not lock.exist?
+      assert_no_publication_artifacts
+    end
   end
 
   test "private file locks exclude a second process" do
@@ -260,11 +342,69 @@ class FileCopyServiceContractTest < ActiveSupport::TestCase
     end
   end
 
+  test "service-specific interrupted attempts are reclaimed or block retries" do
+    staging = @library_root.join("private-attempts")
+    FileUtils.mkdir_p(staging)
+    owner_token = UploadImportFileService.send(:filesystem_owner_token)
+    upload_id = 42
+    upload_attempt = staging.join("upload_#{upload_id}-#{owner_token}-#{"a" * 32}.tmp")
+    libation_basename = "libation_42.m4b"
+    libation_attempt = staging.join(
+      ".#{libation_basename}.#{owner_token}.#{"b" * 32}.tmp"
+    )
+    upload_attempt.binwrite("upload attempt")
+    libation_attempt.binwrite("libation attempt")
+    upload = Struct.new(:id).new(upload_id)
+    upload_service = UploadImportFileService.allocate
+    upload_service.instance_variable_set(:@upload, upload)
+    libation_pattern = /\A\.#{Regexp.escape(libation_basename)}\.#{Regexp.escape(owner_token)}\.[0-9a-f]{32}\.tmp\z/
+
+    staging.open(File::RDONLY | File::NOFOLLOW | File::NONBLOCK) do |directory|
+      if cifs_noserverino_profile?
+        upload_error = assert_raises(UploadImportFileService::Error) do
+          upload_service.send(:reclaim_interrupted_private_attempts!, directory)
+        end
+        libation_error = assert_raises(OwnedMediaImportFileService::Error) do
+          OwnedMediaImportFileService.send(
+            :reclaim_interrupted_copy_attempts!,
+            directory,
+            libation_pattern
+          )
+        end
+        assert_match(/manual cleanup/, upload_error.message)
+        assert_match(/manual cleanup/, libation_error.message)
+        assert upload_attempt.exist?
+        assert libation_attempt.exist?
+      else
+        upload_service.send(:reclaim_interrupted_private_attempts!, directory)
+        OwnedMediaImportFileService.send(
+          :reclaim_interrupted_copy_attempts!,
+          directory,
+          libation_pattern
+        )
+        sleep 2 if cifs_profile? # Let the configured one-second attribute cache expire.
+        assert_not upload_attempt.exist?
+        assert_not libation_attempt.exist?
+      end
+    end
+  end
+
   private
 
   def assert_no_publication_artifacts
-    artifacts = Dir.children(@library_root).grep(/\A\.shelfarr-/)
+    artifacts = Dir.glob(
+      File.join(@library_root, "**", ".shelfarr-*"),
+      File::FNM_DOTMATCH
+    )
     assert_empty artifacts
+  end
+
+  def cifs_profile?
+    ENV.fetch("SHELFARR_FILESYSTEM_CONTRACT_PROFILE", "").start_with?("cifs-")
+  end
+
+  def cifs_noserverino_profile?
+    ENV["SHELFARR_FILESYSTEM_CONTRACT_PROFILE"] == "cifs-noserverino"
   end
 
   def report_contract_profile_once

--- a/test/filesystem_contracts/samba.Dockerfile
+++ b/test/filesystem_contracts/samba.Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 FROM docker.io/library/debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 RUN apt-get update -qq && \

--- a/test/filesystem_contracts/samba.Dockerfile
+++ b/test/filesystem_contracts/samba.Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y samba smbclient && \
+    useradd --uid 1000 --no-create-home --shell /usr/sbin/nologin shelfarr && \
+    printf 'shelfarr-test\nshelfarr-test\n' | smbpasswd -a -s shelfarr && \
+    mkdir /share && \
+    chown shelfarr:shelfarr /share && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+COPY test/filesystem_contracts/smb.conf /etc/samba/smb.conf
+
+EXPOSE 445
+
+CMD ["smbd", "--foreground", "--no-process-group", "--debug-stdout", "--debuglevel=1"]

--- a/test/filesystem_contracts/smb.conf
+++ b/test/filesystem_contracts/smb.conf
@@ -1,0 +1,24 @@
+[global]
+   server role = standalone server
+   security = user
+   map to guest = never
+   server min protocol = SMB2_10
+   server max protocol = SMB3
+   smb ports = 445
+   disable spoolss = yes
+   load printers = no
+   printing = bsd
+   printcap name = /dev/null
+   log file = /dev/stdout
+   max log size = 0
+
+[contracts]
+   path = /share
+   valid users = shelfarr
+   read only = no
+   browseable = yes
+   force user = shelfarr
+   create mask = 0777
+   force create mode = 0600
+   directory mask = 0777
+   force directory mode = 0700

--- a/test/jobs/cleanup_temp_files_job_test.rb
+++ b/test/jobs/cleanup_temp_files_job_test.rb
@@ -242,6 +242,108 @@ class CleanupTempFilesJobIsolatedTest < ActiveJob::TestCase
     assert_not File.directory?(nested)
   end
 
+  test "actual cleanup reclaims stale randomized ordinary upload attempts" do
+    root = @temp_base.join("ebook-library")
+    SettingsService.set(:ebook_output_path, root.to_s)
+    private_directory = root.join(
+      UploadImportFileService::PRIVATE_DIRECTORY,
+      UploadImportFileService.send(:database_fingerprint)
+    )
+    FileUtils.mkdir_p(private_directory)
+    orphan = private_directory.join(
+      UploadImportFileService.send(:private_attempt_basename, 42)
+    )
+    File.binwrite(orphan, "crash-left bytes")
+    FileUtils.touch(orphan, mtime: 25.hours.ago.to_time)
+
+    CleanupTempFilesJob.new.send(:cleanup_upload_temps)
+
+    assert_not orphan.exist?
+  end
+
+  test "ordinary upload cleanup preserves persistent locks and unknown files" do
+    private_directory = @temp_base.join("ordinary-staging")
+    locks_directory = private_directory.join(UploadImportFileService::LOCKS_DIRECTORY)
+    FileUtils.mkdir_p(locks_directory)
+    lock_path = locks_directory.join("lock-0001")
+    unknown = private_directory.join("unrecognized.tmp")
+    foreign_attempt = private_directory.join("upload_42-#{"f" * 32}-#{"a" * 32}.tmp")
+    File.binwrite(lock_path, "")
+    File.binwrite(unknown, "unknown bytes")
+    File.binwrite(foreign_attempt, "foreign attempt")
+    FileUtils.touch([ lock_path, unknown, foreign_attempt ], mtime: 25.hours.ago.to_time)
+    lock = File.open(lock_path, "r+")
+    assert lock.flock(File::LOCK_EX | File::LOCK_NB)
+    lock_identity = [ lock.stat.dev, lock.stat.ino ]
+
+    deleted = CleanupTempFilesJob.new.send(
+      :cleanup_ordinary_upload_directory,
+      private_directory,
+      root: @temp_base,
+      max_age: 24.hours.ago,
+      protected_paths: Set.new
+    )
+
+    assert_equal 0, deleted
+    assert_equal lock_identity, [ File.stat(lock_path).dev, File.stat(lock_path).ino ]
+    assert_equal "unknown bytes", File.binread(unknown)
+    assert_equal "foreign attempt", File.binread(foreign_attempt)
+  ensure
+    lock&.close
+  end
+
+  test "ordinary upload cleanup refuses a replaced staging directory" do
+    private_directory = @temp_base.join("ordinary-staging")
+    displaced_directory = @temp_base.join("displaced-staging")
+    replacement_directory = @temp_base.join("replacement-staging")
+    FileUtils.mkdir_p([ private_directory, replacement_directory ])
+    basename = UploadImportFileService.send(:private_attempt_basename, 42)
+    original = private_directory.join(basename)
+    replacement = replacement_directory.join(basename)
+    File.binwrite(original, "original orphan")
+    File.binwrite(replacement, "unrelated replacement")
+    FileUtils.touch([ original, replacement ], mtime: 25.hours.ago.to_time)
+    real_remove = FileCopyService.method(:remove_regular_file_safely)
+    swap_directory = lambda do |path, **options|
+      File.rename(private_directory, displaced_directory)
+      File.symlink(replacement_directory, private_directory)
+      real_remove.call(path, **options)
+    end
+
+    deleted = FileCopyService.stub(:remove_regular_file_safely, swap_directory) do
+      CleanupTempFilesJob.new.send(
+        :cleanup_ordinary_upload_directory,
+        private_directory,
+        root: @temp_base,
+        max_age: 24.hours.ago,
+        protected_paths: Set.new
+      )
+    end
+
+    assert_equal 0, deleted
+    assert_equal "original orphan", File.binread(displaced_directory.join(basename))
+    assert_equal "unrelated replacement", File.binread(replacement)
+  end
+
+  test "ordinary upload cleanup rejects a staging symlink below the configured root" do
+    root = @temp_base.join("ebook-library")
+    external = @temp_base.join("external-staging")
+    fingerprint = UploadImportFileService.send(:database_fingerprint)
+    external_private = external.join(fingerprint)
+    FileUtils.mkdir_p([ root, external_private ])
+    File.symlink(external, root.join(UploadImportFileService::PRIVATE_DIRECTORY))
+    orphan = external_private.join(
+      UploadImportFileService.send(:private_attempt_basename, 42)
+    )
+    File.binwrite(orphan, "external bytes")
+    FileUtils.touch(orphan, mtime: 25.hours.ago.to_time)
+    SettingsService.set(:ebook_output_path, root.to_s)
+
+    CleanupTempFilesJob.new.send(:cleanup_upload_temps)
+
+    assert_equal "external bytes", File.binread(orphan)
+  end
+
   test "actual cleanup preserves nested files used by active uploads" do
     nested = @uploads_dir.join("database-fingerprint")
     FileUtils.mkdir_p(nested)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -654,7 +654,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
       PostProcessingJob.perform_now(@download.id)
     end
 
-    assert @request.reload.completed?
+    assert @request.reload.completed?, @request.issue_description
     assert_equal Pathname(source).expand_path.to_s, File.readlink(referenced)
     assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
   end
@@ -1078,7 +1078,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal "long-name audio", File.read(File.join(long_title_destination, duplicate_filename))
   end
 
-  test "publishes split imports when the destination filesystem rejects atomic publication" do
+  test "retains split imports when the destination filesystem rejects atomic publication" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
     @book.update!(title: "Book Two")
@@ -1094,9 +1094,12 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
     book_one_destination = File.join(@temp_dest_base, @book.author, "Book One", "Book One.m4b")
     book_two_destination = File.join(@temp_dest_base, @book.author, "Book Two", "Book Two.m4b")
-    assert @request.reload.completed?
-    assert_equal "book one audio", File.read(book_one_destination)
-    assert_equal "book two audio", File.read(book_two_destination)
+    assert @request.reload.attention_needed?
+    assert_match(/safe filesystem operation failed/i, @request.issue_description)
+    assert_not File.exist?(book_one_destination)
+    assert_not File.exist?(book_two_destination)
+    assert_equal "book one audio", File.read(File.join(@temp_source, "Book One.m4b"))
+    assert_equal "book two audio", File.read(File.join(@temp_source, "Book Two.m4b"))
   end
 
   test "does not overwrite a concurrent file when atomic publication is unavailable" do
@@ -1121,9 +1124,12 @@ class PostProcessingJobTest < ActiveJob::TestCase
       end
     end
 
-    assert @request.reload.completed?
+    assert @request.reload.attention_needed?
+    assert_match(/safe filesystem operation failed/i, @request.issue_description)
     assert_equal "concurrent file", File.read(File.join(book_one_destination, "Book One.m4b"))
-    assert_equal "book one audio", File.read(File.join(book_one_destination, "Book One (2).m4b"))
+    assert_not File.exist?(File.join(book_one_destination, "Book One (2).m4b"))
+    assert_equal "book one audio", File.read(File.join(@temp_source, "Book One.m4b"))
+    assert_equal "book two audio", File.read(File.join(@temp_source, "Book Two.m4b"))
   end
 
   test "reclaims interrupted temporary files after publication completed" do
@@ -1395,7 +1401,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal 0o600, File.stat(destination).mode & 0o777
   end
 
-  test "single-file ebook copy supports synthetic Windows ACL modes and compatibility publication" do
+  test "single-file ebook copy fails closed without atomic publication on synthetic Windows ACL modes" do
     source_file = File.join(@temp_source, "Original.epub")
     write_valid_ebook_file(source_file)
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
@@ -1410,14 +1416,13 @@ class PostProcessingJobTest < ActiveJob::TestCase
       end
     end
 
-    destination = Dir.glob(File.join(@temp_dest_base, @book.author, @book.title, "*.epub")).sole
-    assert @request.reload.completed?
-    assert_equal "PK\x03\x04valid ebook content", File.binread(destination)
-    assert_equal 0o666, File.stat(destination).mode & 0o7777
-    assert_equal 0o777, File.stat(File.dirname(destination)).mode & 0o7777
+    assert @request.reload.attention_needed?
+    assert_match(/safe filesystem operation failed/i, @request.issue_description)
+    assert_empty Dir.glob(File.join(@temp_dest_base, @book.author, @book.title, "*.epub"))
+    assert_equal "PK\x03\x04valid ebook content", File.binread(source_file)
   end
 
-  test "recursive audiobook copy supports synthetic Windows ACL modes and compatibility publication" do
+  test "recursive audiobook copy fails closed without atomic publication on synthetic Windows ACL modes" do
     nested_source = File.join(@temp_source, "Disc One")
     FileUtils.mkdir_p(nested_source)
     FileUtils.mv(File.join(@temp_source, "audiobook.mp3"), File.join(nested_source, "chapter.mp3"))
@@ -1430,10 +1435,10 @@ class PostProcessingJobTest < ActiveJob::TestCase
     end
 
     destination = File.join(@temp_dest_base, @book.author, @book.title, "Disc One", "chapter.mp3")
-    assert @request.reload.completed?
-    assert_equal "test audio content", File.binread(destination)
-    assert_equal 0o644, File.stat(destination).mode & 0o7777
-    assert_equal 0o755, File.stat(File.dirname(destination)).mode & 0o7777
+    assert @request.reload.attention_needed?
+    assert_match(/safe filesystem operation failed/i, @request.issue_description)
+    assert_not File.exist?(destination)
+    assert_equal "test audio content", File.binread(File.join(nested_source, "chapter.mp3"))
   end
 
   test "imports through a pre-existing shared author directory without changing its mode" do

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -554,19 +554,19 @@ class PostProcessingJobTest < ActiveJob::TestCase
     source_file = File.join(@temp_source, "audiobook.mp3")
     destination = File.join(@temp_dest_base, @book.author, @book.title)
     destination_file = File.join(destination, "audiobook.mp3")
-    real_publish = FileCopyService.method(:publish_private_child_noreplace!)
+    real_publish = FileCopyService.method(:publish_private_child_atomically_noreplace!)
     raced = false
 
     output = FileCopyService.stub(
-      :publish_private_child_noreplace!,
-      ->(parent, temporary, basename, identity, mode: FileCopyService::LIBRARY_FILE_MODE) {
+      :publish_private_child_atomically_noreplace!,
+      ->(parent, temporary, basename) {
         unless raced
           raced = true
           File.binwrite(File.join(destination, basename), "test audio content")
           raise Errno::EEXIST, basename
         end
 
-        real_publish.call(parent, temporary, basename, identity, mode: mode)
+        real_publish.call(parent, temporary, basename)
       }
     ) do
       FileCopyService.stub(:secure_library_file!, ->(*) { flunk "Hardlink-mode reuse must never chmod the destination" }) do
@@ -1036,18 +1036,18 @@ class PostProcessingJobTest < ActiveJob::TestCase
     FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
     File.write(File.join(@temp_source, "Book One.m4b"), "book one audio")
     File.write(File.join(@temp_source, "Book Two.m4b"), "book two audio")
-    real_publish = FileCopyService.method(:publish_private_child_noreplace!)
+    real_publish = FileCopyService.method(:publish_private_child_atomically_noreplace!)
     publish_race = true
     book_one_destination = File.join(@temp_dest_base, @book.author, "Book One")
 
-    FileCopyService.stub(:publish_private_child_noreplace!, ->(parent, source, destination, identity) {
+    FileCopyService.stub(:publish_private_child_atomically_noreplace!, ->(parent, source, destination) {
       if publish_race
         publish_race = false
         File.write(File.join(book_one_destination, destination), "concurrent file")
         raise Errno::EEXIST, destination
       end
 
-      real_publish.call(parent, source, destination, identity)
+      real_publish.call(parent, source, destination)
     }) do
       PostProcessingJob.perform_now(@download.id)
     end
@@ -1099,7 +1099,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal "book two audio", File.read(book_two_destination)
   end
 
-  test "does not overwrite a concurrent file when hard-link publication is unavailable" do
+  test "does not overwrite a concurrent file when atomic publication is unavailable" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)
     @book.update!(title: "Book Two")
@@ -1109,14 +1109,16 @@ class PostProcessingJobTest < ActiveJob::TestCase
     publish_race = true
     book_one_destination = File.join(@temp_dest_base, @book.author, "Book One")
 
-    FileCopyService.stub(:native_linkat, ->(_source_fd, _source, _destination_fd, destination) {
-      if publish_race
-        publish_race = false
-        File.write(File.join(book_one_destination, destination), "concurrent file")
+    FileCopyService.stub(:native_rename_noreplace, false) do
+      FileCopyService.stub(:native_linkat, ->(_source_fd, _source, _destination_fd, destination) {
+        if publish_race
+          publish_race = false
+          File.write(File.join(book_one_destination, destination), "concurrent file")
+        end
+        raise Errno::EOPNOTSUPP, "hard links unavailable"
+      }) do
+        PostProcessingJob.perform_now(@download.id)
       end
-      raise Errno::EOPNOTSUPP, "hard links unavailable"
-    }) do
-      PostProcessingJob.perform_now(@download.id)
     end
 
     assert @request.reload.completed?

--- a/test/lib/filesystem_syscalls_test.rb
+++ b/test/lib/filesystem_syscalls_test.rb
@@ -29,6 +29,37 @@ class FilesystemSyscallsTest < ActiveSupport::TestCase
     assert_equal 0o600, File.stat(path).mode & 0o777
   end
 
+  test "openat passes the mode required by O_TMPFILE" do
+    skip "O_TMPFILE is unavailable on this platform" unless File.const_defined?(:TMPFILE)
+
+    descriptor = FilesystemSyscalls.openat(
+      @directory.fileno,
+      ".",
+      flags: File::RDWR | File::TMPFILE,
+      mode: 0o600
+    )
+    file = IO.new(descriptor, "w+b", autoclose: true)
+
+    assert_equal 0o600, file.stat.mode & 0o777
+  rescue Errno::EOPNOTSUPP, Errno::EINVAL
+    skip "The test filesystem does not support O_TMPFILE"
+  ensure
+    file&.close unless file&.closed?
+  end
+
+  test "path operations reject embedded null bytes" do
+    assert_raises(ArgumentError) do
+      FilesystemSyscalls.openat(
+        @directory.fileno,
+        "prefix\0suffix",
+        flags: File::WRONLY | File::CREAT | File::EXCL | File::NOFOLLOW,
+        mode: 0o600
+      )
+    end
+
+    assert_not File.exist?(File.join(@temporary_directory, "prefix"))
+  end
+
   test "rename_noreplace publishes once without replacing an existing path" do
     File.binwrite(File.join(@temporary_directory, "source.txt"), "source")
 
@@ -53,7 +84,27 @@ class FilesystemSyscallsTest < ActiveSupport::TestCase
     assert_equal "second", File.binread(File.join(@temporary_directory, "second.txt"))
   end
 
+  test "rename_noreplace preserves invalid topology errors" do
+    parent = File.join(@temporary_directory, "parent")
+    child = File.join(parent, "child")
+    FileUtils.mkdir_p(child)
+    child_directory = File.open(child, File::RDONLY | File::NONBLOCK)
+
+    assert_raises(Errno::EINVAL) do
+      FilesystemSyscalls.rename_noreplace(
+        @directory.fileno,
+        "parent",
+        child_directory.fileno,
+        "moved"
+      )
+    end
+  ensure
+    child_directory&.close unless child_directory&.closed?
+  end
+
   test "ftruncate preserves lengths beyond a signed 32-bit offset" do
+    skip "Shelfarr supports 64-bit filesystem offsets" if Fiddle::SIZEOF_LONG < 8
+
     descriptor = FilesystemSyscalls.openat(
       @directory.fileno,
       "sparse.bin",

--- a/test/lib/filesystem_syscalls_test.rb
+++ b/test/lib/filesystem_syscalls_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilesystemSyscallsTest < ActiveSupport::TestCase
+  setup do
+    @temporary_directory = Dir.mktmpdir("filesystem-syscalls-test")
+    @directory = File.open(@temporary_directory, File::RDONLY | File::NONBLOCK)
+  end
+
+  teardown do
+    @directory.close unless @directory.closed?
+    FileUtils.remove_entry(@temporary_directory)
+  end
+
+  test "openat creates a file with the supplied mode" do
+    descriptor = FilesystemSyscalls.openat(
+      @directory.fileno,
+      "created.txt",
+      flags: File::WRONLY | File::CREAT | File::EXCL | File::NOFOLLOW,
+      mode: 0o600
+    )
+    file = IO.new(descriptor, "wb", autoclose: true)
+    file.write("content")
+    file.close
+
+    path = File.join(@temporary_directory, "created.txt")
+    assert_equal "content", File.binread(path)
+    assert_equal 0o600, File.stat(path).mode & 0o777
+  end
+
+  test "rename_noreplace publishes once without replacing an existing path" do
+    File.binwrite(File.join(@temporary_directory, "source.txt"), "source")
+
+    published = FilesystemSyscalls.rename_noreplace(
+      @directory.fileno,
+      "source.txt",
+      @directory.fileno,
+      "destination.txt"
+    )
+    skip "No native no-replace rename is available on this platform" unless published
+
+    File.binwrite(File.join(@temporary_directory, "second.txt"), "second")
+    assert_raises(Errno::EEXIST) do
+      FilesystemSyscalls.rename_noreplace(
+        @directory.fileno,
+        "second.txt",
+        @directory.fileno,
+        "destination.txt"
+      )
+    end
+    assert_equal "source", File.binread(File.join(@temporary_directory, "destination.txt"))
+    assert_equal "second", File.binread(File.join(@temporary_directory, "second.txt"))
+  end
+
+  test "ftruncate preserves lengths beyond a signed 32-bit offset" do
+    descriptor = FilesystemSyscalls.openat(
+      @directory.fileno,
+      "sparse.bin",
+      flags: File::WRONLY | File::CREAT | File::EXCL | File::NOFOLLOW,
+      mode: 0o600
+    )
+    file = IO.new(descriptor, "wb", autoclose: true)
+    length = (2**31) + 1
+    FilesystemSyscalls.ftruncate(file.fileno, length)
+
+    assert_equal length, file.stat.size
+  ensure
+    file&.close unless file&.closed?
+  end
+end

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -310,14 +310,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       fchmod_error: Errno::EOPNOTSUPP
     ) do
       FileCopyService.ensure_directory(directory, root: @dest_dir)
-      without_atomic_file_publication do
-        FileCopyService.cp_noreplace(
-          @src_file,
-          destination,
-          root: @dest_dir,
-          allow_compatibility_fallback: true
-        )
-      end
+      FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
     end
 
     assert_equal "test content", File.binread(destination)
@@ -325,7 +318,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal 0o775, File.stat(destination).mode & 0o7777
   end
 
-  test "cp_noreplace supports synthetic Windows ACL modes and compatibility publication" do
+  test "cp_noreplace supports synthetic Windows ACL modes" do
     destination = File.join(@dest_dir, "windows-mode.txt")
 
     with_synthetic_library_modes(
@@ -334,14 +327,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       directory_mode: 0o777,
       fchmod_error: Errno::EOPNOTSUPP
     ) do
-      without_atomic_file_publication do
-        FileCopyService.cp_noreplace(
-          @src_file,
-          destination,
-          root: @dest_dir,
-          allow_compatibility_fallback: true
-        )
-      end
+      FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
     end
 
     assert_equal "test content", File.binread(destination)
@@ -422,29 +408,16 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal "other bytes!", File.binread(@src_file)
   end
 
-  test "cp_noreplace uses exclusive copy when atomic publication is unsupported" do
+  test "cp_noreplace fails closed when atomic publication is unsupported" do
     destination = File.join(@dest_dir, "compatible.txt")
 
     without_atomic_file_publication do
-      FileCopyService.cp_noreplace(
-        @src_file,
-        destination,
-        root: @dest_dir,
-        allow_compatibility_fallback: true
-      )
-    end
-
-    assert_equal "test content", File.binread(destination)
-    assert_equal 0o640, File.stat(destination).mode & 0o777
-    assert_empty Dir.children(@dest_dir) - [ "compatible.txt" ]
-  end
-
-  test "cp_noreplace remains strict unless compatibility publication is enabled" do
-    destination = File.join(@dest_dir, "strict.txt")
-
-    without_atomic_file_publication do
       assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
-        FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+        FileCopyService.cp_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir
+        )
       end
     end
 
@@ -453,7 +426,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_empty Dir.children(@dest_dir)
   end
 
-  test "compatibility publication never overwrites an occupied destination" do
+  test "failed atomic publication never overwrites an occupied destination" do
     destination = File.join(@dest_dir, "occupied.txt")
     raced = false
 
@@ -467,12 +440,11 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     FileCopyService.stub(:native_linkat, unsupported_link) do
       FileCopyService.stub(:native_rename_noreplace, false) do
-        assert_raises(Errno::EEXIST) do
+        assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
           FileCopyService.cp_noreplace(
             @src_file,
             destination,
-            root: @dest_dir,
-            allow_compatibility_fallback: true
+            root: @dest_dir
           )
         end
       end
@@ -483,7 +455,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal [ "occupied.txt" ], Dir.children(@dest_dir)
   end
 
-  test "compatibility publication removes an interrupted partial destination" do
+  test "failed atomic publication never starts a direct destination copy" do
     destination = File.join(@dest_dir, "partial.txt")
     real_copy = FileCopyService.method(:copy_source_io)
     copy_calls = 0
@@ -500,38 +472,38 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     FileCopyService.stub(:copy_source_io, interrupted_copy) do
       without_atomic_file_publication do
-        assert_raises(IOError) do
+        assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
           FileCopyService.cp_noreplace(
             @src_file,
             destination,
-            root: @dest_dir,
-            allow_compatibility_fallback: true
+            root: @dest_dir
           )
         end
       end
     end
 
-    assert_equal 2, copy_calls
+    assert_equal 1, copy_calls
     assert_not File.exist?(destination)
     assert_equal "test content", File.binread(@src_file)
     assert_empty Dir.children(@dest_dir)
   end
 
-  test "mv_noreplace removes its source after compatibility publication" do
+  test "mv_noreplace retains its source when atomic publication is unsupported" do
     destination = File.join(@dest_dir, "moved-compatible.txt")
 
     without_atomic_file_publication do
-      FileCopyService.mv_noreplace(
-        @src_file,
-        destination,
-        root: @dest_dir,
-        allow_compatibility_fallback: true
-      )
+      assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+        FileCopyService.mv_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir
+        )
+      end
     end
 
-    assert_not File.exist?(@src_file)
-    assert_equal "test content", File.binread(destination)
-    assert_empty Dir.children(@dest_dir) - [ "moved-compatible.txt" ]
+    assert_equal "test content", File.binread(@src_file)
+    assert_not File.exist?(destination)
+    assert_empty Dir.children(@dest_dir)
   end
 
   test "mv_noreplace retains its source when file fsync is unsupported" do
@@ -800,62 +772,93 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(outside_dest)
   end
 
-  test "cp_noreplace falls back to exclusive copy when rename is unavailable and linkat returns EINVAL" do
+  test "cp_noreplace fails closed when rename is unavailable and linkat returns EINVAL" do
     # CIFS/SMB often returns EINVAL for unsupported hardlinks instead of
-    # EOPNOTSUPP. Compatibility publication must still copy into place.
+    # EOPNOTSUPP. It must still fail without exposing a partial destination.
     destination = File.join(@dest_dir, "cifs-einval.txt")
 
     FileCopyService.stub(:native_rename_noreplace, false) do
       FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EINVAL }) do
-        FileCopyService.cp_noreplace(
-          @src_file,
-          destination,
-          root: @dest_dir,
-          allow_compatibility_fallback: true
-        )
+        assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+          FileCopyService.cp_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir
+          )
+        end
       end
     end
 
-    assert_equal "test content", File.binread(destination)
-    assert_equal 0o640, File.stat(destination).mode & 0o777
-    assert_empty Dir.children(@dest_dir) - [ "cifs-einval.txt" ]
+    assert_not File.exist?(destination)
+    assert_equal "test content", File.binread(@src_file)
+    assert_empty Dir.children(@dest_dir)
   end
 
-  test "cp_noreplace survives a successful link that cannot be reopened" do
+  test "cp_noreplace fails closed when an unreliable filesystem cannot rename" do
     destination = File.join(@dest_dir, "cifs-false-success.txt")
+
+    error = FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+      FileCopyService.stub(:native_rename_noreplace, false) do
+        FileCopyService.stub(:native_linkat, ->(*) { flunk "An unreliable mount must not publish by link" }) do
+          assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+            FileCopyService.cp_noreplace(
+              @src_file,
+              destination,
+              root: @dest_dir
+            )
+          end
+        end
+      end
+    end
+
+    assert_match(/cannot atomically publish/, error.message)
+    assert_not File.exist?(destination)
+    assert_equal "test content", File.binread(@src_file)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "cp_noreplace classifies an unusable linked destination as ambiguous" do
+    destination = File.join(@dest_dir, "ambiguous-link.txt")
     destination_basename = File.basename(destination)
     real_link = FileCopyService.method(:native_linkat)
     real_open = FileCopyService.method(:native_openat)
-    linked_destination = false
+    linked = false
     rejected_open = false
-
     linking = lambda do |source_fd, source_name, destination_fd, destination_name|
-      result = real_link.call(source_fd, source_name, destination_fd, destination_name)
-      linked_destination = true if destination_name == destination_basename
-      result
+      real_link.call(source_fd, source_name, destination_fd, destination_name).tap do
+        linked = true if destination_name == destination_basename
+      end
     end
     opening = lambda do |directory_fd, basename, flags, mode|
-      if linked_destination && !rejected_open && basename == destination_basename
+      if linked && !rejected_open && basename == destination_basename
         rejected_open = true
-        raise Errno::EINVAL, "simulated CIFS post-link open failure"
+        raise Errno::EINVAL, "simulated CIFS reopen failure"
       end
 
       real_open.call(directory_fd, basename, flags, mode)
     end
 
-    FileCopyService.stub(:native_linkat, linking) do
-      FileCopyService.stub(:native_openat, opening) do
-        FileCopyService.cp_noreplace(
-          @src_file,
-          destination,
-          root: @dest_dir,
-          allow_compatibility_fallback: true
-        )
+    error = FileCopyService.stub(:hardlink_identity_unreliable?, false) do
+      FileCopyService.stub(:native_rename_noreplace, false) do
+        FileCopyService.stub(:native_linkat, linking) do
+          FileCopyService.stub(:native_openat, opening) do
+            assert_raises(FileCopyService::AmbiguousPublicationError) do
+              FileCopyService.cp_noreplace(
+                @src_file,
+                destination,
+                root: @dest_dir
+              )
+            end
+          end
+        end
       end
     end
 
+    assert linked
+    assert rejected_open
+    assert_match(/could not be verified after publication/, error.message)
     assert_equal "test content", File.binread(destination)
-    assert_empty Dir.children(@dest_dir) - [ "cifs-false-success.txt" ]
+    assert_empty Dir.children(@dest_dir) - [ destination_basename ]
   end
 
   test "hardlink_noreplace classifies only initial unsupported link errors" do
@@ -969,6 +972,8 @@ class FileCopyServiceTest < ActiveSupport::TestCase
         end
 
         assert_match(/stable hardlink identities/, error.message)
+        assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-hardlink-probe-*.tmp")).size
+        assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
       end
     end
 
@@ -1327,6 +1332,51 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(temporary)
     assert_not File.exist?(lock)
     assert_not File.exist?(quarantine)
+  end
+
+  test "cleanup_interrupted_copies retains quarantines when mount identities are unreliable" do
+    token = "f" * 32
+    temporary = File.join(@dest_dir, ".shelfarr-copy-#{token}.tmp")
+    File.binwrite(temporary, "interrupted bytes")
+    temporary_stat = File.stat(temporary)
+    lock = write_copy_lock(token, temporary_stat)
+    File.chmod(0o644, lock)
+    quarantine = copy_quarantine_path(temporary_stat, "a" * 32)
+    Dir.mkdir(quarantine, 0o700)
+    entry = File.join(quarantine, FileCopyService::COPY_QUARANTINE_ENTRY)
+    File.rename(temporary, entry)
+
+    output = StringIO.new
+    logger = ActiveSupport::Logger.new(output)
+    Rails.stub(:logger, logger) do
+      FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+        assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+          FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+        end
+      end
+    end
+
+    assert_equal "interrupted bytes", File.binread(entry)
+    assert File.exist?(quarantine)
+    assert File.exist?(lock)
+    assert_equal 0o644, File.stat(lock).mode & 0o777
+    assert_match(/require manual cleanup/, output.string)
+  end
+
+  test "cleanup_interrupted_copies reclaims an identity-tagged discard" do
+    discarded = File.join(@dest_dir, ".shelfarr-discard-placeholder.tmp")
+    File.binwrite(discarded, "discarded bytes")
+    stat = File.stat(discarded)
+    tagged = File.join(
+      @dest_dir,
+      ".shelfarr-discard-#{stat.dev.to_s(16)}-#{stat.ino.to_s(16)}-#{"a" * 32}.tmp"
+    )
+    File.rename(discarded, tagged)
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(tagged)
+    assert_empty Dir.children(@dest_dir)
   end
 
   test "cleanup_interrupted_copies recovers a synthetic-mode quarantine" do
@@ -1738,40 +1788,26 @@ class FileCopyServiceTest < ActiveSupport::TestCase
   test "interrupted cleanup removes a hardlink identity probe before its lock" do
     token = "d" * 32
     lock = write_copy_lock(token, File.stat(@src_file))
-    probe_directory = File.join(@dest_dir, ".shelfarr-hardlink-probe-#{token}")
-    FileUtils.mkdir(probe_directory, mode: 0o700)
-    File.link(lock, File.join(probe_directory, FileCopyService::HARDLINK_PROBE_ENTRY))
+    probe = File.join(@dest_dir, ".shelfarr-hardlink-probe-#{token}.tmp")
+    File.link(lock, probe)
 
     FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
 
-    assert_not File.exist?(probe_directory)
+    assert_not File.exist?(probe)
     assert_not File.exist?(lock)
     assert_empty Dir.children(@dest_dir)
   end
 
-  test "hardlink identity probe cleanup removes an empty directory after a stale child listing" do
-    basename = ".shelfarr-hardlink-probe-#{"e" * 32}"
-    path = File.join(@dest_dir, basename)
-    FileUtils.mkdir(path, mode: 0o700)
-    probe_identity = FileCopyService.send(:file_identity, File.stat(path))
-    real_children = FileCopyService.method(:pinned_directory_children)
-    parent = File.open(@dest_dir, File::RDONLY | File::NONBLOCK)
-    stale_children = lambda do |directory, **options|
-      if FileCopyService.send(:file_identity, directory.stat) == probe_identity
-        [ FileCopyService::HARDLINK_PROBE_ENTRY ]
-      else
-        real_children.call(directory, **options)
-      end
-    end
+  test "interrupted cleanup retains a hardlink probe that is not the validated lock" do
+    token = "e" * 32
+    lock = write_copy_lock(token, File.stat(@src_file))
+    probe = File.join(@dest_dir, ".shelfarr-hardlink-probe-#{token}.tmp")
+    File.binwrite(probe, "replacement probe")
 
-    result = FileCopyService.stub(:pinned_directory_children, stale_children) do
-      FileCopyService.send(:remove_hardlink_probe_directory, parent, basename)
-    end
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
 
-    assert_equal :removed, result
-    assert_not File.exist?(path)
-  ensure
-    parent&.close unless parent&.closed?
+    assert_equal "replacement probe", File.binread(probe)
+    assert File.exist?(lock)
   end
 
   test "completed hardlink cleanup retains symlink and directory temp replacements" do
@@ -1816,7 +1852,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test "interrupted cleanup recovers v2 pending and legacy v1 regular temps" do
+  test "interrupted cleanup retains unverified v2 pending and legacy v1 regular temps" do
     pending_token = "d" * 32
     legacy_token = "e" * 32
     pending_temporary = File.join(@dest_dir, ".shelfarr-copy-#{pending_token}.tmp")
@@ -1830,10 +1866,10 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
 
-    assert_not File.exist?(pending_temporary)
-    assert_not File.exist?(pending_lock)
-    assert_not File.exist?(legacy_temporary)
-    assert_not File.exist?(legacy_lock)
+    assert_equal "pending temp", File.binread(pending_temporary)
+    assert File.exist?(pending_lock)
+    assert_equal "legacy temp", File.binread(legacy_temporary)
+    assert File.exist?(legacy_lock)
   end
 
   test "pending and legacy cleanup retain non-regular token replacements" do
@@ -2915,6 +2951,17 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert FileCopyService.remove_source_file(snapshot)
   end
 
+  test "remove_source_file retains data when filesystem identities are unreliable" do
+    snapshot = FileCopyService.snapshot_source_file(@src_file)
+
+    removed = FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+      FileCopyService.remove_source_file(snapshot)
+    end
+
+    assert_not removed
+    assert_equal "test content", File.binread(@src_file)
+  end
+
   test "remove_source_tree only deletes the exact snapshotted directory" do
     source_root_path = File.join(@tmp_dir, "download")
     FileUtils.mkdir_p(source_root_path)
@@ -2923,6 +2970,34 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     assert FileCopyService.remove_source_tree(snapshot)
     assert_not File.exist?(source_root_path)
+  end
+
+  test "remove_source_tree safely retains the source when no-replace rename returns EINVAL" do
+    source_root_path = File.join(@tmp_dir, "download")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(File.join(source_root_path, "chapter.mp3"), "chapter")
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+
+    removed = FileCopyService.stub(:native_rename_noreplace, ->(*) { raise Errno::EINVAL }) do
+      FileCopyService.remove_source_tree(snapshot)
+    end
+
+    assert_not removed
+    assert_equal "chapter", File.binread(File.join(source_root_path, "chapter.mp3"))
+  end
+
+  test "remove_source_tree retains data when filesystem identities are unreliable" do
+    source_root_path = File.join(@tmp_dir, "download")
+    FileUtils.mkdir_p(source_root_path)
+    File.binwrite(File.join(source_root_path, "chapter.mp3"), "chapter")
+    snapshot = FileCopyService.snapshot_source_root(source_root_path)
+
+    removed = FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+      FileCopyService.remove_source_tree(snapshot)
+    end
+
+    assert_not removed
+    assert_equal "chapter", File.binread(File.join(source_root_path, "chapter.mp3"))
   end
 
   test "remove_source_tree restores a replacement that wins before quarantine" do
@@ -3165,6 +3240,36 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_empty Dir.children(outside)
   end
 
+  test "private file publication never falls back to link on an unreliable mount" do
+    private_file = FileCopyService.create_private_file(
+      @dest_dir,
+      root: @dest_dir,
+      prefix: "archive-",
+      suffix: ".zip"
+    )
+    private_file.io.write("private bytes")
+    destination = File.join(@dest_dir, "published.zip")
+
+    FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+      FileCopyService.stub(:native_rename_noreplace, false) do
+        FileCopyService.stub(:native_linkat, ->(*) { flunk "Unreliable identities must not use linkat" }) do
+          assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+            FileCopyService.publish_private_file_noreplace(
+              private_file,
+              destination,
+              root: @dest_dir
+            )
+          end
+        end
+      end
+    end
+
+    assert File.exist?(private_file.name)
+    assert_not File.exist?(destination)
+  ensure
+    private_file&.io&.close unless private_file&.io&.closed?
+  end
+
   test "identity-scoped directory cleanup preserves a same-path replacement" do
     parent = File.join(@dest_dir, "private-staging")
     FileUtils.mkdir_p(parent)
@@ -3221,6 +3326,35 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal [ "winner.mp3" ], Dir.children(destination)
     assert_equal "winner", File.binread(File.join(destination, "winner.mp3"))
     assert_equal "new", File.binread(File.join(source, "new.mp3"))
+  end
+
+  test "mv_directory_noreplace preserves an EINVAL publication error" do
+    source = File.join(@tmp_dir, "staging-tree")
+    destination = File.join(@dest_dir, "published-tree")
+    FileUtils.mkdir_p(source)
+    File.binwrite(File.join(source, "chapter.mp3"), "chapter")
+
+    FileCopyService.stub(:native_rename_noreplace, ->(*) { raise Errno::EINVAL }) do
+      assert_raises(Errno::EINVAL) do
+        FileCopyService.mv_directory_noreplace(source, destination, root: @dest_dir)
+      end
+    end
+
+    assert File.exist?(source)
+    assert_not File.exist?(destination)
+  end
+
+  test "mv_directory_noreplace preserves invalid descendant topology errors" do
+    source = File.join(@dest_dir, "staging-tree")
+    destination = File.join(source, "nested-destination")
+    FileUtils.mkdir_p(source)
+
+    assert_raises(Errno::EINVAL) do
+      FileCopyService.mv_directory_noreplace(source, destination, root: @dest_dir)
+    end
+
+    assert File.exist?(source)
+    assert_not File.exist?(destination)
   end
 
   test "mv_directory_noreplace retains publication when destination parent is swapped" do

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -916,7 +916,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
           )
         end
 
-        assert_match(/stable hardlink identities/, error.message)
+        assert_match(/safely verify hardlink identities/, error.message)
       end
     end
   end
@@ -935,7 +935,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
           )
         end
 
-        assert_match(/stable hardlink identities/, error.message)
+        assert_match(/safely verify hardlink identities/, error.message)
       end
     end
   end

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -43,7 +43,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
   test "cp_noreplace preserves a destination replacement made during the copy" do
     dest_file = File.join(@dest_dir, "output.txt")
 
-    FileCopyService.stub(:publish_private_child_noreplace!, ->(_parent, _source, destination, _identity) {
+    FileCopyService.stub(:publish_private_child_atomically_noreplace!, ->(_parent, _source, destination) {
       File.binwrite(dest_file, "concurrent replacement")
       raise Errno::EEXIST, destination
     }) do
@@ -800,18 +800,62 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(outside_dest)
   end
 
-  test "cp_noreplace falls back to rename when same-directory linkat returns EINVAL" do
+  test "cp_noreplace falls back to exclusive copy when rename is unavailable and linkat returns EINVAL" do
     # CIFS/SMB often returns EINVAL for unsupported hardlinks instead of
-    # EOPNOTSUPP. Intra-directory publish must still rename into place.
+    # EOPNOTSUPP. Compatibility publication must still copy into place.
     destination = File.join(@dest_dir, "cifs-einval.txt")
 
-    FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EINVAL }) do
-      FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+    FileCopyService.stub(:native_rename_noreplace, false) do
+      FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EINVAL }) do
+        FileCopyService.cp_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          allow_compatibility_fallback: true
+        )
+      end
     end
 
     assert_equal "test content", File.binread(destination)
     assert_equal 0o640, File.stat(destination).mode & 0o777
     assert_empty Dir.children(@dest_dir) - [ "cifs-einval.txt" ]
+  end
+
+  test "cp_noreplace survives a successful link that cannot be reopened" do
+    destination = File.join(@dest_dir, "cifs-false-success.txt")
+    destination_basename = File.basename(destination)
+    real_link = FileCopyService.method(:native_linkat)
+    real_open = FileCopyService.method(:native_openat)
+    linked_destination = false
+    rejected_open = false
+
+    linking = lambda do |source_fd, source_name, destination_fd, destination_name|
+      result = real_link.call(source_fd, source_name, destination_fd, destination_name)
+      linked_destination = true if destination_name == destination_basename
+      result
+    end
+    opening = lambda do |directory_fd, basename, flags, mode|
+      if linked_destination && !rejected_open && basename == destination_basename
+        rejected_open = true
+        raise Errno::EINVAL, "simulated CIFS post-link open failure"
+      end
+
+      real_open.call(directory_fd, basename, flags, mode)
+    end
+
+    FileCopyService.stub(:native_linkat, linking) do
+      FileCopyService.stub(:native_openat, opening) do
+        FileCopyService.cp_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          allow_compatibility_fallback: true
+        )
+      end
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_empty Dir.children(@dest_dir) - [ "cifs-false-success.txt" ]
   end
 
   test "hardlink_noreplace classifies only initial unsupported link errors" do
@@ -847,6 +891,117 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "hardlink_noreplace rejects CIFS mounts without stable server inodes before linking" do
+    skip "Linux mountinfo is required" unless RUBY_PLATFORM.include?("linux")
+
+    stat = File.stat(@tmp_dir)
+    device = "#{stat.dev_major}:#{stat.dev_minor}"
+    mountpoint = @tmp_dir.gsub(" ", "\\040")
+    unrelated = "9 0 0:9 / /tmp/invalid-".b + "\xFF".b +
+      " rw,relatime - ext4 /dev/test rw\n".b
+    mountinfo = unrelated +
+      "1 0 #{device} / #{mountpoint} rw,relatime - cifs //server/share rw,noserverino\n".b
+
+    File.stub(:binread, mountinfo) do
+      FileCopyService.stub(:native_linkat, ->(*) { flunk "An unreliable mount must not attempt a hardlink" }) do
+        error = assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            File.join(@dest_dir, "hardlinked.txt"),
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+
+        assert_match(/stable hardlink identities/, error.message)
+      end
+    end
+  end
+
+  test "hardlink_noreplace fails closed when Linux mount metadata is unavailable" do
+    skip "Linux mountinfo is required" unless RUBY_PLATFORM.include?("linux")
+
+    File.stub(:binread, ->(*) { raise Errno::ENOENT }) do
+      FileCopyService.stub(:native_linkat, ->(*) { flunk "Unknown mounts must not attempt a hardlink" }) do
+        error = assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            File.join(@dest_dir, "hardlinked.txt"),
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+
+        assert_match(/stable hardlink identities/, error.message)
+      end
+    end
+  end
+
+  test "hardlink_noreplace classifies an unstable linked identity as unsupported" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    real_identity = FileCopyService.method(:file_identity)
+    linked = false
+    linked_identity_calls = 0
+
+    unstable_identity = lambda do |stat|
+      identity = real_identity.call(stat)
+      if linked && stat.file? && stat.nlink > 1
+        linked_identity_calls += 1
+        [ identity.first, identity.last + [ linked_identity_calls, 2 ].min ]
+      else
+        identity
+      end
+    end
+    real_link = FileCopyService.method(:native_hardlink_probe)
+    linking = lambda do |*arguments|
+      real_link.call(*arguments).tap { linked = true }
+    end
+
+    FileCopyService.stub(:native_hardlink_probe, linking) do
+      FileCopyService.stub(:file_identity, unstable_identity) do
+        error = assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+
+        assert_match(/stable hardlink identities/, error.message)
+      end
+    end
+
+    assert_not File.exist?(destination)
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "hardlink_noreplace uses the visible SMB3 mount when mounts are stacked" do
+    skip "Linux mountinfo is required" unless RUBY_PLATFORM.include?("linux")
+
+    stat = File.stat(@tmp_dir)
+    device = "#{stat.dev_major}:#{stat.dev_minor}"
+    mountpoint = @tmp_dir.gsub(" ", "\\040")
+    mountinfo = [
+      "1 0 #{device} / #{mountpoint} rw,relatime - smb3 //server/share rw,serverino",
+      "2 1 #{device} / #{mountpoint} rw,relatime - smb3 //server/share rw"
+    ].join("\n")
+
+    File.stub(:binread, "#{mountinfo}\n".b) do
+      FileCopyService.stub(:native_linkat, ->(*) { flunk "The hidden serverino mount must not be selected" }) do
+        assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            File.join(@dest_dir, "hardlinked.txt"),
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+      end
+    end
+  end
+
   test "hardlink_noreplace does not classify a post-publication error as unsupported" do
     destination = File.join(@dest_dir, "hardlinked.txt")
     real_validate = FileCopyService.method(:validate_published_child!)
@@ -874,7 +1029,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
   test "hardlink_noreplace cleans its verified temp and lock after publication failure" do
     destination = File.join(@dest_dir, "hardlinked.txt")
 
-    FileCopyService.stub(:publish_private_child_noreplace!, ->(*) { raise IOError, "publication failed" }) do
+    FileCopyService.stub(:publish_private_child_atomically_noreplace!, ->(*) { raise IOError, "publication failed" }) do
       assert_raises(IOError) do
         FileCopyService.hardlink_noreplace(
           @src_file,
@@ -895,7 +1050,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     displaced = File.join(@dest_dir, "displaced-private-link")
     replacement = nil
 
-    publish = lambda do |_parent, temporary_basename, _destination_basename, _identity, mode:|
+    publish = lambda do |_parent, temporary_basename, _destination_basename|
       temporary = File.join(@dest_dir, temporary_basename)
       File.rename(temporary, displaced)
       File.binwrite(temporary, "replacement temp")
@@ -903,7 +1058,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       raise IOError, "publication failed"
     end
 
-    FileCopyService.stub(:publish_private_child_noreplace!, publish) do
+    FileCopyService.stub(:publish_private_child_atomically_noreplace!, publish) do
       assert_raises(IOError) do
         FileCopyService.hardlink_noreplace(
           @src_file,
@@ -939,13 +1094,15 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       real_rename.call(source_fd, source_name, destination_fd, destination_name)
     end
 
-    FileCopyService.stub(:native_renameat, racing_rename) do
-      FileCopyService.hardlink_noreplace(
-        @src_file,
-        destination,
-        root: @dest_dir,
-        source_root: nil
-      )
+    with_link_publication_fallback(destination) do
+      FileCopyService.stub(:native_renameat, racing_rename) do
+        FileCopyService.hardlink_noreplace(
+          @src_file,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
     end
 
     assert swapped
@@ -973,7 +1130,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
   end
 
-  test "destination-local EMLINK falls back to no-replace rename publication" do
+  test "destination-local EMLINK becomes a typed hardlink fallback when rename is unavailable" do
     destination = File.join(@dest_dir, "hardlinked.txt")
     real_link = FileCopyService.method(:native_linkat)
     link_calls = 0
@@ -985,23 +1142,27 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       real_link.call(source_fd, source_name, destination_fd, destination_name)
     end
 
-    FileCopyService.stub(:native_linkat, linking) do
-      FileCopyService.hardlink_noreplace(
-        @src_file,
-        destination,
-        root: @dest_dir,
-        source_root: nil
-      )
+    error = with_link_publication_fallback(destination) do
+      FileCopyService.stub(:native_linkat, linking) do
+        assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+      end
     end
 
     assert_equal 2, link_calls
-    assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
-      [ File.stat(destination).dev, File.stat(destination).ino ]
-    assert_equal [ "hardlinked.txt" ], Dir.children(@dest_dir)
+    assert_instance_of FileCopyService::AtomicPublicationUnsupportedError, error.cause
+    assert_not File.exist?(destination)
+    assert_empty Dir.children(@dest_dir)
   end
 
-  test "destination-local low-level link failures fall back to rename publication" do
-    [ Fiddle::DLError, NotImplementedError ].each_with_index do |error_class, index|
+  test "destination-local low-level link failures become typed hardlink fallbacks" do
+    [ Errno::EXDEV, Fiddle::DLError, NotImplementedError ].each_with_index do |error_class, index|
       destination = File.join(@dest_dir, "hardlinked-#{index}.txt")
       real_link = FileCopyService.method(:native_linkat)
       link_calls = 0
@@ -1013,18 +1174,23 @@ class FileCopyServiceTest < ActiveSupport::TestCase
         real_link.call(source_fd, source_name, destination_fd, destination_name)
       end
 
-      FileCopyService.stub(:native_linkat, linking) do
-        FileCopyService.hardlink_noreplace(
-          @src_file,
-          destination,
-          root: @dest_dir,
-          source_root: nil
-        )
+      error = with_link_publication_fallback(destination) do
+        FileCopyService.stub(:native_linkat, linking) do
+          assert_raises(FileCopyService::HardlinkUnsupportedError) do
+            FileCopyService.hardlink_noreplace(
+              @src_file,
+              destination,
+              root: @dest_dir,
+              source_root: nil
+            )
+          end
+        end
       end
 
       assert_equal 2, link_calls
-      assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
-        [ File.stat(destination).dev, File.stat(destination).ino ]
+      assert_instance_of FileCopyService::AtomicPublicationUnsupportedError, error.cause
+      assert_not File.exist?(destination)
+      assert_empty Dir.children(@dest_dir)
     end
   end
 
@@ -1032,7 +1198,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     copy_destination = File.join(@dest_dir, "copied.txt")
     hardlink_destination = File.join(@dest_dir, "hardlinked.txt")
     real_copy = FileCopyService.method(:copy_source_io)
-    real_publish = FileCopyService.method(:publish_private_child_noreplace!)
+    real_publish = FileCopyService.method(:publish_private_child_atomically_noreplace!)
     verified_copy_lock = false
     verified_hardlink_lock = false
 
@@ -1048,15 +1214,16 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       FileCopyService.cp_noreplace(@src_file, copy_destination, root: @dest_dir)
     end
 
-    inspecting_publish = lambda do |parent, temporary_basename, destination_basename, identity, mode:|
+    inspecting_publish = lambda do |parent, temporary_basename, destination_basename|
       lock_path = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).sole
       record = FileCopyService::COPY_LOCK_RECORD_PATTERN.match(File.binread(lock_path))
       assert record
-      assert_equal identity, [ record[2].to_i, record[3].to_i ]
+      temporary = File.stat(File.join(@dest_dir, temporary_basename))
+      assert_equal [ temporary.dev, temporary.ino ], [ record[2].to_i, record[3].to_i ]
       verified_hardlink_lock = true
-      real_publish.call(parent, temporary_basename, destination_basename, identity, mode: mode)
+      real_publish.call(parent, temporary_basename, destination_basename)
     end
-    FileCopyService.stub(:publish_private_child_noreplace!, inspecting_publish) do
+    FileCopyService.stub(:publish_private_child_atomically_noreplace!, inspecting_publish) do
       FileCopyService.hardlink_noreplace(
         @src_file,
         hardlink_destination,
@@ -1568,6 +1735,45 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_empty Dir.children(@dest_dir)
   end
 
+  test "interrupted cleanup removes a hardlink identity probe before its lock" do
+    token = "d" * 32
+    lock = write_copy_lock(token, File.stat(@src_file))
+    probe_directory = File.join(@dest_dir, ".shelfarr-hardlink-probe-#{token}")
+    FileUtils.mkdir(probe_directory, mode: 0o700)
+    File.link(lock, File.join(probe_directory, FileCopyService::HARDLINK_PROBE_ENTRY))
+
+    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
+
+    assert_not File.exist?(probe_directory)
+    assert_not File.exist?(lock)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "hardlink identity probe cleanup removes an empty directory after a stale child listing" do
+    basename = ".shelfarr-hardlink-probe-#{"e" * 32}"
+    path = File.join(@dest_dir, basename)
+    FileUtils.mkdir(path, mode: 0o700)
+    probe_identity = FileCopyService.send(:file_identity, File.stat(path))
+    real_children = FileCopyService.method(:pinned_directory_children)
+    parent = File.open(@dest_dir, File::RDONLY | File::NONBLOCK)
+    stale_children = lambda do |directory, **options|
+      if FileCopyService.send(:file_identity, directory.stat) == probe_identity
+        [ FileCopyService::HARDLINK_PROBE_ENTRY ]
+      else
+        real_children.call(directory, **options)
+      end
+    end
+
+    result = FileCopyService.stub(:pinned_directory_children, stale_children) do
+      FileCopyService.send(:remove_hardlink_probe_directory, parent, basename)
+    end
+
+    assert_equal :removed, result
+    assert_not File.exist?(path)
+  ensure
+    parent&.close unless parent&.closed?
+  end
+
   test "completed hardlink cleanup retains symlink and directory temp replacements" do
     [ :symlink, :directory ].each do |replacement_type|
       case_directory = File.join(@dest_dir, replacement_type.to_s)
@@ -1588,13 +1794,15 @@ class FileCopyServiceTest < ActiveSupport::TestCase
         result
       end
 
-      FileCopyService.stub(:validate_published_child!, replacing_validate) do
-        FileCopyService.hardlink_noreplace(
-          @src_file,
-          destination,
-          root: @dest_dir,
-          source_root: nil
-        )
+      with_link_publication_fallback(destination) do
+        FileCopyService.stub(:validate_published_child!, replacing_validate) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
       end
 
       assert_equal [ File.stat(@src_file).dev, File.stat(@src_file).ino ],
@@ -1744,14 +1952,16 @@ class FileCopyServiceTest < ActiveSupport::TestCase
       end
     end
 
-    error = FileCopyService.stub(:native_renameat, racing_rename) do
-      assert_raises(FileCopyService::UnsafePathError) do
-        FileCopyService.hardlink_noreplace(
-          @src_file,
-          destination,
-          root: @dest_dir,
-          source_root: nil
-        )
+    error = with_link_publication_fallback(destination) do
+      FileCopyService.stub(:native_renameat, racing_rename) do
+        assert_raises(FileCopyService::UnsafePathError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
       end
     end
 
@@ -3320,6 +3530,20 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     FileCopyService.stub(:native_linkat, ->(*) { raise Errno::EOPNOTSUPP }) do
       FileCopyService.stub(:native_rename_noreplace, false, &operation)
     end
+  end
+
+  def with_link_publication_fallback(destination, &operation)
+    real_rename = FileCopyService.method(:native_rename_noreplace)
+    destination_basename = File.basename(destination)
+    fallback = lambda do |source_fd, source_name, destination_fd, destination_name|
+      if source_name.match?(/\A\.shelfarr-copy-.*\.tmp\z/) && destination_name == destination_basename
+        false
+      else
+        real_rename.call(source_fd, source_name, destination_fd, destination_name)
+      end
+    end
+
+    FileCopyService.stub(:native_rename_noreplace, fallback, &operation)
   end
 
   def copy_quarantine_path(expected_stat, token)

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -972,7 +972,7 @@ class FileCopyServiceTest < ActiveSupport::TestCase
         end
 
         assert_match(/stable hardlink identities/, error.message)
-        assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-hardlink-probe-*.tmp")).size
+        assert_empty Dir.glob(File.join(@dest_dir, ".shelfarr-hardlink-probe-*.tmp"))
         assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
       end
     end
@@ -980,6 +980,71 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(destination)
     FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
     assert_empty Dir.children(@dest_dir)
+  end
+
+  test "hardlink_noreplace cleans a probe after the lock descriptor reports a provisional identity" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    real_identity = FileCopyService.method(:file_identity)
+    real_link = FileCopyService.method(:native_hardlink_probe)
+    linked = false
+    linked_identity_calls = 0
+
+    provisional_descriptor_identity = lambda do |stat|
+      identity = real_identity.call(stat)
+      if linked && stat.file? && stat.nlink > 1
+        linked_identity_calls += 1
+        return [ identity.first, identity.last + 1 ] if linked_identity_calls == 2
+      end
+      identity
+    end
+    linking = lambda do |*arguments|
+      real_link.call(*arguments).tap { linked = true }
+    end
+
+    FileCopyService.stub(:native_hardlink_probe, linking) do
+      FileCopyService.stub(:file_identity, provisional_descriptor_identity) do
+        error = assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+
+        assert_match(/stable hardlink identities/, error.message)
+      end
+    end
+
+    assert_not File.exist?(destination)
+    assert_empty Dir.children(@dest_dir)
+  end
+
+  test "hardlink_noreplace preserves its typed fallback error when teardown is deferred" do
+    destination = File.join(@dest_dir, "hardlinked.txt")
+    capability_failure = lambda do |*|
+      raise FileCopyService::HardlinkUnsupportedError, "hardlink capability unavailable"
+    end
+    teardown_failure = lambda do |*|
+      raise FileCopyService::UnsafePathError, "cleanup identity unavailable"
+    end
+
+    FileCopyService.stub(:verify_hardlink_identity_support!, capability_failure) do
+      FileCopyService.stub(:cleanup_interrupted_copy, teardown_failure) do
+        error = assert_raises(FileCopyService::HardlinkUnsupportedError) do
+          FileCopyService.hardlink_noreplace(
+            @src_file,
+            destination,
+            root: @dest_dir,
+            source_root: nil
+          )
+        end
+
+        assert_equal "hardlink capability unavailable", error.message
+      end
+    end
+
+    assert_not File.exist?(destination)
   end
 
   test "hardlink_noreplace uses the visible SMB3 mount when mounts are stacked" do
@@ -1290,8 +1355,6 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     end
 
     assert verified_lock
-    assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
-    FileCopyService.cleanup_interrupted_copies(@dest_dir, root: @dest_dir)
     assert_empty Dir.children(@dest_dir)
   end
 
@@ -1760,12 +1823,12 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     real_open = FileCopyService.method(:with_pinned_regular_child)
     failed = false
 
-    transient_open = lambda do |parent, basename, &operation|
+    transient_open = lambda do |parent, basename, **options, &operation|
       if !failed && basename.match?(/\A\.shelfarr-copy-.*\.tmp\z/)
         failed = true
         raise Errno::EIO
       end
-      real_open.call(parent, basename, &operation)
+      real_open.call(parent, basename, **options, &operation)
     end
 
     FileCopyService.stub(:with_pinned_regular_child, transient_open) do

--- a/test/services/owned_media_import_file_service_test.rb
+++ b/test/services/owned_media_import_file_service_test.rb
@@ -76,6 +76,31 @@ class OwnedMediaImportFileServiceTest < ActiveSupport::TestCase
     assert_equal "durable audiobook bytes", File.binread(@source)
   end
 
+  test "does not accumulate Libation attempts when filesystem identities are unreliable" do
+    stage_directory = OwnedMediaImportFileService.staging_upload_directory
+    basename = OwnedMediaImportFileService.staging_path_for(@media_import, ".m4b").basename.to_s
+    owner_token = UploadImportFileService.send(:filesystem_owner_token)
+    stale_attempt = stage_directory.join(
+      ".#{basename}.#{owner_token}.#{"a" * 32}.tmp"
+    )
+    File.binwrite(stale_attempt, "interrupted bytes")
+
+    error = FileCopyService.stub(:stable_hardlink_identity?, false) do
+      assert_raises(OwnedMediaImportFileService::Error) do
+        OwnedMediaImportFileService.send(
+          :copy_io_to_staging!,
+          @media_import,
+          StringIO.new("new bytes"),
+          ".m4b",
+          root: Pathname(@output_root)
+        )
+      end
+    end
+
+    assert_match(/manual cleanup/, error.message)
+    assert_equal [ stale_attempt.basename.to_s ], Dir.children(stage_directory).grep(/\.tmp\z/)
+  end
+
   test "reconciles a hard exit after the destination link but before staging unlink" do
     service = persistent_service
     service.with_destination_lock { }
@@ -219,6 +244,55 @@ class OwnedMediaImportFileServiceTest < ActiveSupport::TestCase
     assert_match(/became occupied/, error.message)
     assert_equal "concurrent library bytes", File.binread(destination)
     assert_equal "durable audiobook bytes", File.binread(@upload.file_path)
+  end
+
+  test "an unreliable identity filesystem is never published by hardlink" do
+    service = persistent_service
+    service.with_destination_lock { }
+    destination = Pathname(@media_import.reload.destination_path)
+    service.define_singleton_method(:native_linkat) do |*|
+      flunk "Unreliable identities must not use linkat"
+    end
+
+    error = FileCopyService.stub(:stable_hardlink_identity?, false) do
+      assert_raises(OwnedMediaImportFileService::Error) do
+        service.with_destination_lock { service.finalize! }
+      end
+    end
+
+    assert_match(/stable hardlink identities/, error.message)
+    assert_not destination.exist?
+    assert_equal "durable audiobook bytes", File.binread(@upload.file_path)
+  end
+
+  test "a successful hardlink with an unusable destination retains staged recovery" do
+    service = persistent_service
+    service.with_destination_lock { }
+    destination = Pathname(@media_import.reload.destination_path)
+    real_link = service.method(:native_linkat)
+    real_open = service.method(:native_openat)
+    published = false
+    service.define_singleton_method(:native_linkat) do |*arguments|
+      real_link.call(*arguments).tap { published = true }
+    end
+    service.define_singleton_method(:native_openat) do |directory_fd, basename, flags: nil|
+      if published && basename == destination.basename.to_s
+        raise Errno::EINVAL, "simulated CIFS reopen failure"
+      end
+
+      real_open.call(directory_fd, basename, flags: flags)
+    end
+
+    error = FileCopyService.stub(:stable_hardlink_identity?, true) do
+      assert_raises(OwnedMediaImportFileService::Error) do
+        service.with_destination_lock { service.finalize! }
+      end
+    end
+
+    assert_match(/could not be verified after publication/, error.message)
+    assert destination.exist?
+    assert_equal "durable audiobook bytes", File.binread(@upload.file_path)
+    assert @media_import.reload.destination_path.present?
   end
 
   test "does not delete a replacement file after its own published link is displaced" do

--- a/test/services/upload_import_file_service_test.rb
+++ b/test/services/upload_import_file_service_test.rb
@@ -324,8 +324,10 @@ class UploadImportFileServiceTest < ActiveSupport::TestCase
       File.symlink(outside, destination.parent)
     end
 
-    error = UploadImportFileService.stub(:native_linkat, swapping_linkat) do
-      assert_raises(UploadImportFileService::AmbiguousPublicationError) { service.publish! }
+    error = UploadImportFileService.stub(:native_rename_noreplace, false) do
+      UploadImportFileService.stub(:native_linkat, swapping_linkat) do
+        assert_raises(UploadImportFileService::AmbiguousPublicationError) { service.publish! }
+      end
     end
 
     assert_match(/directory changed/, error.message)
@@ -339,7 +341,59 @@ class UploadImportFileServiceTest < ActiveSupport::TestCase
     FileUtils.rm_rf(moved_parent) if moved_parent
   end
 
-  test "a retry removes a private copy left after the destination was published" do
+  test "an unreliable identity filesystem is never published by hardlink" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+
+    error = FileCopyService.stub(:stable_hardlink_identity?, false) do
+      UploadImportFileService.stub(:native_rename_noreplace, false) do
+        UploadImportFileService.stub(:native_linkat, ->(*) { flunk "Unreliable identities must not use linkat" }) do
+          assert_raises(UploadImportFileService::Error) { service.publish! }
+        end
+      end
+    end
+
+    assert_match(/stable hardlink identities/, error.message)
+    assert File.exist?(@source)
+  end
+
+  test "a successful hardlink with an unusable destination retains an ambiguous reservation" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+    destination = Pathname(@upload.reload.destination_path)
+    real_link = UploadImportFileService.method(:native_linkat)
+    real_open = UploadImportFileService.method(:native_openat)
+    published = false
+    opening = lambda do |directory_fd, basename, flags:, mode: 0|
+      if published && basename == destination.basename.to_s
+        raise Errno::EINVAL, "simulated CIFS reopen failure"
+      end
+
+      real_open.call(directory_fd, basename, flags: flags, mode: mode)
+    end
+    linking = lambda do |*arguments|
+      real_link.call(*arguments).tap { published = true }
+    end
+
+    error = FileCopyService.stub(:stable_hardlink_identity?, true) do
+      UploadImportFileService.stub(:native_rename_noreplace, false) do
+        UploadImportFileService.stub(:native_linkat, linking) do
+          UploadImportFileService.stub(:native_openat, opening) do
+            FileCopyService.stub(:remove_pinned_child_if_identity, ->(*) { raise IOError, "cleanup failed" }) do
+              assert_raises(UploadImportFileService::AmbiguousPublicationError) { service.publish! }
+            end
+          end
+        end
+      end
+    end
+
+    assert_match(/could not be verified after publication/, error.message)
+    assert destination.exist?
+    assert_not service.restore_and_clear!
+    assert_equal destination.to_s, @upload.reload.destination_path
+  end
+
+  test "a retry retains an unverified private copy left after destination publication" do
     service = UploadImportFileService.new(upload: @upload, book: @book)
     service.reserve!
     service.publish!
@@ -353,7 +407,96 @@ class UploadImportFileServiceTest < ActiveSupport::TestCase
     File.binwrite(private_copy, "original ebook bytes")
 
     assert_equal service.book_library_path, service.publish!
-    assert_not File.exist?(private_copy)
+    assert_equal "original ebook bytes", File.binread(private_copy)
+  end
+
+  test "successful rename publication preserves a replacement at the consumed private path" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+    private_directory = File.join(
+      File.realpath(@library_root),
+      UploadImportFileService::PRIVATE_DIRECTORY,
+      UploadImportFileService.send(:database_fingerprint)
+    )
+    private_copy = nil
+    real_rename = UploadImportFileService.method(:native_rename_noreplace)
+    renaming = lambda do |*arguments|
+      real_rename.call(*arguments).tap do |published|
+        private_copy = File.join(private_directory, arguments.fetch(1))
+        File.binwrite(private_copy, "replacement private bytes") if published
+      end
+    end
+
+    UploadImportFileService.stub(:native_rename_noreplace, renaming) do
+      service.publish!
+    end
+    service.publish!
+
+    assert_equal "replacement private bytes", File.binread(private_copy)
+    assert_equal "original ebook bytes", File.binread(@upload.reload.destination_path)
+  end
+
+  test "a crash-left private attempt does not block a retry" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+    private_directory = File.join(
+      File.realpath(@library_root),
+      UploadImportFileService::PRIVATE_DIRECTORY,
+      UploadImportFileService.send(:database_fingerprint)
+    )
+    FileUtils.mkdir_p(private_directory)
+    stale_copy = File.join(private_directory, "upload_#{@upload.id}-#{"a" * 32}.tmp")
+    File.binwrite(stale_copy, "crash-left bytes")
+
+    service.publish!
+
+    assert_equal "crash-left bytes", File.binread(stale_copy)
+    assert_equal "original ebook bytes", File.binread(@upload.reload.destination_path)
+  end
+
+  test "a retry reclaims its owner-tagged private attempt on reliable filesystems" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+    private_directory = File.join(
+      File.realpath(@library_root),
+      UploadImportFileService::PRIVATE_DIRECTORY,
+      UploadImportFileService.send(:database_fingerprint)
+    )
+    FileUtils.mkdir_p(private_directory)
+    stale_copy = File.join(
+      private_directory,
+      UploadImportFileService.send(:private_attempt_basename, @upload.id)
+    )
+    File.binwrite(stale_copy, "interrupted bytes")
+
+    service.publish!
+
+    assert_not File.exist?(stale_copy)
+    assert_equal "original ebook bytes", File.binread(@upload.reload.destination_path)
+  end
+
+  test "a retry does not accumulate owner-tagged attempts when identities are unreliable" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+    private_directory = File.join(
+      File.realpath(@library_root),
+      UploadImportFileService::PRIVATE_DIRECTORY,
+      UploadImportFileService.send(:database_fingerprint)
+    )
+    FileUtils.mkdir_p(private_directory)
+    stale_copy = File.join(
+      private_directory,
+      UploadImportFileService.send(:private_attempt_basename, @upload.id)
+    )
+    File.binwrite(stale_copy, "interrupted bytes")
+
+    error = FileCopyService.stub(:stable_hardlink_identity?, false) do
+      assert_raises(UploadImportFileService::Error) { service.publish! }
+    end
+
+    assert_match(/manual cleanup/, error.message)
+    assert_equal [ File.basename(stale_copy) ], Dir.children(private_directory).grep(/\Aupload_/)
+    assert_not File.exist?(@upload.reload.destination_path)
   end
 
   test "completed cleanup reconciles a source already truncated before its marker cleared" do


### PR DESCRIPTION
## Summary

- centralize native filesystem syscalls with architecture-safe Fiddle signatures and typed no-replace behavior
- fail closed when filesystems cannot provide safe atomic publication or stable identities, while preserving source data and bounding interrupted retries
- use the documented retained-source copy fallback for CIFS hardlink imports because CIFS cannot reliably prove hardlink identity even with `serverino`
- harden upload, Libation, cleanup, and crash-recovery paths with pinned descriptors and owner-tagged private attempts
- add disposable Samba/CIFS contracts for serverino and noserverino profiles on amd64 and arm64 CI runners

## Test plan

- `bin/quality push`
- `test/filesystem_contracts/cifs-smoke.sh`
- CIFS serverino: 10 runs, 56 assertions, 0 failures
- CIFS noserverino: 10 runs, 58 assertions, 0 failures, 1 intentional stable-identity concurrency skip
- full Rails and coverage gates pass locally