### PR TITLE
fix: separate ARM filesystem release validation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,11 +81,7 @@ jobs:
   validate:
     needs: [plan]
     if: needs.plan.outputs.should_release == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [ubuntu-latest, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
@@ -97,7 +93,7 @@ jobs:
           ref: ${{ needs.plan.outputs.head_sha }}
 
       - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y cifs-utils libvips
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
@@ -114,9 +110,6 @@ jobs:
         env:
           RAILS_ENV: test
         run: bin/quality push
-
-      - name: Run CIFS filesystem contracts
-        run: test/filesystem_contracts/cifs-smoke.sh
 
       - name: Audit Shelfarr gems
         run: bin/bundler-audit --update
@@ -153,8 +146,43 @@ jobs:
         working-directory: services/libation_companion
         run: ./tests/container-smoke.sh
 
+  filesystem-contracts:
+    needs: [plan]
+    if: needs.plan.outputs.should_release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout planned commit
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          ref: ${{ needs.plan.outputs.head_sha }}
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y cifs-utils libvips
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Prepare Shelfarr test database
+        env:
+          RAILS_ENV: test
+        run: bin/rails db:test:prepare
+
+      - name: Run CIFS filesystem contracts
+        run: test/filesystem_contracts/cifs-smoke.sh
+
   docker:
-    needs: [plan, validate]
+    needs: [plan, validate, filesystem-contracts]
     if: needs.plan.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/test/config/docker_workflow_test.rb
+++ b/test/config/docker_workflow_test.rb
@@ -48,16 +48,21 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     refute_includes planner, "git log"
   end
 
-  test "release waits for the full validation gate and paired Docker images" do
+  test "release waits for full validation, architecture contracts, and paired Docker images" do
     validation_commands = @jobs.fetch("validate").fetch("steps").filter_map { |step| step["run"] }
+    filesystem_job = @jobs.fetch("filesystem-contracts")
+    filesystem_commands = filesystem_job.fetch("steps").filter_map { |step| step["run"] }
 
     assert validation_commands.any? { |command| command.include?("bin/quality push") }
-    assert validation_commands.any? { |command| command.include?("cifs-smoke.sh") }
     assert validation_commands.any? { |command| command.include?("bin/bundler-audit --update") }
-    assert_includes @jobs.dig("validate", "strategy", "matrix", "runner"), "ubuntu-24.04-arm"
+    assert_equal "ubuntu-latest", @jobs.dig("validate", "runs-on")
+    assert filesystem_commands.any? { |command| command.include?("cifs-utils") }
+    assert filesystem_commands.any? { |command| command.include?("cifs-smoke.sh") }
+    assert_equal %w[ubuntu-latest ubuntu-24.04-arm],
+      filesystem_job.dig("strategy", "matrix", "runner")
 
     docker_job = @jobs.fetch("docker")
-    assert_equal %w[plan validate], docker_job.fetch("needs")
+    assert_equal %w[plan validate filesystem-contracts], docker_job.fetch("needs")
     assert_includes docker_job.fetch("if"), "needs.plan.outputs.should_release == 'true'"
 
     docker_steps = docker_job.fetch("steps")
@@ -98,7 +103,7 @@ class DockerWorkflowTest < ActiveSupport::TestCase
   end
 
   test "every release job uses the commit selected by the planner" do
-    %w[validate docker publish-release].each do |job_name|
+    %w[validate filesystem-contracts docker publish-release].each do |job_name|
       checkout = @jobs.fetch(job_name).fetch("steps").find do |step|
         step["name"] == "Checkout planned commit"
       end


### PR DESCRIPTION
## Summary
- keep the full Rails, browser, audit, and companion release gate on the amd64 runner
- run mounted CIFS contracts in a separate amd64/arm64 matrix
- require both validation paths before building or publishing release images
- lock the release workflow structure with configuration tests

## Test plan
- `bin/rails test test/config/docker_workflow_test.rb`
- `bin/rubocop --force-exclusion --format quiet --fail-level warning test/config/docker_workflow_test.rb`
- `bin/quality commit --staged`
- `bin/quality push`
- repeat pre-push code review: no findings

## Context
The release run for `c92e670` failed on `ubuntu-24.04-arm` before reaching the CIFS contracts because Selenium Manager shipped an incompatible browser-driver helper for that runner. Pull-request CI already keeps browser tests on amd64 and runs only the filesystem contracts across both architectures; this applies the same separation to releases.