### PR TITLE
Feat/per user library routing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # See https://git-scm.com/docs/gitattributes for more about git attribute files.
 
+# Normalize line endings to LF for all text files (prevents CRLF in containers)
+* text=auto eol=lf
+
 # Mark the database schema as having been generated.
 db/schema.rb linguist-generated
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class UsersController < BaseController
-    before_action :set_user, only: [:show, :edit, :update, :destroy]
+    before_action :set_user, only: [:show, :edit, :update, :destroy, :library_routing, :update_library_routing]
 
     def index
       @users = User.active.order(created_at: :desc)
@@ -37,6 +37,17 @@ module Admin
       end
     end
 
+    def library_routing
+    end
+
+    def update_library_routing
+      if @user.update(library_routing_params)
+        redirect_to library_routing_admin_user_path(@user), notice: "Library routing updated."
+      else
+        render :library_routing, status: :unprocessable_entity
+      end
+    end
+
     def destroy
       if @user == Current.user
         redirect_to admin_users_path, alert: "You cannot delete yourself."
@@ -54,6 +65,14 @@ module Admin
 
     def user_params
       params.require(:user).permit(:name, :username, :password, :password_confirmation, :role)
+    end
+
+    def library_routing_params
+      params.require(:user).permit(
+        :preferred_audiobook_library_id,
+        :preferred_ebook_library_id,
+        :preferred_comicbook_library_id
+      )
     end
   end
 end

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -425,7 +425,7 @@ class DownloadJob < ApplicationJob
     end
     return unless finalized
 
-    trigger_library_scan(book) if LibraryPlatformClient.configured?
+    trigger_library_scan(book, user: download.request.user) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
@@ -482,7 +482,7 @@ class DownloadJob < ApplicationJob
     file_service.cleanup_after_run!
     return unless finalized
 
-    trigger_library_scan(book) if LibraryPlatformClient.configured?
+    trigger_library_scan(book, user: download.request.user) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
@@ -547,7 +547,7 @@ class DownloadJob < ApplicationJob
     return unless finalized
 
     # Trigger library scan if configured
-    trigger_library_scan(book) if LibraryPlatformClient.configured?
+    trigger_library_scan(book, user: download.request.user) if LibraryPlatformClient.configured?
 
     # Send notification
     NotificationService.request_completed(download.request)
@@ -1313,8 +1313,15 @@ class DownloadJob < ApplicationJob
     FileCopyService.ensure_directory(root.to_s, root: existing_parent.to_s)
   end
 
-  def trigger_library_scan(book)
-    lib_id = SettingsService.library_id_for_book(book)
+  def trigger_library_scan(book, user: nil)
+    user_library_id = if book.comicbook?
+      user&.preferred_comicbook_library_id
+    elsif book.ebook?
+      user&.preferred_ebook_library_id
+    else
+      user&.preferred_audiobook_library_id
+    end
+    lib_id = user_library_id.presence || SettingsService.library_id_for_book(book)
 
     return unless lib_id.present?
 

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -54,6 +54,7 @@ class PostProcessingJob < ApplicationJob
     request = download.request
     return unless claim_request_for_post_processing(download, request, expected_owner_job_id)
 
+    @request_user = request.user
     book = request.book
     acquisition_finalized = false
 
@@ -523,7 +524,14 @@ class PostProcessingJob < ApplicationJob
   end
 
   def library_id_for(book)
-    SettingsService.library_id_for_book(book)
+    user_library_id = if book.comicbook?
+      @request_user&.preferred_comicbook_library_id
+    elsif book.ebook?
+      @request_user&.preferred_ebook_library_id
+    else
+      @request_user&.preferred_audiobook_library_id
+    end
+    user_library_id.presence || SettingsService.library_id_for_book(book)
   end
 
   def import_files(

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -12,7 +12,7 @@
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Username</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Role</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Created</th>
-          <th class="px-6 py-3 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">Actions</th>
+          <th class="px-6 py-3 text-center text-xs font-medium text-gray-400 uppercase tracking-wider">Actions</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-800">
@@ -28,11 +28,14 @@
               </span>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-gray-500 text-sm"><%= user.created_at.strftime("%b %d, %Y") %></td>
-            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-              <%= link_to "Edit", edit_admin_user_path(user), class: "text-blue-400 hover:text-blue-300 mr-4" %>
-              <% unless user == Current.user %>
-                <%= button_to "Delete", admin_user_path(user), method: :delete, class: "text-red-400 hover:text-red-300", data: { turbo_confirm: "Are you sure you want to delete this user?" } %>
-              <% end %>
+            <td class="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
+              <div class="flex flex-col items-center gap-1">
+                <%= link_to "Edit", edit_admin_user_path(user), class: "text-blue-400 hover:text-blue-300" %>
+                <%= link_to "Library Routing", library_routing_admin_user_path(user), class: "text-blue-400 hover:text-blue-300" %>
+                <% unless user == Current.user %>
+                  <%= button_to "Delete", admin_user_path(user), method: :delete, class: "text-red-400 hover:text-red-300", data: { turbo_confirm: "Are you sure you want to delete this user?" } %>
+                <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/users/library_routing.html.erb
+++ b/app/views/admin/users/library_routing.html.erb
@@ -1,0 +1,52 @@
+<div class="mx-auto max-w-2xl">
+  <div class="mb-6">
+    <%= link_to "&larr; Back to Users".html_safe, admin_users_path, class: "text-blue-400 hover:text-blue-300" %>
+  </div>
+
+  <h1 class="font-bold text-4xl text-white mb-2">Library Routing</h1>
+  <p class="text-gray-400 mb-8">
+    Configure which library <span class="text-white font-medium"><%= @user.name %></span>
+    (<span class="text-gray-300">@<%= @user.username %></span>)
+    has their completed downloads routed to. Leave any field blank to use the system default.
+  </p>
+
+  <div class="bg-gray-900 rounded-lg border border-gray-800 p-6">
+    <% if @user.errors.any? %>
+      <div class="mb-6 bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+        <ul class="list-disc list-inside text-sm text-red-400">
+          <% @user.errors.full_messages.each do |error| %>
+            <li><%= error %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_with model: [:admin, @user], url: library_routing_admin_user_path(@user), method: :patch do |form| %>
+      <div class="mb-5">
+        <%= form.label :preferred_audiobook_library_id, "Audiobook Library ID", class: "block text-gray-300 font-medium mb-2" %>
+        <%= form.text_field :preferred_audiobook_library_id,
+              placeholder: "System default",
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 w-full" %>
+      </div>
+
+      <div class="mb-5">
+        <%= form.label :preferred_ebook_library_id, "Ebook Library ID", class: "block text-gray-300 font-medium mb-2" %>
+        <%= form.text_field :preferred_ebook_library_id,
+              placeholder: "System default",
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 w-full" %>
+      </div>
+
+      <div class="mb-6">
+        <%= form.label :preferred_comicbook_library_id, "Comic Book Library ID", class: "block text-gray-300 font-medium mb-2" %>
+        <%= form.text_field :preferred_comicbook_library_id,
+              placeholder: "System default",
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 w-full" %>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <%= form.submit "Save", class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
+        <%= link_to "Cancel", admin_users_path, class: "text-gray-400 hover:text-gray-300" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,12 @@ Rails.application.routes.draw do
     root "dashboard#index"
     post "check_updates", to: "dashboard#check_updates"
     post "run_health_check", to: "dashboard#run_health_check"
-    resources :users
+    resources :users do
+      member do
+        get  :library_routing
+        patch :library_routing, action: :update_library_routing
+      end
+    end
     resources :uploads, only: [ :index, :new, :create, :show, :destroy ] do
       member do
         post :retry

--- a/db/migrate/20260813000000_add_library_preferences_to_users.rb
+++ b/db/migrate/20260813000000_add_library_preferences_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddLibraryPreferencesToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :preferred_audiobook_library_id, :string
+    add_column :users, :preferred_ebook_library_id, :string
+    add_column :users, :preferred_comicbook_library_id, :string
+  end
+end


### PR DESCRIPTION
## Summary

Closes #445

- Adds three nullable columns to `users` (`preferred_audiobook_library_id`, `preferred_ebook_library_id`, `preferred_comicbook_library_id`)
- When a download completes, `PostProcessingJob` and `DownloadJob` check the requesting user's preferred library ID and fall back to the system default if unset
- Admins configure routing per user via a dedicated **Library Routing** page linked from the Actions column in Admin → Manage Users

## Test plan

- [ ] Run `bin/rails db:migrate` and verify the three new columns exist on `users`
- [ ] As admin, open Manage Users and confirm the **Library Routing** link appears in the Actions column for each user
- [ ] Set a library ID for a user and save — confirm it persists
- [ ] Trigger a download as that user and confirm the library scan targets the overridden ID
- [ ] Leave all fields blank for a user — confirm downloads fall back to the system-wide library setting

🤖 Generated with [Claude Code](https://claude.ai/claude-code)