### PR TITLE
Handle Libation M4B collision copies

### DIFF
--- a/app/jobs/owned_media_backup_job.rb
+++ b/app/jobs/owned_media_backup_job.rb
@@ -358,10 +358,12 @@ class OwnedMediaBackupJob < ApplicationJob
 
   # Libation can retain a previous completed file and write a retry using its
   # usual " (1)" collision suffix. Its current file can differ in metadata, so
-  # use the newest member of that one collision family. Distinct multipart
-  # filenames remain ambiguous and must be rejected.
+  # use the newest member of that one collision family. Require the unsuffixed
+  # canonical file as evidence that the numbered files are collision copies;
+  # otherwise parenthetically numbered multipart files remain ambiguous.
   def select_collision_copy(paths)
     return unless paths.any? { |path| duplicate_suffix?(path) }
+    return unless paths.any? { |path| !duplicate_suffix?(path) }
     return unless paths.map { |path| [ path.dirname, collision_basename(path) ] }.uniq.one?
 
     paths.max_by do |path|

--- a/app/jobs/owned_media_backup_job.rb
+++ b/app/jobs/owned_media_backup_job.rb
@@ -17,6 +17,7 @@ class OwnedMediaBackupJob < ApplicationJob
   COMPANION_DATA_ROOT = Pathname("/data").freeze
   DEFAULT_IMPORT_ROOT = "/imports/libation"
   AUDIO_EXTENSIONS = %w[.m4b .m4a .mp3].freeze
+  LIBATION_COLLISION_SUFFIX = / \(([1-9][0-9]{0,8})\)\z/
   MAX_DIRECTORY_ENTRIES = 10_000
 
   queue_as :default
@@ -363,15 +364,33 @@ class OwnedMediaBackupJob < ApplicationJob
     return unless paths.any? { |path| duplicate_suffix?(path) }
     return unless paths.map { |path| [ path.dirname, collision_basename(path) ] }.uniq.one?
 
-    paths.max_by { |path| [ path.mtime, path.basename.to_s ] }
+    paths.max_by do |path|
+      stat = path.lstat
+      unless stat.file?
+        raise BackupError, "Libation artifact changed while Shelfarr was selecting it"
+      end
+
+      [ stat.mtime, collision_number(path), path.basename.to_s ]
+    end
+  rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, Errno::ENOTDIR
+    raise BackupError, "Libation artifact is not accessible from Shelfarr"
   end
 
   def duplicate_suffix?(path)
-    path.basename(path.extname).to_s.match?(/ \(\d+\)\z/)
+    LIBATION_COLLISION_SUFFIX.match?(collision_stem(path))
   end
 
   def collision_basename(path)
-    path.basename(path.extname).to_s.sub(/ \(\d+\)\z/, "")
+    collision_stem(path).sub(LIBATION_COLLISION_SUFFIX, "")
+  end
+
+  def collision_number(path)
+    match = LIBATION_COLLISION_SUFFIX.match(collision_stem(path))
+    match ? match[1].to_i : 0
+  end
+
+  def collision_stem(path)
+    path.basename(path.extname).to_s
   end
 
   def audio_files_in(directory)

--- a/app/jobs/owned_media_backup_job.rb
+++ b/app/jobs/owned_media_backup_job.rb
@@ -345,11 +345,33 @@ class OwnedMediaBackupJob < ApplicationJob
       matches = candidates.select { |path| path.extname.casecmp?(extension) }
       return matches.first if matches.one?
       if matches.many?
+        collision_copy = select_collision_copy(matches)
+        return collision_copy if collision_copy
+
         raise BackupError, "Libation reported multiple #{extension.delete_prefix('.').upcase} files; a single primary artifact is required"
       end
     end
 
     raise BackupError, "Libation did not report a single primary audiobook artifact"
+  end
+
+  # Libation can retain a previous completed file and write a retry using its
+  # usual " (1)" collision suffix. Its current file can differ in metadata, so
+  # use the newest member of that one collision family. Distinct multipart
+  # filenames remain ambiguous and must be rejected.
+  def select_collision_copy(paths)
+    return unless paths.any? { |path| duplicate_suffix?(path) }
+    return unless paths.map { |path| [ path.dirname, collision_basename(path) ] }.uniq.one?
+
+    paths.max_by { |path| [ path.mtime, path.basename.to_s ] }
+  end
+
+  def duplicate_suffix?(path)
+    path.basename(path.extname).to_s.match?(/ \(\d+\)\z/)
+  end
+
+  def collision_basename(path)
+    path.basename(path.extname).to_s.sub(/ \(\d+\)\z/, "")
   end
 
   def audio_files_in(directory)

--- a/test/jobs/owned_media_backup_job_test.rb
+++ b/test/jobs/owned_media_backup_job_test.rb
@@ -580,6 +580,24 @@ class OwnedMediaBackupJobTest < ActiveJob::TestCase
     end
   end
 
+  test "rejects suffix-only M4Bs without a canonical Libation artifact" do
+    Dir.mktmpdir("libation-import") do |root|
+      book_dir = File.join(root, "Book")
+      FileUtils.mkdir_p(book_dir)
+      File.binwrite(File.join(book_dir, "A Title (1).m4b"), "part one")
+      File.binwrite(File.join(book_dir, "A Title (2).m4b"), "part two")
+
+      job = OwnedMediaBackupJob.new
+      with_env("SHELFARR_LIBATION_IMPORT_ROOT" => root) do
+        error = assert_raises(OwnedMediaBackupJob::BackupError) do
+          job.send(:select_audio_artifact, [ "/data/Book" ])
+        end
+
+        assert_match(/single primary artifact/, error.message)
+      end
+    end
+  end
+
   test "uses the highest collision sequence when filesystem mtimes tie" do
     Dir.mktmpdir("libation-import") do |root|
       book_dir = File.join(root, "Book")

--- a/test/jobs/owned_media_backup_job_test.rb
+++ b/test/jobs/owned_media_backup_job_test.rb
@@ -580,6 +580,53 @@ class OwnedMediaBackupJobTest < ActiveJob::TestCase
     end
   end
 
+  test "uses the highest collision sequence when filesystem mtimes tie" do
+    Dir.mktmpdir("libation-import") do |root|
+      book_dir = File.join(root, "Book")
+      FileUtils.mkdir_p(book_dir)
+      canonical = File.join(book_dir, "A Title.m4b")
+      second = File.join(book_dir, "A Title (2).m4b")
+      tenth = File.join(book_dir, "A Title (10).m4b")
+      [ canonical, second, tenth ].each { |path| File.binwrite(path, File.basename(path)) }
+      timestamp = 1.minute.ago.to_time
+      [ canonical, second, tenth ].each { |path| File.utime(timestamp, timestamp, path) }
+
+      job = OwnedMediaBackupJob.new
+      with_env("SHELFARR_LIBATION_IMPORT_ROOT" => root) do
+        assert_equal Pathname(tenth), job.send(:select_audio_artifact, [ "/data/Book" ])
+      end
+    end
+  end
+
+  test "does not interpret zero or unbounded numeric suffixes as Libation collisions" do
+    Dir.mktmpdir("libation-import") do |root|
+      book_dir = File.join(root, "Book")
+      FileUtils.mkdir_p(book_dir)
+      File.binwrite(File.join(book_dir, "A Title.m4b"), "canonical")
+      File.binwrite(File.join(book_dir, "A Title (0).m4b"), "zero")
+      File.binwrite(File.join(book_dir, "A Title (1000000000).m4b"), "unbounded")
+
+      job = OwnedMediaBackupJob.new
+      with_env("SHELFARR_LIBATION_IMPORT_ROOT" => root) do
+        assert_raises(OwnedMediaBackupJob::BackupError) do
+          job.send(:select_audio_artifact, [ "/data/Book" ])
+        end
+      end
+    end
+  end
+
+  test "reports a collision candidate that disappears during metadata selection" do
+    job = OwnedMediaBackupJob.new
+    error = assert_raises(OwnedMediaBackupJob::BackupError) do
+      job.send(
+        :select_collision_copy,
+        [ Pathname("A Title.m4b"), Pathname("A Title (1).m4b") ]
+      )
+    end
+
+    assert_match(/not accessible/, error.message)
+  end
+
   test "finishes after Shelfarr upload processing completes" do
     upload = Upload.create!(
       user: users(:two),

--- a/test/jobs/owned_media_backup_job_test.rb
+++ b/test/jobs/owned_media_backup_job_test.rb
@@ -546,6 +546,40 @@ class OwnedMediaBackupJobTest < ActiveJob::TestCase
     assert_match(/single primary artifact/, @media_import.error_message)
   end
 
+  test "uses the newest file when Libation reports collision-suffixed M4Bs" do
+    Dir.mktmpdir("libation-import") do |root|
+      book_dir = File.join(root, "Book")
+      FileUtils.mkdir_p(book_dir)
+      canonical = File.join(book_dir, "A Title.m4b")
+      duplicate = File.join(book_dir, "A Title (1).m4b")
+      File.binwrite(canonical, "older audiobook")
+      File.binwrite(duplicate, "newer audiobook")
+      File.utime(2.minutes.ago.to_time, 2.minutes.ago.to_time, canonical)
+      File.utime(1.minute.ago.to_time, 1.minute.ago.to_time, duplicate)
+
+      job = OwnedMediaBackupJob.new
+      with_env("SHELFARR_LIBATION_IMPORT_ROOT" => root) do
+        assert_equal Pathname(duplicate), job.send(:select_audio_artifact, [ "/data/Book" ])
+      end
+    end
+  end
+
+  test "rejects M4Bs that are not Libation collision copies" do
+    Dir.mktmpdir("libation-import") do |root|
+      book_dir = File.join(root, "Book")
+      FileUtils.mkdir_p(book_dir)
+      File.binwrite(File.join(book_dir, "part-1.m4b"), "one")
+      File.binwrite(File.join(book_dir, "part-2.m4b"), "two")
+
+      job = OwnedMediaBackupJob.new
+      with_env("SHELFARR_LIBATION_IMPORT_ROOT" => root) do
+        assert_raises(OwnedMediaBackupJob::BackupError) do
+          job.send(:select_audio_artifact, [ "/data/Book" ])
+        end
+      end
+    end
+  end
+
   test "finishes after Shelfarr upload processing completes" do
     upload = Upload.create!(
       user: users(:two),


### PR DESCRIPTION
## What changed

Recognize Libation collision copies such as `Title.m4b`, `Title (1).m4b`, and `Title (2).m4b` as one artifact family and select the newest file.

An unsuffixed canonical file is required as evidence that numbered files are collision retries. Suffix-only files, distinct multipart M4Bs, different basenames, different directories, zero suffixes, and unbounded numeric suffixes remain ambiguous and are rejected.

## Why

Libation can retain a completed file and create a newer retry using its standard positive numeric collision suffix. Shelfarr previously rejected the whole directory even though the files represented retry copies of one title.

## Maintainer hardening

- Rebased onto current `main` with Brandon's authorship preserved.
- Requires an unsuffixed canonical artifact, preventing suffix-only multipart files from being imported as retries.
- Selects by modification time, then by the numeric Libation collision sequence when filesystem timestamp resolution produces a tie (`(10)` correctly ranks after `(2)`).
- Uses `lstat` and fails with a bounded `BackupError` if a candidate disappears or changes to a non-regular entry during selection.
- Keeps distinct multipart artifacts rejected; this PR does not broaden bundle-import behavior.

## Verification

- `bin/quality push` — passed after rebasing and hardening
- `test/jobs/owned_media_backup_job_test.rb` — 39 runs / 162 assertions, 0 failures
- RuboCop — no offenses
- `git diff --check` — passed

Additional adversarial coverage includes suffix-only multipart files, equal mtimes, numeric suffix ordering, invalid suffix bounds, disappearing candidates, and unrelated multipart M4Bs.
