### PR TITLE
Add media-neutral acquisition result ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Think Jellyseerr, but for books. Your users request ebooks and audiobooks; Shelf
 - **Download Routing** — Route specific indexers to specific clients, with priority ordering
 - **REST API** — Scoped, per-user API tokens under `/api/v1`
 - **Custom Acquisition Providers** — Trusted HTTP providers can contribute search results and resolve selected items into direct, torrent or usenet artifacts
+- **Media Ranking Providers** — Optional ranking-only services can enrich and re-rank the combined result set through a versioned, media-neutral API without receiving download or cover URLs
 - **Third-Party Store Offers (Beta)** — Surface legitimate DRM-free editions from supported sellers without handling checkout or payment data
 - **Audible Backup (Beta)** — Sync purchased Audible titles, explicitly queue a one-time backup of eligible existing purchases, optionally back up future purchases automatically, and import them through the separately packaged Libation companion
 

--- a/app/controllers/admin/ranking_providers_controller.rb
+++ b/app/controllers/admin/ranking_providers_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Admin
+  class RankingProvidersController < BaseController
+    before_action :set_provider, only: [ :show, :edit, :update, :destroy, :test ]
+
+    def index
+      @providers = RankingProvider.by_priority
+    end
+
+    def show
+    end
+
+    def new
+      @provider = RankingProvider.new(timeout_seconds: 30)
+    end
+
+    def create
+      @provider = RankingProvider.new(provider_params)
+      @provider.priority = next_priority
+
+      if @provider.save
+        redirect_to admin_ranking_providers_path, notice: "Ranking provider was successfully created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      attributes = provider_params
+      attributes = attributes.except(:api_key) if attributes[:api_key].blank?
+
+      if @provider.update(attributes)
+        redirect_to admin_ranking_providers_path, notice: "Ranking provider was successfully updated."
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @provider.destroy
+      redirect_to admin_ranking_providers_path, notice: "Ranking provider was successfully deleted."
+    end
+
+    def test
+      if @provider.test_connection
+        redirect_to admin_ranking_providers_path, notice: "Connection to '#{@provider.name}' successful."
+      else
+        redirect_to admin_ranking_providers_path, alert: "Connection to '#{@provider.name}' failed."
+      end
+    end
+
+    private
+
+    def set_provider
+      @provider = RankingProvider.find(params[:id])
+    end
+
+    def provider_params
+      params.require(:ranking_provider).permit(
+        :name, :url, :api_key, :enabled, :allow_private_network, :timeout_seconds
+      )
+    end
+
+    def next_priority
+      (RankingProvider.maximum(:priority) || -1) + 1
+    end
+  end
+end

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -196,6 +196,7 @@ class SearchJob < ApplicationJob
 
       if results.any?
         save_results(request, results)
+        rerank_saved_results(request)
         Rails.logger.info "[SearchJob] Total #{results.count} results for request ##{request.id}"
         attempt_auto_select(request)
       elsif store_offers.any?
@@ -554,6 +555,33 @@ class SearchJob < ApplicationJob
     end
   end
 
+  def rerank_saved_results(request)
+    provider = RankingProvider.enabled.by_priority.first
+    return unless provider
+
+    candidates = request.search_results.selectable.not_blocklisted.to_a
+    return if candidates.empty?
+
+    candidates_by_id = candidates.index_by { |candidate| candidate.id.to_s }
+    rankings = provider.client.rank(request, candidates)
+
+    rankings.each do |ranking|
+      candidate = candidates_by_id[ranking.candidate_id]
+      next unless candidate
+
+      breakdown = (candidate.score_breakdown || {}).merge(
+        "external_rank_score" => ranking.rank_score,
+        "external_rank_provider_id" => provider.id
+      )
+      breakdown["external_rank_evidence"] = ranking.match_evidence unless ranking.match_evidence.nil?
+      candidate.update!(score_breakdown: breakdown)
+    end
+
+    Rails.logger.info "[SearchJob] Applied #{rankings.count} external rankings from #{provider.name} to request ##{request.id}"
+  rescue RankingProviderClient::Error => e
+    Rails.logger.warn "[SearchJob] External ranking failed for request ##{request.id} (provider: #{provider&.name}, error: #{e.class})"
+  end
+
   def save_indexer_result(request, result, source)
     search_result = request.search_results.find_or_initialize_by(guid: result.guid)
     search_result.assign_attributes(
@@ -642,24 +670,28 @@ class SearchJob < ApplicationJob
   end
 
   def save_custom_provider_result(request, result, provider)
-    request.search_results.find_or_create_by!(
+    search_result = request.search_results.find_or_initialize_by(
       acquisition_provider: provider,
       provider_result_id: result.provider_result_id
-    ) do |sr|
-      sr.guid = "custom:#{provider.id}:#{result.provider_result_id}"
-      sr.title = build_custom_provider_title(result)
-      sr.indexer = provider.name
-      sr.size_bytes = result.size_bytes
-      sr.seeders = nil
-      sr.leechers = nil
-      sr.download_url = result.download_url
-      sr.magnet_url = result.magnet_url
-      sr.info_url = result.info_url
-      sr.published_at = result.published_at
-      sr.source = SearchResult::SOURCE_CUSTOM
-      sr.detected_language = result.language
-      sr.provider_payload = result.payload
-    end
+    )
+    search_result.assign_attributes(
+      guid: "custom:#{provider.id}:#{result.provider_result_id}",
+      title: build_custom_provider_title(result),
+      indexer: provider.name,
+      size_bytes: result.size_bytes,
+      seeders: nil,
+      leechers: nil,
+      download_url: result.download_url,
+      magnet_url: result.magnet_url,
+      info_url: result.info_url,
+      published_at: result.published_at,
+      source: SearchResult::SOURCE_CUSTOM,
+      detected_language: result.language,
+      provider_payload: result.payload
+    )
+    search_result.status = :pending unless search_result.blocklisted? || search_result.selected?
+    search_result.save!
+    search_result
   end
 
   def build_custom_provider_title(result)

--- a/app/models/ranking_provider.rb
+++ b/app/models/ranking_provider.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "uri"
+
+class RankingProvider < ApplicationRecord
+  encrypts :api_key
+
+  before_validation :normalize_url
+
+  validates :name, presence: true, uniqueness: true
+  validates :url, presence: true
+  validates :priority, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :timeout_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 120 }
+  validate :url_is_http
+  validate :url_private_network_access
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :by_priority, -> { order(priority: :asc, name: :asc) }
+
+  def client
+    RankingProviderClient.new(self)
+  end
+
+  def test_connection
+    client.test_connection
+  end
+
+  private
+
+  def normalize_url
+    self.url = url.to_s.strip.delete_suffix("/") if url.present?
+  end
+
+  def url_is_http
+    uri = URI.parse(url.to_s)
+    return if %w[http https].include?(uri.scheme) && uri.host.present? && uri.userinfo.blank?
+
+    errors.add(:url, "must be a valid http or https URL")
+  rescue URI::InvalidURIError
+    errors.add(:url, "must be a valid http or https URL")
+  end
+
+  def url_private_network_access
+    return if allow_private_network?
+    return if url.blank? || errors.include?(:url)
+
+    host = URI.parse(url.to_s).host
+    return unless OutboundUrlGuard.obviously_private_host?(host)
+
+    errors.add(:url, "points to a private network address. Enable \"Allow private network\" if this provider runs on your local network.")
+  rescue URI::InvalidURIError
+    nil
+  end
+end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -66,7 +66,31 @@ class SearchResult < ApplicationRecord
     order(Arel.sql("CASE #{download_type_sql} #{type_order_sql} ELSE #{ordered_types.length} END"))
   }
 
-  scope :best_first, -> { preferred_first.order(confidence_score: :desc, seeders: :desc, size_bytes: :asc, id: :asc) }
+  # A trusted ranking provider may rank the combined acquisition result set
+  # after applying external metadata or model-assisted matching. Per-result
+  # ranks returned from a custom provider's /search remain supported as well.
+  # Both are subordinate to download-type preferences and never replace
+  # Shelfarr's confidence score or auto-selection eligibility checks.
+  scope :best_first, -> {
+    provider_rank_sql = <<~SQL.squish
+      CASE
+        WHEN json_type(score_breakdown, '$.external_rank_score') = 'integer'
+          AND EXISTS (
+            SELECT 1
+            FROM ranking_providers
+            WHERE ranking_providers.id = json_extract(score_breakdown, '$.external_rank_provider_id')
+              AND ranking_providers.enabled = 1
+          )
+        THEN json_extract(score_breakdown, '$.external_rank_score')
+        WHEN source = '#{SOURCE_CUSTOM}'
+          AND json_type(provider_payload, '$.rank_score') = 'integer'
+        THEN json_extract(provider_payload, '$.rank_score')
+        ELSE confidence_score
+      END DESC
+    SQL
+
+    preferred_first.order(Arel.sql(provider_rank_sql), confidence_score: :desc, seeders: :desc, size_bytes: :asc, id: :asc)
+  }
 
   scope :high_confidence, ->(threshold = nil) {
     min_score = threshold || SettingsService.get(:min_match_confidence)
@@ -231,6 +255,23 @@ class SearchResult < ApplicationRecord
 
   def preference_adjustment
     score_detail(:preference_adjustment).to_i
+  end
+
+  def provider_rank_score
+    return unless from_custom_provider?
+
+    value = provider_payload_value(:rank_score)
+    score = Integer(value, exception: false)
+    score if score&.between?(0, 100)
+  end
+
+  def external_rank_score
+    score = Integer(score_detail(:external_rank_score), exception: false)
+    score if score&.between?(0, 100)
+  end
+
+  def external_rank_evidence
+    score_detail(:external_rank_evidence)
   end
 
   # Source helpers

--- a/app/services/custom_acquisition_provider_client.rb
+++ b/app/services/custom_acquisition_provider_client.rb
@@ -23,7 +23,7 @@ class CustomAcquisitionProviderClient
   Result = Data.define(
     :provider_result_id, :title, :author, :file_type, :language, :size_bytes,
     :download_type, :download_url, :magnet_url, :info_url, :published_at,
-    :availability, :payload
+    :availability, :rank_score, :payload
   ) do
     def available?
       availability.blank? || availability == "available"
@@ -166,19 +166,7 @@ class CustomAcquisitionProviderClient
         id: request.id,
         language: request.effective_language
       },
-      book: {
-        id: book.id,
-        title: book.title,
-        author: book.author,
-        book_type: book.book_type,
-        year: book.year,
-        language: book.language,
-        isbn: book.isbn,
-        open_library_work_id: book.open_library_work_id,
-        open_library_edition_id: book.open_library_edition_id,
-        google_books_id: book.google_books_id,
-        hardcover_id: book.hardcover_id
-      }.compact
+      book: book_payload(book)
     }
   end
 
@@ -190,13 +178,36 @@ class CustomAcquisitionProviderClient
         id: search_result.request_id,
         language: search_result.request&.effective_language
       },
-      book: {
-        id: search_result.request&.book_id,
-        title: search_result.request&.book&.title,
-        author: search_result.request&.book&.author,
-        book_type: search_result.request&.book&.book_type
-      }.compact
+      book: book_payload(search_result.request&.book)
     }
+  end
+
+  def book_payload(book)
+    return {} unless book
+
+    {
+      id: book.id,
+      title: book.title,
+      author: book.author,
+      book_type: book.book_type,
+      content_kind: book.content_kind,
+      year: book.year,
+      release_date: book.release_date&.iso8601,
+      language: book.language,
+      publisher: book.publisher,
+      series: book.series,
+      series_position: book.series_position,
+      narrator: book.narrator,
+      description: book.description,
+      issue_number: book.issue_number,
+      isbn: book.isbn,
+      metadata_source: book.metadata_source,
+      open_library_work_id: book.open_library_work_id,
+      open_library_edition_id: book.open_library_edition_id,
+      google_books_id: book.google_books_id,
+      hardcover_id: book.hardcover_id,
+      comic_vine_id: book.comic_vine_id
+    }.compact
   end
 
   def search_result_payload(search_result)
@@ -242,9 +253,11 @@ class CustomAcquisitionProviderClient
     download_type = self.class.normalize_download_type(data["download_type"].presence || data["type"].presence)
     download_type ||= infer_download_type(direct_url:, nzb_url:, magnet_url:)
     availability = normalize_availability(data["availability"].presence || "available")
+    rank_score = normalize_rank_score(data["rank_score"])
     payload = data.merge(
       "download_type" => download_type,
-      "availability" => availability
+      "availability" => availability,
+      "rank_score" => rank_score
     )
 
     Result.new(
@@ -260,6 +273,7 @@ class CustomAcquisitionProviderClient
       info_url: data["info_url"].presence,
       published_at: time_or_nil(data["published_at"]),
       availability: availability,
+      rank_score: rank_score,
       payload: payload
     )
   end
@@ -313,6 +327,11 @@ class CustomAcquisitionProviderClient
 
   def integer_or_nil(value)
     Integer(value, exception: false)
+  end
+
+  def normalize_rank_score(value)
+    score = integer_or_nil(value)
+    score if score&.between?(0, 100)
   end
 
   def time_or_nil(value)

--- a/app/services/ranking_provider_client.rb
+++ b/app/services/ranking_provider_client.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+class RankingProviderClient
+  class Error < StandardError; end
+  class ConnectionError < Error; end
+  class ResponseError < Error; end
+
+  Ranking = Data.define(:candidate_id, :rank_score, :match_evidence)
+
+  MAX_RESPONSE_BYTES = 10.megabytes
+  HEALTH_CHECK_TIMEOUT_SECONDS = 10
+  SCHEMA_VERSION = 1
+
+  NETWORK_ERRORS = [
+    SocketError, EOFError, IOError, Errno::ECONNREFUSED, Errno::ECONNRESET,
+    Errno::EHOSTUNREACH, Errno::ENETUNREACH, Net::OpenTimeout, Net::ReadTimeout,
+    OpenSSL::SSL::SSLError
+  ].freeze
+
+  def initialize(provider)
+    @provider = provider
+  end
+
+  def rank(request, search_results)
+    response = post_json("v1/rank", ranking_payload(request, search_results))
+    parse_rankings(response)
+  end
+
+  def test_connection
+    endpoint = validate_endpoint!("health")
+    timeout = [ provider.timeout_seconds, HEALTH_CHECK_TIMEOUT_SECONDS ].min
+    response = start_http(endpoint, read_timeout: timeout) do |http|
+      http.request(build_request(Net::HTTP::Get, endpoint.uri))
+    end
+
+    response.is_a?(Net::HTTPSuccess)
+  rescue Error, *NETWORK_ERRORS
+    false
+  end
+
+  private
+
+  attr_reader :provider
+
+  def ranking_payload(request, search_results)
+    {
+      schema_version: SCHEMA_VERSION,
+      task: "candidate_ranking",
+      media: media_payload(request.book),
+      context: request_context(request),
+      preferences: ranking_preferences(request.book),
+      candidates: Array(search_results).map { |result| candidate_payload(result) }
+    }
+  end
+
+  def media_payload(book)
+    {
+      type: "book",
+      format: book.book_type,
+      title: book.title,
+      release_year: book.year,
+      release_date: book.release_date&.iso8601,
+      language: book.language,
+      contributors: contributor_payload(book),
+      relationships: relationship_payload(book),
+      identifiers: identifier_payload(book),
+      attributes: {
+        content_kind: book.content_kind,
+        publisher: book.publisher,
+        description: book.description,
+        issue_number: book.issue_number,
+        metadata_source: book.metadata_source
+      }.compact
+    }.compact
+  end
+
+  def contributor_payload(book)
+    [
+      ({ role: "author", name: book.author } if book.author.present?),
+      ({ role: "narrator", name: book.narrator } if book.narrator.present?)
+    ].compact
+  end
+
+  def relationship_payload(book)
+    return [] if book.series.blank?
+
+    [ { type: "series", name: book.series, position: book.series_position }.compact ]
+  end
+
+  def identifier_payload(book)
+    {
+      isbn: Array(book.isbn).compact_blank,
+      open_library_work: Array(book.open_library_work_id).compact_blank,
+      open_library_edition: Array(book.open_library_edition_id).compact_blank,
+      google_books: Array(book.google_books_id).compact_blank,
+      hardcover: Array(book.hardcover_id).compact_blank,
+      comic_vine: Array(book.comic_vine_id).compact_blank
+    }.reject { |_key, values| values.empty? }
+  end
+
+  def request_context(request)
+    collection = if request.collection_id.present? || request.collection_title.present?
+      {
+        source: request.collection_source,
+        id: request.collection_id,
+        title: request.collection_title
+      }.compact
+    end
+
+    {
+      request_id: request.id.to_s,
+      language: request.effective_language,
+      scope: request.request_scope,
+      collection: collection
+    }.compact
+  end
+
+  def ranking_preferences(book)
+    format_preferences = SettingsService.format_preferences_for(book.book_type)
+
+    {
+      preferred_download_types: SettingsService.preferred_download_types,
+      approved_formats: format_preferences[:approved_formats],
+      rejected_formats: format_preferences[:rejected_formats],
+      preferred_formats: format_preferences[:preferred_formats],
+      prefer_single_file: format_preferences[:prefer_single_file],
+      prefer_higher_bitrate: format_preferences[:prefer_higher_bitrate],
+      minimum_seeders: SettingsService.get(:auto_select_min_seeders, default: 1)
+    }
+  end
+
+  # Deliberately excludes download, magnet, info, and provider-payload URLs.
+  def candidate_payload(search_result)
+    {
+      candidate_id: search_result.id.to_s,
+      title: search_result.title,
+      source: search_result.source,
+      indexer: search_result.indexer,
+      download_type: search_result.download_type,
+      size_bytes: search_result.size_bytes,
+      seeders: search_result.seeders,
+      leechers: search_result.leechers,
+      published_at: search_result.published_at&.iso8601,
+      detected_language: search_result.detected_language,
+      detected_formats: search_result.detected_extensions,
+      audiobook_structure: search_result.audiobook_structure,
+      audio_bitrate_kbps: search_result.audio_bitrate_kbps,
+      application_score: search_result.confidence_score,
+      application_score_breakdown: search_result.score_breakdown
+    }.compact
+  end
+
+  def parse_rankings(body)
+    rankings = body.is_a?(Hash) ? body.fetch("rankings", nil) : nil
+    unless rankings.is_a?(Array)
+      raise ResponseError, "#{provider.name} returned an invalid rankings list"
+    end
+
+    rankings.filter_map do |item|
+      next unless item.is_a?(Hash)
+
+      candidate_id = item["candidate_id"].to_s.presence
+      rank_score = normalize_rank_score(item["rank_score"])
+      next if candidate_id.blank? || rank_score.nil?
+
+      Ranking.new(
+        candidate_id: candidate_id,
+        rank_score: rank_score,
+        match_evidence: item["match_evidence"]
+      )
+    end
+  end
+
+  def post_json(path, payload)
+    endpoint = validate_endpoint!(path)
+    response_body = nil
+    response = start_http(endpoint, read_timeout: provider.timeout_seconds) do |http|
+      request = build_request(Net::HTTP::Post, endpoint.uri)
+      request["Content-Type"] = "application/json"
+      request.body = JSON.generate(payload)
+
+      http.request(request) do |res|
+        response_body = read_capped_body(res)
+      end
+    end
+
+    raise ResponseError, "#{provider.name} returned HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response_body.to_s)
+  rescue JSON::ParserError => e
+    raise ResponseError, "#{provider.name} returned invalid JSON: #{e.message}"
+  rescue *NETWORK_ERRORS => e
+    raise ConnectionError, "Failed to connect to #{provider.name}: #{e.message}"
+  end
+
+  def validate_endpoint!(path)
+    OutboundUrlGuard.validate!(
+      "#{provider.url}/#{path}",
+      allow_private: provider.allow_private_network?
+    )
+  rescue OutboundUrlGuard::BlockedUrlError => e
+    raise ConnectionError, "Refused to contact #{provider.name}: #{e.message}"
+  end
+
+  def start_http(endpoint, read_timeout:, &block)
+    Net::HTTP.start(
+      endpoint.host,
+      endpoint.port,
+      use_ssl: endpoint.use_ssl?,
+      ipaddr: endpoint.ipaddr,
+      open_timeout: [ read_timeout, 10 ].min,
+      read_timeout: read_timeout,
+      &block
+    )
+  end
+
+  def build_request(request_class, uri)
+    request = request_class.new(uri)
+    request["User-Agent"] = "Shelfarr/1.0"
+    request["Authorization"] = "Bearer #{provider.api_key}" if provider.api_key.present?
+    request
+  end
+
+  def read_capped_body(response)
+    declared_length = response["Content-Length"].presence&.to_i
+    if declared_length && declared_length > MAX_RESPONSE_BYTES
+      raise ResponseError, "#{provider.name} response exceeds #{MAX_RESPONSE_BYTES / 1.megabyte} MB limit"
+    end
+
+    body = +""
+    response.read_body do |chunk|
+      body << chunk
+      if body.bytesize > MAX_RESPONSE_BYTES
+        raise ResponseError, "#{provider.name} response exceeds #{MAX_RESPONSE_BYTES / 1.megabyte} MB limit"
+      end
+    end
+    body
+  end
+
+  def normalize_rank_score(value)
+    score = Integer(value, exception: false)
+    score if score&.between?(0, 100)
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -130,6 +130,7 @@
         <%= link_to "Manage Users", admin_users_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Download Clients", admin_download_clients_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Acquisition Providers", admin_acquisition_providers_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
+        <%= link_to "Ranking Providers", admin_ranking_providers_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Audible Backup (Beta)", admin_owned_library_connections_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Download Routing", admin_download_routing_rules_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>
         <%= link_to "Manual Uploads", admin_uploads_path, class: "block px-4 py-2 rounded bg-gray-700 hover:bg-gray-600 text-gray-300" %>

--- a/app/views/admin/ranking_providers/_form.html.erb
+++ b/app/views/admin/ranking_providers/_form.html.erb
@@ -1,0 +1,54 @@
+<%= form_with model: [:admin, provider], class: "contents" do |form| %>
+  <% if provider.errors.any? %>
+    <div class="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 font-medium rounded-lg mt-3">
+      <h2><%= pluralize(provider.errors.count, "error") %> prohibited this provider from being saved:</h2>
+      <ul class="list-disc list-inside mt-2">
+        <% provider.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="my-5">
+    <%= form.label :name, class: "block text-gray-300 font-medium" %>
+    <%= form.text_field :name, required: true, placeholder: "e.g., Local Media Ranker", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :url, "Base URL", class: "block text-gray-300 font-medium" %>
+    <%= form.url_field :url, required: true, placeholder: "http://media-ranker:4567", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+    <p class="mt-1 text-sm text-gray-500">The service must expose POST /v1/rank. GET /health is used for the test button.</p>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :api_key, "Bearer Token", class: "block text-gray-300 font-medium" %>
+    <%= form.password_field :api_key, placeholder: provider.persisted? && provider.api_key.present? ? "Leave blank to keep current" : "Optional token", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+  </div>
+
+  <div class="my-5">
+    <%= form.label :timeout_seconds, "Timeout Seconds", class: "block text-gray-300 font-medium" %>
+    <%= form.number_field :timeout_seconds, min: 1, max: 120, class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+  </div>
+
+  <div class="my-5">
+    <label class="flex items-center gap-2 text-gray-300">
+      <%= form.check_box :allow_private_network, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+      <span>Allow private network</span>
+    </label>
+    <p class="mt-1 text-sm text-gray-500">Enable this for a ranker running on localhost or your home-lab network.</p>
+  </div>
+
+  <div class="my-5">
+    <label class="flex items-center gap-2 text-gray-300">
+      <%= form.check_box :enabled, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+      <span>Enabled</span>
+    </label>
+    <p class="mt-1 text-sm text-gray-500">When disabled, Shelfarr never contacts this service and uses its normal result ordering.</p>
+  </div>
+
+  <div class="flex items-center gap-4 mt-8">
+    <%= form.submit class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
+    <%= link_to "Cancel", admin_ranking_providers_path, class: "text-gray-400 hover:text-gray-300" %>
+  </div>
+<% end %>

--- a/app/views/admin/ranking_providers/edit.html.erb
+++ b/app/views/admin/ranking_providers/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl text-white mb-8">Edit Ranking Provider</h1>
+  <%= render "form", provider: @provider %>
+</div>

--- a/app/views/admin/ranking_providers/index.html.erb
+++ b/app/views/admin/ranking_providers/index.html.erb
@@ -1,0 +1,47 @@
+<div class="mx-auto max-w-5xl">
+  <div class="flex flex-wrap items-center justify-between gap-3 mb-8">
+    <div>
+      <h1 class="font-bold text-3xl sm:text-4xl text-white">Ranking Providers</h1>
+      <p class="mt-2 text-gray-400">Optional media-neutral services that enrich and re-rank the combined acquisition result set.</p>
+    </div>
+    <%= link_to "New Ranking Provider", new_admin_ranking_provider_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white whitespace-nowrap" %>
+  </div>
+
+  <% if @providers.empty? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-lg p-8 text-center">
+      <p class="text-gray-400 mb-4">No ranking provider is configured. Shelfarr is using its normal result ordering.</p>
+      <%= link_to "Add a ranking provider", new_admin_ranking_provider_path, class: "text-blue-400 hover:text-blue-300" %>
+    </div>
+  <% else %>
+    <div class="bg-gray-900 rounded-lg border border-gray-800 overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-800">
+        <thead class="bg-gray-800/50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Priority</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">URL</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          <% @providers.each do |provider| %>
+            <tr class="hover:bg-gray-800/50 transition">
+              <td class="px-6 py-4 whitespace-nowrap text-gray-300 font-medium"><%= provider.priority + 1 %></td>
+              <td class="px-6 py-4 whitespace-nowrap"><%= link_to provider.name, admin_ranking_provider_path(provider), class: "font-medium text-white hover:text-blue-300" %></td>
+              <td class="px-6 py-4 text-gray-400 text-sm break-all"><%= provider.url %></td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="px-2 py-1 text-xs rounded <%= provider.enabled? ? 'bg-green-500/20 text-green-400' : 'bg-gray-700 text-gray-400' %>"><%= provider.enabled? ? "Enabled" : "Disabled" %></span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <%= button_to "Test", test_admin_ranking_provider_path(provider), method: :post, class: "text-green-400 hover:text-green-300 mr-3" %>
+                <%= link_to "Edit", edit_admin_ranking_provider_path(provider), class: "text-blue-400 hover:text-blue-300 mr-3" %>
+                <%= button_to "Delete", admin_ranking_provider_path(provider), method: :delete, class: "text-red-400 hover:text-red-300", data: { turbo_confirm: "Delete this ranking provider?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/ranking_providers/new.html.erb
+++ b/app/views/admin/ranking_providers/new.html.erb
@@ -1,0 +1,4 @@
+<div class="mx-auto max-w-2xl">
+  <h1 class="font-bold text-4xl text-white mb-8">New Ranking Provider</h1>
+  <%= render "form", provider: @provider %>
+</div>

--- a/app/views/admin/ranking_providers/show.html.erb
+++ b/app/views/admin/ranking_providers/show.html.erb
@@ -1,0 +1,18 @@
+<div class="mx-auto max-w-3xl">
+  <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-8">
+    <h1 class="font-bold text-3xl sm:text-4xl text-white break-words"><%= @provider.name %></h1>
+    <div class="flex flex-wrap gap-3 shrink-0">
+      <%= button_to "Test", test_admin_ranking_provider_path(@provider), method: :post, class: "rounded-md px-4 py-2 bg-green-700 hover:bg-green-600 text-white" %>
+      <%= link_to "Edit", edit_admin_ranking_provider_path(@provider), class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white" %>
+      <%= link_to "Back", admin_ranking_providers_path, class: "rounded-md px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white" %>
+    </div>
+  </div>
+
+  <dl class="bg-gray-900 border border-gray-800 rounded-lg divide-y divide-gray-800">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4"><dt class="text-gray-400">URL</dt><dd class="md:col-span-2 text-gray-100 break-all"><%= @provider.url %></dd></div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4"><dt class="text-gray-400">Protocol</dt><dd class="md:col-span-2 text-gray-100">Media Ranking API v1</dd></div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4"><dt class="text-gray-400">Timeout</dt><dd class="md:col-span-2 text-gray-100"><%= @provider.timeout_seconds %> seconds</dd></div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4"><dt class="text-gray-400">Private Network</dt><dd class="md:col-span-2 text-gray-100"><%= @provider.allow_private_network? ? "Allowed" : "Blocked" %></dd></div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4"><dt class="text-gray-400">Status</dt><dd class="md:col-span-2 text-gray-100"><%= @provider.enabled? ? "Enabled" : "Disabled" %></dd></div>
+  </dl>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,11 @@ Rails.application.routes.draw do
         post :test
       end
     end
+    resources :ranking_providers do
+      member do
+        post :test
+      end
+    end
     resources :owned_library_connections, only: [ :index, :create, :update ] do
       member do
         post :test

--- a/db/migrate/20260814190000_create_ranking_providers.rb
+++ b/db/migrate/20260814190000_create_ranking_providers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateRankingProviders < ActiveRecord::Migration[8.1]
+  def change
+    create_table :ranking_providers do |t|
+      t.string :name, null: false
+      t.string :url, null: false
+      t.string :api_key
+      t.boolean :enabled, null: false, default: true
+      t.boolean :allow_private_network, null: false, default: false
+      t.integer :priority, null: false, default: 0
+      t.integer :timeout_seconds, null: false, default: 30
+
+      t.timestamps
+    end
+
+    add_index :ranking_providers, :name, unique: true
+    add_index :ranking_providers, [ :enabled, :priority ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_190000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -349,6 +349,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
     t.index ["event_type"], name: "index_request_events_on_event_type"
     t.index ["request_id", "event_type", "source"], name: "index_request_events_on_unique_store_offer_state", unique: true, where: "event_type = 'store_offers_found' AND source = 'store_provider'"
     t.index ["request_id"], name: "index_request_events_on_request_id"
+  end
+
+  create_table "ranking_providers", force: :cascade do |t|
+    t.boolean "allow_private_network", default: false, null: false
+    t.string "api_key"
+    t.datetime "created_at", null: false
+    t.boolean "enabled", default: true, null: false
+    t.string "name", null: false
+    t.integer "priority", default: 0, null: false
+    t.integer "timeout_seconds", default: 30, null: false
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.index ["enabled", "priority"], name: "index_ranking_providers_on_enabled_and_priority"
+    t.index ["name"], name: "index_ranking_providers_on_name", unique: true
   end
 
   create_table "requests", force: :cascade do |t|

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 Shelfarr exposes a JSON API under `/api/v1`.
 
-For custom HTTP search/acquisition integrations called by Shelfarr, see [Custom Acquisition Providers](custom-acquisition-providers.md).
+For custom HTTP search/acquisition integrations called by Shelfarr, see [Custom Acquisition Providers](custom-acquisition-providers.md). For optional media-neutral result enrichment and re-ranking, see [Media Ranking Providers](media-ranking-providers.md).
 
 ## Authentication
 

--- a/docs/custom-acquisition-providers.md
+++ b/docs/custom-acquisition-providers.md
@@ -52,15 +52,29 @@ Request body:
     "title": "Dune",
     "author": "Frank Herbert",
     "book_type": "ebook",
+    "content_kind": "book",
     "year": 1965,
+    "release_date": "1965-08-01",
     "language": "en",
+    "publisher": "Chilton Books",
+    "series": "Dune",
+    "series_position": "1",
+    "narrator": null,
+    "description": "Set on the desert planet Arrakis...",
+    "issue_number": null,
     "isbn": "9780441172719",
+    "metadata_source": "hardcover",
     "open_library_work_id": "OL893415W",
     "open_library_edition_id": "OL26712345M",
+    "google_books_id": "abc123",
     "hardcover_id": "789"
   }
 }
 ```
+
+The book object contains metadata already stored by Shelfarr. `cover_url` is
+intentionally omitted so providers do not need another network request just to
+consume the matching context.
 
 Response body can be either a bare array or an object with `results`:
 
@@ -76,6 +90,11 @@ Response body can be either a bare array or an object with `results`:
       "size_bytes": 5242880,
       "download_type": "direct",
       "availability": "available",
+      "rank_score": 96,
+      "match_evidence": {
+        "matched_fields": ["title", "author", "series"],
+        "warnings": []
+      },
       "info_url": "https://provider.example/books/provider-result-1",
       "published_at": "2026-06-08T12:00:00Z"
     }
@@ -96,10 +115,21 @@ Recommended result fields:
 - `size_bytes`
 - `download_type`: `direct`, `torrent`, or `usenet`
 - `availability`: `available`, `unknown`, `temporarily_unavailable`, or provider-specific text
+- `rank_score`: integer from `0` to `100`; replaces this result's ordering score among results with the same preferred download type
+- `match_evidence`: optional provider-defined JSON explaining the ranking decision
 - `info_url`
 - `published_at`
 
 Shelfarr stores the full result object as provider metadata so `/acquire` can receive it later.
+
+`rank_score` is advisory ordering for results returned by this provider, not a replacement for Shelfarr's stored
+confidence score. Results without it continue to rank by Shelfarr confidence.
+It cannot make a low-confidence result auto-selectable, bypass language
+or format preferences, override the configured download-type order, or make an
+unavailable result downloadable. Invalid and out-of-range values are ignored.
+This lets a trusted provider use richer metadata or a model-assisted matcher to
+re-rank credible candidates without giving it control over Shelfarr's safety
+gates.
 
 ## Acquire
 

--- a/docs/media-ranking-providers.md
+++ b/docs/media-ranking-providers.md
@@ -1,0 +1,147 @@
+# Media Ranking Providers
+
+Ranking providers are optional HTTP services that enrich and re-rank the
+combined acquisition candidates Shelfarr has already found. They are separate
+from custom acquisition providers: a ranking-only service does not implement
+search or acquisition and never supplies a downloadable artifact.
+
+Shelfarr uses a versioned, media-neutral contract so the same service can
+support adapters for books, movies, television, music, games, or other media.
+Shelfarr currently sends book-family media, including ebooks, audiobooks, and
+comics. Other applications can send their own media types to the same API.
+
+## Configuration and Disabled Behavior
+
+Add services under **Admin > Ranking Providers**. Each provider has a name,
+base URL, optional encrypted bearer token, timeout, private-network permission,
+and enabled flag.
+
+If no ranking provider is configured or enabled, Shelfarr makes no ranking
+request and uses its existing ordering. If multiple providers are enabled,
+Shelfarr calls the highest-priority provider. A failed request is logged and
+normal ordering is retained. Disabling or deleting a provider also makes
+previously saved scores from that provider stop affecting result order.
+
+The **Test** action calls `GET /health`. Search-time ranking calls
+`POST /v1/rank`.
+
+## Version 1 Ranking Contract
+
+```http
+POST /v1/rank
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+Shelfarr saves and locally scores the complete acquisition set before making
+this call. Candidates can come from Prowlarr, Jackett,
+Newznab/NZBHydra2, Anna's Archive, Z-Library, Project Gutenberg, LibriVox, or
+custom acquisition providers.
+
+```json
+{
+  "schema_version": 1,
+  "task": "candidate_ranking",
+  "media": {
+    "type": "book",
+    "format": "audiobook",
+    "title": "Still",
+    "release_year": 2017,
+    "language": "en",
+    "contributors": [
+      { "role": "author", "name": "Kennedy Ryan" },
+      { "role": "narrator", "name": "Jakobi Diem" }
+    ],
+    "relationships": [
+      { "type": "series", "name": "Grip", "position": "2" }
+    ],
+    "identifiers": {
+      "isbn": ["1515944042"],
+      "hardcover": ["123"]
+    },
+    "attributes": {
+      "content_kind": "book",
+      "publisher": "Example Press",
+      "description": "Stored description...",
+      "metadata_source": "hardcover"
+    }
+  },
+  "context": {
+    "request_id": "35",
+    "language": "en",
+    "scope": "single"
+  },
+  "preferences": {
+    "preferred_download_types": ["usenet", "torrent", "direct"],
+    "approved_formats": ["m4b", "mp3"],
+    "rejected_formats": [],
+    "preferred_formats": ["m4b", "mp3"],
+    "prefer_single_file": true,
+    "prefer_higher_bitrate": true,
+    "minimum_seeders": 1
+  },
+  "candidates": [
+    {
+      "candidate_id": "987",
+      "title": "Still - Kennedy Ryan - Jakobi Diem [M4B]",
+      "source": "prowlarr",
+      "indexer": "Example Books",
+      "download_type": "usenet",
+      "size_bytes": 734003200,
+      "published_at": "2026-06-08T12:00:00Z",
+      "detected_language": "en",
+      "detected_formats": ["m4b"],
+      "audiobook_structure": "single_file",
+      "audio_bitrate_kbps": 128,
+      "application_score": 72,
+      "application_score_breakdown": {
+        "title": 100,
+        "author": 100,
+        "language": 50,
+        "format": 100,
+        "health": 100,
+        "search_attempt": "title_author",
+        "search_query": "Still Kennedy Ryan English"
+      }
+    }
+  ]
+}
+```
+
+The common `media` shape is deliberately extensible. A movie adapter could
+send `type: "movie"`, contributors with the `director` role, TMDB/IMDb
+identifiers, and resolution or edition attributes. A recommendation service
+may share the same normalization and enrichment pipeline and expose a separate
+`POST /v1/recommend` operation; Shelfarr only consumes candidate ranking.
+
+Shelfarr deliberately omits download URLs, magnet links, info URLs, provider
+payloads, and cover URLs. Ranking does not require those fields, and they may
+contain credentials or force additional network lookups.
+
+## Response
+
+The provider returns any subset of the supplied opaque candidate IDs:
+
+```json
+{
+  "schema_version": 1,
+  "rankings": [
+    {
+      "candidate_id": "987",
+      "rank_score": 97,
+      "match_evidence": {
+        "matched_fields": ["title", "author", "series", "narrator"]
+      }
+    }
+  ]
+}
+```
+
+Scores must be integers from 0 through 100. Invalid scores, unknown candidate
+IDs, and malformed entries are ignored. External scores reorder candidates
+only within Shelfarr's configured download-type preference.
+
+Ranking remains advisory. It never changes Shelfarr's confidence score and
+cannot bypass language, format, availability, blocklist, minimum-seeder, or
+confidence gates. An external score of 100 cannot make a below-threshold result
+auto-selectable.

--- a/test/controllers/admin/ranking_providers_controller_test.rb
+++ b/test/controllers/admin/ranking_providers_controller_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::RankingProvidersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as(users(:two))
+  end
+
+  test "index renders providers ordered by priority" do
+    second = create_provider(name: "Second Ranker", url: "http://second-ranker.test", priority: 1)
+    first = create_provider(name: "First Ranker", url: "http://first-ranker.test", priority: 0)
+
+    get admin_ranking_providers_url
+
+    assert_response :success
+    assert_select "h1", "Ranking Providers"
+    assert_select "tbody tr:first-child td", text: first.name
+    assert_select "tbody tr:last-child td", text: second.name
+  end
+
+  test "new renders disabled-by-configuration form" do
+    get new_admin_ranking_provider_url
+
+    assert_response :success
+    assert_select "form[action='#{admin_ranking_providers_path}']"
+    assert_select "input[name='ranking_provider[timeout_seconds]'][value='30']"
+  end
+
+  test "create persists encrypted configuration and assigns next priority" do
+    create_provider(name: "Existing Ranker", priority: 2)
+
+    assert_difference -> { RankingProvider.count }, 1 do
+      post admin_ranking_providers_url, params: {
+        ranking_provider: provider_params(
+          name: "Created Ranker",
+          url: "http://created-ranker.test",
+          api_key: "created-secret",
+          enabled: "1",
+          timeout_seconds: "45"
+        )
+      }
+    end
+
+    assert_redirected_to admin_ranking_providers_path
+    provider = RankingProvider.find_by!(name: "Created Ranker")
+    assert_equal 3, provider.priority
+    assert_equal "created-secret", provider.api_key
+    assert provider.enabled?
+    assert_equal 45, provider.timeout_seconds
+  end
+
+  test "update preserves a blank api key" do
+    provider = create_provider(api_key: "existing-secret")
+
+    patch admin_ranking_provider_url(provider), params: {
+      ranking_provider: provider_params(
+        name: "Updated Ranker",
+        url: "http://updated-ranker.test/",
+        api_key: "",
+        enabled: "0",
+        timeout_seconds: "60"
+      )
+    }
+
+    assert_redirected_to admin_ranking_providers_path
+    provider.reload
+    assert_equal "Updated Ranker", provider.name
+    assert_equal "http://updated-ranker.test", provider.url
+    assert_equal "existing-secret", provider.api_key
+    assert_not provider.enabled?
+    assert_equal 60, provider.timeout_seconds
+  end
+
+  test "show does not render secret" do
+    provider = create_provider(api_key: "secret-token")
+
+    get admin_ranking_provider_url(provider)
+
+    assert_response :success
+    assert_select "h1", provider.name
+    assert_select "dd", text: /secret-token/, count: 0
+  end
+
+  test "test action reports connection result" do
+    provider = create_provider
+
+    VCR.turned_off do
+      stub_request(:get, "#{provider.url}/health").to_return(status: 204)
+      post test_admin_ranking_provider_url(provider)
+    end
+
+    assert_redirected_to admin_ranking_providers_path
+    assert_match(/successful/i, flash[:notice])
+  end
+
+  test "destroy removes provider" do
+    provider = create_provider
+
+    assert_difference -> { RankingProvider.count }, -1 do
+      delete admin_ranking_provider_url(provider)
+    end
+
+    assert_redirected_to admin_ranking_providers_path
+  end
+
+  private
+
+  def create_provider(**attributes)
+    RankingProvider.create!({
+      name: "Local Ranker",
+      url: "http://ranker.test",
+      enabled: true,
+      priority: 0,
+      timeout_seconds: 30
+    }.merge(attributes))
+  end
+
+  def provider_params(**attributes)
+    {
+      name: "Local Ranker",
+      url: "http://ranker.test",
+      enabled: "1",
+      timeout_seconds: "30"
+    }.merge(attributes)
+  end
+end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -2329,6 +2329,8 @@ class SearchJobTest < ActiveJob::TestCase
                 language: "en",
                 size_bytes: 1000,
                 download_type: "direct",
+                rank_score: 93,
+                match_evidence: { matched_fields: %w[title author] },
                 info_url: "https://provider.test/books/provider-1"
               }
             ]
@@ -2345,7 +2347,138 @@ class SearchJobTest < ActiveJob::TestCase
     assert_equal "provider-1", saved_result.provider_result_id
     assert_equal "custom:#{provider.id}:provider-1", saved_result.guid
     assert_equal "direct", saved_result.download_type
+    assert_equal 93, saved_result.provider_rank_score
+    assert_equal %w[title author], saved_result.provider_payload.dig("match_evidence", "matched_fields")
     assert saved_result.downloadable?
+  end
+
+  test "refreshes custom provider ranking metadata for an existing result" do
+    provider = AcquisitionProvider.create!(
+      name: "Ranking Provider",
+      url: "http://provider.test",
+      supports_ebooks: true,
+      supports_audiobooks: false
+    )
+    result_attributes = {
+      provider_result_id: "provider-ranked",
+      title: "The Pending Ebook",
+      author: "Another Author",
+      file_type: "epub",
+      language: "en",
+      size_bytes: 1000,
+      download_type: "direct",
+      download_url: nil,
+      magnet_url: nil,
+      info_url: "https://provider.test/books/provider-ranked",
+      published_at: nil,
+      availability: "available"
+    }
+    job = SearchJob.new
+    initial = CustomAcquisitionProviderClient::Result.new(
+      **result_attributes,
+      rank_score: 25,
+      payload: { "download_type" => "direct", "rank_score" => 25 }
+    )
+    updated = CustomAcquisitionProviderClient::Result.new(
+      **result_attributes,
+      rank_score: 92,
+      payload: {
+        "download_type" => "direct",
+        "rank_score" => 92,
+        "match_evidence" => { "matched_fields" => %w[title author series] }
+      }
+    )
+
+    saved = job.send(:save_custom_provider_result, @request, initial, provider)
+    refreshed = job.send(:save_custom_provider_result, @request, updated, provider)
+
+    assert_equal saved.id, refreshed.id
+    assert_equal 92, refreshed.provider_rank_score
+    assert_equal %w[title author series], refreshed.provider_payload.dig("match_evidence", "matched_fields")
+  end
+
+  test "external ranker reranks the combined saved result set without changing confidence" do
+    @request.search_results.destroy_all
+    RankingProvider.create!(
+      name: "Combined Ranking Provider",
+      url: "http://combined-ranker.test"
+    )
+    candidates = [
+      @request.search_results.create!(guid: "rank-prowlarr", title: "Prowlarr result", source: SearchResult::SOURCE_PROWLARR, confidence_score: 95),
+      @request.search_results.create!(guid: "rank-anna", title: "Anna result", source: SearchResult::SOURCE_ANNA_ARCHIVE, confidence_score: 70),
+      @request.search_results.create!(guid: "rank-zlib", title: "Z-Library result", source: SearchResult::SOURCE_ZLIBRARY, confidence_score: 65),
+      @request.search_results.create!(guid: "rank-librivox", title: "LibriVox result", source: SearchResult::SOURCE_LIBRIVOX, confidence_score: 60)
+    ]
+    VCR.turned_off do
+      stub_request(:post, "http://combined-ranker.test/v1/rank")
+        .with do |request|
+          body = JSON.parse(request.body)
+          body.fetch("candidates").map { |candidate| candidate["source"] }.sort ==
+            %w[anna_archive librivox prowlarr zlibrary].sort
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            rankings: candidates.each_with_index.map do |candidate, index|
+              {
+                candidate_id: candidate.id.to_s,
+                rank_score: 10 + (index * 20),
+                match_evidence: { source_checked: candidate.source }
+              }
+            end
+          }.to_json
+        )
+
+      SearchJob.new.send(:rerank_saved_results, @request)
+    end
+
+    candidates.each_with_index do |candidate, index|
+      candidate.reload
+      assert_equal 10 + (index * 20), candidate.external_rank_score
+      assert_equal candidate.source, candidate.external_rank_evidence["source_checked"]
+    end
+    assert_equal [ 95, 70, 65, 60 ], candidates.map { |candidate| candidate.reload.confidence_score }
+  end
+
+  test "external ranker failure leaves Shelfarr scores and search results unchanged" do
+    RankingProvider.create!(
+      name: "Unavailable Ranking Provider",
+      url: "http://unavailable-ranker.test"
+    )
+    candidate = @request.search_results.create!(
+      guid: "ranker-failure-result",
+      title: "Still usable without ranker",
+      source: SearchResult::SOURCE_PROWLARR,
+      confidence_score: 82,
+      score_breakdown: { "title" => 100 }
+    )
+
+    VCR.turned_off do
+      stub_request(:post, "http://unavailable-ranker.test/v1/rank").to_return(status: 500)
+      assert_nothing_raised { SearchJob.new.send(:rerank_saved_results, @request) }
+    end
+
+    candidate.reload
+    assert_equal 82, candidate.confidence_score
+    assert_equal({ "title" => 100 }, candidate.score_breakdown)
+  end
+
+  test "search uses normal scores without contacting a ranker when none is configured" do
+    RankingProvider.delete_all
+    candidate = @request.search_results.create!(
+      guid: "no-ranker-result",
+      title: "Normal Shelfarr ordering",
+      source: SearchResult::SOURCE_PROWLARR,
+      confidence_score: 84,
+      score_breakdown: { "title" => 100 }
+    )
+
+    assert_nothing_raised { SearchJob.new.send(:rerank_saved_results, @request) }
+
+    candidate.reload
+    assert_equal 84, candidate.confidence_score
+    assert_equal({ "title" => 100 }, candidate.score_breakdown)
   end
 
   test "heartbeats a long provider sequence so the watchdog does not preempt healthy work" do

--- a/test/models/ranking_provider_test.rb
+++ b/test/models/ranking_provider_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RankingProviderTest < ActiveSupport::TestCase
+  test "normalizes trailing slash from URL" do
+    provider = RankingProvider.create!(name: "Ranker", url: "http://ranker.test/")
+
+    assert_equal "http://ranker.test", provider.url
+  end
+
+  test "requires an http or https URL" do
+    provider = RankingProvider.new(name: "Ranker", url: "file:///tmp/ranker")
+
+    assert_not provider.valid?
+    assert_includes provider.errors[:url], "must be a valid http or https URL"
+  end
+
+  test "rejects private network URLs unless explicitly allowed" do
+    provider = RankingProvider.new(name: "Ranker", url: "http://localhost:4567")
+
+    assert_not provider.valid?
+    assert_match(/private network address/, provider.errors[:url].first)
+
+    provider.allow_private_network = true
+    assert provider.valid?, provider.errors.full_messages.join(", ")
+  end
+
+  test "orders enabled providers by priority" do
+    second = RankingProvider.create!(name: "Second", url: "http://second-ranker.test", priority: 2)
+    first = RankingProvider.create!(name: "First", url: "http://first-ranker.test", priority: 1)
+    RankingProvider.create!(name: "Disabled", url: "http://disabled-ranker.test", priority: 0, enabled: false)
+
+    assert_equal [ first, second ], RankingProvider.enabled.by_priority.to_a
+  end
+
+  test "encrypts api key" do
+    provider = RankingProvider.create!(name: "Secure", url: "http://secure-ranker.test", api_key: "secret-ranker-token")
+
+    provider.reload
+    assert_equal "secret-ranker-token", provider.api_key
+    assert_not_equal "secret-ranker-token", provider.api_key_before_type_cast
+  end
+end

--- a/test/models/search_result_test.rb
+++ b/test/models/search_result_test.rb
@@ -105,6 +105,92 @@ class SearchResultTest < ActiveSupport::TestCase
     assert_equal [ direct_result, usenet_result, torrent_result ], request.search_results.best_first.to_a
   end
 
+  test "best_first lets custom providers rerank results within a preferred download type" do
+    request = requests(:pending_request)
+    request.search_results.destroy_all
+    provider = AcquisitionProvider.create!(name: "Ranking Provider", url: "http://provider.test")
+
+    locally_higher = request.search_results.create!(
+      guid: "custom-local-score",
+      title: "Locally higher",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "local-score",
+      provider_payload: { "download_type" => "direct", "rank_score" => 10 },
+      confidence_score: 99
+    )
+    provider_higher = request.search_results.create!(
+      guid: "custom-provider-score",
+      title: "Provider higher",
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "provider-score",
+      provider_payload: { "download_type" => "direct", "rank_score" => 95 },
+      confidence_score: 90
+    )
+
+    SettingsService.set(:preferred_download_types, %w[direct usenet torrent])
+
+    assert_equal [ provider_higher, locally_higher ], request.search_results.best_first.to_a
+    assert_equal 95, provider_higher.provider_rank_score
+  end
+
+  test "best_first applies external ranks to results from every provider" do
+    request = requests(:pending_request)
+    request.search_results.destroy_all
+    ranker = RankingProvider.create!(name: "Model Ranker", url: "http://model-ranker.test")
+
+    anna = request.search_results.create!(
+      guid: "externally-ranked-anna",
+      title: "Anna",
+      source: SearchResult::SOURCE_ANNA_ARCHIVE,
+      confidence_score: 99,
+      score_breakdown: { "external_rank_score" => 10, "external_rank_provider_id" => ranker.id }
+    )
+    zlibrary = request.search_results.create!(
+      guid: "externally-ranked-zlibrary",
+      title: "Z-Library",
+      source: SearchResult::SOURCE_ZLIBRARY,
+      confidence_score: 70,
+      score_breakdown: {
+        "external_rank_score" => 95,
+        "external_rank_provider_id" => ranker.id,
+        "external_rank_evidence" => { "series" => "matched" }
+      }
+    )
+
+    SettingsService.set(:preferred_download_types, %w[direct torrent usenet])
+
+    assert_equal [ zlibrary, anna ], request.search_results.best_first.to_a
+    assert_equal 95, zlibrary.external_rank_score
+    assert_equal "matched", zlibrary.external_rank_evidence["series"]
+  end
+
+  test "best_first ignores saved external ranks when their provider is disabled" do
+    request = requests(:pending_request)
+    request.search_results.destroy_all
+    ranker = RankingProvider.create!(name: "Disabled Model Ranker", url: "http://disabled-model-ranker.test", enabled: false)
+
+    locally_higher = request.search_results.create!(
+      guid: "disabled-ranker-local",
+      title: "Locally higher",
+      source: SearchResult::SOURCE_ANNA_ARCHIVE,
+      confidence_score: 95,
+      score_breakdown: { "external_rank_score" => 10, "external_rank_provider_id" => ranker.id }
+    )
+    externally_higher = request.search_results.create!(
+      guid: "disabled-ranker-external",
+      title: "Externally higher",
+      source: SearchResult::SOURCE_ZLIBRARY,
+      confidence_score: 70,
+      score_breakdown: { "external_rank_score" => 100, "external_rank_provider_id" => ranker.id }
+    )
+
+    SettingsService.set(:preferred_download_types, %w[direct torrent usenet])
+
+    assert_equal [ locally_higher, externally_higher ], request.search_results.best_first.to_a
+  end
+
   test "best_first treats custom provider direct results as direct" do
     request = requests(:pending_request)
     request.search_results.destroy_all

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -150,6 +150,59 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert result.reload.selected?
   end
 
+  test "provider rank cannot make a low confidence custom result auto selectable" do
+    provider = AcquisitionProvider.create!(
+      name: "Ranking Provider",
+      url: "http://provider.test"
+    )
+    ranked_but_ineligible = create_search_result(
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "ranked-ineligible",
+      provider_payload: { "download_type" => "direct", "rank_score" => 100 },
+      confidence_score: 49
+    )
+    eligible = create_search_result(
+      source: SearchResult::SOURCE_CUSTOM,
+      acquisition_provider: provider,
+      provider_result_id: "eligible",
+      provider_payload: { "download_type" => "direct", "rank_score" => 10 },
+      confidence_score: 95
+    )
+
+    selection = AutoSelectService.call(@request)
+
+    assert selection.success?
+    assert_equal eligible, selection.search_result
+    assert ranked_but_ineligible.reload.rejected?
+  end
+
+  test "external rank cannot make a low confidence indexer result auto selectable" do
+    ranker = RankingProvider.create!(name: "Auto-select Ranker", url: "http://auto-select-ranker.test")
+    ranked_but_ineligible = create_search_result(
+      guid: "external-rank-ineligible",
+      source: SearchResult::SOURCE_PROWLARR,
+      score_breakdown: { "external_rank_score" => 100, "external_rank_provider_id" => ranker.id },
+      confidence_score: 49,
+      seeders: 10,
+      magnet_url: "magnet:?xt=urn:btih:external-ineligible"
+    )
+    eligible = create_search_result(
+      guid: "external-rank-eligible",
+      source: SearchResult::SOURCE_PROWLARR,
+      score_breakdown: { "external_rank_score" => 10, "external_rank_provider_id" => ranker.id },
+      confidence_score: 95,
+      seeders: 10,
+      magnet_url: "magnet:?xt=urn:btih:external-eligible"
+    )
+
+    selection = AutoSelectService.call(@request)
+
+    assert selection.success?
+    assert_equal eligible, selection.search_result
+    assert ranked_but_ineligible.reload.rejected?
+  end
+
   test "creates download record and enqueues job on success" do
     result = create_search_result(
       title: "Test Book - Audiobook",

--- a/test/services/custom_acquisition_provider_client_test.rb
+++ b/test/services/custom_acquisition_provider_client_test.rb
@@ -15,6 +15,19 @@ class CustomAcquisitionProviderClientTest < ActiveSupport::TestCase
   end
 
   test "search posts request and book context and parses results" do
+    @request.book.update!(
+      content_kind: :book,
+      release_date: Date.new(2019, 4, 2),
+      publisher: "Example Press",
+      series: "Example Series",
+      series_position: "2",
+      narrator: "Example Narrator",
+      description: "Enough local context to disambiguate the requested work.",
+      isbn: "9781234567890",
+      metadata_source: "hardcover",
+      hardcover_id: "hc-123"
+    )
+
     VCR.turned_off do
       stub_request(:post, "http://provider.test/search")
         .with do |request|
@@ -22,6 +35,16 @@ class CustomAcquisitionProviderClientTest < ActiveSupport::TestCase
           request.headers["Authorization"] == "Bearer secret" &&
             body["book"]["title"] == @request.book.title &&
             body["book"]["book_type"] == "ebook" &&
+            body["book"]["content_kind"] == "book" &&
+            body["book"]["release_date"] == "2019-04-02" &&
+            body["book"]["publisher"] == "Example Press" &&
+            body["book"]["series"] == "Example Series" &&
+            body["book"]["series_position"] == "2" &&
+            body["book"]["narrator"] == "Example Narrator" &&
+            body["book"]["description"].present? &&
+            body["book"]["metadata_source"] == "hardcover" &&
+            body["book"]["hardcover_id"] == "hc-123" &&
+            !body["book"].key?("cover_url") &&
             body["request"]["language"].present?
         end
         .to_return(
@@ -51,6 +74,44 @@ class CustomAcquisitionProviderClientTest < ActiveSupport::TestCase
       assert_equal "epub", results.first.file_type
       assert_equal "direct", results.first.download_type
       assert results.first.available?
+    end
+  end
+
+  test "search normalizes provider rank score and preserves match evidence" do
+    VCR.turned_off do
+      stub_request(:post, "http://provider.test/search")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            results: [
+              {
+                id: "ranked",
+                title: "Ranked Provider Result",
+                direct_url: "https://files.test/book.epub",
+                rank_score: 97,
+                match_evidence: {
+                  matched_fields: %w[title author series],
+                  warnings: []
+                }
+              },
+              {
+                id: "invalid-rank",
+                title: "Invalid Rank",
+                direct_url: "https://files.test/other.epub",
+                rank_score: 101
+              }
+            ]
+          }.to_json
+        )
+
+      ranked, invalid = @client.search(@request)
+
+      assert_equal 97, ranked.rank_score
+      assert_equal 97, ranked.payload["rank_score"]
+      assert_equal %w[title author series], ranked.payload.dig("match_evidence", "matched_fields")
+      assert_nil invalid.rank_score
+      assert_nil invalid.payload["rank_score"]
     end
   end
 

--- a/test/services/ranking_provider_client_test.rb
+++ b/test/services/ranking_provider_client_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RankingProviderClientTest < ActiveSupport::TestCase
+  setup do
+    @provider = RankingProvider.create!(
+      name: "Local Media Ranker",
+      url: "http://ranker.test",
+      api_key: "secret",
+      timeout_seconds: 5
+    )
+    @client = @provider.client
+    @request = requests(:pending_request)
+    @request.update!(request_scope: "collection", collection_title: "Example Series")
+    @request.book.update!(
+      release_date: Date.new(2019, 4, 2),
+      publisher: "Example Press",
+      series: "Example Series",
+      series_position: "2",
+      narrator: "Example Narrator",
+      description: "Enough local context to disambiguate the requested work.",
+      isbn: "9781234567890",
+      metadata_source: "hardcover",
+      hardcover_id: "hc-123"
+    )
+  end
+
+  test "rank sends versioned media-neutral context and safe candidates" do
+    results = [
+      @request.search_results.create!(
+        guid: "prowlarr-rank",
+        title: "Prowlarr Candidate [EPUB]",
+        source: SearchResult::SOURCE_PROWLARR,
+        indexer: "Books Indexer",
+        download_url: "https://secret.test/download?id=token",
+        info_url: "https://secret.test/details",
+        confidence_score: 71,
+        score_breakdown: { "title" => 100, "search_attempt" => "exact_title", "extensions" => [ "epub" ] }
+      ),
+      @request.search_results.create!(
+        guid: "anna-rank",
+        title: "Anna Candidate [PDF]",
+        source: SearchResult::SOURCE_ANNA_ARCHIVE,
+        confidence_score: 68,
+        score_breakdown: { "title" => 80, "extensions" => [ "pdf" ] }
+      )
+    ]
+
+    VCR.turned_off do
+      stub_request(:post, "http://ranker.test/v1/rank")
+        .with do |request|
+          body = JSON.parse(request.body)
+          media = body.fetch("media")
+          candidates = body.fetch("candidates")
+
+          request.headers["Authorization"] == "Bearer secret" &&
+            body["schema_version"] == 1 &&
+            body["task"] == "candidate_ranking" &&
+            media["type"] == "book" &&
+            media["format"] == "ebook" &&
+            media["title"] == @request.book.title &&
+            media["contributors"].include?({ "role" => "author", "name" => @request.book.author }) &&
+            media["contributors"].include?({ "role" => "narrator", "name" => "Example Narrator" }) &&
+            media["relationships"] == [ { "type" => "series", "name" => "Example Series", "position" => "2" } ] &&
+            media.dig("identifiers", "isbn") == [ "9781234567890" ] &&
+            media.dig("identifiers", "hardcover") == [ "hc-123" ] &&
+            !media.key?("cover_url") &&
+            body.dig("context", "collection", "title") == "Example Series" &&
+            body.dig("preferences", "preferred_download_types").is_a?(Array) &&
+            candidates.map { |candidate| candidate["source"] } == %w[prowlarr anna_archive] &&
+            candidates.first["candidate_id"] == results.first.id.to_s &&
+            candidates.first["application_score"] == 71 &&
+            candidates.first.dig("application_score_breakdown", "search_attempt") == "exact_title" &&
+            candidates.first["detected_formats"] == [ "epub" ] &&
+            candidates.none? { |candidate| candidate.key?("download_url") || candidate.key?("magnet_url") || candidate.key?("info_url") || candidate.key?("provider_payload") }
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            schema_version: 1,
+            rankings: [
+              {
+                candidate_id: results.last.id.to_s,
+                rank_score: 96,
+                match_evidence: { matched_fields: %w[title author] }
+              }
+            ]
+          }.to_json
+        )
+
+      rankings = @client.rank(@request, results)
+
+      assert_equal 1, rankings.size
+      assert_equal results.last.id.to_s, rankings.first.candidate_id
+      assert_equal 96, rankings.first.rank_score
+      assert_equal %w[title author], rankings.first.match_evidence["matched_fields"]
+    end
+  end
+
+  test "rank ignores malformed entries and out-of-range scores" do
+    VCR.turned_off do
+      stub_request(:post, "http://ranker.test/v1/rank")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            rankings: [
+              { candidate_id: "valid", rank_score: 75 },
+              { candidate_id: "too-high", rank_score: 101 },
+              { rank_score: 50 },
+              "invalid"
+            ]
+          }.to_json
+        )
+
+      assert_equal [ "valid" ], @client.rank(@request, []).map(&:candidate_id)
+    end
+  end
+
+  test "rank rejects an invalid response shape" do
+    VCR.turned_off do
+      stub_request(:post, "http://ranker.test/v1/rank")
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: { results: [] }.to_json)
+
+      assert_raises(RankingProviderClient::ResponseError) { @client.rank(@request, []) }
+    end
+  end
+
+  test "test connection calls health endpoint" do
+    VCR.turned_off do
+      stub_request(:get, "http://ranker.test/health").to_return(status: 204)
+      assert @client.test_connection
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an optional, standalone ranking service that can re-order the combined results from every Shelfarr acquisition source. It is separate from custom acquisition providers and uses a media-neutral `POST /v1/rank` API.

```mermaid
flowchart LR
    A[All acquisition sources] --> B[Shelfarr normalizes and scores]
    B -->|Ranker enabled| C[POST /v1/rank<br/>safe metadata and opaque IDs]
    B -->|No ranker| D[Normal Shelfarr ordering]
    C -->|Scores returned| E[Apply advisory ranking]
    C -->|Error or invalid response| D
    E --> F[Download type → external rank → Shelfarr score]
    D --> F
    F --> G[Existing auto-selection safety gates]
```

## Exactly what it does

1. Shelfarr saves and scores results from Prowlarr, Jackett/Newznab, Anna's Archive, Z-Library, Gutenberg, LibriVox, and custom providers.
2. If a ranking provider is enabled, Shelfarr sends the candidates to `POST /v1/rank` with target metadata, contributors, series, identifiers, preferences, and Shelfarr's score breakdown.
3. The service returns `candidate_id`, `rank_score` (0–100), and optional `match_evidence`.
4. Shelfarr uses that score only to order results within the configured download-type preference.

No ranker configured or enabled means no request is made. Timeouts, HTTP errors, malformed responses, and unknown IDs fall back to normal Shelfarr ordering. Disabling or deleting a ranker also stops its saved scores from affecting results.

Shelfarr does **not** send download URLs, magnets, info URLs, provider payloads, credentials, or cover URLs.

The API envelope is media-neutral (`media`, `contributors`, `relationships`, `identifiers`, and `attributes`). Shelfarr currently sends books; another application can use the same ranking service for movies, TV, music, or games. This PR does not add media recommendations or a recommendation endpoint.

Custom acquisition providers also receive richer locally stored book metadata and may return a rank for their own `/search` results.

## Safety

External ranking never changes Shelfarr's confidence score or bypasses download-type, language, format, availability, blocklist, seeder, or auto-selection thresholds.

## Validation

- 186 focused tests: 683 assertions, 0 failures
- 152 directly affected tests: 574 assertions, 0 failures
- RuboCop and `git diff --check` pass
- The full suite's four failures are unrelated root/permission tests and reproduce on the unmodified container
