### PR TITLE
fix: resolve download and filesystem backlog

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.20.0)
+    json (2.21.2)
     json-jwt (1.17.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -204,7 +204,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -233,7 +233,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4.1)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -446,14 +446,14 @@ GEM
       railties (>= 7.1)
       thor (>= 1.3.1)
     sorbet-runtime (0.6.13153)
-    sqlite3 (2.9.5-aarch64-linux-gnu)
-    sqlite3 (2.9.5-aarch64-linux-musl)
-    sqlite3 (2.9.5-arm-linux-gnu)
-    sqlite3 (2.9.5-arm-linux-musl)
-    sqlite3 (2.9.5-arm64-darwin)
-    sqlite3 (2.9.5-x86_64-darwin)
-    sqlite3 (2.9.5-x86_64-linux-gnu)
-    sqlite3 (2.9.5-x86_64-linux-musl)
+    sqlite3 (2.9.6-aarch64-linux-gnu)
+    sqlite3 (2.9.6-aarch64-linux-musl)
+    sqlite3 (2.9.6-arm-linux-gnu)
+    sqlite3 (2.9.6-arm-linux-musl)
+    sqlite3 (2.9.6-arm64-darwin)
+    sqlite3 (2.9.6-x86_64-darwin)
+    sqlite3 (2.9.6-x86_64-linux-gnu)
+    sqlite3 (2.9.6-x86_64-linux-musl)
     sshkit (1.25.0)
       base64
       logger

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -424,17 +424,30 @@ class RequestsController < ApplicationController
 
     tmp = Tempfile.new([ "shelfarr-ref-", ".zip" ])
     tmp.binmode
+    tmp.close
     Zip::File.open(tmp.path, create: true) do |zip|
-      entries.each do |entry_name, target_path|
-        zip.get_output_stream(entry_name) { |out| out.write(File.binread(target_path)) }
+      entries.each do |entry_name, target_path, content_root|
+        zip.get_output_stream(entry_name) do |out|
+          FileCopyService.with_regular_file(target_path, root: content_root) do |input|
+            IO.copy_stream(input, out)
+          end
+        end
       end
     end
-    tmp.rewind
-    send_data tmp.read, filename: zip_filename, type: "application/zip", disposition: "attachment"
-  rescue UnsafeDownloadPathError, SystemCallError, Zip::Error => e
+    archive_stat = File.lstat(tmp.path)
+    archive_file = FileCopyService.open_pinned_regular_file(
+      tmp.path,
+      root: File.dirname(tmp.path),
+      expected_device: archive_stat.dev,
+      expected_inode: archive_stat.ino
+    )
+    send_pinned_file(archive_file, filename: zip_filename, type: "application/zip")
+    archive_file = nil
+  rescue UnsafeDownloadPathError, FileCopyService::UnsafePathError, SystemCallError, Zip::Error => e
     Rails.logger.warn "[Download] Reference tree zip failed for book ##{book.id}: #{e.class}"
     redirect_to @request, alert: "Unable to prepare a download for this reference library item."
   ensure
+    archive_file&.close unless archive_file&.closed?
     tmp&.close!
   end
 
@@ -454,16 +467,20 @@ class RequestsController < ApplicationController
         target = child.parent.join(target) unless target.absolute?
         real = target.expand_path.realpath
         raise UnsafeDownloadPathError, "reference leaf is not a file" unless File.lstat(real).file?
-        unless content_roots.any? { |root| canonical_path_contained?(real.to_s, root.to_s) }
-          raise UnsafeDownloadPathError, "reference leaf escapes authorized roots"
-        end
-        results << [ relative, real.to_s ]
+        content_root = content_roots.select do |root|
+          canonical_path_contained?(real.to_s, root.to_s)
+        end.max_by { |root| root.to_s.length }
+        raise UnsafeDownloadPathError, "reference leaf escapes authorized roots" unless content_root
+
+        results << [ relative, real.to_s, content_root.to_s ]
       elsif stat.file?
         real = child.realpath
-        unless content_roots.any? { |root| canonical_path_contained?(real.to_s, root.to_s) }
-          raise UnsafeDownloadPathError, "library file escapes authorized roots"
-        end
-        results << [ relative, real.to_s ]
+        content_root = content_roots.select do |root|
+          canonical_path_contained?(real.to_s, root.to_s)
+        end.max_by { |root| root.to_s.length }
+        raise UnsafeDownloadPathError, "library file escapes authorized roots" unless content_root
+
+        results << [ relative, real.to_s, content_root.to_s ]
       else
         raise UnsafeDownloadPathError, "unsupported library entry type"
       end
@@ -577,7 +594,8 @@ class RequestsController < ApplicationController
     [
       SettingsService.get(:download_local_path, default: "/downloads"),
       SettingsService.get(:download_remote_path),
-      *client_paths
+      *client_paths,
+      *@request.book.reference_target_roots
     ].compact_blank
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -428,7 +428,12 @@ class RequestsController < ApplicationController
     Zip::File.open(tmp.path, create: true) do |zip|
       entries.each do |entry_name, target_path, content_root|
         zip.get_output_stream(entry_name) do |out|
-          FileCopyService.with_regular_file(target_path, root: content_root) do |input|
+          root_snapshot = content_root if content_root.is_a?(FileCopyService::ReferenceRootSnapshot)
+          FileCopyService.with_regular_file(
+            target_path,
+            root: root_snapshot ? root_snapshot.path : content_root,
+            authorized_root_snapshot: root_snapshot
+          ) do |input|
             IO.copy_stream(input, out)
           end
         end
@@ -452,7 +457,6 @@ class RequestsController < ApplicationController
   end
 
   def collect_authorized_reference_entries(directory, library_root:, prefix: nil)
-    content_roots = authorized_content_roots
     results = []
     Dir.each_child(directory) do |name|
       child = directory.join(name)
@@ -467,15 +471,15 @@ class RequestsController < ApplicationController
         target = child.parent.join(target) unless target.absolute?
         real = target.expand_path.realpath
         raise UnsafeDownloadPathError, "reference leaf is not a file" unless File.lstat(real).file?
-        content_root = content_roots.select do |root|
-          canonical_path_contained?(real.to_s, root.to_s)
-        end.max_by { |root| root.to_s.length }
+        content_root = authorized_reference_target_roots.select do |root|
+          canonical_path_contained?(real.to_s, root.path.to_s)
+        end.max_by { |root| root.path.to_s.length }
         raise UnsafeDownloadPathError, "reference leaf escapes authorized roots" unless content_root
 
-        results << [ relative, real.to_s, content_root.to_s ]
+        results << [ relative, real.to_s, content_root ]
       elsif stat.file?
         real = child.realpath
-        content_root = content_roots.select do |root|
+        content_root = canonical_output_roots.select do |root|
           canonical_path_contained?(real.to_s, root.to_s)
         end.max_by { |root| root.to_s.length }
         raise UnsafeDownloadPathError, "library file escapes authorized roots" unless content_root
@@ -564,14 +568,14 @@ class RequestsController < ApplicationController
     target_stat = File.lstat(canonical_target)
     raise UnsafeDownloadPathError, "reference target is not a regular file" unless target_stat.file?
 
-    content_root = authorized_content_roots.select do |root|
-      canonical_path_contained?(canonical_target.to_s, root.to_s)
-    end.max_by { |root| root.to_s.length }
+    content_root = authorized_reference_target_roots.select do |root|
+      canonical_path_contained?(canonical_target.to_s, root.path.to_s)
+    end.max_by { |root| root.path.to_s.length }
     raise UnsafeDownloadPathError, "reference target resolves outside authorized roots" unless content_root
 
     DownloadBoundary.new(
       target: canonical_target.to_s,
-      root: content_root.to_s,
+      root: content_root.path.to_s,
       device: target_stat.dev,
       inode: target_stat.ino,
       kind: :file
@@ -594,8 +598,7 @@ class RequestsController < ApplicationController
     [
       SettingsService.get(:download_local_path, default: "/downloads"),
       SettingsService.get(:download_remote_path),
-      *client_paths,
-      *@request.book.reference_target_roots
+      *client_paths
     ].compact_blank
   end
 
@@ -610,8 +613,34 @@ class RequestsController < ApplicationController
     canonicalize_roots(allowed_output_paths)
   end
 
-  def authorized_content_roots
-    canonicalize_roots(allowed_output_paths + allowed_download_paths)
+  def authorized_reference_target_roots
+    book = @request.book
+    if book.reference_target_roots_recorded?
+      validate_persisted_reference_target_roots(book.reference_target_roots)
+    else
+      canonicalize_roots(allowed_output_paths + allowed_download_paths).filter_map do |path|
+        FileCopyService.snapshot_reference_root(path)
+      rescue FileCopyService::UnsafePathError
+        nil
+      end
+    end
+  end
+
+  def validate_persisted_reference_target_roots(roots)
+    roots.filter_map do |root|
+      path = Pathname(root.path)
+      stat = File.lstat(path)
+      next unless stat.directory?
+      next unless [ stat.dev, stat.ino ] == [ root.device, root.inode ]
+
+      FileCopyService::ReferenceRootSnapshot.new(
+        path: path,
+        device: root.device,
+        inode: root.inode
+      ).freeze
+    rescue SystemCallError, ArgumentError
+      nil
+    end
   end
 
   def canonicalize_roots(paths)

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -570,10 +570,15 @@ class RequestsController < ApplicationController
   end
 
   def allowed_download_paths
+    client_paths = @request.book.requests
+      .joins(downloads: :download_client)
+      .where.not(download_clients: { download_path: [ nil, "" ] })
+      .pluck("download_clients.download_path")
     [
       SettingsService.get(:download_local_path, default: "/downloads"),
-      SettingsService.get(:download_remote_path)
-    ].compact.reject(&:blank?)
+      SettingsService.get(:download_remote_path),
+      *client_paths
+    ].compact_blank
   end
 
   def canonical_path_contained?(path, root)

--- a/app/jobs/book_metadata_backfill_job.rb
+++ b/app/jobs/book_metadata_backfill_job.rb
@@ -21,6 +21,11 @@ class BookMetadataBackfillJob < ApplicationJob
   def books_for_backfill(book_ids)
     return Book.where(id: book_ids) if book_ids.present?
 
-    Book.where(series: [ nil, "" ]).or(Book.where(series_position: [ nil, "" ]))
+    missing_series = Book.where(series: [ nil, "" ]).or(Book.where(series_position: [ nil, "" ]))
+    missing_comic_run_year = Book.comicbooks
+      .where(series_start_year: nil)
+      .where("comic_vine_id LIKE ?", "4000-%")
+
+    missing_series.or(missing_comic_run_year)
   end
 end

--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -178,6 +178,10 @@ class HealthCheckJob < ApplicationJob
     return "#{name} path not configured" if path.blank?
     return "#{name} path does not exist" unless Dir.exist?(path)
     return "#{name} path not writable" unless File.writable?(path)
+
+    legacy_diagnostic = DirectDownloadFileService.legacy_staging_diagnostic(root: path)
+    return "#{name} #{legacy_diagnostic}" if legacy_diagnostic
+
     nil
   end
 

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -291,7 +291,7 @@ class PostProcessingJob < ApplicationJob
     when FileCopyService::DurabilityUnsupportedError
       "The library filesystem cannot safely complete destructive imports because fsync is unsupported; use another filesystem or retain the download source"
     when FileCopyService::AmbiguousPublicationError
-      "An incomplete library publication was retained for manual review; preserve the destination and .shelfarr-copy artifacts before retrying"
+      "An incomplete library publication was retained for manual review; preserve the destination and adjacent Shelfarr filesystem artifacts before retrying"
     when FileCopyService::AtomicPublicationUnsupportedError
       if bounded_exception_message(error).match?(/manual (?:cleanup|review)/i)
         "Interrupted library publication artifacts were retained for manual review before retrying"

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -277,6 +277,14 @@ class PostProcessingJob < ApplicationJob
       location ? "#{message} at #{location}" : message
     when FileCopyService::DurabilityUnsupportedError
       "The library filesystem cannot safely complete destructive imports because fsync is unsupported; use another filesystem or retain the download source"
+    when FileCopyService::AmbiguousPublicationError
+      "An incomplete library publication was retained for manual review; preserve the destination and .shelfarr-copy artifacts before retrying"
+    when FileCopyService::AtomicPublicationUnsupportedError
+      if bounded_exception_message(error).match?(/manual (?:cleanup|review)/i)
+        "Interrupted library publication artifacts were retained for manual review before retrying"
+      else
+        safe_attention_detail(error)
+      end
     when FileCopyService::UnsafePathError
       "The download contains a symbolic link or non-regular path, or changed during its safety checks"
     when AudiobookBundleImportPlanner::UnsafeDestinationError

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -39,6 +39,7 @@ class PostProcessingJob < ApplicationJob
     @hardlink_fallback_copied_count = 0
     @referenced_file_count = 0
     @reused_file_count = 0
+    @completed_reference_target_roots = []
     download = Download.find_by(id: download_id)
     return unless download&.completed?
 
@@ -96,11 +97,15 @@ class PostProcessingJob < ApplicationJob
       if source_path_unavailable?(source_path)
         return retry_source_path_later(download, request, source_path, source_path_retry_count)
       end
-      source_authorization = validate_download_specific_source_path!(
-        source_path,
-        source_resolution[:authorized_roots],
-        download
-      )
+      source_authorization = begin
+        validate_download_specific_source_path!(
+          source_path,
+          source_resolution[:authorized_roots],
+          download
+        )
+      rescue FileCopyService::ReferenceTargetUnavailableError
+        return retry_source_path_later(download, request, source_path, source_path_retry_count)
+      end
 
       # Reference mode keeps download bytes as the only content; never delete
       # usenet/client sources after a symlink-only import.
@@ -189,15 +194,23 @@ class PostProcessingJob < ApplicationJob
       end
 
       if book.file_path.blank?
+        reference_target_roots = Book.dump_reference_target_roots(
+          @completed_reference_target_roots
+        )
         claimed = Book.where(id: book.id)
           .where("file_path IS NULL OR TRIM(file_path) = ''")
           .where(acquisition_reservation_token: nil)
-          .update_all(file_path: imported_path, updated_at: Time.current)
+          .update_all(
+            file_path: imported_path,
+            reference_target_roots: reference_target_roots,
+            updated_at: Time.current
+          )
         unless claimed == 1
           raise BookAcquisitionConflictError,
             "Another acquisition claimed this title while post-processing was finalizing"
         end
         book.file_path = imported_path
+        book[:reference_target_roots] = reference_target_roots
       elsif book.file_path != imported_path
         raise BookAcquisitionConflictError,
           "Another acquisition already attached a different library file to this title"
@@ -400,7 +413,14 @@ class PostProcessingJob < ApplicationJob
     end
 
     snapshot = if source_stat.directory?
-      FileCopyService.snapshot_source_root(source_path)
+      if reference_completed_downloads?
+        FileCopyService.snapshot_reference_source_root(
+          source_path,
+          authorized_roots: shared_roots
+        )
+      else
+        FileCopyService.snapshot_source_root(source_path)
+      end
     elsif source_stat.file?
       FileCopyService.snapshot_source_file(source_path)
     elsif reference_link
@@ -424,7 +444,24 @@ class PostProcessingJob < ApplicationJob
       raise "Refusing to import source outside a configured download root."
     end
 
-    { directory: source_stat.directory?, snapshot: snapshot }
+    {
+      directory: source_stat.directory?,
+      snapshot: snapshot,
+      reference_regular_source_root: reference_completed_downloads? ?
+        reference_regular_source_root_for(snapshot, snapshotted_path, roots) : nil
+    }
+  end
+
+  def reference_regular_source_root_for(snapshot, source_path, source_roots)
+    return if snapshot.is_a?(FileCopyService::ReferenceSourceSnapshot)
+    if snapshot.is_a?(FileCopyService::SourceRoot) &&
+        snapshot.entries.values.none? { |manifest| manifest[2] == :file }
+      return
+    end
+
+    source_roots.select do |root|
+      path_inside_root?(source_path, root)
+    end.max_by(&:length)
   end
 
   def shared_download_roots(download)
@@ -566,6 +603,8 @@ class PostProcessingJob < ApplicationJob
     source_authorization ||= authorize_import_source(source)
     directory_source = source_authorization.fetch(:directory)
     source_snapshot = source_authorization.fetch(:snapshot)
+    @completed_reference_target_roots = []
+    @reference_regular_source_root = source_authorization[:reference_regular_source_root]
     @import_source_root = source_snapshot if directory_source
     @import_source_file_snapshot = source_snapshot unless directory_source
     @imported_renamed_files = []
@@ -655,6 +694,7 @@ class PostProcessingJob < ApplicationJob
     remove_instance_variable(:@import_base_path) if instance_variable_defined?(:@import_base_path)
     remove_instance_variable(:@import_source_root) if instance_variable_defined?(:@import_source_root)
     remove_instance_variable(:@import_source_file_snapshot) if instance_variable_defined?(:@import_source_file_snapshot)
+    remove_instance_variable(:@reference_regular_source_root) if instance_variable_defined?(:@reference_regular_source_root)
     remove_instance_variable(:@verified_library_snapshots) if instance_variable_defined?(:@verified_library_snapshots)
     remove_instance_variable(:@require_durable_import) if instance_variable_defined?(:@require_durable_import)
   end
@@ -791,7 +831,7 @@ class PostProcessingJob < ApplicationJob
     paths = ebook_directory_files(source)
 
     paths.each do |path|
-      if File.symlink?(path)
+      if File.symlink?(path) && !reference_source_snapshot(path)
         raise "Unsupported ebook import file type: #{File.basename(path)}"
       end
 
@@ -816,6 +856,14 @@ class PostProcessingJob < ApplicationJob
   end
 
   def allowed_ebook_import_file?(path, extension: nil)
+    if (snapshot = reference_source_snapshot(path)).is_a?(FileCopyService::ReferenceSourceSnapshot)
+      target = snapshot.target_snapshot.path.to_s
+      extension ||= File.extname(path).delete_prefix(".").downcase
+      return false unless File.file?(target) && !File.symlink?(target)
+
+      return EBOOK_ALLOWED_EXTENSIONS.include?(extension) &&
+        valid_ebook_import_content?(target, extension)
+    end
     return false if File.symlink?(path)
     return false unless File.file?(path)
 
@@ -895,12 +943,13 @@ class PostProcessingJob < ApplicationJob
 
   def import_file(source, destination)
     if reference_completed_downloads?
+      source_snapshot = reference_source_snapshot(source)
       FileCopyService.reference_noreplace(
         source,
         destination,
         root: @import_base_path,
-        source_root: @import_source_root,
-        source_snapshot: @import_source_file_snapshot
+        source_root: source_snapshot ? nil : @import_source_root,
+        source_snapshot: source_snapshot
       )
       @referenced_file_count += 1
     elsif hardlink_completed_downloads?
@@ -1025,12 +1074,13 @@ class PostProcessingJob < ApplicationJob
   end
 
   def reference_target_matches?(source, destination)
+    source_snapshot = reference_source_snapshot(source)
     FileCopyService.reference_target_matches?(
       source,
       destination,
       root: @import_base_path,
-      source_root: @import_source_root,
-      source_snapshot: @import_source_file_snapshot
+      source_root: source_snapshot ? nil : @import_source_root,
+      source_snapshot: source_snapshot
     )
   end
 
@@ -1059,7 +1109,11 @@ class PostProcessingJob < ApplicationJob
   def import_directory_entry(source, destination)
     stat = File.lstat(source)
     if stat.symlink?
-      raise "Refusing to import symbolic link: #{source}"
+      unless reference_completed_downloads? && reference_source_snapshot(source)
+        raise "Refusing to import symbolic link: #{source}"
+      end
+
+      import_file_without_duplicate_content(source, File.join(destination, File.basename(source)))
     elsif stat.directory?
       nested_destination = File.join(destination, File.basename(source))
       ensure_real_import_directory!(nested_destination)
@@ -1180,17 +1234,42 @@ class PostProcessingJob < ApplicationJob
   end
 
   def record_imported_source!(source)
+    record_reference_target_root!(source) if reference_completed_downloads?
     return unless @import_source_root
 
     relative = Pathname(source).expand_path.relative_path_from(@import_source_root.path)
     manifest = @import_source_root.entries[relative.to_s]
-    unless manifest && manifest[2] == :file
+    unless manifest && manifest[2].in?([ :file, :reference ])
       raise FileCopyService::UnsafePathError, "imported source is absent from the immutable manifest"
     end
 
     @imported_source_files << relative.to_s
   rescue ArgumentError
     raise FileCopyService::UnsafePathError, "imported source escaped the immutable manifest"
+  end
+
+  def record_reference_target_root!(source)
+    snapshot = reference_source_snapshot(source)
+    root = if snapshot.is_a?(FileCopyService::ReferenceSourceSnapshot)
+      snapshot.authorized_root.to_s
+    else
+      @reference_regular_source_root
+    end
+    @completed_reference_target_roots << root if root.present?
+    @completed_reference_target_roots.uniq!
+  end
+
+  def reference_source_snapshot(source)
+    expanded = Pathname(source).expand_path
+    if @import_source_file_snapshot && expanded == @import_source_file_snapshot.path
+      return @import_source_file_snapshot
+    end
+    return unless @import_source_root&.reference_snapshots
+
+    relative = expanded.relative_path_from(@import_source_root.path).to_s
+    @import_source_root.reference_snapshots[relative]
+  rescue ArgumentError
+    nil
   end
 
   def renamed_destination_file(source, destination, book)

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -118,6 +118,7 @@ class PostProcessingJob < ApplicationJob
         require_durable: move_completed_downloads? || remove_usenet_download,
         source_authorization: source_authorization
       )
+      validate_completed_reference_target_roots! if reference_completed_downloads?
 
       book_path = imported_book_path(book, destination)
       cleanup_state = source_cleanup&.fetch(:state)
@@ -431,7 +432,7 @@ class PostProcessingJob < ApplicationJob
     snapshotted_path = if source_stat.directory?
       snapshot.canonical_path.to_s
     elsif reference_link
-      snapshot.target_snapshot.path.to_s
+      snapshot.canonical_target_path.to_s
     else
       snapshot.canonical_parent_path.join(snapshot.path.basename).to_s
     end
@@ -459,9 +460,10 @@ class PostProcessingJob < ApplicationJob
       return
     end
 
-    source_roots.select do |root|
+    root = source_roots.select do |root|
       path_inside_root?(source_path, root)
     end.max_by(&:length)
+    FileCopyService.snapshot_reference_root(root) if root
   end
 
   def shared_download_roots(download)
@@ -944,12 +946,15 @@ class PostProcessingJob < ApplicationJob
   def import_file(source, destination)
     if reference_completed_downloads?
       source_snapshot = reference_source_snapshot(source)
+      regular_root_snapshot = @reference_regular_source_root unless
+        source_snapshot.is_a?(FileCopyService::ReferenceSourceSnapshot)
       FileCopyService.reference_noreplace(
         source,
         destination,
         root: @import_base_path,
         source_root: source_snapshot ? nil : @import_source_root,
-        source_snapshot: source_snapshot
+        source_snapshot: source_snapshot,
+        authorized_root_snapshot: regular_root_snapshot
       )
       @referenced_file_count += 1
     elsif hardlink_completed_downloads?
@@ -1075,12 +1080,15 @@ class PostProcessingJob < ApplicationJob
 
   def reference_target_matches?(source, destination)
     source_snapshot = reference_source_snapshot(source)
+    regular_root_snapshot = @reference_regular_source_root unless
+      source_snapshot.is_a?(FileCopyService::ReferenceSourceSnapshot)
     FileCopyService.reference_target_matches?(
       source,
       destination,
       root: @import_base_path,
       source_root: source_snapshot ? nil : @import_source_root,
-      source_snapshot: source_snapshot
+      source_snapshot: source_snapshot,
+      authorized_root_snapshot: regular_root_snapshot
     )
   end
 
@@ -1251,12 +1259,22 @@ class PostProcessingJob < ApplicationJob
   def record_reference_target_root!(source)
     snapshot = reference_source_snapshot(source)
     root = if snapshot.is_a?(FileCopyService::ReferenceSourceSnapshot)
-      snapshot.authorized_root.to_s
+      FileCopyService::ReferenceRootSnapshot.new(
+        path: snapshot.authorized_root,
+        device: snapshot.authorized_root_device,
+        inode: snapshot.authorized_root_inode
+      ).freeze
     else
       @reference_regular_source_root
     end
     @completed_reference_target_roots << root if root.present?
     @completed_reference_target_roots.uniq!
+  end
+
+  def validate_completed_reference_target_roots!
+    @completed_reference_target_roots.each do |root|
+      FileCopyService.validate_reference_root_snapshot!(root)
+    end
   end
 
   def reference_source_snapshot(source)

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -365,15 +365,22 @@ class PostProcessingJob < ApplicationJob
   end
 
   def source_path_unavailable?(source_path)
-    source_path.present? && !File.exist?(source_path)
+    source_path.present? && !File.exist?(source_path) &&
+      !(reference_completed_downloads? && File.symlink?(source_path))
   end
 
   def validate_download_specific_source_path!(source_path, authorized_roots, download)
     return unless source_path.present?
 
-    source = canonical_path(source_path)
     roots = Array(authorized_roots).filter_map { |path| canonical_download_root(path) }.uniq
     shared_roots = shared_download_roots(download).filter_map { |path| canonical_download_root(path) }.uniq
+    source_stat = File.lstat(source_path)
+    reference_link = source_stat.symlink? && reference_completed_downloads?
+    source = if reference_link
+      File.join(canonical_path(File.dirname(source_path)), File.basename(source_path))
+    else
+      canonical_path(source_path)
+    end
 
     if shared_roots.include?(source)
       raise "Refusing to import shared download root. " \
@@ -384,16 +391,19 @@ class PostProcessingJob < ApplicationJob
       raise "Refusing to import source outside a configured download root."
     end
 
-    source_stat = File.lstat(source_path)
     snapshot = if source_stat.directory?
       FileCopyService.snapshot_source_root(source_path)
     elsif source_stat.file?
       FileCopyService.snapshot_source_file(source_path)
+    elsif reference_link
+      FileCopyService.snapshot_reference_source(source_path, authorized_roots: shared_roots)
     else
       raise "Refusing to import non-regular path"
     end
     snapshotted_path = if source_stat.directory?
       snapshot.canonical_path.to_s
+    elsif reference_link
+      snapshot.target_snapshot.path.to_s
     else
       snapshot.canonical_parent_path.join(snapshot.path.basename).to_s
     end
@@ -401,7 +411,8 @@ class PostProcessingJob < ApplicationJob
       raise "Refusing to import shared download root. " \
         "The download client must report a download-specific file or directory."
     end
-    unless roots.any? { |root| path_inside_root?(snapshotted_path, root) }
+    final_roots = reference_link ? shared_roots : roots
+    unless final_roots.any? { |root| path_inside_root?(snapshotted_path, root) }
       raise "Refusing to import source outside a configured download root."
     end
 
@@ -757,6 +768,12 @@ class PostProcessingJob < ApplicationJob
 
   def validate_ebook_source!(source)
     unless File.directory?(source)
+      if @import_source_file_snapshot.is_a?(FileCopyService::ReferenceSourceSnapshot)
+        extension = File.extname(source).delete_prefix(".").downcase
+        target = @import_source_file_snapshot.target_snapshot.path.to_s
+        return if EBOOK_FILE_EXTENSIONS.include?(extension) &&
+          allowed_ebook_import_file?(target, extension: extension)
+      end
       return if ebook_file?(source) && allowed_ebook_import_file?(source)
 
       raise "Unsupported ebook import file type: #{File.basename(source)}"
@@ -790,11 +807,11 @@ class PostProcessingJob < ApplicationJob
     end
   end
 
-  def allowed_ebook_import_file?(path)
+  def allowed_ebook_import_file?(path, extension: nil)
     return false if File.symlink?(path)
     return false unless File.file?(path)
 
-    extension = File.extname(path).delete_prefix(".").downcase
+    extension ||= File.extname(path).delete_prefix(".").downcase
     EBOOK_ALLOWED_EXTENSIONS.include?(extension) && valid_ebook_import_content?(path, extension)
   end
 
@@ -874,7 +891,8 @@ class PostProcessingJob < ApplicationJob
         source,
         destination,
         root: @import_base_path,
-        source_root: @import_source_root
+        source_root: @import_source_root,
+        source_snapshot: @import_source_file_snapshot
       )
       @referenced_file_count += 1
     elsif hardlink_completed_downloads?

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -110,15 +110,22 @@ class PostProcessingJob < ApplicationJob
       # Reference mode keeps download bytes as the only content; never delete
       # usenet/client sources after a symlink-only import.
       remove_usenet_download = usenet_cleanup_requested?(download) && !reference_completed_downloads?
-      source_cleanup = import_files(
-        source_path,
-        destination,
-        book: book,
-        base_path: base_path,
-        require_durable: move_completed_downloads? || remove_usenet_download,
-        source_authorization: source_authorization
-      )
-      validate_completed_reference_target_roots! if reference_completed_downloads?
+      source_cleanup = begin
+        imported = import_files(
+          source_path,
+          destination,
+          book: book,
+          base_path: base_path,
+          require_durable: move_completed_downloads? || remove_usenet_download,
+          source_authorization: source_authorization
+        )
+        validate_completed_reference_target_roots! if reference_completed_downloads?
+        imported
+      rescue FileCopyService::ReferenceTargetUnavailableError
+        return retry_source_path_later(download, request, source_path, source_path_retry_count)
+      rescue FileCopyService::PublicationBusyError
+        return retry_busy_publication_later(download, request, source_path_retry_count)
+      end
 
       book_path = imported_book_path(book, destination)
       cleanup_state = source_cleanup&.fetch(:state)
@@ -537,6 +544,34 @@ class PostProcessingJob < ApplicationJob
     raise source_path_not_found_message(source_path)
   end
 
+  def retry_busy_publication_later(download, request, retry_count)
+    retry_limit = SettingsService.get(:post_processing_source_path_retries).to_i
+    if retry_count < retry_limit
+      next_retry_count = retry_count + 1
+      wait_interval = SettingsService.get(:download_check_interval).to_i.clamp(1, 86_400).seconds
+
+      Rails.logger.warn(
+        "[PostProcessingJob] Library publication is busy for download ##{download.id}. " \
+          "Retrying #{next_retry_count}/#{retry_limit} in #{wait_interval.to_i}s."
+      )
+
+      track_request_event(
+        request,
+        "post_processing_waiting",
+        download: download,
+        message: "Library publication is busy; retrying post-processing",
+        level: :warn,
+        details: { retry_count: next_retry_count, retry_limit: retry_limit }
+      )
+
+      retry_job = self.class.new(download.id, next_retry_count, job_id)
+      raise "Failed to enqueue post-processing retry" unless retry_job.enqueue(wait: wait_interval)
+      return
+    end
+
+    raise "Library publication remained busy after #{retry_limit} retries"
+  end
+
   def cleanup_usenet_download(download)
     Rails.logger.info "[PostProcessingJob] Removing usenet download ##{download.id}"
     download.download_client.adapter.remove_torrent(download.external_id, delete_files: true)
@@ -599,6 +634,11 @@ class PostProcessingJob < ApplicationJob
 
     unless File.exist?(source)
       Rails.logger.error "[PostProcessingJob] Completed download source is not visible"
+      if reference_completed_downloads? && File.symlink?(source)
+        raise FileCopyService::ReferenceTargetUnavailableError,
+          "reference target is not visible yet"
+      end
+
       raise source_path_not_found_message(source)
     end
 

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -950,10 +950,17 @@ class SearchJob < ApplicationJob
     series = book.series.to_s.squish
     return [] if issue_number.blank? || series.blank?
 
-    numeric_match = issue_number.match(/\A0*(\d+)\z/)
-    display_number = numeric_match ? numeric_match[1].to_i.to_s : issue_number
+    numeric_match = issue_number.match(/\A0*(\d+)((?:\.\d+)?[a-z]?)\z/i)
+    display_number = if numeric_match
+      "#{numeric_match[1].to_i}#{numeric_match[2]}"
+    else
+      issue_number
+    end
     queries = [ "#{series} #{display_number}", "#{series} ##{display_number}" ]
-    queries << "#{series} #{display_number.rjust(3, '0')}" if numeric_match
+    if numeric_match
+      padded_number = "#{numeric_match[1].to_i.to_s.rjust(3, '0')}#{numeric_match[2]}"
+      queries << "#{series} #{padded_number}"
+    end
     queries.uniq
   end
 

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -301,6 +301,9 @@ class SearchJob < ApplicationJob
     book = request.book
     query = indexer_language_hint(request)
     categories = primary_indexer_categories(request)
+    issue_queries = comic_issue_search_queries(book)
+    structured_title = issue_queries.second || book.title
+    structured_author = issue_queries.any? ? nil : book.author
 
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} for request ##{request.id} (type: #{book.book_type})"
 
@@ -309,8 +312,8 @@ class SearchJob < ApplicationJob
         query,
         book_type: book.book_type,
         categories: categories,
-        title: book.title,
-        author: book.author
+        title: structured_title,
+        author: structured_author
       ),
       attempt: SearchAttempt.new(name: :structured_book, query: query, score_penalty: 0)
     )
@@ -915,6 +918,14 @@ class SearchJob < ApplicationJob
   def generic_indexer_attempts(request)
     book = request.book
     language_hint = indexer_language_hint(request)
+    issue_queries = comic_issue_search_queries(book)
+    if issue_queries.any?
+      attempts = issue_queries.map do |query|
+        build_search_attempt(:comic_issue, [ query, language_hint ])
+      end
+      return deduplicate_search_attempts(attempts)
+    end
+
     attempts = [
       build_search_attempt(:exact_title, [ book.title, language_hint ]),
       build_search_attempt(:title_author, [ book.title, book.author, language_hint ])
@@ -932,6 +943,18 @@ class SearchJob < ApplicationJob
     end
 
     deduplicate_search_attempts(attempts)
+  end
+
+  def comic_issue_search_queries(book)
+    issue_number = book.issue_number_for_matching.to_s.delete_prefix("#").squish
+    series = book.series.to_s.squish
+    return [] if issue_number.blank? || series.blank?
+
+    numeric_match = issue_number.match(/\A0*(\d+)\z/)
+    display_number = numeric_match ? numeric_match[1].to_i.to_s : issue_number
+    queries = [ "#{series} #{display_number}", "#{series} ##{display_number}" ]
+    queries << "#{series} #{display_number.rjust(3, '0')}" if numeric_match
+    queries.uniq
   end
 
   def suppress_database_debug_logging(&block)

--- a/app/jobs/upload_processing_job.rb
+++ b/app/jobs/upload_processing_job.rb
@@ -225,7 +225,7 @@ class UploadProcessingJob < ApplicationJob
           if ordinary_file_service || zip_file_service
             claim_book_file_path!(book, destination, upload)
           else
-            book.update!(file_path: destination)
+            book.update!(file_path: destination, reference_target_roots: nil)
           end
 
           completed_file_path = if ordinary_file_service
@@ -368,6 +368,7 @@ class UploadProcessingJob < ApplicationJob
       )
       .update_all(
         file_path: destination,
+        reference_target_roots: nil,
         acquisition_reservation_token: nil,
         acquisition_reservation_owner_type: nil,
         acquisition_reservation_owner_id: nil,

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -28,6 +28,24 @@ class Book < ApplicationRecord
     file_path.present?
   end
 
+  def reference_target_roots
+    roots = JSON.parse(self[:reference_target_roots].to_s)
+    return [] unless roots.is_a?(Array)
+
+    roots.filter_map { |root| root.to_s.presence if root.is_a?(String) }.uniq
+  rescue JSON::ParserError, TypeError
+    []
+  end
+
+  def reference_target_roots=(roots)
+    self[:reference_target_roots] = self.class.dump_reference_target_roots(roots)
+  end
+
+  def self.dump_reference_target_roots(roots)
+    values = Array(roots).filter_map { |root| root.to_s.presence }.uniq
+    values.any? ? JSON.generate(values) : nil
+  end
+
   def acquisition_reserved?
     acquisition_reservation_token.present?
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,5 +1,9 @@
+require "json"
+require "pathname"
+
 class Book < ApplicationRecord
   METADATA_SOURCE_NAMES = MetadataSources::NAMES
+  ReferenceTargetRoot = Data.define(:path, :device, :inode)
 
   has_many :requests, dependent: :restrict_with_error
   has_many :uploads, dependent: :nullify
@@ -29,21 +33,46 @@ class Book < ApplicationRecord
   end
 
   def reference_target_roots
-    roots = JSON.parse(self[:reference_target_roots].to_s)
-    return [] unless roots.is_a?(Array)
-
-    roots.filter_map { |root| root.to_s.presence if root.is_a?(String) }.uniq
-  rescue JSON::ParserError, TypeError
-    []
+    self.class.load_reference_target_roots(self[:reference_target_roots])
   end
 
   def reference_target_roots=(roots)
     self[:reference_target_roots] = self.class.dump_reference_target_roots(roots)
   end
 
+  def reference_target_roots_recorded?
+    !self[:reference_target_roots].nil?
+  end
+
+  def self.load_reference_target_roots(payload)
+    values = JSON.parse(payload.to_s)
+    return [] unless values.is_a?(Array)
+
+    roots = values.map { |value| normalize_reference_target_root(value) }
+    return [] if roots.any?(&:nil?) || conflicting_reference_target_roots?(roots)
+
+    roots.uniq
+  rescue JSON::ParserError, TypeError
+    []
+  end
+
   def self.dump_reference_target_roots(roots)
-    values = Array(roots).filter_map { |root| root.to_s.presence }.uniq
-    values.any? ? JSON.generate(values) : nil
+    values = Array(roots)
+    return if values.empty?
+
+    normalized = values.map do |value|
+      normalize_reference_target_root(value) ||
+        raise(ArgumentError, "reference target root provenance is invalid")
+    end
+    if conflicting_reference_target_roots?(normalized)
+      raise ArgumentError, "reference target root identities conflict"
+    end
+
+    JSON.generate(
+      normalized.uniq.map do |root|
+        { "path" => root.path.to_s, "device" => root.device, "inode" => root.inode }
+      end
+    )
   end
 
   def acquisition_reserved?
@@ -281,6 +310,35 @@ class Book < ApplicationRecord
   end
 
   private
+
+  def self.normalize_reference_target_root(value)
+    attributes = if value.is_a?(Hash)
+      value.with_indifferent_access
+    elsif value.respond_to?(:path) && value.respond_to?(:device) && value.respond_to?(:inode)
+      { path: value.path, device: value.device, inode: value.inode }.with_indifferent_access
+    else
+      return
+    end
+    raw_path = attributes[:path].to_s
+    path = Pathname(raw_path)
+    device = Integer(attributes[:device], exception: false)
+    inode = Integer(attributes[:inode], exception: false)
+    return if raw_path.blank? || raw_path.include?("\0")
+    return unless path.absolute? && path.cleanpath.to_s == raw_path && !path.root?
+    return unless device && device >= 0 && inode&.positive?
+
+    ReferenceTargetRoot.new(path: path.freeze, device: device, inode: inode)
+  rescue ArgumentError
+    nil
+  end
+
+  def self.conflicting_reference_target_roots?(roots)
+    roots.group_by(&:path).any? do |_path, matches|
+      matches.map { |root| [ root.device, root.inode ] }.uniq.many?
+    end
+  end
+
+  private_class_method :normalize_reference_target_root, :conflicting_reference_target_roots?
 
   def prevent_destroy_during_active_acquisition
     message = if acquisition_reserved?

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -109,6 +109,14 @@ class Book < ApplicationRecord
     end
   end
 
+  def issue_number_for_matching
+    return unless comicbook?
+    return issue_number.to_s.squish.presence if issue_number.present?
+    return unless comic_vine_id.to_s.match?(/\A4000-\d+\z/)
+
+    series_position.to_s.squish.presence
+  end
+
   def metadata_source_attribution
     return nil if metadata_source_name.blank?
 

--- a/app/services/book_metadata_backfill_service.rb
+++ b/app/services/book_metadata_backfill_service.rb
@@ -37,7 +37,12 @@ class BookMetadataBackfillService
         publisher: value_for(book.publisher, metadata[:publisher], fallback_attrs[:publisher]),
         content_kind: content_kind_value_for(book, metadata[:content_kind], fallback_attrs[:content_kind]),
         issue_number: value_for(book.issue_number, metadata[:issue_number], fallback_attrs[:issue_number]),
-        release_date: value_for(book.release_date, metadata[:release_date], fallback_attrs[:release_date])
+        release_date: value_for(book.release_date, metadata[:release_date], fallback_attrs[:release_date]),
+        series_start_year: numeric_value_for(
+          book.series_start_year,
+          metadata[:series_start_year],
+          fallback_attrs[:series_start_year]
+        )
       }.compact
 
       attrs[:metadata_source] = source if book.metadata_source.blank? || book.new_record?

--- a/app/services/book_metadata_lookup_service.rb
+++ b/app/services/book_metadata_lookup_service.rb
@@ -15,6 +15,7 @@ class BookMetadataLookupService
     content_kind: :content_kind,
     issue_number: :issue_number,
     release_date: :release_date,
+    series_start_year: :series_start_year,
     series: :series_name,
     series_position: :series_position,
     collection_id: :collection_id,

--- a/app/services/comic_vine_client.rb
+++ b/app/services/comic_vine_client.rb
@@ -22,7 +22,7 @@ class ComicVineClient
   Result = Data.define(
     :id, :resource_type, :resource_key, :title, :description, :cover_url,
     :publisher, :creators, :series_name, :issue_number, :release_date,
-    :content_kind, :collection_id, :collection_title, :web_url, :raw_payload
+    :series_start_year, :content_kind, :collection_id, :collection_title, :web_url, :raw_payload
   ) do
     def author
       creators
@@ -64,6 +64,8 @@ class ComicVineClient
       payload = response["results"]
       return nil unless payload.is_a?(Hash)
 
+      payload = with_volume_start_year(payload) if type == "issue"
+
       parse_result(payload.merge("resource_type" => type), requested_content_kind: content_kind)
     end
 
@@ -77,6 +79,7 @@ class ComicVineClient
       remaining = limit&.to_i
       offset = 0
       issues = []
+      series_start_year = volume_start_year(volume_id)
 
       loop do
         page_size = remaining ? [ remaining, MAX_PAGE_SIZE ].min : MAX_PAGE_SIZE
@@ -90,6 +93,11 @@ class ComicVineClient
         )
 
         page = Array(response["results"]).filter_map do |payload|
+          payload = with_volume_start_year(
+            payload,
+            series_start_year: series_start_year,
+            lookup: false
+          )
           parse_result(payload.merge("resource_type" => "issue"), requested_content_kind: content_kind)
         end
         issues.concat(page)
@@ -160,6 +168,8 @@ class ComicVineClient
         series_name: resource_type == "issue" ? volume["name"] : payload["name"],
         issue_number: resource_type == "issue" ? payload["issue_number"].presence : nil,
         release_date: release_date,
+        series_start_year: resource_type == "issue" ?
+          volume["start_year"].presence&.to_i : payload["start_year"].presence&.to_i,
         content_kind: ContentKinds::GRAPHIC,
         collection_id: resource_type == "issue" ? resource_key("volume", volume["id"]) : resource_key("volume", payload["id"]),
         collection_title: resource_type == "issue" ? volume["name"] : payload["name"],
@@ -182,6 +192,30 @@ class ComicVineClient
     def volume_id_from_resource_key(resource_key)
       _type, id = parse_resource_key(resource_key)
       id
+    end
+
+    def with_volume_start_year(payload, series_start_year: nil, lookup: true)
+      volume = payload["volume"]
+      return payload unless volume.is_a?(Hash)
+
+      series_start_year ||= volume["start_year"].presence&.to_i
+      series_start_year ||= volume_start_year(volume["id"]) if lookup
+      return payload unless series_start_year
+
+      payload.merge("volume" => volume.merge("start_year" => series_start_year))
+    end
+
+    def volume_start_year(volume_id)
+      return if volume_id.blank?
+
+      response = get_json(
+        "/volume/4050-#{volume_id}/",
+        field_list: "id,start_year"
+      )
+      response.dig("results", "start_year").presence&.to_i
+    rescue Error => e
+      Rails.logger.warn("[ComicVineClient] Volume start year lookup failed: #{e.message}")
+      nil
     end
 
     def resource_key(resource_type, id)

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -12,6 +12,7 @@ class DirectDownloadFileService
   LEGACY_STAGING_DIRECTORY = ".shelfarr-staging"
   STAGING_DIRECTORY = ".shelfarr-staging-v2"
   DIRECT_DOWNLOADS_DIRECTORY = "direct-downloads"
+  STAGING_BASENAME_PATTERN = /\Adownload-([1-9]\d*)-[0-9a-f]{32}\z/
   ORPHAN_MAX_AGE = 24.hours
   ACTIVE_TIMEOUT = 30.minutes
   HEARTBEAT_INTERVAL = 10.seconds
@@ -31,11 +32,7 @@ class DirectDownloadFileService
 
     def staging_parent(root:)
       root = Pathname(root).expand_path
-      directory = root.join(
-        STAGING_DIRECTORY,
-        DIRECT_DOWNLOADS_DIRECTORY,
-        database_fingerprint
-      )
+      directory = staging_parent_path(root: root)
       FileCopyService.secure_private_directory!(directory.to_s, root: root.to_s)
       directory
     rescue SystemCallError, FileCopyService::UnsafePathError => error
@@ -67,23 +64,34 @@ class DirectDownloadFileService
 
     def cleanup_orphans!(root:, max_age: ORPHAN_MAX_AGE.ago)
       parent = staging_parent(root: root)
+      parent_identity = FileCopyService.directory_identity(parent.to_s, root: root)
       referenced = Download.where.not(direct_staging_path: nil).pluck(:direct_staging_path).to_set
       removed = 0
 
       FileCopyService.directory_children(parent.to_s, root: root).each do |child|
-        next unless child.name.start_with?("download-")
+        next unless v2_staging_basename?(child.name)
         next unless child.type == :directory && child.mtime <= max_age
 
         path = parent.join(child.name)
         next if referenced.include?(path.to_s)
 
-        removed += 1 if FileCopyService.remove_directory_child_if_identity(
-          parent.to_s,
+        cleanup = remove_v2_staging_child(
+          parent,
           child.name,
           root: root,
-          device: child.device,
-          inode: child.inode
+          expected_identity: [ child.device, child.inode ],
+          expected_parent_identity: parent_identity
         )
+        if cleanup == :not_drvfs
+          cleanup = FileCopyService.remove_directory_child_if_identity(
+            parent.to_s,
+            child.name,
+            root: root,
+            device: child.device,
+            inode: child.inode
+          ) ? :removed : :retained
+        end
+        removed += 1 if cleanup == :removed
       rescue Errno::ENOENT, Errno::EACCES, FileCopyService::UnsafePathError
         next
       end
@@ -119,6 +127,42 @@ class DirectDownloadFileService
     end
 
     private
+
+    def staging_parent_path(root:)
+      Pathname(root).expand_path.join(
+        STAGING_DIRECTORY,
+        DIRECT_DOWNLOADS_DIRECTORY,
+        database_fingerprint
+      )
+    end
+
+    def v2_staging_basename?(basename, download_id: nil)
+      match = STAGING_BASENAME_PATTERN.match(basename.to_s)
+      match && (!download_id || match[1].to_i == download_id.to_i)
+    end
+
+    def remove_v2_staging_child(
+      parent,
+      child_name,
+      root:,
+      expected_identity:,
+      expected_parent_identity:,
+      download_id: nil
+    )
+      expected_parent = staging_parent_path(root: root)
+      return :retained unless Pathname(parent).expand_path == expected_parent
+      return :retained unless v2_staging_basename?(child_name, download_id: download_id)
+      return :retained unless expected_identity&.all?(&:present?)
+      return :retained unless expected_parent_identity&.all?(&:present?)
+
+      FileCopyService.remove_owned_private_tree_on_drvfs(
+        expected_parent.to_s,
+        child_name,
+        root: Pathname(root).expand_path.to_s,
+        expected_identity: expected_identity,
+        expected_parent_identity: expected_parent_identity
+      )
+    end
 
     def service_for(download)
       new(
@@ -223,14 +267,29 @@ class DirectDownloadFileService
         return true
       end
 
-      File.lstat(path)
-
       parent = staging_parent(root: download.direct_output_root)
       expanded = Pathname(path).expand_path
       return false unless expanded.parent == parent
 
-      snapshot = FileCopyService.snapshot_source_root(expanded)
       expected_identity = [ download.direct_staging_device, download.direct_staging_inode ]
+      expected_parent_identity = [
+        download.direct_staging_parent_device,
+        download.direct_staging_parent_inode
+      ]
+      cleanup = remove_v2_staging_child(
+        parent,
+        expanded.basename.to_s,
+        root: download.direct_output_root,
+        expected_identity: expected_identity,
+        expected_parent_identity: expected_parent_identity,
+        download_id: download.id
+      )
+      return true if cleanup.in?([ :removed, :missing ])
+      return false if cleanup == :retained
+
+      File.lstat(path)
+
+      snapshot = FileCopyService.snapshot_source_root(expanded)
       return false unless [ snapshot.device, snapshot.inode ] == expected_identity
 
       FileCopyService.remove_source_tree(snapshot)
@@ -321,6 +380,8 @@ class DirectDownloadFileService
     @staging_path = created.name
     @staging_device = created.device
     @staging_inode = created.inode
+    @staging_parent_device = created.parent_device
+    @staging_parent_inode = created.parent_inode
 
     persisted = Download.where(
       id: download.id,
@@ -607,6 +668,17 @@ class DirectDownloadFileService
     parent = self.class.staging_parent(root: output_root)
     expanded = Pathname(@staging_path).expand_path
     return unless expanded.parent == parent
+
+    cleanup = self.class.send(
+      :remove_v2_staging_child,
+      parent,
+      expanded.basename.to_s,
+      root: output_root,
+      expected_identity: [ @staging_device, @staging_inode ],
+      expected_parent_identity: [ @staging_parent_device, @staging_parent_inode ],
+      download_id: download.id
+    )
+    return if cleanup.in?([ :removed, :missing, :retained ])
 
     FileCopyService.remove_directory_child_if_identity(
       parent.to_s,

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -9,7 +9,8 @@ require "pathname"
 # a short, durable Book reservation prevents every acquisition pipeline from
 # claiming the same title while publication is in progress.
 class DirectDownloadFileService
-  STAGING_DIRECTORY = ".shelfarr-staging"
+  LEGACY_STAGING_DIRECTORY = ".shelfarr-staging"
+  STAGING_DIRECTORY = ".shelfarr-staging-v2"
   DIRECT_DOWNLOADS_DIRECTORY = "direct-downloads"
   ORPHAN_MAX_AGE = 24.hours
   ACTIVE_TIMEOUT = 30.minutes
@@ -89,6 +90,23 @@ class DirectDownloadFileService
       removed
     rescue Error, Errno::ENOENT
       0
+    end
+
+    def legacy_staging_diagnostic(root:)
+      root = Pathname(root).expand_path
+      legacy = root.join(LEGACY_STAGING_DIRECTORY)
+      stat = File.lstat(legacy)
+      mode = stat.mode & 0o7777
+      return if stat.directory? && mode == 0o700
+
+      type = stat.directory? ? "directory" : "non-directory entry"
+      "legacy direct-download staging is a retained #{type} with mode #{format('%04o', mode)}; " \
+        "new downloads use #{STAGING_DIRECTORY}, and the legacy entry requires manual review"
+    rescue Errno::ENOENT
+      nil
+    rescue SystemCallError
+      "legacy direct-download staging could not be safely inspected; new downloads use " \
+        "#{STAGING_DIRECTORY}, and the legacy entry requires manual review"
     end
 
     def output_roots
@@ -197,6 +215,14 @@ class DirectDownloadFileService
       return false if download.direct_output_root.blank?
       return false unless valid_output_root_identity?(download)
 
+      if legacy_staging_path?(download)
+        Rails.logger.warn(
+          "[DirectDownloadFileService] Retained legacy staging for download ##{download.id}; " \
+            "its recovery state was released for manual review"
+        )
+        return true
+      end
+
       File.lstat(path)
 
       parent = staging_parent(root: download.direct_output_root)
@@ -211,6 +237,20 @@ class DirectDownloadFileService
     rescue Errno::ENOENT
       valid_output_root_identity?(download) && valid_staging_parent_identity?(download)
     rescue Error, SystemCallError, FileCopyService::UnsafePathError
+      false
+    end
+
+    def legacy_staging_path?(download)
+      root = Pathname(download.direct_output_root).expand_path
+      path = Pathname(download.direct_staging_path).expand_path
+      relative = path.relative_path_from(root)
+      parts = relative.each_filename.to_a
+      parts.length == 4 &&
+        parts[0] == LEGACY_STAGING_DIRECTORY &&
+        parts[1] == DIRECT_DOWNLOADS_DIRECTORY &&
+        parts[2].match?(/\A[0-9a-f]{12}\z/) &&
+        parts[3].match?(/\Adownload-#{download.id}-[0-9a-f]{32}\z/)
+    rescue ArgumentError
       false
     end
 

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -439,6 +439,9 @@ class DirectDownloadFileService
       if relative.to_s == ".." || relative.to_s.start_with?("..#{File::SEPARATOR}")
         raise Error, "Direct-download destination is outside the configured library root"
       end
+      if LibraryPathSafety.internal_relative_path?(relative)
+        raise Error, "Direct-download destination uses a Shelfarr internal staging directory"
+      end
     rescue ArgumentError
       raise Error, "Direct-download destination is outside the configured library root"
     end

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -513,6 +513,7 @@ class DirectDownloadFileService
 
       current_book.update!(
         file_path: book_path,
+        reference_target_roots: nil,
         acquisition_reservation_token: nil,
         acquisition_reservation_owner_type: nil,
         acquisition_reservation_owner_id: nil

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -105,7 +105,12 @@ class DirectDownloadFileService
       legacy = root.join(LEGACY_STAGING_DIRECTORY)
       stat = File.lstat(legacy)
       mode = stat.mode & 0o7777
-      return if stat.directory? && mode == 0o700
+      if stat.directory? && mode == 0o700
+        return if Dir.empty?(legacy)
+
+        return "legacy direct-download staging contains retained entries; new downloads use " \
+          "#{STAGING_DIRECTORY}, and the legacy entry requires manual review"
+      end
 
       type = stat.directory? ? "directory" : "non-directory entry"
       "legacy direct-download staging is a retained #{type} with mode #{format('%04o', mode)}; " \
@@ -262,9 +267,9 @@ class DirectDownloadFileService
       if legacy_staging_path?(download)
         Rails.logger.warn(
           "[DirectDownloadFileService] Retained legacy staging for download ##{download.id}; " \
-            "its recovery state was released for manual review"
+            "its recovery state remains attached for manual review"
         )
-        return true
+        return false
       end
 
       parent = staging_parent(root: download.direct_output_root)

--- a/app/services/download_clients/decypharr.rb
+++ b/app/services/download_clients/decypharr.rb
@@ -4,10 +4,6 @@ module DownloadClients
   class Decypharr < Qbittorrent
     private
 
-    def adapter_specific_add_torrent_params
-      { sequentialDownload: "true" }
-    end
-
     def session_cookie_pattern
       /\b(?<name>SID|sid)=(?<value>[^;]+)/i
     end

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -209,10 +209,12 @@ class FileCopyService
       root:,
       source_root:,
       source_snapshot: nil,
-      authorized_roots: nil
+      authorized_roots: nil,
+      authorized_root_snapshot: nil
     )
       source_path = Pathname(src).expand_path
       destination_path = Pathname(dest).expand_path
+      validate_reference_root_snapshot!(authorized_root_snapshot) if authorized_root_snapshot
 
       with_pinned_reference_source(
         source_path,
@@ -260,11 +262,19 @@ class FileCopyService
           validate_current_directory_identity!(parent_path, parent)
         end
       end
+      validate_reference_root_snapshot!(authorized_root_snapshot) if authorized_root_snapshot
 
       dest.to_s
     end
 
-    def reference_target_matches?(source, destination, root:, source_root: nil, source_snapshot: nil)
+    def reference_target_matches?(
+      source,
+      destination,
+      root:,
+      source_root: nil,
+      source_snapshot: nil,
+      authorized_root_snapshot: nil
+    )
       if source_root.nil? == source_snapshot.nil?
         raise ArgumentError, "reference source requires exactly one authorization snapshot"
       end
@@ -273,6 +283,7 @@ class FileCopyService
       if source_snapshot && source_path != source_snapshot.path
         raise UnsafePathError, "reference source does not match its authorization snapshot"
       end
+      validate_reference_root_snapshot!(authorized_root_snapshot) if authorized_root_snapshot
       result = nil
       with_pinned_reference_source(
         source_path,
@@ -291,6 +302,7 @@ class FileCopyService
           result = matches
         end
       end
+      validate_reference_root_snapshot!(authorized_root_snapshot) if authorized_root_snapshot
       result
     end
 
@@ -316,6 +328,23 @@ class FileCopyService
       end
     rescue Errno::ELOOP, Errno::ENOTDIR => error
       raise UnsafePathError, "reference target contains a symbolic link or non-directory: #{error.message}"
+    end
+
+    def snapshot_reference_root(path)
+      canonical_reference_roots([ path ]).first ||
+        raise(UnsafePathError, "reference target root is not safely accessible")
+    end
+
+    def validate_reference_root_snapshot!(snapshot)
+      unless snapshot.is_a?(ReferenceRootSnapshot)
+        raise UnsafePathError, "reference target root snapshot is invalid"
+      end
+
+      validate_reference_root_identity!(
+        snapshot.path,
+        device: snapshot.device,
+        inode: snapshot.inode
+      )
     end
 
     # Publish from a source descriptor already pinned by the caller (for
@@ -674,10 +703,14 @@ class FileCopyService
 
     # Yield a regular file through a pinned parent and reject any identity/stat
     # change across the read.
-    def with_regular_file(path, root:)
+    def with_regular_file(path, root:, authorized_root_snapshot: nil)
       raise ArgumentError, "a file block is required" unless block_given?
 
-      with_pinned_destination_parent(path, root: root) do |parent, basename, parent_path|
+      result = with_pinned_destination_parent(
+        path,
+        root: root,
+        root_snapshot: authorized_root_snapshot
+      ) do |parent, basename, parent_path|
         with_pinned_regular_child(parent, basename) do |file|
           expected = file_manifest_entry(file.stat)
           result = yield file
@@ -690,6 +723,8 @@ class FileCopyService
           result
         end
       end
+      validate_reference_root_snapshot!(authorized_root_snapshot) if authorized_root_snapshot
+      result
     end
 
     # Refresh a regular file's cleanup lease through its pinned descriptor.
@@ -3805,12 +3840,19 @@ class FileCopyService
         "a replacement download directory was retained in quarantine for manual review"
     end
 
-    def with_pinned_destination_parent(destination, root:)
+    def with_pinned_destination_parent(destination, root:, root_snapshot: nil)
       destination = Pathname(destination).expand_path
       expanded_root, canonical_root, relative = destination_root_and_relative(destination, root)
       parent_relative = relative.dirname
 
       with_pinned_absolute_directory(canonical_root) do |root_directory|
+        if root_snapshot
+          expected_root = Pathname(root_snapshot.path).expand_path
+          unless expected_root == expanded_root &&
+              file_identity(root_directory.stat) == [ root_snapshot.device, root_snapshot.inode ]
+            raise Errno::ESTALE, "reference target root changed before file access"
+          end
+        end
         validate_current_directory_identity!(expanded_root, root_directory)
         with_pinned_relative_directory(root_directory, parent_relative, create: false) do |parent|
           yield parent, destination.basename.to_s, destination.parent

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -73,6 +73,7 @@ class FileCopyService
     :manifest,
     keyword_init: true
   )
+  ReferenceRootSnapshot = Struct.new(:path, :device, :inode, keyword_init: true)
   ReferenceSourceSnapshot = Struct.new(
     :path,
     :parent_path,
@@ -81,7 +82,10 @@ class FileCopyService
     :parent_inode,
     :link_target,
     :target_snapshot,
+    :canonical_target_path,
     :authorized_root,
+    :authorized_root_device,
+    :authorized_root_inode,
     keyword_init: true
   )
   SourceRoot = Struct.new(
@@ -3051,7 +3055,7 @@ class FileCopyService
       expanded = Pathname(path).expand_path
       if source_snapshot.is_a?(ReferenceSourceSnapshot)
         return with_pinned_reference_source_snapshot(expanded, source_snapshot) do |source|
-          yield source, source_snapshot.target_snapshot.path.to_s
+          yield source, source_snapshot.canonical_target_path.to_s
         end
       end
       if source_snapshot
@@ -3071,7 +3075,7 @@ class FileCopyService
       if File.lstat(expanded).symlink?
         snapshot = snapshot_reference_source(expanded, authorized_roots: authorized_roots)
         return with_pinned_reference_source_snapshot(expanded, snapshot) do |source|
-          yield source, snapshot.target_snapshot.path.to_s
+          yield source, snapshot.canonical_target_path.to_s
         end
       end
 
@@ -3083,13 +3087,20 @@ class FileCopyService
         raise UnsafePathError, "reference source does not match its authorization snapshot"
       end
 
+      validate_reference_authorized_root!(snapshot)
       with_pinned_absolute_directory(snapshot.canonical_parent_path) do |parent|
         unless file_identity(parent.stat) == [ snapshot.parent_device, snapshot.parent_inode ]
           raise Errno::ESTALE, "reference source parent changed after it was snapshotted"
         end
         validate_reference_source_link!(parent, snapshot)
-        result = with_pinned_source_snapshot(snapshot.target_snapshot) { |source, *| yield source }
+        result = with_pinned_source_snapshot(snapshot.target_snapshot) do |source, *|
+          validate_reference_authorized_root!(snapshot)
+          published = yield source
+          validate_reference_authorized_root!(snapshot)
+          published
+        end
         validate_reference_source_link!(parent, snapshot)
+        validate_reference_authorized_root!(snapshot)
         result
       end
     rescue Errno::EINVAL, Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
@@ -3106,13 +3117,22 @@ class FileCopyService
 
     def canonical_reference_roots(paths)
       Array(paths).filter_map do |path|
-        root = Pathname(path).expand_path.realpath
-        next if root.root? || !root.lstat.directory?
+        expanded = Pathname(path).expand_path
+        canonical = expanded.realpath
+        next if canonical.root? || !canonical.lstat.directory?
 
-        root
+        with_pinned_absolute_directory(canonical) do |root|
+          validate_current_directory_identity!(expanded, root)
+          stat = root.stat
+          ReferenceRootSnapshot.new(
+            path: canonical,
+            device: stat.dev,
+            inode: stat.ino
+          ).freeze
+        end
       rescue ArgumentError, SystemCallError
         nil
-      end.uniq
+      end.uniq(&:path)
     end
 
     def path_beneath_root?(path, root)
@@ -3424,14 +3444,19 @@ class FileCopyService
     def snapshot_reference_source_at(expanded, parent, canonical_parent, link_target, authorized_roots)
       target = Pathname(link_target)
       target = canonical_parent.join(target) unless target.absolute?
-      canonical_target = canonical_reference_target(target)
+      target_snapshot = snapshot_reference_target(target)
+      canonical_target = target_snapshot.canonical_parent_path.join(target_snapshot.path.basename)
       authorized_root = authorized_roots.select do |root|
-        path_beneath_root?(canonical_target, root)
-      end.max_by { |root| root.to_s.length }
+        path_beneath_root?(canonical_target, root.path)
+      end.max_by { |root| root.path.to_s.length }
       unless authorized_root
         raise UnsafePathError, "reference target is outside authorized source roots"
       end
-      target_snapshot = snapshot_reference_target(canonical_target)
+      validate_reference_root_identity!(
+        authorized_root.path,
+        device: authorized_root.device,
+        inode: authorized_root.inode
+      )
 
       validate_current_directory_identity!(expanded.parent, parent)
       unless native_readlinkat(parent.fileno, expanded.basename.to_s) == link_target
@@ -3446,19 +3471,35 @@ class FileCopyService
         parent_inode: parent_stat.ino,
         link_target: link_target,
         target_snapshot: target_snapshot,
-        authorized_root: authorized_root
+        canonical_target_path: canonical_target,
+        authorized_root: authorized_root.path,
+        authorized_root_device: authorized_root.device,
+        authorized_root_inode: authorized_root.inode
       ).freeze
     end
 
-    def canonical_reference_target(target)
-      target.parent.realpath.join(target.basename)
-    rescue Errno::ENOENT => error
-      raise ReferenceTargetUnavailableError,
-        "reference target is not visible yet: #{error.message}"
+    def validate_reference_authorized_root!(snapshot)
+      validate_reference_root_identity!(
+        snapshot.authorized_root,
+        device: snapshot.authorized_root_device,
+        inode: snapshot.authorized_root_inode
+      )
     end
 
-    def snapshot_reference_target(canonical_target)
-      snapshot_source_file(canonical_target)
+    def validate_reference_root_identity!(path, device:, inode:)
+      with_pinned_absolute_directory(path) do |root|
+        unless file_identity(root.stat) == [ device, inode ]
+          raise Errno::ESTALE, "reference target root changed after it was authorized"
+        end
+        validate_current_directory_identity!(path, root)
+      end
+      true
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP, Errno::ENOTDIR
+      raise Errno::ESTALE, "reference target root changed after it was authorized"
+    end
+
+    def snapshot_reference_target(target)
+      snapshot_source_file(target)
     rescue Errno::ENOENT => error
       raise ReferenceTargetUnavailableError,
         "reference target is not visible yet: #{error.message}"

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -34,6 +34,7 @@ class FileCopyService
   OWNER_PROBE_PATTERN = /\A\.shelfarr-owner-probe-[0-9a-f]{32}\.tmp\z/
   COPY_LOCK_COMPATIBILITY_PREPARED_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:prepared:([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_LOCK_COMPATIBILITY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:(copying|complete):([0-9]+):([0-9]+):([0-9]+):([0-9]+):([0-9a-f]+)\z/
+  COPY_LOCK_DRVFS_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):drvfs:(prepared|copying|complete|conflict):([0-9]+):([0-9a-f]{64}):([0-9a-f]+)\z/
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   DISCARD_PATTERN = /\A\.shelfarr-discard-([0-9a-f]+)-([0-9a-f]+)-[0-9a-f]{32}\.tmp\z/
   SOURCE_QUARANTINE_PATTERN = /\A\.shelfarr-source-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
@@ -1505,8 +1506,12 @@ class FileCopyService
         entries = Dir.children(parent_path)
         unless identity_reliable
           retained = entries.any? do |entry|
-            COPY_LOCK_PATTERN.match?(entry) || COPY_QUARANTINE_PATTERN.match?(entry) ||
-              DISCARD_PATTERN.match?(entry) || OWNER_PROBE_PATTERN.match?(entry)
+            if (match = COPY_LOCK_PATTERN.match(entry))
+              !drvfs_mount?(parent) || !resolved_drvfs_copy_lock?(parent, entry, match[1])
+            else
+              COPY_QUARANTINE_PATTERN.match?(entry) || DISCARD_PATTERN.match?(entry) ||
+                OWNER_PROBE_PATTERN.match?(entry)
+            end
           end
           if retained
             Rails.logger.warn(
@@ -1789,6 +1794,32 @@ class FileCopyService
 
       cleanup_interrupted_copies(File.dirname(destination), root: root)
       with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
+        if drvfs_mount?(parent)
+          journal_root = Pathname(root.presence || parent_path).expand_path
+          cleanup_interrupted_copies(journal_root.to_s, root: journal_root.to_s)
+          with_pinned_directory(
+            journal_root,
+            root: journal_root,
+            create: false,
+            mode: DIRECTORY_MODE
+          ) do |journal_parent|
+            publish_source_io_by_drvfs_exclusive_copy!(
+              source,
+              parent,
+              basename,
+              journal_parent: journal_parent,
+              destination_parent_validator: -> { validate_current_directory_identity!(parent_path, parent) },
+              heartbeat: heartbeat,
+              source_validator: source_validator,
+              accepted_modes: accepted_modes,
+              require_durable: require_durable,
+              path: destination,
+              root: root
+            )
+          end
+          return
+        end
+
         token = SecureRandom.hex(16)
         temporary_basename = ".shelfarr-copy-#{token}.tmp"
         lock_basename = ".shelfarr-copy-#{token}.lock"
@@ -1884,15 +1915,25 @@ class FileCopyService
           # otherwise delete a replacement installed by another worker.
           raise
         ensure
-          temporary_cleanup = remove_pinned_child_if_identity(
-            parent,
-            temporary_basename,
-            temporary_identity
-          )
-          if temporary_cleanup.in?([ :removed, :missing ])
-            remove_pinned_child_if_identity(parent, lock_basename, lock_identity)
+          in_flight_error = $!
+          begin
+            temporary_cleanup = remove_pinned_child_if_identity(
+              parent,
+              temporary_basename,
+              temporary_identity
+            )
+            if temporary_cleanup.in?([ :removed, :missing ])
+              remove_pinned_child_if_identity(parent, lock_basename, lock_identity)
+            end
+            sync_io(parent)
+          rescue => cleanup_error
+            raise unless in_flight_error
+
+            Rails.logger.warn(
+              "[FileCopyService] Publication teardown was deferred after " \
+                "#{in_flight_error.class}: #{cleanup_error.class}"
+            )
           end
-          sync_io(parent)
         end
       end
     end
@@ -2179,6 +2220,177 @@ class FileCopyService
         cause: error
     end
 
+    def publish_source_io_by_drvfs_exclusive_copy!(
+      source,
+      parent,
+      destination_basename,
+      journal_parent:,
+      destination_parent_validator:,
+      heartbeat:,
+      source_validator:,
+      accepted_modes:,
+      require_durable:,
+      path:,
+      root:
+    )
+      source_size, source_digest = io_content_identity(source, heartbeat: heartbeat)
+      source_validator&.call
+      token = SecureRandom.hex(16)
+      lock_basename = ".shelfarr-copy-#{token}.lock"
+      destination_created = false
+      published_mode = nil
+
+      with_created_regular_child(journal_parent, lock_basename, 0o600) do |lock|
+        raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
+
+        apply_file_mode!(lock, 0o600, accepted_modes: LIBRARY_FILE_MODES, path: path, root: root)
+        persist_drvfs_copy_lock!(
+          lock,
+          token,
+          :prepared,
+          source_size,
+          source_digest,
+          destination_basename
+        )
+        sync_io(journal_parent)
+
+        begin
+          with_created_regular_child(parent, destination_basename, 0o600) do |destination|
+            destination_created = true
+            persist_drvfs_copy_lock!(
+              lock,
+              token,
+              :copying,
+              source_size,
+              source_digest,
+              destination_basename
+            )
+            sync_io(parent)
+            apply_file_mode!(
+              destination,
+              0o600,
+              accepted_modes: accepted_modes,
+              path: path,
+              root: root
+            )
+            copy_source_io(source, destination, heartbeat: heartbeat)
+            published_mode = apply_file_mode!(
+              destination,
+              LIBRARY_FILE_MODE,
+              accepted_modes: accepted_modes,
+              path: path,
+              root: root
+            )
+            file_durable = flush_and_sync(destination)
+            if require_durable && !file_durable
+              raise DurabilityUnsupportedError, "destination file fsync is unsupported"
+            end
+            unless io_matches_identity?(destination, source_size, source_digest)
+              raise Errno::ESTALE, "direct-copy destination changed while it was written"
+            end
+          end
+
+          source_validator&.call
+          2.times do
+            unless drvfs_destination_matches_source?(
+              source,
+              parent,
+              destination_basename,
+              source_size,
+              source_digest,
+              published_mode
+            )
+              raise Errno::ESTALE, "direct-copy destination could not be verified"
+            end
+          end
+          source_validator&.call
+          destination_parent_validator.call
+          parent_durable = sync_io(parent)
+          if require_durable && !parent_durable
+            raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
+          end
+          persist_drvfs_copy_lock!(
+            lock,
+            token,
+            :complete,
+            source_size,
+            source_digest,
+            destination_basename
+          )
+          sync_io(journal_parent)
+        rescue Errno::EEXIST
+          persist_drvfs_copy_lock!(
+            lock,
+            token,
+            :conflict,
+            source_size,
+            source_digest,
+            destination_basename
+          )
+          raise
+        rescue StandardError => error
+          raise unless destination_created
+
+          raise AmbiguousPublicationError.new(
+            "An incomplete DrvFS direct-copy publication was retained for manual review"
+          ), cause: error
+        end
+      end
+
+      Rails.logger.warn(
+        "[FileCopyService] DrvFS lacks atomic no-clobber publication; " \
+          "used verified O_EXCL direct-copy compatibility mode"
+      )
+    end
+
+    def io_content_identity(io, heartbeat: nil)
+      original_position = io.pos
+      io.rewind
+      size = 0
+      digest = Digest::SHA256.new
+      buffer = +""
+      while io.read(BUFFER_SIZE, buffer)
+        size += buffer.bytesize
+        digest << buffer
+        heartbeat&.call
+      end
+      [ size, digest.hexdigest ]
+    ensure
+      io.seek(original_position) if original_position
+    end
+
+    def io_matches_identity?(io, expected_size, expected_digest)
+      size, digest = io_content_identity(io)
+      size == expected_size && digest == expected_digest
+    end
+
+    def drvfs_destination_matches_source?(
+      source,
+      parent,
+      basename,
+      expected_size,
+      expected_digest,
+      expected_mode
+    )
+      matches = false
+      source_position = nil
+      with_pinned_regular_child(parent, basename) do |destination|
+        stat = destination.stat
+        next unless stat.size == expected_size && (stat.mode & 0o7777) == expected_mode
+        next unless io_matches_identity?(destination, expected_size, expected_digest)
+
+        source_position = source.pos
+        source.rewind
+        destination.rewind
+        matches = compare_io(source, destination)
+      end
+      matches
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, UnsafePathError
+      false
+    ensure
+      source.seek(source_position) if source_position
+    end
+
     def validate_published_child!(
       parent,
       basename,
@@ -2394,6 +2606,44 @@ class FileCopyService
         lock,
         "#{COPY_LOCK_MAGIC}:#{token}:full:#{identity.first}:#{identity.last}"
       )
+    end
+
+    def persist_drvfs_copy_lock!(lock, token, state, source_size, source_digest, destination_basename)
+      encoded_basename = destination_basename.b.unpack1("H*")
+      record = "#{COPY_LOCK_MAGIC}:#{token}:drvfs:#{state}:#{source_size}:" \
+        "#{source_digest}:#{encoded_basename}"
+      checksum = Digest::SHA256.hexdigest(record)
+      lock.seek(0, IO::SEEK_END)
+      lock.write("#{record}:#{checksum}\n")
+      flush_and_sync(lock)
+    end
+
+    def resolved_drvfs_copy_lock?(parent, basename, token)
+      resolved = false
+      with_pinned_regular_child(parent, basename, writable: true) do |lock|
+        next unless lock.flock(File::LOCK_EX | File::LOCK_NB)
+        next unless secure_copy_lock?(lock, parent)
+
+        lock.rewind
+        resolved = drvfs_copy_lock_state(lock.read, token).in?([ :complete, :conflict ])
+      end
+      resolved
+    rescue Errno::ENOENT, Errno::EACCES, Errno::EWOULDBLOCK, IOError, UnsafePathError
+      false
+    end
+
+    def drvfs_copy_lock_state(contents, token)
+      contents.lines(chomp: true).reverse_each do |line|
+        record, separator, checksum = line.rpartition(":")
+        next if separator.empty? || checksum.length != 64
+        next unless Digest::SHA256.hexdigest(record) == checksum
+
+        match = COPY_LOCK_DRVFS_PATTERN.match(record)
+        next unless match && match[1] == token
+
+        return match[2].to_sym
+      end
+      :malformed
     end
 
     def persist_copy_lock_record!(lock, record)
@@ -2971,6 +3221,35 @@ class FileCopyService
     def hardlink_identity_unreliable?(*filesystem_entries, reject_cifs: false)
       return false unless RUBY_PLATFORM.include?("linux")
 
+      mounts, mount_parents = filesystem_mounts
+
+      filesystem_entries.any? do |entry|
+        mount = filesystem_mount_for(entry, mounts, mount_parents)
+        next true unless mount
+        next true if drvfs_mount_record?(mount)
+        next false unless mount.fetch(4).in?([ "cifs", "smb3" ])
+        next true if reject_cifs
+
+        options = "#{mount.fetch(5)},#{mount.fetch(6)}".split(",")
+        !options.include?("serverino")
+      end
+    rescue ArgumentError, Encoding::CompatibilityError, IOError, SystemCallError
+      true
+    end
+
+    def drvfs_mount?(*filesystem_entries)
+      return false unless RUBY_PLATFORM.include?("linux")
+
+      mounts, mount_parents = filesystem_mounts
+      filesystem_entries.any? do |entry|
+        mount = filesystem_mount_for(entry, mounts, mount_parents)
+        mount && drvfs_mount_record?(mount)
+      end
+    rescue ArgumentError, Encoding::CompatibilityError, IOError, SystemCallError
+      false
+    end
+
+    def filesystem_mounts
       mounts = File.binread("/proc/self/mountinfo").lines(chomp: true).filter_map do |line|
         mount_fields, separator, filesystem_fields = line.partition(" - ")
         next if separator.empty?
@@ -2989,38 +3268,39 @@ class FileCopyService
         [ mount_id, parent_id, fields.fetch(2), mountpoint, filesystem.fetch(0), fields.fetch(5), filesystem.fetch(2) ]
       end
       mount_parents = mounts.to_h { |mount_id, parent_id, *| [ mount_id, parent_id ] }
+      [ mounts, mount_parents ]
+    end
 
-      filesystem_entries.any? do |entry|
-        expanded, stat = if entry.respond_to?(:fileno) && entry.respond_to?(:stat)
-          descriptor_path = File.readlink("/proc/self/fd/#{entry.fileno}").delete_suffix(" (deleted)")
-          [ Pathname(descriptor_path).expand_path.to_s.b, entry.stat ]
-        else
-          path = Pathname(entry).expand_path.realpath
-          [ path.to_s.b, File.stat(path) ]
-        end
-        device = "#{stat.dev_major}:#{stat.dev_minor}"
-        mount = mounts.select do |_mount_id, _parent_id, mount_device, mountpoint, *|
-          mount_device == device &&
-            (expanded == mountpoint || expanded.start_with?("#{mountpoint.delete_suffix("/")}/"))
-        end.max_by do |mount_id, _parent_id, _mount_device, mountpoint, *|
-          depth = 0
-          seen = Set.new
-          current = mount_id
-          while (parent = mount_parents[current]) && seen.add?(current)
-            depth += 1
-            current = parent
-          end
-          [ mountpoint.bytesize, depth ]
-        end
-        next true unless mount
-        next false unless mount.fetch(4).in?([ "cifs", "smb3" ])
-        next true if reject_cifs
-
-        options = "#{mount.fetch(5)},#{mount.fetch(6)}".split(",")
-        !options.include?("serverino")
+    def filesystem_mount_for(entry, mounts, mount_parents)
+      expanded, stat = if entry.respond_to?(:fileno) && entry.respond_to?(:stat)
+        descriptor_path = File.readlink("/proc/self/fd/#{entry.fileno}").delete_suffix(" (deleted)")
+        [ Pathname(descriptor_path).expand_path.to_s.b, entry.stat ]
+      else
+        path = Pathname(entry).expand_path.realpath
+        [ path.to_s.b, File.stat(path) ]
       end
-    rescue ArgumentError, Encoding::CompatibilityError, IOError, SystemCallError
-      true
+      device = "#{stat.dev_major}:#{stat.dev_minor}"
+      mounts.select do |_mount_id, _parent_id, mount_device, mountpoint, *|
+        mount_device == device &&
+          (expanded == mountpoint || expanded.start_with?("#{mountpoint.delete_suffix("/")}/"))
+      end.max_by do |mount_id, _parent_id, _mount_device, mountpoint, *|
+        depth = 0
+        seen = Set.new
+        current = mount_id
+        while (parent = mount_parents[current]) && seen.add?(current)
+          depth += 1
+          current = parent
+        end
+        [ mountpoint.bytesize, depth ]
+      end
+    end
+
+    def drvfs_mount_record?(mount)
+      return false unless mount.fetch(4) == "9p"
+
+      "#{mount.fetch(5)},#{mount.fetch(6)}".split(",").any? do |option|
+        option.match?(/\Aaname=drvfs(?:;|\z)/)
+      end
     end
 
     def pinned_child_identity(parent, basename, directory: false)
@@ -3271,6 +3551,7 @@ class FileCopyService
       quarantine_kind: :copy,
       expected_owner_uid: nil
     )
+      return :retained if drvfs_mount?(parent)
       return :mismatch unless expected_identity
 
       begin

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -38,6 +38,8 @@ class FileCopyService
   DRVFS_COPY_JOURNAL_BASENAME = ".shelfarr-drvfs-copy.journal"
   DRVFS_COPY_TERMINAL_STATES = [ :empty, :complete, :conflict, :aborted ].freeze
   DRVFS_COPY_LOCK_RETRY_INTERVAL = 0.05
+  DRVFS_PRIVATE_STAGING_FILE_MODES = [ 0o600, LIBRARY_FILE_MODE ].freeze
+  DRVFS_PRIVATE_STAGING_DIRECTORY_MODES = [ 0o700, DIRECTORY_MODE ].freeze
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   DISCARD_PATTERN = /\A\.shelfarr-discard-([0-9a-f]+)-([0-9a-f]+)-[0-9a-f]{32}\.tmp\z/
   SOURCE_QUARANTINE_PATTERN = /\A\.shelfarr-source-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
@@ -991,6 +993,76 @@ class FileCopyService
       false
     end
 
+    # DrvFS can change inode identities during rename, so the generic
+    # quarantine-based remover must continue to reject it. Direct-download v2
+    # staging instead uses an application-authenticated private namespace and
+    # can remove a fully preflighted tree without renaming it. Callers must
+    # validate that parent_path and child_name name that exact namespace.
+    def remove_owned_private_tree_on_drvfs(
+      parent_path,
+      child_name,
+      root:,
+      expected_identity:,
+      expected_parent_identity:
+    )
+      if child_name.include?(File::SEPARATOR) || child_name.in?([ ".", ".." ])
+        raise UnsafePathError, "private directory child name is unsafe"
+      end
+
+      with_pinned_directory(parent_path, root: root, create: false, mode: 0o700) do |parent|
+        return :not_drvfs unless drvfs_mount?(parent)
+
+        parent_stat = parent.stat
+        if expected_parent_identity && file_identity(parent_stat) != expected_parent_identity
+          return :retained
+        end
+        unless drvfs_private_staging_directory?(parent_stat, parent, root: true)
+          return :retained
+        end
+
+        child = begin
+          open_pinned_directory_child(parent, child_name)
+        rescue Errno::ENOENT
+          return :missing
+        end
+        begin
+          child_stat = child.stat
+          child_identity = file_identity(child_stat)
+          return :retained if expected_identity && child_identity != expected_identity
+          return :retained unless drvfs_private_staging_directory?(child_stat, parent, root: true)
+
+          root_manifest = drvfs_private_staging_manifest(child_stat, parent)
+          current_root = lambda do
+            validate_current_directory_identity!(Pathname(parent_path).expand_path, parent)
+            drvfs_private_staging_child_manifest(parent, child_name) == root_manifest
+          rescue SystemCallError, IOError, UnsafePathError
+            false
+          end
+
+          return :retained unless current_root.call
+
+          manifest = snapshot_pinned_drvfs_private_tree(child)
+          return :retained unless current_root.call
+
+          remove_pinned_drvfs_private_tree_contents!(
+            child,
+            manifest,
+            before_remove: current_root
+          )
+          return :retained unless current_root.call
+
+          native_unlinkat(parent.fileno, child_name, AT_REMOVEDIR)
+          sync_io(parent)
+          validate_current_directory_identity!(Pathname(parent_path).expand_path, parent)
+          :removed
+        ensure
+          child.close unless child.closed?
+        end
+      end
+    rescue SystemCallError, IOError, UnsafePathError
+      :retained
+    end
+
     # Compare regular files through pinned descriptors. This is used by retry
     # reconciliation so a path swap cannot trick an import into reusing an
     # unrelated library file.
@@ -1747,6 +1819,133 @@ class FileCopyService
         raise UnsafePathError, "private staging path is unsafe"
       end
       relative
+    end
+
+    def snapshot_pinned_drvfs_private_tree(directory, prefix = nil, manifest = {})
+      entries = pinned_directory_children(directory)
+      entries.each do |entry|
+        descriptor = native_openat(
+          directory.fileno,
+          entry,
+          File::RDONLY | File::NOFOLLOW | File::NONBLOCK,
+          0
+        )
+        child = IO.new(descriptor, "rb", autoclose: true)
+        begin
+          relative = prefix ? prefix.join(entry) : Pathname(entry)
+          stat = child.stat
+          manifest[relative.to_s] = drvfs_private_staging_manifest(stat, directory)
+          if stat.directory?
+            snapshot_pinned_drvfs_private_tree(child, relative, manifest)
+          elsif !stat.file?
+            raise UnsafePathError, "private staging tree contains a special entry"
+          end
+        ensure
+          child.close unless child.closed?
+        end
+      end
+      unless pinned_directory_children(directory) == entries
+        raise Errno::ESTALE, "private staging tree changed during validation"
+      end
+
+      manifest
+    end
+
+    def remove_pinned_drvfs_private_tree_contents!(directory, expected_entries, prefix = nil, before_remove:)
+      children = pinned_directory_children(directory)
+      expected_children = expected_entries.keys.filter_map do |relative|
+        path = Pathname(relative)
+        next unless path.dirname == (prefix || Pathname("."))
+
+        path.basename.to_s
+      end.sort
+      unless children == expected_children
+        raise Errno::ESTALE, "private staging tree changed before cleanup"
+      end
+
+      children.each do |entry|
+        raise Errno::ESTALE, "private staging root changed during cleanup" unless before_remove.call
+
+        relative = prefix ? prefix.join(entry) : Pathname(entry)
+        expected = expected_entries.fetch(relative.to_s)
+        descriptor = native_openat(
+          directory.fileno,
+          entry,
+          File::RDONLY | File::NOFOLLOW | File::NONBLOCK,
+          0
+        )
+        child = IO.new(descriptor, "rb", autoclose: true)
+        begin
+          stat = child.stat
+          current = drvfs_private_staging_manifest(stat, directory)
+          unless current == expected
+            raise Errno::ESTALE, "private staging entry changed before cleanup"
+          end
+
+          if stat.directory?
+            remove_pinned_drvfs_private_tree_contents!(
+              child,
+              expected_entries,
+              relative,
+              before_remove: before_remove
+            )
+          elsif !stat.file?
+            raise UnsafePathError, "private staging tree contains a special entry"
+          end
+
+          raise Errno::ESTALE, "private staging root changed during cleanup" unless before_remove.call
+          unless drvfs_private_staging_child_manifest(directory, entry) == expected
+            raise Errno::ESTALE, "private staging entry was replaced during cleanup"
+          end
+
+          native_unlinkat(directory.fileno, entry, stat.directory? ? AT_REMOVEDIR : 0)
+          sync_io(directory)
+        ensure
+          child.close unless child.closed?
+        end
+      end
+    end
+
+    def drvfs_private_staging_child_manifest(parent, basename)
+      descriptor = native_openat(
+        parent.fileno,
+        basename,
+        File::RDONLY | File::NOFOLLOW | File::NONBLOCK,
+        0
+      )
+      child = IO.new(descriptor, "rb", autoclose: true)
+      drvfs_private_staging_manifest(child.stat, parent)
+    ensure
+      child&.close unless child&.closed?
+    end
+
+    def drvfs_private_staging_manifest(stat, parent)
+      unless private_entry_owned_by_process?(stat, parent)
+        raise UnsafePathError, "private staging entry is owned by another user"
+      end
+
+      mode = stat.mode & 0o7777
+      if stat.directory?
+        unless mode.in?(DRVFS_PRIVATE_STAGING_DIRECTORY_MODES)
+          raise UnsafePathError, "private staging directory permissions changed"
+        end
+        [ stat.dev, stat.ino, :directory, mode, stat.uid ]
+      elsif stat.file?
+        unless mode.in?(DRVFS_PRIVATE_STAGING_FILE_MODES)
+          raise UnsafePathError, "private staging file permissions changed"
+        end
+        [ stat.dev, stat.ino, :file, stat.size, stat.mtime.to_r, stat.ctime.to_r, mode, stat.uid ]
+      else
+        raise UnsafePathError, "private staging tree contains a special entry"
+      end
+    end
+
+    def drvfs_private_staging_directory?(stat, parent, root: false)
+      return false unless stat.directory?
+      return false unless private_entry_owned_by_process?(stat, parent)
+
+      mode = stat.mode & 0o7777
+      root ? mode == 0o700 : mode.in?(DRVFS_PRIVATE_STAGING_DIRECTORY_MODES)
     end
 
     def apply_file_mode!(file, requested_mode, accepted_modes:, path: nil, root: nil)

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -34,7 +34,10 @@ class FileCopyService
   OWNER_PROBE_PATTERN = /\A\.shelfarr-owner-probe-[0-9a-f]{32}\.tmp\z/
   COPY_LOCK_COMPATIBILITY_PREPARED_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:prepared:([0-9]+):([0-9]+):([0-9a-f]+)\z/
   COPY_LOCK_COMPATIBILITY_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):compatibility:(copying|complete):([0-9]+):([0-9]+):([0-9]+):([0-9]+):([0-9a-f]+)\z/
-  COPY_LOCK_DRVFS_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):drvfs:(prepared|copying|complete|conflict):([0-9]+):([0-9a-f]{64}):([0-9a-f]+)\z/
+  COPY_LOCK_DRVFS_PATTERN = /\A#{Regexp.escape(COPY_LOCK_MAGIC)}:([0-9a-f]{32}):drvfs:(prepared|copying|complete|conflict|aborted):([0-9]+):([0-9a-f]{64}):([0-9a-f]+)\z/
+  DRVFS_COPY_JOURNAL_BASENAME = ".shelfarr-drvfs-copy.journal"
+  DRVFS_COPY_TERMINAL_STATES = [ :empty, :complete, :conflict, :aborted ].freeze
+  DRVFS_COPY_LOCK_RETRY_INTERVAL = 0.05
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
   DISCARD_PATTERN = /\A\.shelfarr-discard-([0-9a-f]+)-([0-9a-f]+)-[0-9a-f]{32}\.tmp\z/
   SOURCE_QUARANTINE_PATTERN = /\A\.shelfarr-source-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
@@ -1550,12 +1553,8 @@ class FileCopyService
         entries = Dir.children(parent_path)
         unless identity_reliable
           retained = entries.any? do |entry|
-            if (match = COPY_LOCK_PATTERN.match(entry))
-              !drvfs_mount?(parent) || !resolved_drvfs_copy_lock?(parent, entry, match[1])
-            else
-              COPY_QUARANTINE_PATTERN.match?(entry) || DISCARD_PATTERN.match?(entry) ||
-                OWNER_PROBE_PATTERN.match?(entry)
-            end
+            COPY_LOCK_PATTERN.match?(entry) || COPY_QUARANTINE_PATTERN.match?(entry) ||
+              DISCARD_PATTERN.match?(entry) || OWNER_PROBE_PATTERN.match?(entry)
           end
           if retained
             Rails.logger.warn(
@@ -1840,26 +1839,34 @@ class FileCopyService
       with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
         if drvfs_mount?(parent)
           journal_root = Pathname(root.presence || parent_path).expand_path
-          cleanup_interrupted_copies(journal_root.to_s, root: journal_root.to_s)
+          journal_destination = Pathname(destination).expand_path.relative_path_from(journal_root).to_s
           with_pinned_directory(
             journal_root,
             root: journal_root,
             create: false,
             mode: DIRECTORY_MODE
           ) do |journal_parent|
-            publish_source_io_by_drvfs_exclusive_copy!(
-              source,
-              parent,
-              basename,
-              journal_parent: journal_parent,
-              destination_parent_validator: -> { validate_current_directory_identity!(parent_path, parent) },
+            with_drvfs_copy_journal(
+              journal_parent,
               heartbeat: heartbeat,
-              source_validator: source_validator,
-              accepted_modes: accepted_modes,
-              require_durable: require_durable,
               path: destination,
               root: root
-            )
+            ) do |journal|
+              publish_source_io_by_drvfs_exclusive_copy!(
+                source,
+                parent,
+                basename,
+                journal: journal,
+                journal_destination: journal_destination,
+                destination_parent_validator: -> { validate_current_directory_identity!(parent_path, parent) },
+                heartbeat: heartbeat,
+                source_validator: source_validator,
+                accepted_modes: accepted_modes,
+                require_durable: require_durable,
+                path: destination,
+                root: root
+              )
+            end
           end
           return
         end
@@ -2268,7 +2275,8 @@ class FileCopyService
       source,
       parent,
       destination_basename,
-      journal_parent:,
+      journal:,
+      journal_destination:,
       destination_parent_validator:,
       heartbeat:,
       source_validator:,
@@ -2280,105 +2288,111 @@ class FileCopyService
       source_size, source_digest = io_content_identity(source, heartbeat: heartbeat)
       source_validator&.call
       token = SecureRandom.hex(16)
-      lock_basename = ".shelfarr-copy-#{token}.lock"
       destination_created = false
       published_mode = nil
 
-      with_created_regular_child(journal_parent, lock_basename, 0o600) do |lock|
-        raise UnsafePathError, "copy lock could not be acquired" unless lock.flock(File::LOCK_EX)
+      reset_drvfs_copy_journal!(
+        journal,
+        token,
+        :prepared,
+        source_size,
+        source_digest,
+        journal_destination
+      )
 
-        apply_file_mode!(lock, 0o600, accepted_modes: LIBRARY_FILE_MODES, path: path, root: root)
+      begin
+        with_created_regular_child(
+          parent,
+          destination_basename,
+          0o600,
+          created: -> { destination_created = true }
+        ) do |destination|
+          persist_drvfs_copy_lock!(
+            journal,
+            token,
+            :copying,
+            source_size,
+            source_digest,
+            journal_destination
+          )
+          sync_io(parent)
+          apply_file_mode!(
+            destination,
+            0o600,
+            accepted_modes: accepted_modes,
+            path: path,
+            root: root
+          )
+          copy_source_io(source, destination, heartbeat: heartbeat)
+          published_mode = apply_file_mode!(
+            destination,
+            LIBRARY_FILE_MODE,
+            accepted_modes: accepted_modes,
+            path: path,
+            root: root
+          )
+          file_durable = flush_and_sync(destination)
+          if require_durable && !file_durable
+            raise DurabilityUnsupportedError, "destination file fsync is unsupported"
+          end
+          unless io_matches_identity?(destination, source_size, source_digest)
+            raise Errno::ESTALE, "direct-copy destination changed while it was written"
+          end
+        end
+
+        source_validator&.call
+        2.times do
+          unless drvfs_destination_matches_source?(
+            source,
+            parent,
+            destination_basename,
+            source_size,
+            source_digest,
+            published_mode
+          )
+            raise Errno::ESTALE, "direct-copy destination could not be verified"
+          end
+        end
+        source_validator&.call
+        destination_parent_validator.call
+        parent_durable = sync_io(parent)
+        if require_durable && !parent_durable
+          raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
+        end
         persist_drvfs_copy_lock!(
-          lock,
+          journal,
           token,
-          :prepared,
+          :complete,
           source_size,
           source_digest,
-          destination_basename
+          journal_destination
         )
-        sync_io(journal_parent)
-
-        begin
-          with_created_regular_child(parent, destination_basename, 0o600) do |destination|
-            destination_created = true
-            persist_drvfs_copy_lock!(
-              lock,
-              token,
-              :copying,
-              source_size,
-              source_digest,
-              destination_basename
-            )
-            sync_io(parent)
-            apply_file_mode!(
-              destination,
-              0o600,
-              accepted_modes: accepted_modes,
-              path: path,
-              root: root
-            )
-            copy_source_io(source, destination, heartbeat: heartbeat)
-            published_mode = apply_file_mode!(
-              destination,
-              LIBRARY_FILE_MODE,
-              accepted_modes: accepted_modes,
-              path: path,
-              root: root
-            )
-            file_durable = flush_and_sync(destination)
-            if require_durable && !file_durable
-              raise DurabilityUnsupportedError, "destination file fsync is unsupported"
-            end
-            unless io_matches_identity?(destination, source_size, source_digest)
-              raise Errno::ESTALE, "direct-copy destination changed while it was written"
-            end
-          end
-
-          source_validator&.call
-          2.times do
-            unless drvfs_destination_matches_source?(
-              source,
-              parent,
-              destination_basename,
-              source_size,
-              source_digest,
-              published_mode
-            )
-              raise Errno::ESTALE, "direct-copy destination could not be verified"
-            end
-          end
-          source_validator&.call
-          destination_parent_validator.call
-          parent_durable = sync_io(parent)
-          if require_durable && !parent_durable
-            raise DurabilityUnsupportedError, "destination filesystem fsync is unsupported"
-          end
+      rescue Errno::EEXIST
+        persist_drvfs_copy_lock!(
+          journal,
+          token,
+          :conflict,
+          source_size,
+          source_digest,
+          journal_destination
+        )
+        raise
+      rescue StandardError => error
+        unless destination_created
           persist_drvfs_copy_lock!(
-            lock,
+            journal,
             token,
-            :complete,
+            :aborted,
             source_size,
             source_digest,
-            destination_basename
-          )
-          sync_io(journal_parent)
-        rescue Errno::EEXIST
-          persist_drvfs_copy_lock!(
-            lock,
-            token,
-            :conflict,
-            source_size,
-            source_digest,
-            destination_basename
+            journal_destination
           )
           raise
-        rescue StandardError => error
-          raise unless destination_created
-
-          raise AmbiguousPublicationError.new(
-            "An incomplete DrvFS direct-copy publication was retained for manual review"
-          ), cause: error
         end
+
+        raise AmbiguousPublicationError.new(
+          "An incomplete DrvFS direct-copy publication was retained for manual review"
+        ), cause: error
       end
 
       Rails.logger.warn(
@@ -2652,38 +2666,81 @@ class FileCopyService
       )
     end
 
-    def persist_drvfs_copy_lock!(lock, token, state, source_size, source_digest, destination_basename)
-      encoded_basename = destination_basename.b.unpack1("H*")
+    def reset_drvfs_copy_journal!(lock, token, state, source_size, source_digest, destination)
+      lock.rewind
+      lock.truncate(0)
+      persist_drvfs_copy_lock!(lock, token, state, source_size, source_digest, destination)
+    end
+
+    def persist_drvfs_copy_lock!(lock, token, state, source_size, source_digest, destination)
+      encoded_destination = destination.b.unpack1("H*")
       record = "#{COPY_LOCK_MAGIC}:#{token}:drvfs:#{state}:#{source_size}:" \
-        "#{source_digest}:#{encoded_basename}"
+        "#{source_digest}:#{encoded_destination}"
       checksum = Digest::SHA256.hexdigest(record)
       lock.seek(0, IO::SEEK_END)
       lock.write("#{record}:#{checksum}\n")
       flush_and_sync(lock)
     end
 
-    def resolved_drvfs_copy_lock?(parent, basename, token)
-      resolved = false
-      with_pinned_regular_child(parent, basename, writable: true) do |lock|
-        next unless lock.flock(File::LOCK_EX | File::LOCK_NB)
-        next unless secure_copy_lock?(lock, parent)
+    def with_drvfs_copy_journal(parent, heartbeat:, path:, root:)
+      descriptor = native_openat(
+        parent.fileno,
+        DRVFS_COPY_JOURNAL_BASENAME,
+        File::RDWR | File::CREAT | File::NOFOLLOW | File::NONBLOCK,
+        0o600
+      )
+      journal = File.for_fd(descriptor, "r+b", autoclose: true)
+      begin
+        raise UnsafePathError, "DrvFS copy journal is not a regular file" unless journal.stat.file?
 
-        lock.rewind
-        resolved = drvfs_copy_lock_state(lock.read, token).in?([ :complete, :conflict ])
+        acquired = begin
+          journal.flock(File::LOCK_EX | File::LOCK_NB)
+        rescue Errno::EWOULDBLOCK
+          false
+        end
+        until acquired
+          heartbeat&.call
+          sleep(DRVFS_COPY_LOCK_RETRY_INTERVAL)
+          acquired = begin
+            journal.flock(File::LOCK_EX | File::LOCK_NB)
+          rescue Errno::EWOULDBLOCK
+            false
+          end
+        end
+        unless private_entry_owned_by_process?(journal.stat, parent)
+          raise UnsafePathError, "DrvFS copy journal is not safely owned"
+        end
+        apply_file_mode!(
+          journal,
+          0o600,
+          accepted_modes: LIBRARY_FILE_MODES,
+          path: path,
+          root: root
+        )
+
+        journal.rewind
+        state = drvfs_copy_journal_state(journal.read)
+        unless state.in?(DRVFS_COPY_TERMINAL_STATES)
+          raise AtomicPublicationUnsupportedError,
+            "Interrupted DrvFS publication evidence requires manual cleanup before another import"
+        end
+        sync_io(parent)
+        yield journal
+      ensure
+        journal.close unless journal.closed?
       end
-      resolved
-    rescue Errno::ENOENT, Errno::EACCES, Errno::EWOULDBLOCK, IOError, UnsafePathError
-      false
     end
 
-    def drvfs_copy_lock_state(contents, token)
+    def drvfs_copy_journal_state(contents)
+      return :empty if contents.empty?
+
       contents.lines(chomp: true).reverse_each do |line|
         record, separator, checksum = line.rpartition(":")
         next if separator.empty? || checksum.length != 64
         next unless Digest::SHA256.hexdigest(record) == checksum
 
         match = COPY_LOCK_DRVFS_PATTERN.match(record)
-        next unless match && match[1] == token
+        next unless match
 
         return match[2].to_sym
       end
@@ -3685,13 +3742,14 @@ class FileCopyService
       end
     end
 
-    def with_created_regular_child(parent, basename, mode)
+    def with_created_regular_child(parent, basename, mode, created: nil)
       descriptor = native_openat(
         parent.fileno,
         basename,
         File::RDWR | File::CREAT | File::EXCL | File::NOFOLLOW,
         mode
       )
+      created&.call
       file = File.for_fd(descriptor, "r+b", autoclose: true)
       begin
         raise UnsafePathError, "created path is not a regular file" unless file.stat.file?

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -38,6 +38,7 @@ class FileCopyService
   DRVFS_COPY_JOURNAL_BASENAME = ".shelfarr-drvfs-copy.journal"
   DRVFS_COPY_TERMINAL_STATES = [ :empty, :complete, :conflict, :aborted ].freeze
   DRVFS_COPY_LOCK_RETRY_INTERVAL = 0.05
+  DRVFS_COPY_LOCK_TIMEOUT = 30.0
   DRVFS_PRIVATE_STAGING_FILE_MODES = [ 0o600, LIBRARY_FILE_MODE ].freeze
   DRVFS_PRIVATE_STAGING_DIRECTORY_MODES = [ 0o700, DIRECTORY_MODE ].freeze
   COPY_QUARANTINE_PATTERN = /\A\.shelfarr-copy-quarantine-([0-9a-f]+)-([0-9a-f]+)-([0-9a-f]{32})\z/
@@ -63,6 +64,7 @@ class FileCopyService
   class AmbiguousPublicationError < StandardError; end
   class DurabilityUnsupportedError < StandardError; end
   class HardlinkUnsupportedError < StandardError; end
+  class PublicationBusyError < StandardError; end
   class ReferenceTargetUnavailableError < UnsafePathError; end
   SourceFileSnapshot = Struct.new(
     :path,
@@ -2936,8 +2938,14 @@ class FileCopyService
         rescue Errno::EWOULDBLOCK
           false
         end
+        lock_deadline = monotonic_time + drvfs_copy_lock_timeout
         until acquired
           heartbeat&.call
+          if monotonic_time >= lock_deadline
+            raise PublicationBusyError,
+              "another DrvFS publication is still active; retry this import later"
+          end
+
           sleep(DRVFS_COPY_LOCK_RETRY_INTERVAL)
           acquired = begin
             journal.flock(File::LOCK_EX | File::LOCK_NB)
@@ -2983,6 +2991,14 @@ class FileCopyService
         return match[2].to_sym
       end
       :malformed
+    end
+
+    def drvfs_copy_lock_timeout
+      DRVFS_COPY_LOCK_TIMEOUT
+    end
+
+    def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def persist_copy_lock_record!(lock, record)

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -58,6 +58,7 @@ class FileCopyService
   class AmbiguousPublicationError < StandardError; end
   class DurabilityUnsupportedError < StandardError; end
   class HardlinkUnsupportedError < StandardError; end
+  class ReferenceTargetUnavailableError < UnsafePathError; end
   SourceFileSnapshot = Struct.new(
     :path,
     :parent_path,
@@ -75,6 +76,7 @@ class FileCopyService
     :parent_inode,
     :link_target,
     :target_snapshot,
+    :authorized_root,
     keyword_init: true
   )
   SourceRoot = Struct.new(
@@ -90,6 +92,7 @@ class FileCopyService
     :parent_device,
     :parent_inode,
     :entries,
+    :reference_snapshots,
     keyword_init: true
   )
   DirectoryChild = Struct.new(
@@ -293,30 +296,14 @@ class FileCopyService
       canonical_parent = expanded.parent.realpath
       with_pinned_absolute_directory(canonical_parent) do |parent|
         validate_current_directory_identity!(expanded.parent, parent)
-        parent_stat = parent.stat
         link_target = native_readlinkat(parent.fileno, expanded.basename.to_s)
-        target = Pathname(link_target)
-        target = canonical_parent.join(target) unless target.absolute?
-        canonical_target = target.parent.realpath.join(target.basename)
-        unless roots.any? { |root| path_beneath_root?(canonical_target, root) }
-          raise UnsafePathError, "reference target is outside authorized source roots"
-        end
-
-        target_snapshot = snapshot_source_file(canonical_target)
-        validate_current_directory_identity!(expanded.parent, parent)
-        unless native_readlinkat(parent.fileno, expanded.basename.to_s) == link_target
-          raise Errno::ESTALE, "reference source changed while it was being resolved"
-        end
-
-        return ReferenceSourceSnapshot.new(
-          path: expanded,
-          parent_path: expanded.parent,
-          canonical_parent_path: canonical_parent,
-          parent_device: parent_stat.dev,
-          parent_inode: parent_stat.ino,
-          link_target: link_target,
-          target_snapshot: target_snapshot
-        ).freeze
+        return snapshot_reference_source_at(
+          expanded,
+          parent,
+          canonical_parent,
+          link_target,
+          roots
+        )
       end
     rescue Errno::ELOOP, Errno::ENOTDIR => error
       raise UnsafePathError, "reference target contains a symbolic link or non-directory: #{error.message}"
@@ -1189,6 +1176,63 @@ class FileCopyService
     rescue Errno::ELOOP, Errno::ENOTDIR => error
       raise UnsafePathError,
         "source tree contains a symbolic link or non-regular path: #{error.message}"
+    rescue Errno::ENOENT, Errno::EACCES => error
+      raise UnsafePathError, "source tree is not safely accessible: #{error.message}"
+    end
+
+    # Snapshot a regular directory tree while accepting symlink leaves only for
+    # reference imports. Every link and final target receives its own pinned
+    # authorization snapshot; directory links and chained links remain invalid.
+    def snapshot_reference_source_root(
+      path,
+      authorized_roots:,
+      heartbeat: nil,
+      max_entries: nil,
+      max_depth: nil
+    )
+      expanded = Pathname(path).expand_path
+      canonical = expanded.realpath
+      parent_path = expanded.parent
+      canonical_parent = parent_path.realpath
+      parent_stat = File.lstat(canonical_parent)
+      roots = canonical_reference_roots(authorized_roots)
+      raise UnsafePathError, "reference source has no authorized target root" if roots.empty?
+
+      with_pinned_absolute_directory(canonical) do |directory|
+        validate_current_directory_identity!(expanded, directory)
+        raise UnsafePathError, "source root is not a directory" unless directory.stat.directory?
+
+        reference_snapshots = {}
+        entries = snapshot_pinned_reference_tree(
+          directory,
+          expanded,
+          roots,
+          reference_snapshots: reference_snapshots,
+          heartbeat: heartbeat,
+          max_entries: max_entries,
+          max_depth: max_depth
+        )
+        validate_current_directory_identity!(expanded, directory)
+        stat = directory.stat
+        return SourceRoot.new(
+          path: expanded,
+          canonical_path: canonical,
+          device: stat.dev,
+          inode: stat.ino,
+          size: stat.size,
+          mtime: stat.mtime.to_r,
+          ctime: stat.ctime.to_r,
+          parent_path: parent_path,
+          canonical_parent_path: canonical_parent,
+          parent_device: parent_stat.dev,
+          parent_inode: parent_stat.ino,
+          entries: entries.freeze,
+          reference_snapshots: reference_snapshots.freeze
+        ).freeze
+      end
+    rescue Errno::ELOOP, Errno::ENOTDIR => error
+      raise UnsafePathError,
+        "source tree contains a chained symbolic link or non-regular path: #{error.message}"
     rescue Errno::ENOENT, Errno::EACCES => error
       raise UnsafePathError, "source tree is not safely accessible: #{error.message}"
     end
@@ -3046,6 +3090,132 @@ class FileCopyService
         end
       end
       manifest
+    end
+
+    def snapshot_pinned_reference_tree(
+      directory,
+      source_root_path,
+      authorized_roots,
+      prefix = nil,
+      manifest = {},
+      reference_snapshots:,
+      heartbeat: nil,
+      max_entries: nil,
+      max_depth: nil,
+      depth: 0
+    )
+      remaining = max_entries && max_entries - manifest.size
+      pinned_directory_children(directory, max_entries: remaining).each do |entry|
+        heartbeat&.call
+        relative = prefix ? prefix.join(entry) : Pathname(entry)
+        descriptor = begin
+          native_openat(
+            directory.fileno,
+            entry,
+            File::RDONLY | File::NOFOLLOW | File::NONBLOCK,
+            0
+          )
+        rescue Errno::ELOOP
+          parent_path = source_root_path.join(relative.dirname)
+          canonical_parent = parent_path.realpath
+          validate_current_directory_identity!(parent_path, directory)
+          link_target = native_readlinkat(directory.fileno, entry)
+          snapshot = snapshot_reference_source_at(
+            source_root_path.join(relative),
+            directory,
+            canonical_parent,
+            link_target,
+            authorized_roots
+          )
+          manifest[relative.to_s] = reference_manifest_entry(snapshot)
+          reference_snapshots[relative.to_s] = snapshot
+          next
+        end
+
+        child = IO.new(descriptor, "rb", autoclose: true)
+        begin
+          stat = child.stat
+          if stat.directory?
+            if max_depth && depth + 1 > max_depth
+              raise UnsafePathError, "source tree nesting is too deep"
+            end
+
+            manifest[relative.to_s] = directory_manifest_entry(stat)
+            snapshot_pinned_reference_tree(
+              child,
+              source_root_path,
+              authorized_roots,
+              relative,
+              manifest,
+              reference_snapshots: reference_snapshots,
+              heartbeat: heartbeat,
+              max_entries: max_entries,
+              max_depth: max_depth,
+              depth: depth + 1
+            )
+          elsif stat.file?
+            manifest[relative.to_s] = file_manifest_entry(stat)
+          else
+            raise UnsafePathError, "source tree contains a symbolic link or non-regular path"
+          end
+        ensure
+          child.close unless child.closed?
+        end
+      end
+      manifest
+    end
+
+    def snapshot_reference_source_at(expanded, parent, canonical_parent, link_target, authorized_roots)
+      target = Pathname(link_target)
+      target = canonical_parent.join(target) unless target.absolute?
+      canonical_target = canonical_reference_target(target)
+      authorized_root = authorized_roots.select do |root|
+        path_beneath_root?(canonical_target, root)
+      end.max_by { |root| root.to_s.length }
+      unless authorized_root
+        raise UnsafePathError, "reference target is outside authorized source roots"
+      end
+      target_snapshot = snapshot_reference_target(canonical_target)
+
+      validate_current_directory_identity!(expanded.parent, parent)
+      unless native_readlinkat(parent.fileno, expanded.basename.to_s) == link_target
+        raise Errno::ESTALE, "reference source changed while it was being resolved"
+      end
+      parent_stat = parent.stat
+      ReferenceSourceSnapshot.new(
+        path: expanded,
+        parent_path: expanded.parent,
+        canonical_parent_path: canonical_parent,
+        parent_device: parent_stat.dev,
+        parent_inode: parent_stat.ino,
+        link_target: link_target,
+        target_snapshot: target_snapshot,
+        authorized_root: authorized_root
+      ).freeze
+    end
+
+    def canonical_reference_target(target)
+      target.parent.realpath.join(target.basename)
+    rescue Errno::ENOENT => error
+      raise ReferenceTargetUnavailableError,
+        "reference target is not visible yet: #{error.message}"
+    end
+
+    def snapshot_reference_target(canonical_target)
+      snapshot_source_file(canonical_target)
+    rescue Errno::ENOENT => error
+      raise ReferenceTargetUnavailableError,
+        "reference target is not visible yet: #{error.message}"
+    end
+
+    def reference_manifest_entry(snapshot)
+      [
+        snapshot.parent_device,
+        snapshot.parent_inode,
+        :reference,
+        snapshot.link_target,
+        snapshot.target_snapshot.manifest
+      ].freeze
     end
 
     def secure_pinned_library_tree!(directory, heartbeat: nil)

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -2938,10 +2938,15 @@ class FileCopyService
         rescue Errno::EWOULDBLOCK
           false
         end
-        lock_deadline = monotonic_time + drvfs_copy_lock_timeout
+        # Direct-download publications provide a heartbeat that both renews
+        # their durable lease and aborts when ownership is lost. Keep those
+        # cancellable waiters serialized even when another legitimate copy is
+        # long-running. Callers without a heartbeat (notably completed-download
+        # post-processing) must yield their worker after a bounded wait.
+        lock_deadline = monotonic_time + drvfs_copy_lock_timeout unless heartbeat
         until acquired
           heartbeat&.call
-          if monotonic_time >= lock_deadline
+          if lock_deadline && monotonic_time >= lock_deadline
             raise PublicationBusyError,
               "another DrvFS publication is still active; retry this import later"
           end

--- a/app/services/file_copy_service.rb
+++ b/app/services/file_copy_service.rb
@@ -66,6 +66,16 @@ class FileCopyService
     :manifest,
     keyword_init: true
   )
+  ReferenceSourceSnapshot = Struct.new(
+    :path,
+    :parent_path,
+    :canonical_parent_path,
+    :parent_device,
+    :parent_inode,
+    :link_target,
+    :target_snapshot,
+    keyword_init: true
+  )
   SourceRoot = Struct.new(
     :path,
     :canonical_path,
@@ -177,15 +187,26 @@ class FileCopyService
     end
 
     # Create a no-replace library entry that is a symlink to a verified regular
-    # source under source_root (reference import mode for debrid/rclone mounts).
+    # source, resolving one immediate source symlink for debrid/rclone staging.
     # Publication uses symlinkat against a pinned destination parent so an
     # ancestor rename cannot redirect the library entry outside the root.
-    def reference_noreplace(src, dest, root:, source_root:)
+    def reference_noreplace(
+      src,
+      dest,
+      root:,
+      source_root:,
+      source_snapshot: nil,
+      authorized_roots: nil
+    )
       source_path = Pathname(src).expand_path
       destination_path = Pathname(dest).expand_path
-      target = source_path.to_s
 
-      with_pinned_source(source_path, source_root: source_root) do |source, *_rest|
+      with_pinned_reference_source(
+        source_path,
+        source_root: source_root,
+        source_snapshot: source_snapshot,
+        authorized_roots: authorized_roots
+      ) do |source, target|
         raise Errno::EINVAL, "source is not a regular file" unless source.stat.file?
 
         with_pinned_destination_parent(destination_path, root: root) do |parent, basename, parent_path|
@@ -239,19 +260,17 @@ class FileCopyService
       if source_snapshot && source_path != source_snapshot.path
         raise UnsafePathError, "reference source does not match its authorization snapshot"
       end
-      source_operation = if source_snapshot
-        ->(&operation) { with_pinned_source_snapshot(source_snapshot, &operation) }
-      else
-        ->(&operation) { with_pinned_source(source_path, source_root: source_root, &operation) }
-      end
-
       result = nil
-      source_operation.call do |pinned_source, *_source_path|
+      with_pinned_reference_source(
+        source_path,
+        source_root: source_root,
+        source_snapshot: source_snapshot
+      ) do |pinned_source, target|
         raise Errno::EINVAL, "source is not a regular file" unless pinned_source.stat.file?
 
         with_pinned_destination_parent(destination, root: root) do |parent, basename, parent_path|
           matches = begin
-            native_readlinkat(parent.fileno, basename) == source_path.to_s
+            native_readlinkat(parent.fileno, basename) == target
           rescue Errno::EINVAL
             false
           end
@@ -260,6 +279,46 @@ class FileCopyService
         end
       end
       result
+    end
+
+    # Resolve only an immediate source symlink. Both the staging parent and the
+    # final regular-file parent are pinned and revalidated; the final leaf is
+    # always opened with O_NOFOLLOW.
+    def snapshot_reference_source(path, authorized_roots:)
+      expanded = Pathname(path).expand_path
+      roots = canonical_reference_roots(authorized_roots)
+      raise UnsafePathError, "reference source has no authorized target root" if roots.empty?
+
+      canonical_parent = expanded.parent.realpath
+      with_pinned_absolute_directory(canonical_parent) do |parent|
+        validate_current_directory_identity!(expanded.parent, parent)
+        parent_stat = parent.stat
+        link_target = native_readlinkat(parent.fileno, expanded.basename.to_s)
+        target = Pathname(link_target)
+        target = canonical_parent.join(target) unless target.absolute?
+        canonical_target = target.parent.realpath.join(target.basename)
+        unless roots.any? { |root| path_beneath_root?(canonical_target, root) }
+          raise UnsafePathError, "reference target is outside authorized source roots"
+        end
+
+        target_snapshot = snapshot_source_file(canonical_target)
+        validate_current_directory_identity!(expanded.parent, parent)
+        unless native_readlinkat(parent.fileno, expanded.basename.to_s) == link_target
+          raise Errno::ESTALE, "reference source changed while it was being resolved"
+        end
+
+        return ReferenceSourceSnapshot.new(
+          path: expanded,
+          parent_path: expanded.parent,
+          canonical_parent_path: canonical_parent,
+          parent_device: parent_stat.dev,
+          parent_inode: parent_stat.ino,
+          link_target: link_target,
+          target_snapshot: target_snapshot
+        ).freeze
+      end
+    rescue Errno::ELOOP, Errno::ENOTDIR => error
+      raise UnsafePathError, "reference target contains a symbolic link or non-directory: #{error.message}"
     end
 
     # Publish from a source descriptor already pinned by the caller (for
@@ -2431,6 +2490,83 @@ class FileCopyService
         return true unless left_bytes || right_bytes
         return false unless left_bytes == right_bytes
       end
+    end
+
+    def with_pinned_reference_source(
+      path,
+      source_root:,
+      source_snapshot: nil,
+      authorized_roots: nil
+    )
+      expanded = Pathname(path).expand_path
+      if source_snapshot.is_a?(ReferenceSourceSnapshot)
+        return with_pinned_reference_source_snapshot(expanded, source_snapshot) do |source|
+          yield source, source_snapshot.target_snapshot.path.to_s
+        end
+      end
+      if source_snapshot
+        unless expanded == source_snapshot.path
+          raise UnsafePathError, "reference source does not match its authorization snapshot"
+        end
+
+        return with_pinned_source_snapshot(source_snapshot) do |source, *|
+          yield source, expanded.to_s
+        end
+      end
+      if source_root
+        return with_pinned_source(expanded, source_root: source_root) do |source, *|
+          yield source, expanded.to_s
+        end
+      end
+      if File.lstat(expanded).symlink?
+        snapshot = snapshot_reference_source(expanded, authorized_roots: authorized_roots)
+        return with_pinned_reference_source_snapshot(expanded, snapshot) do |source|
+          yield source, snapshot.target_snapshot.path.to_s
+        end
+      end
+
+      with_pinned_source(expanded) { |source, *| yield source, expanded.to_s }
+    end
+
+    def with_pinned_reference_source_snapshot(expanded, snapshot)
+      unless expanded == snapshot.path
+        raise UnsafePathError, "reference source does not match its authorization snapshot"
+      end
+
+      with_pinned_absolute_directory(snapshot.canonical_parent_path) do |parent|
+        unless file_identity(parent.stat) == [ snapshot.parent_device, snapshot.parent_inode ]
+          raise Errno::ESTALE, "reference source parent changed after it was snapshotted"
+        end
+        validate_reference_source_link!(parent, snapshot)
+        result = with_pinned_source_snapshot(snapshot.target_snapshot) { |source, *| yield source }
+        validate_reference_source_link!(parent, snapshot)
+        result
+      end
+    rescue Errno::EINVAL, Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
+      raise Errno::ESTALE, "reference source changed after it was snapshotted"
+    end
+
+    def validate_reference_source_link!(parent, snapshot)
+      validate_current_directory_identity!(snapshot.parent_path, parent)
+      unless native_readlinkat(parent.fileno, snapshot.path.basename.to_s) == snapshot.link_target
+        raise Errno::ESTALE, "reference source changed after it was snapshotted"
+      end
+      true
+    end
+
+    def canonical_reference_roots(paths)
+      Array(paths).filter_map do |path|
+        root = Pathname(path).expand_path.realpath
+        next if root.root? || !root.lstat.directory?
+
+        root
+      rescue ArgumentError, SystemCallError
+        nil
+      end.uniq
+    end
+
+    def path_beneath_root?(path, root)
+      path.to_s.start_with?("#{root.to_s.delete_suffix(File::SEPARATOR)}#{File::SEPARATOR}")
     end
 
     def with_pinned_source(path, source_root: nil)

--- a/app/services/library_path_safety.rb
+++ b/app/services/library_path_safety.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+# Namespaces beneath a configured library root that are owned by Shelfarr's
+# recovery machinery and must never be selected as library destinations.
+class LibraryPathSafety
+  INTERNAL_DIRECTORIES = %w[
+    .shelfarr-staging
+    .shelfarr-staging-v2
+    .shelfarr-upload-staging
+    .shelfarr-upload-zip-staging
+  ].freeze
+  INTERNAL_DIRECTORY_KEYS = INTERNAL_DIRECTORIES.map(&:downcase).freeze
+
+  class << self
+    def internal_relative_path?(path)
+      first = Pathname(path.to_s).each_filename.first
+      first.present? && INTERNAL_DIRECTORY_KEYS.include?(first.downcase)
+    rescue ArgumentError
+      false
+    end
+
+    def internal_path?(path, root:)
+      expanded_root = Pathname(root).expand_path
+      relative = Pathname(path).expand_path.relative_path_from(expanded_root)
+      return false if relative.to_s == "." || relative.to_s == ".."
+      return false if relative.to_s.start_with?("..#{File::SEPARATOR}")
+
+      internal_relative_path?(relative)
+    rescue ArgumentError
+      false
+    end
+
+    def template_targets_internal_directory?(template)
+      first = template.to_s.split(File::SEPARATOR).reject(&:blank?).first
+      first.present? && INTERNAL_DIRECTORY_KEYS.include?(first.downcase)
+    end
+  end
+end

--- a/app/services/metadata_collection_service.rb
+++ b/app/services/metadata_collection_service.rb
@@ -99,6 +99,7 @@ class MetadataCollectionService
           ),
           issue_number: result.issue_number,
           release_date: result.release_date,
+          series_start_year: result.series_start_year,
           series: result.series_name,
           series_position: result.issue_number,
           request_scope: "collection",

--- a/app/services/owned_media_import_file_service.rb
+++ b/app/services/owned_media_import_file_service.rb
@@ -555,10 +555,12 @@ class OwnedMediaImportFileService
     def safe_library_destination?(destination, root, staging_root)
       return false unless path_within?(destination, root)
       return false if path_within?(destination, staging_root)
+      return false if LibraryPathSafety.internal_path?(destination, root: root)
 
       resolved_parent = destination.parent.realpath
       path_within?(resolved_parent, root.realpath) &&
-        !path_within?(resolved_parent, staging_root.realpath)
+        !path_within?(resolved_parent, staging_root.realpath) &&
+        !LibraryPathSafety.internal_path?(resolved_parent, root: root.realpath)
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
       false
     end
@@ -813,7 +815,7 @@ class OwnedMediaImportFileService
     library_path = Pathname(value.presence || book_library_path(canonical_destination_path)).expand_path
     unless path_within?(library_path, @output_root) &&
         library_path != @output_root &&
-        !path_within?(library_path, @output_root.join(STAGING_DIRECTORY))
+        !LibraryPathSafety.internal_path?(library_path, root: @output_root)
       raise Error, "The planned audiobook library path is outside the configured library"
     end
 
@@ -885,7 +887,8 @@ class OwnedMediaImportFileService
   def validate_destination_path!(destination)
     root = @output_root.realpath
     expanded = destination.expand_path
-    unless path_within?(expanded, root) && !path_within?(expanded, root.join(STAGING_DIRECTORY))
+    unless path_within?(expanded, root) &&
+        !LibraryPathSafety.internal_path?(expanded, root: root)
       raise Error, "The planned audiobook destination is outside the configured library"
     end
   end
@@ -972,7 +975,7 @@ class OwnedMediaImportFileService
     resolved_root = @output_root.realpath
     current_stat = File.lstat(destination.dirname)
     unless path_within?(resolved_parent, resolved_root) &&
-        !path_within?(resolved_parent, resolved_root.join(STAGING_DIRECTORY)) &&
+        !LibraryPathSafety.internal_path?(resolved_parent, root: resolved_root) &&
         current_stat.directory? &&
         same_file_identity?(current_stat, directory.stat)
       raise Error, "The planned audiobook destination changed during finalization"
@@ -989,7 +992,8 @@ class OwnedMediaImportFileService
   def with_pinned_destination_parent(destination, create:)
     destination = Pathname(destination).expand_path
     relative = destination.dirname.relative_path_from(@output_root)
-    if relative.to_s.start_with?("..") || path_within?(destination, @output_root.join(STAGING_DIRECTORY))
+    if relative.to_s.start_with?("..") ||
+        LibraryPathSafety.internal_path?(destination, root: @output_root)
       raise Error, "The planned audiobook destination is outside the configured library"
     end
 

--- a/app/services/path_template_service.rb
+++ b/app/services/path_template_service.rb
@@ -12,6 +12,8 @@ class PathTemplateService
   DEFAULT_FILENAME_TEMPLATE = "{author} - {title}".freeze
   TOKEN_PATTERN = /\{([^{}]+)\}/
 
+  class UnsafePathError < StandardError; end
+
   class << self
     # Build a relative path from a template and book metadata
     def build_path(book, template)
@@ -47,6 +49,10 @@ class PathTemplateService
       # Check for path traversal attempts
       if mode == :path && (template.include?("..") || template.start_with?("/"))
         return [ false, "Template cannot contain '..' or start with '/'" ]
+      end
+
+      if mode == :path && LibraryPathSafety.template_targets_internal_directory?(template)
+        return [ false, "Template cannot use a Shelfarr internal staging directory" ]
       end
 
       # Check for unknown variables
@@ -166,7 +172,12 @@ class PathTemplateService
       return "" if template.blank?
 
       result = render_template(book, template, variant: :path)
-      sanitize_path(cleanup_path_result(result))
+      sanitized = sanitize_path(cleanup_path_result(result))
+      if LibraryPathSafety.internal_relative_path?(sanitized)
+        raise UnsafePathError, "Rendered library path uses a Shelfarr internal staging directory"
+      end
+
+      sanitized
     end
 
     def render_filename_template(book, template)

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -363,8 +363,12 @@ class ReleaseScorer
   end
 
   def comic_issue_run_year_conflict?(detected)
+    return false if detected[:run_year].blank?
+
     requested_year = @book.series_start_year
-    detected[:run_year].present? && requested_year.present? && detected[:run_year] != requested_year
+    return @book.comic_vine_id.to_s.start_with?("4000-") if requested_year.blank?
+
+    detected[:run_year] != requested_year
   end
 
   def explicit_format_conflict?

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -5,6 +5,7 @@
 class ReleaseScorer
   COMIC_ISSUE_EXACT_BONUS = 15
   COMIC_ISSUE_UNKNOWN_MAX_SCORE = 49
+  COMIC_ISSUE_VALUE_PATTERN = '\d+(?:\.\d+)?(?:[a-z]|-[a-z])?'
 
   ROMAN_NUMBER_TOKENS = {
     "II" => "2",
@@ -273,12 +274,13 @@ class ReleaseScorer
     tail_offset = series_match.end(:series)
     tail = title[tail_offset..]
     marker = '(?:#|(?:issues?|no\.?|numbers?)\s*#?\s*)'
-    issue_value = '\d+(?:\.\d+)?[a-z]?'
+    issue_value = COMIC_ISSUE_VALUE_PATTERN
     issue = "(?<issue>#{issue_value})"
+    issue_terminator = '(?=\z|\s|[\(\[])'
     tail, consumed = extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
     tail_offset += consumed
 
-    explicit = tail.match(/\A#{separator}*#{marker}\s*#{issue}(?![[:alnum:]])/i)
+    explicit = tail.match(/\A#{separator}*#{marker}\s*#{issue}#{issue_terminator}/i)
     if explicit
       return comic_issue_detection(
         explicit,
@@ -286,12 +288,11 @@ class ReleaseScorer
         title: title,
         series_range: series_range,
         tail_offset: tail_offset,
-        marker: marker,
         issue_value: issue_value
       )
     end
 
-    plain = tail.match(/\A#{separator}+#{issue}(?![[:alnum:]])/i)
+    plain = tail.match(/\A\s+#{issue}#{issue_terminator}/i)
     return unless plain
     return if plain[:issue].match?(/\A(?:19|20)\d{2}\z/)
 
@@ -301,7 +302,6 @@ class ReleaseScorer
       title: title,
       series_range: series_range,
       tail_offset: tail_offset,
-      marker: marker,
       issue_value: issue_value
     )
   end
@@ -318,11 +318,11 @@ class ReleaseScorer
     [ tail, 0 ]
   end
 
-  def comic_issue_detection(match, tail, title:, series_range:, tail_offset:, marker:, issue_value:)
+  def comic_issue_detection(match, tail, title:, series_range:, tail_offset:, issue_value:)
     issue_range = (tail_offset + match.begin(:issue))...(tail_offset + match.end(:issue))
     run_years = comic_run_years(title, excluded_ranges: [ series_range, issue_range ])
     remainder = tail[match.end(0)..]
-    ambiguous = run_years.many? || additional_comic_issue?(remainder, marker:, issue_value:, run_years:)
+    ambiguous = run_years.many? || additional_comic_issue?(remainder, issue_value:, run_years:)
 
     { value: match[:issue], ambiguous: ambiguous, run_year: run_years.one? ? run_years.first : nil }
   end
@@ -344,20 +344,10 @@ class ReleaseScorer
     left.begin < right.end && right.begin < left.end
   end
 
-  def additional_comic_issue?(tail, marker:, issue_value:, run_years:)
-    return true if tail.match?(/#{marker}\s*#{issue_value}(?![[:alnum:]])/i)
-
-    remainder = tail
-    while (plain = remainder.match(/\A\s+(?<additional>#{issue_value})(?![[:alnum:]])/i))
-      return true if additional_comic_issue_value?(plain[:additional], run_years)
-
-      remainder = remainder[plain.end(0)..]
-    end
-
-    connector = '(?:[[:punct:]–—]+|\b(?:and|to|thru|through)\b)'
+  def additional_comic_issue?(tail, issue_value:, run_years:)
     tail.to_enum(
       :scan,
-      /#{connector}\s*(?:#{marker})?\s*(?<additional>#{issue_value})(?![[:alnum:]])/i
+      /(?<![[:alnum:]])(?<additional>#{issue_value})(?![[:alnum:]])/i
     ).any? do
       additional_comic_issue_value?(Regexp.last_match[:additional], run_years)
     end
@@ -380,7 +370,7 @@ class ReleaseScorer
 
   def normalize_issue_number(value)
     normalized = value.to_s.delete_prefix("#").squish.downcase
-    numeric_stem = normalized.match(/\A0*(\d+)((?:\.\d+)?[a-z]?)\z/i)
+    numeric_stem = normalized.match(/\A0*(\d+)((?:\.\d+)?(?:[a-z]|-[a-z])?)\z/i)
     return normalized unless numeric_stem
 
     "#{numeric_stem[1].to_i}#{numeric_stem[2]}"

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -262,9 +262,10 @@ class ReleaseScorer
     return if series_tokens.empty?
 
     separator = '[\s._:–—-]'
+    series_separator = "[\\s._:,&/'’()!?+\\[\\]–—-]"
     run_year = '(?:19|20)\d{2}'
     year_metadata = "(?:[\\(\\[]#{run_year}[\\)\\]]|#{run_year})"
-    series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("[^[:alnum:]]*")
+    series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("#{series_separator}*")
     series_match = title.match(
       /\A#{separator}*(?:#{year_metadata}#{separator}+)*?(?<series>#{series_pattern})(?![[:alnum:]])/i
     )
@@ -273,7 +274,7 @@ class ReleaseScorer
     series_range = series_match.begin(:series)...series_match.end(:series)
     tail_offset = series_match.end(:series)
     tail = title[tail_offset..]
-    marker = '(?:#|(?:issues?|no\.?|numbers?)\s*#?\s*)'
+    marker = '(?:#|(?<![[:alnum:]])(?:issues?|no\.?|numbers?)(?![[:alnum:]])\s*#?\s*)'
     issue_value = COMIC_ISSUE_VALUE_PATTERN
     issue = "(?<issue>#{issue_value})"
     issue_terminator = '(?=\z|\s|[\(\[])'
@@ -288,6 +289,7 @@ class ReleaseScorer
         title: title,
         series_range: series_range,
         tail_offset: tail_offset,
+        marker: marker,
         issue_value: issue_value
       )
     end
@@ -302,6 +304,7 @@ class ReleaseScorer
       title: title,
       series_range: series_range,
       tail_offset: tail_offset,
+      marker: marker,
       issue_value: issue_value
     )
   end
@@ -318,11 +321,11 @@ class ReleaseScorer
     [ tail, 0 ]
   end
 
-  def comic_issue_detection(match, tail, title:, series_range:, tail_offset:, issue_value:)
+  def comic_issue_detection(match, tail, title:, series_range:, tail_offset:, marker:, issue_value:)
     issue_range = (tail_offset + match.begin(:issue))...(tail_offset + match.end(:issue))
     run_years = comic_run_years(title, excluded_ranges: [ series_range, issue_range ])
     remainder = tail[match.end(0)..]
-    ambiguous = run_years.many? || additional_comic_issue?(remainder, issue_value:, run_years:)
+    ambiguous = run_years.many? || additional_comic_issue?(remainder, marker:, issue_value:, run_years:)
 
     { value: match[:issue], ambiguous: ambiguous, run_year: run_years.one? ? run_years.first : nil }
   end
@@ -344,7 +347,9 @@ class ReleaseScorer
     left.begin < right.end && right.begin < left.end
   end
 
-  def additional_comic_issue?(tail, issue_value:, run_years:)
+  def additional_comic_issue?(tail, marker:, issue_value:, run_years:)
+    return true if tail.match?(/#{marker}\s*#{issue_value}(?![[:alnum:]])/i)
+
     tail.to_enum(
       :scan,
       /(?<![[:alnum:]])(?<additional>#{issue_value})(?![[:alnum:]])/i

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -59,12 +59,15 @@ class ReleaseScorer
   # @return [Result] Score result with total, breakdown, and detected metadata
   def score
     issue_status = @comic_issue_match&.fetch(:status, nil)
-    auto_select_allowed = @format_preferences.auto_select_allowed && (@comic_issue_match.nil? || issue_status == :exact)
+    format_score = calculate_format_score
+    auto_select_allowed = @format_preferences.auto_select_allowed &&
+      !explicit_format_conflict? &&
+      (@comic_issue_match.nil? || issue_status == :exact)
     breakdown = {
       title: calculate_title_score,
       author: calculate_author_score,
       language: calculate_language_score,
-      format: calculate_format_score,
+      format: format_score,
       health: calculate_health_score,
       preference_adjustment: @format_preferences.score_adjustment,
       auto_select_allowed: auto_select_allowed,
@@ -253,32 +256,43 @@ class ReleaseScorer
   end
 
   def detect_comic_issue_number
+    title = @search_result.title.to_s
     series_tokens = @book.series.to_s.downcase.scan(/[[:alnum:]]+/)
     return if series_tokens.empty?
 
     series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("[^[:alnum:]]*")
-    series_match = @search_result.title.to_s.match(/(?<![[:alnum:]])#{series_pattern}(?![[:alnum:]])/i)
+    series_match = title.match(/(?<![[:alnum:]])#{series_pattern}(?![[:alnum:]])/i)
     return unless series_match
+    return unless bounded_comic_series_match?(title, series_match, series_tokens)
 
-    tail = @search_result.title.to_s[series_match.end(0)..]
+    tail = title[series_match.end(0)..]
     separator = '[\s._:–—-]'
     marker = '(?:#|(?:issues?|no\.?|numbers?)\s*#?\s*)'
     issue_value = '\d+(?:\.\d+)?[a-z]?'
     issue = "(?<issue>#{issue_value})"
     tail, run_year = extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
-    multiple = tail.match(
-      /\A#{separator}*#{marker}?#{issue}(?:\s*(?:-|–|—|to|,|&|\+|and)\s*|\s+(?=#))#{marker}?#{issue_value}(?![[:alnum:]])/i
-    )
-    return comic_issue_detection(multiple, tail, run_year:, ambiguous: true) if multiple
+    run_years = bracketed_comic_run_years(title)
+    run_years << run_year if run_year
 
     explicit = tail.match(/\A#{separator}*#{marker}\s*#{issue}(?![[:alnum:]])/i)
-    return comic_issue_detection(explicit, tail, run_year:) if explicit
+    return comic_issue_detection(explicit, tail, run_years:, marker:, issue_value:) if explicit
 
     plain = tail.match(/\A#{separator}+#{issue}(?![[:alnum:]])/i)
     return unless plain
     return if plain[:issue].match?(/\A(?:19|20)\d{2}\z/)
 
-    comic_issue_detection(plain, tail, run_year:)
+    comic_issue_detection(plain, tail, run_years:, marker:, issue_value:)
+  end
+
+  def bounded_comic_series_match?(title, series_match, series_tokens)
+    return true unless series_tokens.one? && series_tokens.first.match?(/\A\d+\z/)
+
+    prefix = title[...series_match.begin(0)]
+    prefix.match?(/\A(?:[\s._:–—-]*[\(\[]\d{4}[\)\]])*[\s._:–—-]*\z/)
+  end
+
+  def bracketed_comic_run_years(title)
+    title.scan(/[\(\[](\d{4})[\)\]]/).flatten.map(&:to_i).uniq
   end
 
   def extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
@@ -293,9 +307,26 @@ class ReleaseScorer
     [ tail, nil ]
   end
 
-  def comic_issue_detection(match, tail, run_year:, ambiguous: false)
-    run_year ||= comic_run_year_after(tail[match.end(0)..])
-    { value: match[:issue], ambiguous: ambiguous, run_year: run_year }
+  def comic_issue_detection(match, tail, run_years:, marker:, issue_value:)
+    remainder = tail[match.end(0)..]
+    run_years << comic_run_year_after(remainder)
+    run_years = run_years.compact.uniq
+    ambiguous = run_years.many? || additional_comic_issue?(remainder, marker:, issue_value:, run_years:)
+
+    { value: match[:issue], ambiguous: ambiguous, run_year: run_years.one? ? run_years.first : nil }
+  end
+
+  def additional_comic_issue?(tail, marker:, issue_value:, run_years:)
+    return true if tail.match?(/#{marker}\s*#{issue_value}(?![[:alnum:]])/i)
+
+    connector = '(?:[[:punct:]–—]+|\b(?:and|to|thru|through)\b)'
+    tail.to_enum(
+      :scan,
+      /#{connector}\s*(?:#{marker})?\s*(?<additional>#{issue_value})(?![[:alnum:]])/i
+    ).any? do
+      additional = Regexp.last_match[:additional]
+      !additional.match?(/\A\d{4}\z/) || !run_years.include?(additional.to_i)
+    end
   end
 
   def comic_run_year_after(tail)
@@ -308,6 +339,12 @@ class ReleaseScorer
   def comic_issue_run_year_conflict?(detected)
     requested_year = @book.release_date&.year
     detected[:run_year].present? && requested_year.present? && detected[:run_year] != requested_year
+  end
+
+  def explicit_format_conflict?
+    detected = @parsed[:format]
+    requested = @book.book_type&.to_sym
+    detected.present? && requested.in?([ :audiobook, :ebook, :comicbook ]) && detected != requested
   end
 
   def normalize_issue_number(value)

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -260,80 +260,111 @@ class ReleaseScorer
     series_tokens = @book.series.to_s.downcase.scan(/[[:alnum:]]+/)
     return if series_tokens.empty?
 
-    series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("[^[:alnum:]]*")
-    series_match = title.match(/(?<![[:alnum:]])#{series_pattern}(?![[:alnum:]])/i)
-    return unless series_match
-    return unless bounded_comic_series_match?(title, series_match, series_tokens)
-
-    tail = title[series_match.end(0)..]
     separator = '[\s._:–—-]'
+    run_year = '(?:19|20)\d{2}'
+    year_metadata = "(?:[\\(\\[]#{run_year}[\\)\\]]|#{run_year})"
+    series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("[^[:alnum:]]*")
+    series_match = title.match(
+      /\A#{separator}*(?:#{year_metadata}#{separator}+)*?(?<series>#{series_pattern})(?![[:alnum:]])/i
+    )
+    return unless series_match
+
+    series_range = series_match.begin(:series)...series_match.end(:series)
+    tail_offset = series_match.end(:series)
+    tail = title[tail_offset..]
     marker = '(?:#|(?:issues?|no\.?|numbers?)\s*#?\s*)'
     issue_value = '\d+(?:\.\d+)?[a-z]?'
     issue = "(?<issue>#{issue_value})"
-    tail, run_year = extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
-    run_years = bracketed_comic_run_years(title)
-    run_years << run_year if run_year
+    tail, consumed = extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
+    tail_offset += consumed
 
     explicit = tail.match(/\A#{separator}*#{marker}\s*#{issue}(?![[:alnum:]])/i)
-    return comic_issue_detection(explicit, tail, run_years:, marker:, issue_value:) if explicit
+    if explicit
+      return comic_issue_detection(
+        explicit,
+        tail,
+        title: title,
+        series_range: series_range,
+        tail_offset: tail_offset,
+        marker: marker,
+        issue_value: issue_value
+      )
+    end
 
     plain = tail.match(/\A#{separator}+#{issue}(?![[:alnum:]])/i)
     return unless plain
     return if plain[:issue].match?(/\A(?:19|20)\d{2}\z/)
 
-    comic_issue_detection(plain, tail, run_years:, marker:, issue_value:)
-  end
-
-  def bounded_comic_series_match?(title, series_match, series_tokens)
-    return true unless series_tokens.one? && series_tokens.first.match?(/\A\d+\z/)
-
-    prefix = title[...series_match.begin(0)]
-    prefix.match?(/\A(?:[\s._:–—-]*[\(\[]\d{4}[\)\]])*[\s._:–—-]*\z/)
-  end
-
-  def bracketed_comic_run_years(title)
-    title.scan(/[\(\[](\d{4})[\)\]]/).flatten.map(&:to_i).uniq
+    comic_issue_detection(
+      plain,
+      tail,
+      title: title,
+      series_range: series_range,
+      tail_offset: tail_offset,
+      marker: marker,
+      issue_value: issue_value
+    )
   end
 
   def extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
-    wrapped = tail.match(/\A#{separator}*[\(\[](?<year>\d{4})[\)\]]/)
-    return [ tail[wrapped.end(0)..], wrapped[:year].to_i ] if wrapped
+    wrapped = tail.match(/\A#{separator}*[\(\[](?<year>(?:19|20)\d{2})[\)\]]/)
+    return [ tail[wrapped.end(0)..], wrapped.end(0) ] if wrapped
 
     plain = tail.match(
-      /\A#{separator}*(?<year>\d{4})(?=#{separator}+(?:#{marker})?#{issue_value}(?![[:alnum:]]))/i
+      /\A#{separator}*(?<year>(?:19|20)\d{2})(?=#{separator}+(?:#{marker})?#{issue_value}(?![[:alnum:]]))/i
     )
-    return [ tail[plain.end(0)..], plain[:year].to_i ] if plain
+    return [ tail[plain.end(0)..], plain.end(0) ] if plain
 
-    [ tail, nil ]
+    [ tail, 0 ]
   end
 
-  def comic_issue_detection(match, tail, run_years:, marker:, issue_value:)
+  def comic_issue_detection(match, tail, title:, series_range:, tail_offset:, marker:, issue_value:)
+    issue_range = (tail_offset + match.begin(:issue))...(tail_offset + match.end(:issue))
+    run_years = comic_run_years(title, excluded_ranges: [ series_range, issue_range ])
     remainder = tail[match.end(0)..]
-    run_years << comic_run_year_after(remainder)
-    run_years = run_years.compact.uniq
     ambiguous = run_years.many? || additional_comic_issue?(remainder, marker:, issue_value:, run_years:)
 
     { value: match[:issue], ambiguous: ambiguous, run_year: run_years.one? ? run_years.first : nil }
   end
 
+  def comic_run_years(title, excluded_ranges:)
+    title.to_enum(
+      :scan,
+      /(?<![[:alnum:]])(?<year>(?:19|20)\d{2})(?![[:alnum:]])/
+    ).filter_map do
+      match = Regexp.last_match
+      range = match.begin(:year)...match.end(:year)
+      next if excluded_ranges.any? { |excluded| ranges_overlap?(range, excluded) }
+
+      match[:year].to_i
+    end.uniq
+  end
+
+  def ranges_overlap?(left, right)
+    left.begin < right.end && right.begin < left.end
+  end
+
   def additional_comic_issue?(tail, marker:, issue_value:, run_years:)
     return true if tail.match?(/#{marker}\s*#{issue_value}(?![[:alnum:]])/i)
+
+    remainder = tail
+    while (plain = remainder.match(/\A\s+(?<additional>#{issue_value})(?![[:alnum:]])/i))
+      return true if additional_comic_issue_value?(plain[:additional], run_years)
+
+      remainder = remainder[plain.end(0)..]
+    end
 
     connector = '(?:[[:punct:]–—]+|\b(?:and|to|thru|through)\b)'
     tail.to_enum(
       :scan,
       /#{connector}\s*(?:#{marker})?\s*(?<additional>#{issue_value})(?![[:alnum:]])/i
     ).any? do
-      additional = Regexp.last_match[:additional]
-      !additional.match?(/\A\d{4}\z/) || !run_years.include?(additional.to_i)
+      additional_comic_issue_value?(Regexp.last_match[:additional], run_years)
     end
   end
 
-  def comic_run_year_after(tail)
-    match = tail.to_s.match(
-      /\A[\s._:–—-]*(?:[\(\[](?<wrapped>\d{4})[\)\]]|(?<plain>\d{4})(?!\d))/
-    )
-    (match&.[](:wrapped) || match&.[](:plain))&.to_i
+  def additional_comic_issue_value?(value, run_years)
+    !value.match?(/\A(?:19|20)\d{2}\z/) || !run_years.include?(value.to_i)
   end
 
   def comic_issue_run_year_conflict?(detected)

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -242,7 +242,7 @@ class ReleaseScorer
     normalized_requested = normalize_issue_number(requested)
     normalized_detected = normalize_issue_number(detected[:value])
     status = if normalized_requested == normalized_detected
-      :exact
+      comic_issue_run_year_conflict?(detected) ? :unknown : :exact
     elsif numeric_issue_number?(normalized_requested) && numeric_issue_number?(normalized_detected)
       :mismatch
     else
@@ -253,33 +253,69 @@ class ReleaseScorer
   end
 
   def detect_comic_issue_number
-    series_tokens = normalize_for_matching(@book.series).split
+    series_tokens = @book.series.to_s.downcase.scan(/[[:alnum:]]+/)
     return if series_tokens.empty?
 
-    series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("[^[:alnum:]]+")
+    series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("[^[:alnum:]]*")
     series_match = @search_result.title.to_s.match(/(?<![[:alnum:]])#{series_pattern}(?![[:alnum:]])/i)
     return unless series_match
 
     tail = @search_result.title.to_s[series_match.end(0)..]
     separator = '[\s._:–—-]'
-    marker = '(?:#|issues?\s*|no\.?\s*|numbers?\s*)'
-    issue = '(\d+(?:\.\d+)?[a-z]?)'
-    range = tail.match(/\A#{separator}*#{marker}?#{issue}\s*(?:-|–|—|to)\s*\d+(?:\.\d+)?[a-z]?/i)
-    return { value: range[1], ambiguous: true } if range
+    marker = '(?:#|(?:issues?|no\.?|numbers?)\s*#?\s*)'
+    issue_value = '\d+(?:\.\d+)?[a-z]?'
+    issue = "(?<issue>#{issue_value})"
+    tail, run_year = extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
+    multiple = tail.match(
+      /\A#{separator}*#{marker}?#{issue}(?:\s*(?:-|–|—|to|,|&|\+|and)\s*|\s+(?=#))#{marker}?#{issue_value}(?![[:alnum:]])/i
+    )
+    return comic_issue_detection(multiple, tail, run_year:, ambiguous: true) if multiple
 
     explicit = tail.match(/\A#{separator}*#{marker}\s*#{issue}(?![[:alnum:]])/i)
-    return { value: explicit[1], ambiguous: false } if explicit
+    return comic_issue_detection(explicit, tail, run_year:) if explicit
 
     plain = tail.match(/\A#{separator}+#{issue}(?![[:alnum:]])/i)
     return unless plain
-    return if plain[1].match?(/\A(?:19|20)\d{2}\z/)
+    return if plain[:issue].match?(/\A(?:19|20)\d{2}\z/)
 
-    { value: plain[1], ambiguous: false }
+    comic_issue_detection(plain, tail, run_year:)
+  end
+
+  def extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
+    wrapped = tail.match(/\A#{separator}*[\(\[](?<year>\d{4})[\)\]]/)
+    return [ tail[wrapped.end(0)..], wrapped[:year].to_i ] if wrapped
+
+    plain = tail.match(
+      /\A#{separator}*(?<year>\d{4})(?=#{separator}+(?:#{marker})?#{issue_value}(?![[:alnum:]]))/i
+    )
+    return [ tail[plain.end(0)..], plain[:year].to_i ] if plain
+
+    [ tail, nil ]
+  end
+
+  def comic_issue_detection(match, tail, run_year:, ambiguous: false)
+    run_year ||= comic_run_year_after(tail[match.end(0)..])
+    { value: match[:issue], ambiguous: ambiguous, run_year: run_year }
+  end
+
+  def comic_run_year_after(tail)
+    match = tail.to_s.match(
+      /\A[\s._:–—-]*(?:[\(\[](?<wrapped>\d{4})[\)\]]|(?<plain>\d{4})(?!\d))/
+    )
+    (match&.[](:wrapped) || match&.[](:plain))&.to_i
+  end
+
+  def comic_issue_run_year_conflict?(detected)
+    requested_year = @book.release_date&.year
+    detected[:run_year].present? && requested_year.present? && detected[:run_year] != requested_year
   end
 
   def normalize_issue_number(value)
     normalized = value.to_s.delete_prefix("#").squish.downcase
-    numeric_issue_number?(normalized) ? normalized.to_i.to_s : normalized
+    numeric_stem = normalized.match(/\A0*(\d+)((?:\.\d+)?[a-z]?)\z/i)
+    return normalized unless numeric_stem
+
+    "#{numeric_stem[1].to_i}#{numeric_stem[2]}"
   end
 
   def numeric_issue_number?(value)

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -277,7 +277,7 @@ class ReleaseScorer
     marker = '(?:#|(?<![[:alnum:]])(?:issues?|no\.?|numbers?)(?![[:alnum:]])\s*#?\s*)'
     issue_value = COMIC_ISSUE_VALUE_PATTERN
     issue = "(?<issue>#{issue_value})"
-    issue_terminator = '(?=\z|\s|[\(\[])'
+    issue_terminator = '(?=\z|\s|[._:\(\[])'
     tail, consumed = extract_leading_comic_run_year(tail, separator:, marker:, issue_value:)
     tail_offset += consumed
 
@@ -363,7 +363,7 @@ class ReleaseScorer
   end
 
   def comic_issue_run_year_conflict?(detected)
-    requested_year = @book.release_date&.year
+    requested_year = @book.series_start_year
     detected[:run_year].present? && requested_year.present? && detected[:run_year] != requested_year
   end
 

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -3,6 +3,9 @@
 # Scores search results based on how well they match a request.
 # Returns a confidence score (0-100) with a detailed breakdown.
 class ReleaseScorer
+  COMIC_ISSUE_EXACT_BONUS = 15
+  COMIC_ISSUE_UNKNOWN_MAX_SCORE = 49
+
   ROMAN_NUMBER_TOKENS = {
     "II" => "2",
     "III" => "3",
@@ -49,11 +52,14 @@ class ReleaseScorer
     @book = request.book
     @parsed = ReleaseParserService.parse(search_result.title)
     @format_preferences = FormatPreferenceService.evaluate(title: search_result.title, book_type: @book.book_type)
+    @comic_issue_match = classify_comic_issue_match
   end
 
   # Calculate the confidence score
   # @return [Result] Score result with total, breakdown, and detected metadata
   def score
+    issue_status = @comic_issue_match&.fetch(:status, nil)
+    auto_select_allowed = @format_preferences.auto_select_allowed && (@comic_issue_match.nil? || issue_status == :exact)
     breakdown = {
       title: calculate_title_score,
       author: calculate_author_score,
@@ -61,19 +67,29 @@ class ReleaseScorer
       format: calculate_format_score,
       health: calculate_health_score,
       preference_adjustment: @format_preferences.score_adjustment,
-      auto_select_allowed: @format_preferences.auto_select_allowed,
+      auto_select_allowed: auto_select_allowed,
       extension: @format_preferences.matched_extension,
       extensions: @format_preferences.detected_extensions,
       audiobook_structure: @format_preferences.audiobook_structure,
       audio_bitrate_kbps: @format_preferences.audio_bitrate_kbps
     }
+    if @comic_issue_match
+      breakdown.merge!(
+        issue_match: @comic_issue_match[:status],
+        requested_issue_number: @comic_issue_match[:requested],
+        detected_issue_number: @comic_issue_match[:detected],
+        issue_adjustment: comic_issue_adjustment
+      )
+    end
 
     # Calculate weighted total
     base_total = WEIGHTS.sum do |key, weight|
       (breakdown[key] * weight) / 100.0
     end.round
 
-    total = (base_total + @format_preferences.score_adjustment).clamp(0, 100)
+    total = (base_total + @format_preferences.score_adjustment + comic_issue_adjustment).clamp(0, 100)
+    total = [ total, COMIC_ISSUE_UNKNOWN_MAX_SCORE ].min if issue_status == :unknown
+    total = 0 if issue_status == :mismatch
 
     Result.new(
       total: total,
@@ -98,6 +114,8 @@ class ReleaseScorer
   # Title matching score (0-100)
   # Uses trigram similarity like BookMatcherService
   def calculate_title_score
+    return 100 if @comic_issue_match&.fetch(:status, nil) == :exact
+
     release_title = normalize_for_matching(@search_result.title)
     book_title = normalize_for_matching(@book.title)
 
@@ -114,6 +132,7 @@ class ReleaseScorer
   # Author matching score (0-100)
   # Checks if author name appears in release title
   def calculate_author_score
+    return 50 if @comic_issue_match&.fetch(:status, nil) == :exact
     return 50 if @book.author.blank?  # Neutral if no author to match
 
     release_title = normalize_for_matching(@search_result.title)
@@ -206,6 +225,65 @@ class ReleaseScorer
     @search_result.download_url.present? &&
       @search_result.magnet_url.blank? &&
       @search_result.seeders.nil?
+  end
+
+  def comic_issue_adjustment
+    @comic_issue_match&.fetch(:status, nil) == :exact ? COMIC_ISSUE_EXACT_BONUS : 0
+  end
+
+  def classify_comic_issue_match
+    requested = @book.issue_number_for_matching
+    return unless requested
+
+    detected = detect_comic_issue_number
+    return { status: :unknown, requested: requested, detected: nil } unless detected
+    return { status: :unknown, requested: requested, detected: detected[:value] } if detected[:ambiguous]
+
+    normalized_requested = normalize_issue_number(requested)
+    normalized_detected = normalize_issue_number(detected[:value])
+    status = if normalized_requested == normalized_detected
+      :exact
+    elsif numeric_issue_number?(normalized_requested) && numeric_issue_number?(normalized_detected)
+      :mismatch
+    else
+      :unknown
+    end
+
+    { status: status, requested: requested, detected: detected[:value] }
+  end
+
+  def detect_comic_issue_number
+    series_tokens = normalize_for_matching(@book.series).split
+    return if series_tokens.empty?
+
+    series_pattern = series_tokens.map { |token| Regexp.escape(token) }.join("[^[:alnum:]]+")
+    series_match = @search_result.title.to_s.match(/(?<![[:alnum:]])#{series_pattern}(?![[:alnum:]])/i)
+    return unless series_match
+
+    tail = @search_result.title.to_s[series_match.end(0)..]
+    separator = '[\s._:–—-]'
+    marker = '(?:#|issues?\s*|no\.?\s*|numbers?\s*)'
+    issue = '(\d+(?:\.\d+)?[a-z]?)'
+    range = tail.match(/\A#{separator}*#{marker}?#{issue}\s*(?:-|–|—|to)\s*\d+(?:\.\d+)?[a-z]?/i)
+    return { value: range[1], ambiguous: true } if range
+
+    explicit = tail.match(/\A#{separator}*#{marker}\s*#{issue}(?![[:alnum:]])/i)
+    return { value: explicit[1], ambiguous: false } if explicit
+
+    plain = tail.match(/\A#{separator}+#{issue}(?![[:alnum:]])/i)
+    return unless plain
+    return if plain[1].match?(/\A(?:19|20)\d{2}\z/)
+
+    { value: plain[1], ambiguous: false }
+  end
+
+  def normalize_issue_number(value)
+    normalized = value.to_s.delete_prefix("#").squish.downcase
+    numeric_issue_number?(normalized) ? normalized.to_i.to_s : normalized
+  end
+
+  def numeric_issue_number?(value)
+    value.to_s.match?(/\A\d+\z/)
   end
 
   # Normalize text for matching

--- a/app/services/request_creation_service.rb
+++ b/app/services/request_creation_service.rb
@@ -212,7 +212,8 @@ class RequestCreationService
       :publisher,
       :content_kind,
       :issue_number,
-      :release_date
+      :release_date,
+      :series_start_year
     )
     attrs[:year] ||= attrs.delete(:first_publish_year)
     attrs

--- a/app/services/safe_library_deletion_service.rb
+++ b/app/services/safe_library_deletion_service.rb
@@ -11,10 +11,7 @@ class SafeLibraryDeletionService
   class Error < StandardError; end
 
   AT_REMOVEDIR = RbConfig::CONFIG.fetch("host_os").match?(/darwin/i) ? 0x80 : 0x200
-  INTERNAL_DIRECTORIES = [
-    OwnedMediaImportFileService::STAGING_DIRECTORY,
-    UploadImportFileService::PRIVATE_DIRECTORY
-  ].freeze
+  INTERNAL_DIRECTORIES = LibraryPathSafety::INTERNAL_DIRECTORIES
 
   def initialize(book)
     @book = book

--- a/app/services/upload_import_file_service.rb
+++ b/app/services/upload_import_file_service.rb
@@ -497,7 +497,8 @@ class UploadImportFileService
 
     def validate_path_within_root!(path, root)
       expanded = Pathname(path).expand_path
-      return if expanded.to_s.start_with?("#{root}#{File::SEPARATOR}")
+      return if expanded.to_s.start_with?("#{root}#{File::SEPARATOR}") &&
+        !LibraryPathSafety.internal_path?(expanded, root: root)
 
       raise Error, "The reserved upload path is outside its snapshotted root"
     end

--- a/app/services/upload_zip_import_file_service.rb
+++ b/app/services/upload_zip_import_file_service.rb
@@ -200,7 +200,8 @@ class UploadZipImportFileService
     end
 
     def validate_within_root!(path, root)
-      return if path.to_s.start_with?("#{root}#{File::SEPARATOR}")
+      return if path.to_s.start_with?("#{root}#{File::SEPARATOR}") &&
+        !LibraryPathSafety.internal_path?(path, root: root)
 
       raise Error, "The ZIP upload destination escaped its reserved root"
     end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -128,8 +128,8 @@
                 <% end %>
 
                 <%# Type Badge %>
-                <span class="absolute top-2 right-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium backdrop-blur-sm <%= book.audiobook? ? 'bg-purple-500/90 text-white' : 'bg-blue-500/90 text-white' %>">
-                  <%= book.audiobook? ? 'Audio' : 'Ebook' %>
+                <span class="absolute top-2 right-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium backdrop-blur-sm text-white <%= book.audiobook? ? 'bg-purple-500/90' : (book.comicbook? ? 'bg-emerald-500/90' : 'bg-blue-500/90') %>">
+                  <%= book.audiobook? ? "Audio" : book.book_type_label %>
                 </span>
 
                 <%# Hover Overlay %>
@@ -211,8 +211,8 @@
                 </span>
 
                 <%# Type Badge %>
-                <span class="absolute top-2 left-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium backdrop-blur-sm <%= book.audiobook? ? 'bg-purple-500/90 text-white' : 'bg-blue-500/90 text-white' %>">
-                  <%= book.audiobook? ? 'Audio' : 'Ebook' %>
+                <span class="absolute top-2 left-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium backdrop-blur-sm text-white <%= book.audiobook? ? 'bg-purple-500/90' : (book.comicbook? ? 'bg-emerald-500/90' : 'bg-blue-500/90') %>">
+                  <%= book.audiobook? ? "Audio" : book.book_type_label %>
                 </span>
 
                 <%# Hover Overlay %>

--- a/app/views/library/_book_card.html.erb
+++ b/app/views/library/_book_card.html.erb
@@ -30,8 +30,8 @@
           <span class="rounded bg-orange-600/90 px-2 py-0.5 text-xs font-medium text-white backdrop-blur-sm" title="Owned on Audible">Audible</span>
         <% end %>
       </div>
-      <span class="absolute right-2 top-2 inline-flex items-center rounded px-2 py-0.5 text-xs font-medium text-white backdrop-blur-sm <%= book.audiobook? ? 'bg-purple-500/90' : 'bg-blue-500/90' %>">
-        <%= book.audiobook? ? "Audio" : "Ebook" %>
+      <span class="absolute right-2 top-2 inline-flex items-center rounded px-2 py-0.5 text-xs font-medium text-white backdrop-blur-sm <%= book.audiobook? ? 'bg-purple-500/90' : (book.comicbook? ? 'bg-emerald-500/90' : 'bg-blue-500/90') %>">
+        <%= book.audiobook? ? "Audio" : book.book_type_label %>
       </span>
 
     </div>

--- a/app/views/library/show.html.erb
+++ b/app/views/library/show.html.erb
@@ -30,17 +30,22 @@
           <% end %>
 
           <div class="flex flex-wrap gap-2 mb-4">
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium <%= @book.audiobook? ? 'bg-purple-500/20 text-purple-400' : 'bg-blue-500/20 text-blue-400' %>">
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium <%= @book.audiobook? ? 'bg-purple-500/20 text-purple-400' : (@book.comicbook? ? 'bg-emerald-500/20 text-emerald-400' : 'bg-blue-500/20 text-blue-400') %>">
               <% if @book.audiobook? %>
                 <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
                 </svg>
                 Audiobook
-              <% else %>
+              <% elsif @book.ebook? %>
                 <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
                 Ebook
+              <% else %>
+                <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5h16M4 19h16M6 5v14m12-14v14M8 8h8v8H8z" />
+                </svg>
+                <%= @book.book_type_label %>
               <% end %>
             </span>
             <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-500/20 text-green-400">

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -133,8 +133,8 @@
                     <% end %>
                   </div>
                   <div class="flex max-w-full flex-wrap items-center gap-2 sm:flex-shrink-0">
-                    <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium <%= request.book.audiobook? ? 'bg-purple-500/20 text-purple-400' : 'bg-blue-500/20 text-blue-400' %>">
-                      <%= request.book.audiobook? ? 'Audiobook' : 'Ebook' %>
+                    <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium <%= request.book.audiobook? ? 'bg-purple-500/20 text-purple-400' : (request.book.comicbook? ? 'bg-emerald-500/20 text-emerald-400' : 'bg-blue-500/20 text-blue-400') %>">
+                      <%= request.book.book_type_label %>
                     </span>
                     <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium <%= request_status_color(request.status) %>">
                       <%= request.status.humanize %>

--- a/db/migrate/20260817120000_add_reference_target_roots_to_books.rb
+++ b/db/migrate/20260817120000_add_reference_target_roots_to_books.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReferenceTargetRootsToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :reference_target_roots, :text
+  end
+end

--- a/db/migrate/20260819090000_add_series_start_year_to_books.rb
+++ b/db/migrate/20260819090000_add_series_start_year_to_books.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSeriesStartYearToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :series_start_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -85,6 +85,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_120000) do
     t.string "open_library_edition_id"
     t.string "open_library_work_id"
     t.string "publisher"
+    t.text "reference_target_roots"
     t.date "release_date"
     t.string "series"
     t.string "series_position"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -89,6 +89,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
     t.date "release_date"
     t.string "series"
     t.string "series_position"
+    t.integer "series_start_year"
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.integer "year"

--- a/services/libation_companion/tests/container-smoke.sh
+++ b/services/libation_companion/tests/container-smoke.sh
@@ -275,7 +275,9 @@ test "${token_mode}" = "600"
 # subsequent PUID/PGID change must migrate all of it without following the
 # symlink out of the private state volume.
 job_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-job_created_at="$(date -u -d "1 minute ago" +%Y-%m-%dT%H:%M:%SZ)"
+if ! job_created_at="$(date -u -d "1 minute ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"; then
+  job_created_at="$(date -u -v-1M +%Y-%m-%dT%H:%M:%SZ)"
+fi
 job_completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 docker exec -u 23456:23456 \
   -e JOB_CREATED_AT="${job_created_at}" \

--- a/services/libation_companion/tests/container-smoke.sh
+++ b/services/libation_companion/tests/container-smoke.sh
@@ -275,11 +275,16 @@ test "${token_mode}" = "600"
 # subsequent PUID/PGID change must migrate all of it without following the
 # symlink out of the private state volume.
 job_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-docker exec -u 23456:23456 "${container}" sh -c '
+job_created_at="$(date -u -d "1 minute ago" +%Y-%m-%dT%H:%M:%SZ)"
+job_completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+docker exec -u 23456:23456 \
+  -e JOB_CREATED_AT="${job_created_at}" \
+  -e JOB_COMPLETED_AT="${job_completed_at}" \
+  "${container}" sh -c '
   set -eu
   umask 077
   mkdir -p /config/shelfarr-companion/jobs /config/in-progress/example /data/Example\ Book
-  printf "%s" "{\"id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"kind\":\"sync\",\"status\":\"succeeded\",\"createdAt\":\"2026-07-18T00:00:00Z\",\"completedAt\":\"2026-07-18T00:01:00Z\"}" > /config/shelfarr-companion/jobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json
+  printf "%s" "{\"id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"kind\":\"sync\",\"status\":\"succeeded\",\"createdAt\":\"${JOB_CREATED_AT}\",\"completedAt\":\"${JOB_COMPLETED_AT}\"}" > /config/shelfarr-companion/jobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json
   printf "%s" "{\"schemaVersion\":1,\"generatedAt\":\"2026-07-18T00:00:00Z\",\"libationVersion\":\"13.5.1\",\"skippedItems\":0,\"items\":[]}" > /config/shelfarr-companion/library.json
   printf chunk > /config/in-progress/example/chunk.partial
   printf sidecar > /config/LibationContext.db-wal.audit

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DashboardControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    sign_in_as(@user)
+  end
+
+  test "labels recent comic library items and requests as Comics and Manga" do
+    book = Book.create!(
+      title: "Dashboard Comic Label",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-dashboard-label",
+      file_path: "/comics/dashboard-label.cbz"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending)
+
+    get root_path
+
+    assert_response :success
+    assert_select "a[href='#{library_path(book)}'] span[class*='bg-emerald-500/90']",
+      text: "Comics & Manga"
+    assert_select "a[href='#{request_path(request)}'] span[class*='bg-emerald-500/90']",
+      text: "Comics & Manga"
+  end
+end

--- a/test/controllers/library_controller_test.rb
+++ b/test/controllers/library_controller_test.rb
@@ -28,6 +28,27 @@ class LibraryControllerTest < ActionDispatch::IntegrationTest
     assert_select "img[src='https://covers.example.test/private-cover.jpg'][referrerpolicy='no-referrer']"
   end
 
+  test "comic library cards and details use the Comics and Manga badge" do
+    book = Book.create!(
+      title: "Library Comic Label",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-library-label",
+      file_path: "/comics/library-label.cbz"
+    )
+
+    get library_index_path(q: book.title)
+
+    assert_response :success
+    assert_select "[data-library-book-id='#{book.id}'] span[class*='bg-emerald-500/90']",
+      text: "Comics & Manga"
+
+    get library_path(book)
+
+    assert_response :success
+    assert_select "span[class*='bg-emerald-500/20']", text: "Comics & Manga"
+  end
+
   test "admin library shows purchased Audible titles without creating placeholder books" do
     sign_out
     sign_in_as(@admin)

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -2022,6 +2022,7 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     FileUtils.mkdir_p([ output_root, download_root, content_root ])
     File.binwrite(target, "final debrid audio")
     File.symlink(target, library_path)
+    content_root_stat = File.lstat(content_root)
     SettingsService.set(:audiobook_output_path, output_root)
     SettingsService.set(:download_local_path, download_root)
     client = DownloadClient.create!(
@@ -2036,7 +2037,13 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
       author: "Security Test",
       book_type: :audiobook,
       file_path: library_path,
-      reference_target_roots: [ content_root ]
+      reference_target_roots: [
+        {
+          path: Pathname(content_root).realpath.to_s,
+          device: content_root_stat.dev,
+          inode: content_root_stat.ino
+        }
+      ]
     )
     request = Request.create!(book: book, user: @user, status: :completed)
     request.downloads.create!(
@@ -2066,6 +2073,96 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     FileUtils.rm_rf(temp_dir)
   end
 
+  test "download rejects a persisted reference root replaced by a symlink" do
+    temp_dir = Dir.mktmpdir
+    output_root = File.join(temp_dir, "library")
+    download_root = File.join(temp_dir, "downloads")
+    content_root = File.join(temp_dir, "debrid-content")
+    displaced_root = File.join(temp_dir, "debrid-content-original")
+    staging = File.join(download_root, "staged-book.epub")
+    target = File.join(content_root, "passwd")
+    FileUtils.mkdir_p([ output_root, download_root, content_root ])
+    File.binwrite(target, "PK\x03\x04authorized ebook")
+    File.symlink(target, staging)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:ebook_output_path, output_root)
+    SettingsService.set(:ebook_path_template, "")
+    SettingsService.set(:ebook_filename_template, "{author} - {title}")
+    SettingsService.set(:download_local_path, download_root)
+    SettingsService.set(:completed_download_import_mode, "reference")
+    client = DownloadClient.create!(
+      name: "Persisted reference root",
+      client_type: "deluge",
+      url: "http://localhost:8112",
+      password: "deluge",
+      download_path: content_root
+    )
+    book = Book.create!(
+      title: "Immutable reference boundary",
+      author: "Security Test",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: @user, status: :downloading)
+    download = request.downloads.create!(
+      name: book.title,
+      status: :completed,
+      progress: 100,
+      download_path: staging,
+      download_client: client
+    )
+    PostProcessingJob.perform_now(download.id)
+    assert request.reload.completed?, request.issue_description
+    assert File.symlink?(book.reload.file_path)
+    client.destroy!
+    SettingsService.set(:download_remote_path, content_root)
+
+    File.rename(content_root, displaced_root)
+    File.symlink("/etc", content_root)
+    get download_request_path(request)
+
+    assert_redirected_to request_path(request)
+    assert_equal "Invalid file path", flash[:alert]
+    assert_not_equal File.binread("/etc/passwd"), response.body
+
+    File.unlink(content_root)
+    FileUtils.mkdir_p(content_root)
+    File.binwrite(target, "replacement root bytes")
+    get download_request_path(request)
+
+    assert_redirected_to request_path(request)
+    assert_equal "Invalid file path", flash[:alert]
+    assert_not_includes response.body, "replacement root bytes"
+  ensure
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  test "download uses current configured roots when reference provenance is absent" do
+    temp_dir = Dir.mktmpdir
+    output_root = File.join(temp_dir, "library")
+    download_root = File.join(temp_dir, "downloads")
+    target = File.join(download_root, "legacy-book.m4b")
+    library_path = File.join(output_root, "legacy-book.m4b")
+    FileUtils.mkdir_p([ output_root, download_root ])
+    File.binwrite(target, "legacy reference bytes")
+    File.symlink(target, library_path)
+    SettingsService.set(:audiobook_output_path, output_root)
+    SettingsService.set(:download_local_path, download_root)
+    book = Book.create!(
+      title: "Legacy reference",
+      author: "Security Test",
+      book_type: :audiobook,
+      file_path: library_path
+    )
+    request = Request.create!(book: book, user: @user, status: :completed)
+
+    get download_request_path(request)
+
+    assert_response :success
+    assert_equal "legacy reference bytes", response.body
+  ensure
+    FileUtils.rm_rf(temp_dir)
+  end
+
   test "download sends the committed reference tree archive inode" do
     require "zip"
 
@@ -2077,13 +2174,21 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     FileUtils.mkdir_p([ book_directory, content_root ])
     File.binwrite(target, "archived debrid audio")
     File.symlink(target, File.join(book_directory, "book.m4b"))
+    File.binwrite(File.join(book_directory, "cover.txt"), "regular sidecar")
+    content_root_stat = File.lstat(content_root)
     SettingsService.set(:audiobook_output_path, output_root)
     book = Book.create!(
       title: "Reference Archive",
       author: "Security Test",
       book_type: :audiobook,
       file_path: book_directory,
-      reference_target_roots: [ content_root ]
+      reference_target_roots: [
+        {
+          path: Pathname(content_root).realpath.to_s,
+          device: content_root_stat.dev,
+          inode: content_root_stat.ino
+        }
+      ]
     )
     request = Request.create!(book: book, user: @user, status: :completed)
 
@@ -2093,8 +2198,9 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "application/zip", response.content_type
     assert_operator response.body.bytesize, :>, 0
     Zip::File.open_buffer(response.body) do |archive|
-      assert_equal [ "book.m4b" ], archive.entries.map(&:name)
-      assert_equal "archived debrid audio", archive.entries.sole.get_input_stream.read
+      assert_equal [ "book.m4b", "cover.txt" ], archive.entries.map(&:name).sort
+      assert_equal "archived debrid audio", archive.read("book.m4b")
+      assert_equal "regular sidecar", archive.read("cover.txt")
     end
   ensure
     FileUtils.rm_rf(temp_dir)
@@ -2111,27 +2217,95 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     File.binwrite(target, "authorized audio")
     File.binwrite(outside, "outside secret")
     File.symlink(target, File.join(book_directory, "book.m4b"))
+    content_root_stat = File.lstat(content_root)
     SettingsService.set(:audiobook_output_path, output_root)
     book = Book.create!(
       title: "Raced Archive",
       author: "Security Test",
       book_type: :audiobook,
       file_path: book_directory,
-      reference_target_roots: [ content_root ]
+      reference_target_roots: [
+        {
+          path: Pathname(content_root).realpath.to_s,
+          device: content_root_stat.dev,
+          inode: content_root_stat.ino
+        }
+      ]
     )
     request = Request.create!(book: book, user: @user, status: :completed)
     original = FileCopyService.method(:with_regular_file)
     swapped = false
-    swap_target = lambda do |path, root:, &block|
+    swap_target = lambda do |path, root:, authorized_root_snapshot: nil, &block|
       unless swapped
         File.unlink(target)
         File.symlink(outside, target)
         swapped = true
       end
-      original.call(path, root: root, &block)
+      original.call(
+        path,
+        root: root,
+        authorized_root_snapshot: authorized_root_snapshot,
+        &block
+      )
     end
 
     FileCopyService.stub(:with_regular_file, swap_target) do
+      get download_request_path(request)
+    end
+
+    assert swapped
+    assert_redirected_to request_path(request)
+    assert_equal "Unable to prepare a download for this reference library item.", flash[:alert]
+    assert_not_includes response.body, "outside secret"
+  ensure
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  test "reference archive rejects a persisted root swapped before file access" do
+    temp_dir = Dir.mktmpdir
+    output_root = File.join(temp_dir, "library")
+    book_directory = File.join(output_root, "Security Test", "Root Raced Archive")
+    content_root = File.join(temp_dir, "debrid-content")
+    displaced_root = File.join(temp_dir, "debrid-content-original")
+    outside_root = File.join(temp_dir, "outside")
+    target = File.join(content_root, "book.m4b")
+    FileUtils.mkdir_p([ book_directory, content_root, outside_root ])
+    File.binwrite(target, "authorized audio")
+    File.binwrite(File.join(outside_root, "book.m4b"), "outside secret")
+    File.symlink(target, File.join(book_directory, "book.m4b"))
+    content_root_stat = File.lstat(content_root)
+    SettingsService.set(:audiobook_output_path, output_root)
+    book = Book.create!(
+      title: "Root Raced Archive",
+      author: "Security Test",
+      book_type: :audiobook,
+      file_path: book_directory,
+      reference_target_roots: [
+        {
+          path: Pathname(content_root).realpath.to_s,
+          device: content_root_stat.dev,
+          inode: content_root_stat.ino
+        }
+      ]
+    )
+    request = Request.create!(book: book, user: @user, status: :completed)
+    original = FileCopyService.method(:with_regular_file)
+    swapped = false
+    swap_root = lambda do |path, root:, authorized_root_snapshot: nil, &block|
+      unless swapped
+        File.rename(content_root, displaced_root)
+        File.symlink(outside_root, content_root)
+        swapped = true
+      end
+      original.call(
+        path,
+        root: root,
+        authorized_root_snapshot: authorized_root_snapshot,
+        &block
+      )
+    end
+
+    FileCopyService.stub(:with_regular_file, swap_root) do
       get download_request_path(request)
     end
 

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -2035,7 +2035,8 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
       title: "Final reference target",
       author: "Security Test",
       book_type: :audiobook,
-      file_path: library_path
+      file_path: library_path,
+      reference_target_roots: [ content_root ]
     )
     request = Request.create!(book: book, user: @user, status: :completed)
     request.downloads.create!(
@@ -2049,6 +2050,95 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal "final debrid audio", response.body
+
+    replacement_root = File.join(temp_dir, "replacement-content")
+    FileUtils.mkdir_p(replacement_root)
+    client.update!(download_path: replacement_root)
+    get download_request_path(request)
+    assert_response :success
+    assert_equal "final debrid audio", response.body
+
+    client.destroy!
+    get download_request_path(request)
+    assert_response :success
+    assert_equal "final debrid audio", response.body
+  ensure
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  test "download sends the committed reference tree archive inode" do
+    require "zip"
+
+    temp_dir = Dir.mktmpdir
+    output_root = File.join(temp_dir, "library")
+    book_directory = File.join(output_root, "Security Test", "Reference Archive")
+    content_root = File.join(temp_dir, "debrid-content")
+    target = File.join(content_root, "book.m4b")
+    FileUtils.mkdir_p([ book_directory, content_root ])
+    File.binwrite(target, "archived debrid audio")
+    File.symlink(target, File.join(book_directory, "book.m4b"))
+    SettingsService.set(:audiobook_output_path, output_root)
+    book = Book.create!(
+      title: "Reference Archive",
+      author: "Security Test",
+      book_type: :audiobook,
+      file_path: book_directory,
+      reference_target_roots: [ content_root ]
+    )
+    request = Request.create!(book: book, user: @user, status: :completed)
+
+    get download_request_path(request)
+
+    assert_response :success
+    assert_equal "application/zip", response.content_type
+    assert_operator response.body.bytesize, :>, 0
+    Zip::File.open_buffer(response.body) do |archive|
+      assert_equal [ "book.m4b" ], archive.entries.map(&:name)
+      assert_equal "archived debrid audio", archive.entries.sole.get_input_stream.read
+    end
+  ensure
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  test "reference archive rejects a target swapped after authorization" do
+    temp_dir = Dir.mktmpdir
+    output_root = File.join(temp_dir, "library")
+    book_directory = File.join(output_root, "Security Test", "Raced Archive")
+    content_root = File.join(temp_dir, "debrid-content")
+    target = File.join(content_root, "book.m4b")
+    outside = File.join(temp_dir, "outside-secret.m4b")
+    FileUtils.mkdir_p([ book_directory, content_root ])
+    File.binwrite(target, "authorized audio")
+    File.binwrite(outside, "outside secret")
+    File.symlink(target, File.join(book_directory, "book.m4b"))
+    SettingsService.set(:audiobook_output_path, output_root)
+    book = Book.create!(
+      title: "Raced Archive",
+      author: "Security Test",
+      book_type: :audiobook,
+      file_path: book_directory,
+      reference_target_roots: [ content_root ]
+    )
+    request = Request.create!(book: book, user: @user, status: :completed)
+    original = FileCopyService.method(:with_regular_file)
+    swapped = false
+    swap_target = lambda do |path, root:, &block|
+      unless swapped
+        File.unlink(target)
+        File.symlink(outside, target)
+        swapped = true
+      end
+      original.call(path, root: root, &block)
+    end
+
+    FileCopyService.stub(:with_regular_file, swap_target) do
+      get download_request_path(request)
+    end
+
+    assert swapped
+    assert_redirected_to request_path(request)
+    assert_equal "Unable to prepare a download for this reference library item.", flash[:alert]
+    assert_not_includes response.body, "outside secret"
   ensure
     FileUtils.rm_rf(temp_dir)
   end

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -27,6 +27,22 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select "nav a[href=?]", search_path, text: "Search", minimum: 1
   end
 
+  test "index labels comic requests as Comics and Manga" do
+    book = Book.create!(
+      title: "Request Comic Label",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-request-label"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending)
+
+    get requests_path
+
+    assert_response :success
+    assert_select "a[href='#{request_path(request)}'] span[class*='bg-emerald-500/20']",
+      text: "Comics & Manga"
+  end
+
   test "admin sees all requests" do
     sign_out
     sign_in_as(@admin)

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -2012,6 +2012,47 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     FileUtils.rm_rf(temp_dir)
   end
 
+  test "download follows a reference import directly to an authorized final target" do
+    temp_dir = Dir.mktmpdir
+    output_root = File.join(temp_dir, "library")
+    download_root = File.join(temp_dir, "downloads")
+    content_root = File.join(temp_dir, "debrid-content")
+    target = File.join(content_root, "book.m4b")
+    library_path = File.join(output_root, "book.m4b")
+    FileUtils.mkdir_p([ output_root, download_root, content_root ])
+    File.binwrite(target, "final debrid audio")
+    File.symlink(target, library_path)
+    SettingsService.set(:audiobook_output_path, output_root)
+    SettingsService.set(:download_local_path, download_root)
+    client = DownloadClient.create!(
+      name: "Download reference content root",
+      client_type: "deluge",
+      url: "http://localhost:8112",
+      password: "deluge",
+      download_path: content_root
+    )
+    book = Book.create!(
+      title: "Final reference target",
+      author: "Security Test",
+      book_type: :audiobook,
+      file_path: library_path
+    )
+    request = Request.create!(book: book, user: @user, status: :completed)
+    request.downloads.create!(
+      name: "Reference source",
+      status: :completed,
+      download_client: client,
+      download_path: File.join(download_root, "staged-book.m4b")
+    )
+
+    get download_request_path(request)
+
+    assert_response :success
+    assert_equal "final debrid audio", response.body
+  ensure
+    FileUtils.rm_rf(temp_dir)
+  end
+
   test "download rejects a symlinked directory below the configured output root" do
     temp_dir = Dir.mktmpdir
     output_root = File.join(temp_dir, "library")

--- a/test/jobs/book_metadata_backfill_job_test.rb
+++ b/test/jobs/book_metadata_backfill_job_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class BookMetadataBackfillJobTest < ActiveJob::TestCase
-  test "processes books with blank series or series position by default" do
+  test "processes books with blank series metadata or missing Comic Vine run years by default" do
     blank_series = Book.create!(
       title: "Blank Series",
       author: "Author One",
@@ -27,6 +27,15 @@ class BookMetadataBackfillJobTest < ActiveJob::TestCase
       series: "Known Series",
       series_position: "3"
     )
+    missing_comic_run_year = Book.create!(
+      title: "Batman - #1",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-105811",
+      series: "Batman",
+      series_position: "1",
+      series_start_year: nil
+    )
 
     processed = []
 
@@ -41,6 +50,7 @@ class BookMetadataBackfillJobTest < ActiveJob::TestCase
 
     assert_includes processed_ids, blank_series.id
     assert_includes processed_ids, blank_series_position.id
+    assert_includes processed_ids, missing_comic_run_year.id
     assert_not_includes processed_ids, filled_series.id
     assert_equal "Known Series", filled_series.reload.series
   end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -1073,7 +1073,15 @@ class DownloadJobTest < ActiveJob::TestCase
       assert_not File.exist?(destination)
       assert @gutenberg_download.reload.failed?
       assert_nil @gutenberg_request.book.reload.file_path
-      assert_empty Dir.glob(File.join(dir, ".shelfarr-staging", "direct-downloads", "**", "download-*"))
+      assert_empty Dir.glob(
+        File.join(
+          dir,
+          DirectDownloadFileService::STAGING_DIRECTORY,
+          DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY,
+          "**",
+          "download-*"
+        )
+      )
     end
   end
 

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -367,6 +367,26 @@ class HealthCheckJobTest < ActiveJob::TestCase
     end
   end
 
+  test "reports nonempty private legacy direct staging without exposing its output root" do
+    Dir.mktmpdir("legacy-audiobooks") do |audiobook_dir|
+      Dir.mktmpdir("legacy-ebooks-private-root") do |ebook_dir|
+        setup_output_paths(audiobook_dir, ebook_dir)
+        legacy = File.join(ebook_dir, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+        FileUtils.mkdir_p(File.join(legacy, DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY))
+        File.chmod(0o700, legacy)
+
+        HealthCheckJob.perform_now(service: "output_paths")
+
+        health = SystemHealth.for_service("output_paths")
+        assert health.degraded?
+        assert_includes health.message, "Ebook legacy direct-download staging"
+        assert_includes health.message, "contains retained entries"
+        assert_includes health.message, DirectDownloadFileService::STAGING_DIRECTORY
+        refute_includes health.message, ebook_dir
+      end
+    end
+  end
+
   test "marks output_paths as degraded when one path has issues" do
     Dir.mktmpdir do |valid_dir|
       setup_output_paths(valid_dir, "/nonexistent/path")

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -346,6 +346,27 @@ class HealthCheckJobTest < ActiveJob::TestCase
     end
   end
 
+  test "reports retained broad legacy direct staging without exposing its output root" do
+    Dir.mktmpdir("legacy-audiobooks") do |audiobook_dir|
+      Dir.mktmpdir("legacy-ebooks-private-root") do |ebook_dir|
+        setup_output_paths(audiobook_dir, ebook_dir)
+        legacy = File.join(ebook_dir, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+        FileUtils.mkdir_p(legacy)
+        File.chmod(0o777, legacy)
+
+        HealthCheckJob.perform_now(service: "output_paths")
+
+        health = SystemHealth.for_service("output_paths")
+        assert health.degraded?
+        assert_includes health.message, "Ebook legacy direct-download staging"
+        assert_includes health.message, "0777"
+        assert_includes health.message, "retained"
+        assert_includes health.message, DirectDownloadFileService::STAGING_DIRECTORY
+        refute_includes health.message, ebook_dir
+      end
+    end
+  end
+
   test "marks output_paths as degraded when one path has issues" do
     Dir.mktmpdir do |valid_dir|
       setup_output_paths(valid_dir, "/nonexistent/path")
@@ -406,7 +427,7 @@ class HealthCheckJobTest < ActiveJob::TestCase
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
-          body: { "libraries" => [{ "id" => "lib-1", "name" => "Audiobooks" }] }.to_json
+          body: { "libraries" => [ { "id" => "lib-1", "name" => "Audiobooks" } ] }.to_json
         )
 
       HealthCheckJob.perform_now

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -172,6 +172,26 @@ class PostProcessingJobTest < ActiveJob::TestCase
     FileUtils.rm_rf(unauthorized_source) if unauthorized_source && File.exist?(unauthorized_source)
   end
 
+  test "reference mode refuses a final target outside every configured download root" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    unauthorized_root = Dir.mktmpdir("outside-reference-root")
+    target = File.join(unauthorized_root, "private-audiobook.mp3")
+    staging = File.join(@temp_download_base, "escaped-reference.mp3")
+    File.binwrite(target, "private audiobook content")
+    File.symlink(target, staging)
+    @download.update!(download_path: staging)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    assert @request.reload.attention_needed?
+    assert_not File.exist?(destination)
+    assert_equal "private audiobook content", File.binread(target)
+  ensure
+    FileUtils.rm_rf(unauthorized_root)
+  end
+
   test "skips a completed download replaced by a manual selection" do
     old_result = @request.search_results.create!(
       guid: "old-result",
@@ -657,6 +677,93 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.reload.completed?, @request.issue_description
     assert_equal Pathname(source).expand_path.to_s, File.readlink(referenced)
     assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
+  end
+
+  test "reference mode imports a top-level source symlink to its final target" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    FileUtils.rm_rf(@temp_source)
+    target_directory = File.join(@temp_download_base, "debrid-content")
+    target = File.join(target_directory, "remote-audiobook.mp3")
+    staging = File.join(@temp_download_base, "staged-audiobook.mp3")
+    FileUtils.mkdir_p(target_directory)
+    File.binwrite(target, "remote audiobook content")
+    File.symlink(target, staging)
+    @download.update!(download_path: staging)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    referenced = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      PathTemplateService.build_filename(@book, ".mp3")
+    )
+    assert @request.reload.completed?, @request.issue_description
+    assert File.symlink?(referenced)
+    assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
+    assert File.symlink?(staging), "reference imports must not clean up the staging link"
+    File.unlink(staging)
+    assert_equal "remote audiobook content", File.binread(referenced)
+  end
+
+  test "reference mode validates and imports a relative top-level ebook symlink" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:ebook_output_path, @temp_dest_base)
+    SettingsService.set(:completed_download_import_mode, "reference")
+    @book.update!(book_type: :ebook)
+    FileUtils.rm_rf(@temp_source)
+    staging_directory = File.join(@temp_download_base, "staging")
+    target = File.join(@temp_download_base, "debrid-content", "remote-book.epub")
+    staging = File.join(staging_directory, "staged-book.epub")
+    FileUtils.mkdir_p([ staging_directory, File.dirname(target) ])
+    File.binwrite(target, "PK\x03\x04remote ebook content")
+    File.symlink(File.join("..", "debrid-content", "remote-book.epub"), staging)
+    @download.update!(download_path: staging)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    referenced = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      PathTemplateService.build_filename(@book, ".epub")
+    )
+    assert @request.reload.completed?, @request.issue_description
+    assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
+    assert_equal "PK\x03\x04remote ebook content", File.binread(referenced)
+  end
+
+  test "reference mode authorizes a final target under the download client root" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    content_root = Dir.mktmpdir("debrid-client-content")
+    target = File.join(content_root, "remote-audiobook.mp3")
+    staging = File.join(@temp_download_base, "client-staged-audiobook.mp3")
+    File.binwrite(target, "client-root audiobook content")
+    File.symlink(target, staging)
+    client = DownloadClient.create!(
+      name: "Debrid content mount",
+      client_type: "deluge",
+      url: "http://localhost:8112",
+      password: "deluge",
+      download_path: content_root
+    )
+    @download.update!(download_path: staging, download_client: client)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    referenced = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      PathTemplateService.build_filename(@book, ".mp3")
+    )
+    assert @request.reload.completed?, @request.issue_description
+    assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
+    assert_equal "client-root audiobook content", File.binread(referenced)
+  ensure
+    FileUtils.rm_rf(content_root)
   end
 
   test "reference retry suffixes a mismatched symlink" do
@@ -1712,6 +1819,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "rejects symbolic links and fifo entries anywhere in a recursive source" do
     SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
     nested = File.join(@temp_source, "nested")
     FileUtils.mkdir_p(nested)
     File.symlink(File.join(@temp_source, "audiobook.mp3"), File.join(nested, "linked.mp3"))

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -714,7 +714,12 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.reload.completed?, @request.issue_description
     assert_equal Pathname(source).expand_path.to_s, File.readlink(referenced)
     assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
-    assert_includes @book.reload.reference_target_roots, Pathname(@temp_download_base).realpath.to_s
+    root = @book.reload.reference_target_roots.find do |candidate|
+      candidate.path.to_s == Pathname(@temp_download_base).realpath.to_s
+    end
+    assert root
+    root_stat = File.lstat(@temp_download_base)
+    assert_equal [ root_stat.dev, root_stat.ino ], [ root.device, root.inode ]
   end
 
   test "reference mode imports a top-level source symlink to its final target" do
@@ -800,9 +805,42 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.reload.completed?, @request.issue_description
     assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
     assert_equal "client-root audiobook content", File.binread(referenced)
-    assert_equal [ Pathname(content_root).realpath.to_s ], @book.reload.reference_target_roots
+    assert_equal [ Pathname(content_root).realpath.to_s ],
+      @book.reload.reference_target_roots.map { |root| root.path.to_s }
   ensure
     FileUtils.rm_rf(content_root)
+  end
+
+  test "reference mode authorizes a top-level target under a symlinked download client root" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    content_parent = Dir.mktmpdir("symlinked-debrid-root")
+    real_content_root = File.join(content_parent, "real-debrid-content")
+    configured_content_root = File.join(content_parent, "configured-debrid-content")
+    target = File.join(configured_content_root, "remote-audiobook.mp3")
+    staging = File.join(@temp_download_base, "client-staged-symlinked-root.mp3")
+    FileUtils.mkdir_p(real_content_root)
+    File.symlink(real_content_root, configured_content_root)
+    File.binwrite(File.join(real_content_root, "remote-audiobook.mp3"), "client-root audiobook content")
+    File.symlink(target, staging)
+    client = DownloadClient.create!(
+      name: "Symlinked debrid content mount",
+      client_type: "deluge",
+      url: "http://localhost:8112",
+      password: "deluge",
+      download_path: configured_content_root
+    )
+    @download.update!(download_path: staging, download_client: client)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    assert @request.reload.completed?, @request.issue_description
+    root = @book.reload.reference_target_roots.sole
+    root_stat = File.lstat(real_content_root)
+    assert_equal Pathname(real_content_root).realpath.to_s, root.path.to_s
+    assert_equal [ root_stat.dev, root_stat.ino ], [ root.device, root.inode ]
+  ensure
+    FileUtils.rm_rf(content_parent) if content_parent
   end
 
   test "reference mode imports a Decypharr directory containing immediate symlink leaves" do
@@ -838,7 +876,8 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
     assert_equal "decypharr mounted audio", File.binread(referenced)
     assert File.symlink?(File.join(@temp_source, "remote-audiobook.m4b"))
-    assert_equal [ Pathname(content_root).realpath.to_s ], @book.reload.reference_target_roots
+    assert_equal [ Pathname(content_root).realpath.to_s ],
+      @book.reload.reference_target_roots.map { |root| root.path.to_s }
   ensure
     FileUtils.rm_rf(content_root)
   end
@@ -2714,7 +2753,14 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
   test "non-reference acquisition clears stale reference target provenance" do
     SettingsService.set(:audiobookshelf_url, "")
-    @book.update!(reference_target_roots: [ @temp_download_base ])
+    root_stat = File.lstat(@temp_download_base)
+    @book.update!(reference_target_roots: [
+      {
+        path: Pathname(@temp_download_base).realpath.to_s,
+        device: root_stat.dev,
+        inode: root_stat.ino
+      }
+    ])
 
     PostProcessingJob.perform_now(@download.id)
 

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -677,6 +677,7 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.reload.completed?, @request.issue_description
     assert_equal Pathname(source).expand_path.to_s, File.readlink(referenced)
     assert_not File.exist?(File.join(destination, "audiobook (2).mp3"))
+    assert_includes @book.reload.reference_target_roots, Pathname(@temp_download_base).realpath.to_s
   end
 
   test "reference mode imports a top-level source symlink to its final target" do
@@ -762,6 +763,45 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.reload.completed?, @request.issue_description
     assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
     assert_equal "client-root audiobook content", File.binread(referenced)
+    assert_equal [ Pathname(content_root).realpath.to_s ], @book.reload.reference_target_roots
+  ensure
+    FileUtils.rm_rf(content_root)
+  end
+
+  test "reference mode imports a Decypharr directory containing immediate symlink leaves" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    content_root = Dir.mktmpdir("decypharr-content")
+    target_directory = File.join(content_root, "__all__", "release-hash")
+    target = File.join(target_directory, "remote-audiobook.m4b")
+    FileUtils.mkdir_p(target_directory)
+    File.binwrite(target, "decypharr mounted audio")
+    File.symlink(target, File.join(@temp_source, "remote-audiobook.m4b"))
+    client = DownloadClient.create!(
+      name: "Decypharr directory source",
+      client_type: "decypharr",
+      url: "http://localhost:8282",
+      username: "http://shelfarr:3000",
+      password: "Password123!",
+      download_path: content_root
+    )
+    @download.update!(download_client: client)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    referenced = File.join(
+      @temp_dest_base,
+      @book.author,
+      @book.title,
+      "remote-audiobook.m4b"
+    )
+    assert @request.reload.completed?, @request.issue_description
+    assert File.symlink?(referenced)
+    assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
+    assert_equal "decypharr mounted audio", File.binread(referenced)
+    assert File.symlink?(File.join(@temp_source, "remote-audiobook.m4b"))
+    assert_equal [ Pathname(content_root).realpath.to_s ], @book.reload.reference_target_roots
   ensure
     FileUtils.rm_rf(content_root)
   end
@@ -1869,9 +1909,8 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal 0o640, File.stat(existing).mode & 0o777
   end
 
-  test "rejects symbolic links and fifo entries anywhere in a recursive source" do
+  test "non-reference mode rejects symbolic links and fifo entries anywhere in a recursive source" do
     SettingsService.set(:audiobookshelf_url, "")
-    SettingsService.set(:completed_download_import_mode, "reference")
     nested = File.join(@temp_source, "nested")
     FileUtils.mkdir_p(nested)
     File.symlink(File.join(@temp_source, "audiobook.mp3"), File.join(nested, "linked.mp3"))
@@ -1883,6 +1922,40 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.reload.attention_needed?
     assert_match(/symbolic link or non-regular path/i, @request.issue_description)
     assert_not File.exist?(destination)
+  end
+
+  test "reference directory rejects chained links and special targets" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    FileUtils.rm_f(File.join(@temp_source, "audiobook.mp3"))
+    content_root = Dir.mktmpdir("unsafe-reference-content")
+    regular = File.join(content_root, "regular.mp3")
+    chained = File.join(content_root, "chained.mp3")
+    fifo = File.join(content_root, "target.pipe")
+    File.binwrite(regular, "audio")
+    File.symlink(regular, chained)
+    File.mkfifo(fifo)
+    File.symlink(chained, File.join(@temp_source, "chain.mp3"))
+    File.symlink(fifo, File.join(@temp_source, "fifo.mp3"))
+    client = DownloadClient.create!(
+      name: "Unsafe reference targets",
+      client_type: "decypharr",
+      url: "http://localhost:8282",
+      username: "http://shelfarr:3000",
+      password: "Password123!",
+      download_path: content_root
+    )
+    @download.update!(download_client: client)
+
+    PostProcessingJob.perform_now(@download.id)
+
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    assert @request.reload.attention_needed?
+    assert_match(/symbolic link or non-regular path/i, @request.issue_description)
+    assert_not File.exist?(destination)
+    assert_equal "audio", File.binread(regular)
+  ensure
+    FileUtils.rm_rf(content_root)
   end
 
   test "never imports outside bytes after the download root is swapped" do
@@ -2566,6 +2639,46 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert @request.processing?
     assert_nil @request.issue_description
     assert_equal retry_job.arguments.third, @download.reload.post_processing_job_id
+  end
+
+  test "retries later when a reference target is not visible yet" do
+    FileUtils.rm_rf(@temp_source)
+    debrid_root = Dir.mktmpdir("delayed-reference-target")
+    staging = File.join(@temp_download_base, "delayed-audiobook.m4b")
+    target = File.join(debrid_root, "delayed-audiobook.m4b")
+    File.symlink(target, staging)
+    @download.update!(download_path: staging)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    SettingsService.set(:download_remote_path, debrid_root)
+    SettingsService.set(:post_processing_source_path_retries, 2)
+
+    retry_args = ->(args) { args.first(2) == [ @download.id, 1 ] && args.third.present? }
+    retry_job = assert_enqueued_with(job: PostProcessingJob, args: retry_args) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    assert @request.reload.processing?
+    assert_nil @request.issue_description
+    File.binwrite(target, "delayed debrid audio")
+    retry_job.perform_now
+
+    assert @request.reload.completed?, @request.issue_description
+    referenced = Dir.glob(File.join(@temp_dest_base, "**", "*.m4b")).sole
+    assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
+    assert_equal "delayed debrid audio", File.binread(referenced)
+  ensure
+    FileUtils.rm_rf(debrid_root)
+  end
+
+  test "non-reference acquisition clears stale reference target provenance" do
+    SettingsService.set(:audiobookshelf_url, "")
+    @book.update!(reference_target_roots: [ @temp_download_base ])
+
+    PostProcessingJob.perform_now(@download.id)
+
+    assert @request.reload.completed?, @request.issue_description
+    assert_empty @book.reload.reference_target_roots
   end
 
   test "copies when source path appears on a later retry" do

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -1277,7 +1277,9 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal "test audio content", File.binread(expected_dest)
     assert_equal @request.book.reload.file_path, File.dirname(expected_dest)
     assert_empty Dir.glob(File.join(File.dirname(expected_dest), ".shelfarr-copy-*.lock"))
-    assert_equal 1, Dir.glob(File.join(@temp_dest_base, ".shelfarr-copy-*.lock")).size
+    journal = File.join(@temp_dest_base, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+    assert File.file?(journal)
+    assert_match(/drvfs:complete/, File.binread(journal))
   end
 
   test "retains interrupted DrvFS publication artifacts for actionable review" do
@@ -1296,9 +1298,11 @@ class PostProcessingJobTest < ActiveJob::TestCase
 
     assert @request.reload.attention_needed?
     assert_includes @request.issue_description, "retained for manual review"
-    assert_includes @request.issue_description, ".shelfarr-copy artifacts"
+    assert_includes @request.issue_description, "Shelfarr filesystem artifacts"
     assert_equal "partial audio", File.binread(expected_dest)
-    assert_equal 1, Dir.glob(File.join(@temp_dest_base, ".shelfarr-copy-*.lock")).size
+    journal = File.join(@temp_dest_base, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+    assert File.file?(journal)
+    assert_match(/drvfs:copying/, File.binread(journal))
   end
 
   test "does not overwrite a concurrent file when atomic publication is unavailable" do

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -1209,6 +1209,58 @@ class PostProcessingJobTest < ActiveJob::TestCase
     assert_equal "book two audio", File.read(File.join(@temp_source, "Book Two.m4b"))
   end
 
+  test "publishes ordinary copies through the DrvFS compatibility path" do
+    SettingsService.set(:audiobookshelf_url, "")
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title, "audiobook.mp3")
+    real_rename = FileCopyService.method(:native_rename_noreplace)
+    real_link = FileCopyService.method(:native_linkat)
+    rejecting_import_rename = lambda do |*arguments|
+      flunk "DrvFS imports must not rename" if arguments.last == File.basename(expected_dest)
+
+      real_rename.call(*arguments)
+    end
+    rejecting_import_link = lambda do |*arguments|
+      flunk "DrvFS imports must not hardlink" if arguments.last == File.basename(expected_dest)
+
+      real_link.call(*arguments)
+    end
+
+    FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:native_rename_noreplace, rejecting_import_rename) do
+        FileCopyService.stub(:native_linkat, rejecting_import_link) do
+          PostProcessingJob.perform_now(@download.id)
+        end
+      end
+    end
+
+    assert @request.reload.completed?
+    assert_equal "test audio content", File.binread(expected_dest)
+    assert_equal @request.book.reload.file_path, File.dirname(expected_dest)
+    assert_empty Dir.glob(File.join(File.dirname(expected_dest), ".shelfarr-copy-*.lock"))
+    assert_equal 1, Dir.glob(File.join(@temp_dest_base, ".shelfarr-copy-*.lock")).size
+  end
+
+  test "retains interrupted DrvFS publication artifacts for actionable review" do
+    SettingsService.set(:audiobookshelf_url, "")
+    expected_dest = File.join(@temp_dest_base, @book.author, @book.title, "audiobook.mp3")
+
+    FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:copy_source_io, lambda { |_source, destination, **|
+        destination.write("partial audio")
+        destination.flush
+        raise IOError, "simulated DrvFS interruption"
+      }) do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert @request.reload.attention_needed?
+    assert_includes @request.issue_description, "retained for manual review"
+    assert_includes @request.issue_description, ".shelfarr-copy artifacts"
+    assert_equal "partial audio", File.binread(expected_dest)
+    assert_equal 1, Dir.glob(File.join(@temp_dest_base, ".shelfarr-copy-*.lock")).size
+  end
+
   test "does not overwrite a concurrent file when atomic publication is unavailable" do
     SettingsService.set(:audiobookshelf_url, "")
     SettingsService.set(:split_audiobook_bundle_imports, true)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -2751,6 +2751,64 @@ class PostProcessingJobTest < ActiveJob::TestCase
     FileUtils.rm_rf(debrid_root)
   end
 
+  test "retries later when a reference target disappears after authorization" do
+    FileUtils.rm_rf(@temp_source)
+    debrid_root = Dir.mktmpdir("vanished-reference-target")
+    staging = File.join(@temp_download_base, "vanished-audiobook.m4b")
+    target = File.join(debrid_root, "vanished-audiobook.m4b")
+    File.binwrite(target, "temporary debrid audio")
+    File.symlink(target, staging)
+    @download.update!(download_path: staging)
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    SettingsService.set(:download_remote_path, debrid_root)
+    SettingsService.set(:post_processing_source_path_retries, 2)
+
+    job = PostProcessingJob.new(@download.id)
+    authorize = job.method(:validate_download_specific_source_path!)
+    authorize_then_hide = lambda do |*arguments|
+      authorization = authorize.call(*arguments)
+      File.unlink(target)
+      authorization
+    end
+    retry_args = ->(args) { args.first(2) == [ @download.id, 1 ] && args.third.present? }
+
+    retry_job = assert_enqueued_with(job: PostProcessingJob, args: retry_args) do
+      job.stub(:validate_download_specific_source_path!, authorize_then_hide) { job.perform_now }
+    end
+
+    assert @request.reload.processing?
+    assert_nil @request.issue_description
+    assert_empty Dir.glob(File.join(@temp_dest_base, "**", "*.m4b"))
+
+    File.binwrite(target, "restored debrid audio")
+    retry_job.perform_now
+
+    assert @request.reload.completed?, @request.issue_description
+    referenced = Dir.glob(File.join(@temp_dest_base, "**", "*.m4b")).sole
+    assert_equal Pathname(target).realpath.to_s, File.readlink(referenced)
+    assert_equal "restored debrid audio", File.binread(referenced)
+  ensure
+    FileUtils.rm_rf(debrid_root)
+  end
+
+  test "retries later when the library publication lock stays busy" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:post_processing_source_path_retries, 2)
+    busy = ->(*) { raise FileCopyService::PublicationBusyError, "library busy" }
+    retry_args = ->(args) { args.first(2) == [ @download.id, 1 ] && args.third.present? }
+
+    retry_job = FileCopyService.stub(:cp_noreplace, busy) do
+      assert_enqueued_with(job: PostProcessingJob, args: retry_args) do
+        PostProcessingJob.perform_now(@download.id)
+      end
+    end
+
+    assert @request.reload.processing?
+    assert_nil @request.issue_description
+    assert_equal retry_job.arguments.third, @download.reload.post_processing_job_id
+  end
+
   test "non-reference acquisition clears stale reference target provenance" do
     SettingsService.set(:audiobookshelf_url, "")
     root_stat = File.lstat(@temp_download_base)

--- a/test/jobs/post_processing_job_test.rb
+++ b/test/jobs/post_processing_job_test.rb
@@ -192,6 +192,43 @@ class PostProcessingJobTest < ActiveJob::TestCase
     FileUtils.rm_rf(unauthorized_root)
   end
 
+  test "reference mode rejects a target parent swapped before target snapshot" do
+    SettingsService.set(:audiobookshelf_url, "")
+    SettingsService.set(:completed_download_import_mode, "reference")
+    FileUtils.rm_rf(@temp_source)
+    target_parent = File.join(@temp_download_base, "debrid-content")
+    displaced_parent = File.join(@temp_download_base, "debrid-content-original")
+    outside_root = Dir.mktmpdir("outside-reference-race")
+    staging = File.join(@temp_download_base, "raced-reference.mp3")
+    FileUtils.mkdir_p(target_parent)
+    File.binwrite(File.join(target_parent, "audiobook.mp3"), "authorized content")
+    File.binwrite(File.join(outside_root, "audiobook.mp3"), "outside secret")
+    File.symlink(File.join(target_parent, "audiobook.mp3"), staging)
+    @download.update!(download_path: staging)
+    original_snapshot = FileCopyService.method(:snapshot_reference_target)
+    swapped = false
+    swap_parent = lambda do |target|
+      unless swapped
+        File.rename(target_parent, displaced_parent)
+        File.symlink(outside_root, target_parent)
+        swapped = true
+      end
+      original_snapshot.call(target)
+    end
+
+    FileCopyService.stub(:snapshot_reference_target, swap_parent) do
+      PostProcessingJob.perform_now(@download.id)
+    end
+
+    destination = File.join(@temp_dest_base, @book.author, @book.title)
+    assert swapped
+    assert @request.reload.attention_needed?
+    assert_not File.exist?(destination)
+    assert_equal "outside secret", File.binread(File.join(outside_root, "audiobook.mp3"))
+  ensure
+    FileUtils.rm_rf(outside_root) if outside_root
+  end
+
   test "skips a completed download replaced by a manual selection" do
     old_result = @request.search_results.create!(
       guid: "old-result",

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -993,7 +993,7 @@ class SearchJobTest < ActiveJob::TestCase
     assert_equal volume.title, job.send(:generic_indexer_attempts, volume_request).first.query
   end
 
-  test "does not zero-pad nonnumeric comic issue labels" do
+  test "zero-pads alphanumeric comic issue labels" do
     book = Book.create!(
       title: "Saga - #7A",
       book_type: :comicbook,
@@ -1005,7 +1005,37 @@ class SearchJobTest < ActiveJob::TestCase
 
     attempts = SearchJob.new.send(:generic_indexer_attempts, request)
 
-    assert_equal [ "Saga 7A", "Saga #7A" ], attempts.map(&:query)
+    assert_equal [ "Saga 7A", "Saga #7A", "Saga 007A" ], attempts.map(&:query)
+  end
+
+  test "zero-pads decimal comic issue labels" do
+    book = Book.create!(
+      title: "Saga - #7.5",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "7.5",
+      series: "Saga"
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    attempts = SearchJob.new.send(:generic_indexer_attempts, request)
+
+    assert_equal [ "Saga 7.5", "Saga #7.5", "Saga 007.5" ], attempts.map(&:query)
+  end
+
+  test "does not zero-pad comic issue labels without a numeric stem" do
+    book = Book.create!(
+      title: "Saga - Special",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "Special",
+      series: "Saga"
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    attempts = SearchJob.new.send(:generic_indexer_attempts, request)
+
+    assert_equal [ "Saga Special", "Saga #Special" ], attempts.map(&:query)
   end
 
   test "sends the author to Prowlarr indexers that only accept free text" do

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -915,6 +915,99 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
+  test "uses compact issue title without author for structured Prowlarr search" do
+    SettingsService.set(:indexer_search_scope, "strict")
+    book = Book.create!(
+      title: "Saga - #7 - The Chapter",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-437",
+      issue_number: "7",
+      series: "Saga",
+      series_position: "7"
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+    searches = []
+    search = lambda do |query, **options|
+      searches << { query: query, options: options }
+      []
+    end
+
+    IndexerClient.stub(:search, search) do
+      SearchJob.new.send(:search_prowlarr, request)
+    end
+
+    structured = searches.first
+    assert_equal "Saga #7", structured.dig(:options, :title)
+    assert_nil structured.dig(:options, :author)
+  end
+
+  test "uses only compact issue variants for generic indexer searches" do
+    book = Book.create!(
+      title: "Saga - #7 - The Chapter",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-438",
+      issue_number: "7",
+      series: "Saga",
+      series_position: "7"
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    attempts = SearchJob.new.send(:generic_indexer_attempts, request)
+
+    assert_equal [ "Saga 7", "Saga #7", "Saga 007" ], attempts.map(&:query)
+    assert attempts.none? { |attempt| attempt.query.include?(book.author) }
+    assert_not_includes attempts.map(&:query), book.series
+  end
+
+  test "falls back to series position only for confirmed Comic Vine issues" do
+    issue = Book.create!(
+      title: "Saga - The Chapter",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-441",
+      issue_number: nil,
+      series: "Saga",
+      series_position: "9"
+    )
+    volume = Book.create!(
+      title: "Saga Deluxe Volume",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4050-441",
+      issue_number: nil,
+      series: "Saga",
+      series_position: "9"
+    )
+
+    issue_request = Request.create!(book: issue, user: users(:one), status: :pending)
+    volume_request = Request.create!(book: volume, user: users(:one), status: :pending)
+    job = SearchJob.new
+
+    assert_equal [ "Saga 9", "Saga #9", "Saga 009" ], job.send(:generic_indexer_attempts, issue_request).map(&:query)
+    assert_equal volume.title, job.send(:generic_indexer_attempts, volume_request).first.query
+  end
+
+  test "does not zero-pad nonnumeric comic issue labels" do
+    book = Book.create!(
+      title: "Saga - #7A",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "7A",
+      series: "Saga"
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending)
+
+    attempts = SearchJob.new.send(:generic_indexer_attempts, request)
+
+    assert_equal [ "Saga 7A", "Saga #7A" ], attempts.map(&:query)
+  end
+
   test "sends the author to Prowlarr indexers that only accept free text" do
     VCR.turned_off do
       stub_prowlarr_indexers(FREE_TEXT_INDEXERS)

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -3,15 +3,23 @@
 require "test_helper"
 
 class BookTest < ActiveSupport::TestCase
-  test "reference target roots serialize as an immutable path list" do
+  test "reference target roots serialize immutable path and identity records" do
     book = Book.create!(
       title: "Reference provenance",
       book_type: :ebook,
-      reference_target_roots: [ "/debrid", "", "/debrid", "/other" ]
+      reference_target_roots: [
+        { path: "/debrid", device: 10, inode: 20 },
+        FileCopyService::ReferenceRootSnapshot.new(path: Pathname("/debrid"), device: 10, inode: 20),
+        { "path" => "/other", "device" => 30, "inode" => 40 }
+      ]
     )
 
-    assert_equal [ "/debrid", "/other" ], book.reload.reference_target_roots
-    assert_equal '["/debrid","/other"]', book[:reference_target_roots]
+    roots = book.reload.reference_target_roots
+    assert_equal [ "/debrid", "/other" ], roots.map { |root| root.path.to_s }
+    assert_equal [ [ 10, 20 ], [ 30, 40 ] ], roots.map { |root| [ root.device, root.inode ] }
+    assert_equal \
+      '[{"path":"/debrid","device":10,"inode":20},{"path":"/other","device":30,"inode":40}]',
+      book[:reference_target_roots]
   end
 
   test "malformed reference target roots fail closed" do
@@ -19,6 +27,33 @@ class BookTest < ActiveSupport::TestCase
     Book.where(id: book.id).update_all(reference_target_roots: '{"root":"/"}')
 
     assert_empty book.reload.reference_target_roots
+    assert book.reference_target_roots_recorded?
+  end
+
+  test "blank non-null reference target provenance is recorded" do
+    book = Book.create!(title: "Blank provenance", book_type: :ebook)
+    Book.where(id: book.id).update_all(reference_target_roots: "")
+
+    assert_empty book.reload.reference_target_roots
+    assert book.reference_target_roots_recorded?
+  end
+
+  test "obsolete path-only reference provenance is not accepted" do
+    book = Book.create!(title: "Obsolete provenance", book_type: :ebook)
+    Book.where(id: book.id).update_all(reference_target_roots: '["/debrid"]')
+
+    assert_empty book.reload.reference_target_roots
+    assert book.reference_target_roots_recorded?
+  end
+
+  test "invalid or conflicting reference target roots cannot be dumped" do
+    assert_raises(ArgumentError) { Book.dump_reference_target_roots([ "/debrid" ]) }
+    assert_raises(ArgumentError) do
+      Book.dump_reference_target_roots([
+        { path: "/debrid", device: 10, inode: 20 },
+        { path: "/debrid", device: 10, inode: 21 }
+      ])
+    end
   end
 
   test "acquired scope only includes books with a usable path" do

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -3,6 +3,24 @@
 require "test_helper"
 
 class BookTest < ActiveSupport::TestCase
+  test "reference target roots serialize as an immutable path list" do
+    book = Book.create!(
+      title: "Reference provenance",
+      book_type: :ebook,
+      reference_target_roots: [ "/debrid", "", "/debrid", "/other" ]
+    )
+
+    assert_equal [ "/debrid", "/other" ], book.reload.reference_target_roots
+    assert_equal '["/debrid","/other"]', book[:reference_target_roots]
+  end
+
+  test "malformed reference target roots fail closed" do
+    book = Book.create!(title: "Malformed provenance", book_type: :ebook)
+    Book.where(id: book.id).update_all(reference_target_roots: '{"root":"/"}')
+
+    assert_empty book.reload.reference_target_roots
+  end
+
   test "acquired scope only includes books with a usable path" do
     acquired = Book.create!(title: "Acquired", book_type: :ebook, file_path: "/books/acquired.epub")
     blank = Book.create!(title: "Blank", book_type: :ebook, file_path: "")

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -269,6 +269,57 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert_equal 0, @request.downloads.count
   end
 
+  test "does not auto-select a comic issue from a conflicting release year" do
+    @book.update!(
+      title: "Batman - #1 - The Legend of the Batman",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-105811",
+      issue_number: "1",
+      series: "Batman",
+      series_position: "1",
+      release_date: Date.new(1940, 4, 1)
+    )
+    result = create_search_result(
+      title: "Batman #001 (2016) English Comic CBZ",
+      seeders: 100,
+      magnet_url: "magnet:?conflicting-run"
+    )
+    result.calculate_score!
+
+    selection = AutoSelectService.call(@request)
+
+    assert_not selection.success?
+    assert_equal :no_matching_results, selection.reason
+    assert result.reload.pending?
+    assert_equal 0, @request.downloads.count
+  end
+
+  test "does not auto-select a multi-issue comic pack" do
+    @book.update!(
+      title: "Saga - #1",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-438",
+      issue_number: "1",
+      series: "Saga",
+      series_position: "1"
+    )
+    result = create_search_result(
+      title: "Saga #001-#006 English Comic CBZ",
+      seeders: 100,
+      magnet_url: "magnet:?issue-pack"
+    )
+    result.calculate_score!
+
+    selection = AutoSelectService.call(@request)
+
+    assert_not selection.success?
+    assert_equal :no_matching_results, selection.reason
+    assert result.reload.pending?
+    assert_equal 0, @request.downloads.count
+  end
+
   test "selection result error reason works" do
     # Test that the SelectionResult with error reason works correctly
     result = AutoSelectService::SelectionResult.new(selected: false, reason: :error)

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -278,7 +278,8 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
       issue_number: "1",
       series: "Batman",
       series_position: "1",
-      release_date: Date.new(1940, 4, 1)
+      release_date: Date.new(2018, 4, 1),
+      series_start_year: 1940
     )
     result = create_search_result(
       title: "Batman #001 (2016) English Comic CBZ",
@@ -408,7 +409,8 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert_comic_title_not_auto_selected(
       series: "Batman",
       issue: "1",
-      release_date: Date.new(1940, 4, 1),
+      release_date: Date.new(2018, 4, 1),
+      series_start_year: 1940,
       title: "2016 Batman #001 English Comic CBZ"
     )
   end
@@ -424,7 +426,13 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
 
   private
 
-  def assert_comic_title_not_auto_selected(series:, issue:, title:, release_date: nil)
+  def assert_comic_title_not_auto_selected(
+    series:,
+    issue:,
+    title:,
+    release_date: nil,
+    series_start_year: nil
+  )
     @book.update!(
       title: "#{series} - ##{issue}",
       book_type: :comicbook,
@@ -433,7 +441,8 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
       issue_number: issue,
       series: series,
       series_position: issue,
-      release_date: release_date
+      release_date: release_date,
+      series_start_year: series_start_year
     )
     result = create_search_result(
       title: title,

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -388,6 +388,22 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     )
   end
 
+  test "does not auto-select a marked year-shaped issue pack" do
+    assert_comic_title_not_auto_selected(
+      series: "2000 AD",
+      issue: "2000",
+      title: "2000.AD #2000 and #2012 English Comic CBZ"
+    )
+  end
+
+  test "does not auto-select an issue marker consumed as series punctuation" do
+    assert_comic_title_not_auto_selected(
+      series: "X-23",
+      issue: "7",
+      title: "X #23 #007 English Comic CBZ"
+    )
+  end
+
   test "does not auto-select a conflicting unwrapped release year" do
     assert_comic_title_not_auto_selected(
       series: "Batman",

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -364,6 +364,30 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     )
   end
 
+  test "does not auto-select a partially consumed comic issue label" do
+    assert_comic_title_not_auto_selected(
+      series: "Saga",
+      issue: "1",
+      title: "Saga #1-A English Comic CBZ"
+    )
+  end
+
+  test "does not auto-select a punctuation-extended series identity" do
+    assert_comic_title_not_auto_selected(
+      series: "X",
+      issue: "23",
+      title: "X-23 English Comic CBZ"
+    )
+  end
+
+  test "does not auto-select an issue pack with a language word separator" do
+    assert_comic_title_not_auto_selected(
+      series: "Saga",
+      issue: "1",
+      title: "Saga #1 y 2 English Comic CBZ"
+    )
+  end
+
   test "does not auto-select a conflicting unwrapped release year" do
     assert_comic_title_not_auto_selected(
       series: "Batman",

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -348,6 +348,31 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert_equal 0, @request.downloads.count
   end
 
+  test "does not auto-select when the requested series is only a release title suffix" do
+    assert_comic_title_not_auto_selected(
+      series: "X",
+      issue: "7",
+      title: "Generation X #007 English Comic CBZ"
+    )
+  end
+
+  test "does not auto-select a whitespace-separated comic issue pack" do
+    assert_comic_title_not_auto_selected(
+      series: "Saga",
+      issue: "1",
+      title: "Saga #001 002 English Comic CBZ"
+    )
+  end
+
+  test "does not auto-select a conflicting unwrapped release year" do
+    assert_comic_title_not_auto_selected(
+      series: "Batman",
+      issue: "1",
+      release_date: Date.new(1940, 4, 1),
+      title: "2016 Batman #001 English Comic CBZ"
+    )
+  end
+
   test "selection result error reason works" do
     # Test that the SelectionResult with error reason works correctly
     result = AutoSelectService::SelectionResult.new(selected: false, reason: :error)
@@ -358,6 +383,32 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
   end
 
   private
+
+  def assert_comic_title_not_auto_selected(series:, issue:, title:, release_date: nil)
+    @book.update!(
+      title: "#{series} - ##{issue}",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-#{SecureRandom.random_number(1_000_000_000)}",
+      issue_number: issue,
+      series: series,
+      series_position: issue,
+      release_date: release_date
+    )
+    result = create_search_result(
+      title: title,
+      seeders: 100,
+      magnet_url: "magnet:?#{SecureRandom.hex(20)}"
+    )
+    result.calculate_score!
+
+    selection = AutoSelectService.call(@request)
+
+    assert_not selection.success?
+    assert_equal :no_matching_results, selection.reason
+    assert result.reload.pending?
+    assert_equal 0, @request.downloads.count
+  end
 
   def create_search_result(attrs = {})
     result = @request.search_results.create!({

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -320,6 +320,34 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert_equal 0, @request.downloads.count
   end
 
+  test "does not auto-select an exact comic issue with a conflicting format" do
+    @book.update!(
+      title: "Saga - #7",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-439",
+      issue_number: "7",
+      series: "Saga",
+      series_position: "7"
+    )
+    result = create_search_result(
+      title: "Saga #007 English EPUB",
+      seeders: 100,
+      magnet_url: "magnet:?conflicting-format"
+    )
+    result.calculate_score!
+
+    selection = AutoSelectService.call(@request)
+
+    assert_not selection.success?
+    assert_equal :no_matching_results, selection.reason
+    assert_equal :exact, result.score_breakdown["issue_match"].to_sym
+    assert_equal 0, result.score_breakdown["format"]
+    assert_not result.score_breakdown["auto_select_allowed"]
+    assert result.reload.pending?
+    assert_equal 0, @request.downloads.count
+  end
+
   test "selection result error reason works" do
     # Test that the SelectionResult with error reason works correctly
     result = AutoSelectService::SelectionResult.new(selected: false, reason: :error)

--- a/test/services/auto_select_service_test.rb
+++ b/test/services/auto_select_service_test.rb
@@ -243,6 +243,32 @@ class AutoSelectServiceTest < ActiveSupport::TestCase
     assert blocked.reload.rejected?
   end
 
+  test "does not auto-select a confidently conflicting comic issue" do
+    @book.update!(
+      title: "Saga",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-437",
+      issue_number: "7",
+      series: "Saga",
+      series_position: "7"
+    )
+    result = create_search_result(
+      title: "Saga #8 English Comic CBZ",
+      seeders: 100,
+      magnet_url: "magnet:?conflicting-issue"
+    )
+    result.calculate_score!
+
+    selection = AutoSelectService.call(@request)
+
+    assert_not selection.success?
+    assert_equal :no_matching_results, selection.reason
+    assert result.reload.pending?
+    assert_equal 0, @request.downloads.count
+  end
+
   test "selection result error reason works" do
     # Test that the SelectionResult with error reason works correctly
     result = AutoSelectService::SelectionResult.new(selected: false, reason: :error)

--- a/test/services/comic_vine_client_test.rb
+++ b/test/services/comic_vine_client_test.rb
@@ -26,6 +26,7 @@ class ComicVineClientTest < ActiveSupport::TestCase
             "results" => issue_payload("123", "1", "Series One", "Issue One")
           }.to_json
         )
+      stub_volume_start_year
 
       result = ComicVineClient.details("comic_vine:4000-123", content_kind: "comic")
 
@@ -34,6 +35,7 @@ class ComicVineClientTest < ActiveSupport::TestCase
       assert_equal "4050-99", result.collection_id
       assert_equal "Series One", result.collection_title
       assert_equal "graphic", result.content_kind
+      assert_equal 2012, result.series_start_year
     end
   end
 
@@ -53,6 +55,7 @@ class ComicVineClientTest < ActiveSupport::TestCase
             ]
           }.to_json
         )
+      stub_volume_start_year
 
       issues = ComicVineClient.volume_issues("4050-99", limit: 2, content_kind: "manga")
 
@@ -60,6 +63,7 @@ class ComicVineClientTest < ActiveSupport::TestCase
       assert_equal "4000-123", issues.first.resource_key
       assert_equal "2", issues.second.issue_number
       assert_equal "graphic", issues.second.content_kind
+      assert_equal [ 2012, 2012 ], issues.map(&:series_start_year)
     end
   end
 
@@ -71,6 +75,18 @@ class ComicVineClientTest < ActiveSupport::TestCase
   end
 
   private
+
+  def stub_volume_start_year
+    stub_request(:get, %r{comicvine\.gamespot\.com/api/volume/4050-99/})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          "status_code" => 1,
+          "results" => { "id" => 99, "start_year" => "2012" }
+        }.to_json
+      )
+  end
 
   def issue_payload(id, number, volume_name, name)
     {

--- a/test/services/direct_download_file_service_test.rb
+++ b/test/services/direct_download_file_service_test.rb
@@ -93,12 +93,14 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     File.binwrite(legacy_marker, "legacy bytes")
     File.chmod(0o777, legacy)
     legacy_stat = File.stat(legacy)
-    chmod_paths = []
+    legacy_identity = [ legacy_stat.dev, legacy_stat.ino ]
+    chmod_identities = []
     real_fchmod = FileCopyService.method(:native_fchmod)
     guarded_fchmod = lambda do |descriptor, mode|
-      path = File.readlink("/proc/self/fd/#{descriptor}").delete_suffix(" (deleted)")
-      chmod_paths << path
-      raise Errno::EPERM, "legacy fchmod denied" if path == legacy || path.start_with?("#{legacy}/")
+      descriptor_stat = IO.for_fd(descriptor, autoclose: false).stat
+      identity = [ descriptor_stat.dev, descriptor_stat.ino ]
+      chmod_identities << identity
+      raise Errno::EPERM, "legacy fchmod denied" if identity == legacy_identity
 
       real_fchmod.call(descriptor, mode)
     end
@@ -118,7 +120,7 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert_equal [ legacy_stat.dev, legacy_stat.ino ], [ File.stat(legacy).dev, File.stat(legacy).ino ]
     assert_equal 0o777, File.stat(legacy).mode & 0o7777
     assert_equal "legacy bytes", File.binread(legacy_marker)
-    assert chmod_paths.none? { |path| path == legacy || path.start_with?("#{legacy}/") }
+    assert_not_includes chmod_identities, legacy_identity
   end
 
   test "rejects destinations in every internal library namespace" do
@@ -138,7 +140,7 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     end
   end
 
-  test "stale persisted legacy staging is retained while its recovery row is released" do
+  test "stale persisted legacy staging retains its recovery owner for manual review" do
     legacy_parent = File.join(
       @output_root,
       DirectDownloadFileService::LEGACY_STAGING_DIRECTORY,
@@ -158,7 +160,7 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
       ),
       legacy_parent,
       legacy_staging
-    ].each { |path| File.chmod(0o777, path) }
+    ].each { |path| File.chmod(0o700, path) }
     staging_stat = File.stat(legacy_staging)
     parent_stat = File.stat(legacy_parent)
     root_stat = File.stat(@output_root)
@@ -182,26 +184,18 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
       updated_at: 1.hour.ago
     )
     legacy_identity = [ staging_stat.dev, staging_stat.ino ]
-    real_fchmod = FileCopyService.method(:native_fchmod)
-    guarded_fchmod = lambda do |descriptor, mode|
-      path = File.readlink("/proc/self/fd/#{descriptor}").delete_suffix(" (deleted)")
-      if path.include?(DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
-        raise Errno::EPERM, "legacy fchmod denied"
-      end
-
-      real_fchmod.call(descriptor, mode)
-    end
-
-    result = FileCopyService.stub(:native_fchmod, guarded_fchmod) do
-      DirectDownloadFileService.reconcile!(@download)
-    end
+    result = DirectDownloadFileService.reconcile!(@download)
 
     assert_not result
-    assert_nil @download.reload.direct_staging_path
-    assert_nil @download.direct_reservation_token
-    assert_not @book.reload.acquisition_reserved?
+    assert_equal legacy_staging, @download.reload.direct_staging_path
+    assert_equal token, @download.direct_reservation_token
+    assert @book.reload.acquisition_reserved?
+    assert_match(
+      /contains retained entries/,
+      DirectDownloadFileService.legacy_staging_diagnostic(root: @output_root)
+    )
     assert_equal legacy_identity, [ File.stat(legacy_staging).dev, File.stat(legacy_staging).ino ]
-    assert_equal 0o777, File.stat(legacy_staging).mode & 0o7777
+    assert_equal 0o700, File.stat(legacy_staging).mode & 0o7777
     assert_equal "untrusted legacy bytes", File.binread(legacy_partial)
   end
 
@@ -698,6 +692,8 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
       path.to_s == "/proc/self/mountinfo" ? mountinfo : real_binread.call(path, *arguments)
     end
 
-    File.stub(:binread, reader) { yield }
+    FileCopyService.stub(:drvfs_mount?, true) do
+      File.stub(:binread, reader) { yield }
+    end
   end
 end

--- a/test/services/direct_download_file_service_test.rb
+++ b/test/services/direct_download_file_service_test.rb
@@ -55,6 +55,108 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert_nil @download.reload.direct_staging_path
   end
 
+  test "new staging bypasses an unrepairable broad legacy namespace" do
+    legacy = File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+    legacy_marker = File.join(legacy, "retained-legacy-entry")
+    FileUtils.mkdir_p(legacy)
+    File.binwrite(legacy_marker, "legacy bytes")
+    File.chmod(0o777, legacy)
+    legacy_stat = File.stat(legacy)
+    chmod_paths = []
+    real_fchmod = FileCopyService.method(:native_fchmod)
+    guarded_fchmod = lambda do |descriptor, mode|
+      path = File.readlink("/proc/self/fd/#{descriptor}").delete_suffix(" (deleted)")
+      chmod_paths << path
+      raise Errno::EPERM, "legacy fchmod denied" if path == legacy || path.start_with?("#{legacy}/")
+
+      real_fchmod.call(descriptor, mode)
+    end
+
+    parent = FileCopyService.stub(:native_fchmod, guarded_fchmod) do
+      DirectDownloadFileService.staging_parent(root: @output_root)
+    end
+
+    expected = File.join(
+      @output_root,
+      DirectDownloadFileService::STAGING_DIRECTORY,
+      DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY,
+      DirectDownloadFileService.database_fingerprint
+    )
+    assert_equal expected, parent.to_s
+    assert_equal 0o700, File.stat(parent).mode & 0o7777
+    assert_equal [ legacy_stat.dev, legacy_stat.ino ], [ File.stat(legacy).dev, File.stat(legacy).ino ]
+    assert_equal 0o777, File.stat(legacy).mode & 0o7777
+    assert_equal "legacy bytes", File.binread(legacy_marker)
+    assert chmod_paths.none? { |path| path == legacy || path.start_with?("#{legacy}/") }
+  end
+
+  test "stale persisted legacy staging is retained while its recovery row is released" do
+    legacy_parent = File.join(
+      @output_root,
+      DirectDownloadFileService::LEGACY_STAGING_DIRECTORY,
+      DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY,
+      DirectDownloadFileService.database_fingerprint
+    )
+    legacy_staging = File.join(legacy_parent, "download-#{@download.id}-#{'a' * 32}")
+    legacy_partial = File.join(legacy_staging, "partial.epub")
+    FileUtils.mkdir_p(legacy_staging)
+    File.binwrite(legacy_partial, "untrusted legacy bytes")
+    [
+      File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY),
+      File.join(
+        @output_root,
+        DirectDownloadFileService::LEGACY_STAGING_DIRECTORY,
+        DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY
+      ),
+      legacy_parent,
+      legacy_staging
+    ].each { |path| File.chmod(0o777, path) }
+    staging_stat = File.stat(legacy_staging)
+    parent_stat = File.stat(legacy_parent)
+    root_stat = File.stat(@output_root)
+    token = SecureRandom.hex(32)
+    @book.update!(
+      acquisition_reservation_token: token,
+      acquisition_reservation_owner_type: "Download",
+      acquisition_reservation_owner_id: @download.id
+    )
+    @download.update_columns(
+      status: Download.statuses[:failed],
+      direct_reservation_token: token,
+      direct_staging_path: legacy_staging,
+      direct_staging_device: staging_stat.dev,
+      direct_staging_inode: staging_stat.ino,
+      direct_staging_parent_device: parent_stat.dev,
+      direct_staging_parent_inode: parent_stat.ino,
+      direct_output_root: @output_root,
+      direct_output_root_device: root_stat.dev,
+      direct_output_root_inode: root_stat.ino,
+      updated_at: 1.hour.ago
+    )
+    legacy_identity = [ staging_stat.dev, staging_stat.ino ]
+    real_fchmod = FileCopyService.method(:native_fchmod)
+    guarded_fchmod = lambda do |descriptor, mode|
+      path = File.readlink("/proc/self/fd/#{descriptor}").delete_suffix(" (deleted)")
+      if path.include?(DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+        raise Errno::EPERM, "legacy fchmod denied"
+      end
+
+      real_fchmod.call(descriptor, mode)
+    end
+
+    result = FileCopyService.stub(:native_fchmod, guarded_fchmod) do
+      DirectDownloadFileService.reconcile!(@download)
+    end
+
+    assert_not result
+    assert_nil @download.reload.direct_staging_path
+    assert_nil @download.direct_reservation_token
+    assert_not @book.reload.acquisition_reserved?
+    assert_equal legacy_identity, [ File.stat(legacy_staging).dev, File.stat(legacy_staging).ino ]
+    assert_equal 0o777, File.stat(legacy_staging).mode & 0o7777
+    assert_equal "untrusted legacy bytes", File.binread(legacy_partial)
+  end
+
   test "an interrupted publication retains ownership until recovery safely removes staging" do
     staging = @service.create_staging!
 

--- a/test/services/direct_download_file_service_test.rb
+++ b/test/services/direct_download_file_service_test.rb
@@ -90,6 +90,23 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert chmod_paths.none? { |path| path == legacy || path.start_with?("#{legacy}/") }
   end
 
+  test "rejects destinations in every internal library namespace" do
+    LibraryPathSafety::INTERNAL_DIRECTORIES.each do |directory|
+      internal = File.join(@output_root, directory, "book.epub")
+
+      assert_raises(DirectDownloadFileService::Error) do
+        DirectDownloadFileService.new(
+          download: @download,
+          book: @book,
+          output_root: @output_root,
+          destination_path: internal,
+          book_path: internal,
+          kind: :file
+        )
+      end
+    end
+  end
+
   test "stale persisted legacy staging is retained while its recovery row is released" do
     legacy_parent = File.join(
       @output_root,

--- a/test/services/direct_download_file_service_test.rb
+++ b/test/services/direct_download_file_service_test.rb
@@ -55,6 +55,37 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert_nil @download.reload.direct_staging_path
   end
 
+  test "completed DrvFS direct file cleanup removes private v2 staging and recovery state" do
+    with_forced_drvfs_mount(@output_root) do
+      staging = @service.create_staging!
+      staged = FileCopyService.create_private_file(
+        staging,
+        root: @output_root,
+        prefix: "ebook-",
+        suffix: ".epub"
+      )
+      begin
+        staged.io.write("PK\x03\x04complete DrvFS ebook")
+        staged.io.flush
+        staged.io.fsync
+        assert @service.publish_file_and_finalize!(staged.io)
+      ensure
+        staged.io.close unless staged.io.closed?
+      end
+
+      assert File.directory?(staging)
+      assert @service.cleanup_after_run!
+      assert_not File.exist?(staging)
+    end
+
+    assert_nil @download.reload.direct_staging_path
+    assert_nil @download.direct_output_root
+    assert_nil @download.direct_destination_path
+    assert_nil @download.direct_content_manifest
+    assert_nil @download.direct_staging_parent_device
+    assert_equal "PK\x03\x04complete DrvFS ebook", File.binread(@destination)
+  end
+
   test "new staging bypasses an unrepairable broad legacy namespace" do
     legacy = File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
     legacy_marker = File.join(legacy, "retained-legacy-entry")
@@ -434,6 +465,31 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert File.directory?(displaced)
   end
 
+  test "DrvFS recovery retains a private same-mode staging replacement" do
+    displaced = nil
+    with_forced_drvfs_mount(@output_root) do
+      staging = @service.create_staging!
+      displaced = "#{staging}-original"
+      File.rename(staging, displaced)
+      FileUtils.mkdir_p(staging, mode: 0o700)
+      File.chmod(0o700, staging)
+      replacement = FileCopyService.create_private_file(
+        staging,
+        root: @output_root,
+        prefix: "replacement-"
+      )
+      replacement.io.write("preserve replacement")
+      replacement.io.close
+      @download.update_columns(status: Download.statuses[:failed], updated_at: 1.hour.ago)
+
+      assert_not DirectDownloadFileService.reconcile!(@download)
+      assert_equal "preserve replacement", File.binread(replacement.name)
+      assert_equal staging, @download.reload.direct_staging_path
+    end
+  ensure
+    FileUtils.rm_rf(displaced) if displaced
+  end
+
   test "recovery retains state when the persisted staging parent was replaced" do
     staging = @service.create_staging!
     @service.send(:reserve_book!)
@@ -507,7 +563,12 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
 
   test "orphan cleanup reclaims only old unreferenced instance staging directories" do
     parent = DirectDownloadFileService.staging_parent(root: @output_root)
-    orphan = Dir.mktmpdir("download-orphan-", parent)
+    orphan_id = Download.maximum(:id).to_i + 100_000
+    orphan = FileCopyService.create_private_directory(
+      parent.to_s,
+      root: @output_root,
+      prefix: "download-#{orphan_id}-"
+    ).name
     File.binwrite(File.join(orphan, "large.partial"), "partial")
     old = 2.days.ago.to_time
     File.utime(old, old, File.join(orphan, "large.partial"))
@@ -521,6 +582,80 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert File.directory?(active)
     @download.update!(status: :failed)
     DirectDownloadFileService.reconcile!(@download)
+  end
+
+  test "orphan cleanup reclaims old private v2 staging on DrvFS" do
+    with_forced_drvfs_mount(@output_root) do
+      parent = DirectDownloadFileService.staging_parent(root: @output_root)
+      orphan_id = Download.maximum(:id).to_i + 100_000
+      orphan = FileCopyService.create_private_directory(
+        parent.to_s,
+        root: @output_root,
+        prefix: "download-#{orphan_id}-"
+      )
+      staged = FileCopyService.create_private_file(
+        orphan.name,
+        root: @output_root,
+        prefix: "ebook-",
+        suffix: ".epub"
+      )
+      staged.io.write("PK\x03\x04orphaned DrvFS payload")
+      staged.io.close
+      nested = FileCopyService.ensure_private_relative_directory(
+        orphan.name,
+        "nested/deep",
+        root: @output_root
+      )
+      nested_file = FileCopyService.create_private_file(
+        nested,
+        root: @output_root,
+        prefix: "chapter-",
+        suffix: ".m4b"
+      )
+      nested_file.io.write("nested payload")
+      nested_file.io.close
+      old = 2.days.ago.to_time
+      File.utime(old, old, orphan.name)
+
+      assert_equal 1, DirectDownloadFileService.cleanup_orphans!(root: @output_root)
+      assert_not File.exist?(orphan.name)
+    end
+  end
+
+  test "DrvFS orphan cleanup retains lookalikes symlinks and special entries" do
+    skip "mkfifo is unavailable" unless File.respond_to?(:mkfifo)
+
+    with_forced_drvfs_mount(@output_root) do
+      parent = DirectDownloadFileService.staging_parent(root: @output_root)
+      next_id = Download.maximum(:id).to_i + 100_000
+      outside = File.join(@output_root, "outside-payload")
+      File.binwrite(outside, "outside bytes")
+
+      symlink_tree = FileCopyService.create_private_directory(
+        parent.to_s,
+        root: @output_root,
+        prefix: "download-#{next_id}-"
+      ).name
+      File.symlink(outside, File.join(symlink_tree, "linked.epub"))
+
+      special_tree = FileCopyService.create_private_directory(
+        parent.to_s,
+        root: @output_root,
+        prefix: "download-#{next_id + 1}-"
+      ).name
+      File.mkfifo(File.join(special_tree, "partial.pipe"), 0o600)
+
+      lookalike = File.join(parent, "download-orphan-#{'a' * 32}")
+      Dir.mkdir(lookalike, 0o700)
+      old = 2.days.ago.to_time
+      [ symlink_tree, special_tree, lookalike ].each { |path| File.utime(old, old, path) }
+
+      assert_equal 0, DirectDownloadFileService.cleanup_orphans!(root: @output_root)
+      assert File.symlink?(File.join(symlink_tree, "linked.epub"))
+      assert File.pipe?(File.join(special_tree, "partial.pipe"))
+      assert File.directory?(lookalike)
+      assert_equal "outside bytes", File.binread(outside)
+    end
   end
 
   private
@@ -549,5 +684,20 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
       book_path: directory_destination,
       kind: :directory
     )
+  end
+
+  def with_forced_drvfs_mount(root)
+    stat = File.stat(root)
+    device = "#{stat.dev_major}:#{stat.dev_minor}"
+    mountpoint = root.gsub(" ", "\\040")
+    mountinfo =
+      "500 1 #{device} / #{mountpoint} rw,noatime - 9p C:\\\\ " \
+      "rw,aname=drvfs;path=C:\\\\;uid=#{Process.euid};gid=#{Process.egid};metadata\n".b
+    real_binread = File.method(:binread)
+    reader = lambda do |path, *arguments|
+      path.to_s == "/proc/self/mountinfo" ? mountinfo : real_binread.call(path, *arguments)
+    end
+
+    File.stub(:binread, reader) { yield }
   end
 end

--- a/test/services/download_clients/decypharr_test.rb
+++ b/test/services/download_clients/decypharr_test.rb
@@ -46,7 +46,7 @@ class DownloadClients::DecypharrTest < ActiveSupport::TestCase
     end
   end
 
-  test "adds torrents with sequential download flag" do
+  test "adds magnet torrents without sequential download flag" do
     VCR.turned_off do
       stub_request(:post, "http://localhost:8282/api/v2/auth/login")
         .to_return(
@@ -56,7 +56,11 @@ class DownloadClients::DecypharrTest < ActiveSupport::TestCase
         )
 
       add_stub = stub_request(:post, "http://localhost:8282/api/v2/torrents/add")
-        .with(body: hash_including("urls" => "magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "sequentialDownload" => "true"))
+        .with do |request|
+          params = URI.decode_www_form(request.body).to_h
+          params["urls"] == "magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" &&
+            !params.key?("sequentialDownload")
+        end
         .to_return(status: 200, body: "Ok.")
 
       stub_request(:get, "http://localhost:8282/api/v2/torrents/info?hashes=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
@@ -72,7 +76,7 @@ class DownloadClients::DecypharrTest < ActiveSupport::TestCase
     end
   end
 
-  test "uploads torrent files with sequential download flag" do
+  test "uploads torrent files without sequential download flag" do
     VCR.turned_off do
       info_dict = {
         "name" => "Decypharr Book.epub",
@@ -99,8 +103,9 @@ class DownloadClients::DecypharrTest < ActiveSupport::TestCase
 
       add_stub = stub_request(:post, "http://localhost:8282/api/v2/torrents/add")
         .with do |request|
-          request.body.include?("name=\"sequentialDownload\"") &&
-            request.body.include?("true")
+          request.headers["Content-Type"]&.include?("multipart/form-data") &&
+            request.body.include?("name=\"torrents\"") &&
+            !request.body.include?("name=\"sequentialDownload\"")
         end
         .to_return(status: 200, body: "Ok.")
 

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -1138,9 +1138,118 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     assert_equal "test content", File.binread(destination)
     assert_includes FileCopyService::LIBRARY_FILE_MODES, File.stat(destination).mode & 0o7777
-    locks = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock"))
-    assert_equal 1, locks.size
-    assert_match(/drvfs:complete/, File.binread(locks.sole))
+    journal = File.join(@dest_dir, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+    assert File.file?(journal)
+    assert_match(/drvfs:complete/, File.binread(journal))
+  end
+
+  test "DrvFS publications serialize on one journal instead of rejecting an active worker" do
+    destinations = [ "first", "second" ].map do |name|
+      directory = File.join(@dest_dir, name)
+      FileUtils.mkdir_p(directory)
+      File.join(directory, "book.txt")
+    end
+    copy_started = Queue.new
+    release_copy = Queue.new
+    second_started = Queue.new
+    first_copy = true
+    real_copy = FileCopyService.method(:copy_source_io)
+    blocking_copy = lambda do |source, target, heartbeat: nil|
+      block_this_copy = first_copy
+      first_copy = false
+      if block_this_copy
+        copy_started << true
+        release_copy.pop
+      end
+      real_copy.call(source, target, heartbeat: heartbeat)
+    end
+    first = nil
+    second = nil
+
+    FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+        FileCopyService.stub(:copy_source_io, blocking_copy) do
+          first = Thread.new do
+            FileCopyService.cp_noreplace(@src_file, destinations.first, root: @dest_dir)
+            :published
+          rescue => error
+            error
+          end
+          copy_started.pop
+          second = Thread.new do
+            second_started << true
+            FileCopyService.cp_noreplace(@src_file, destinations.second, root: @dest_dir)
+            :published
+          rescue => error
+            error
+          end
+          second_started.pop
+          sleep 0.1
+          assert second.alive?, "the second publication should wait for the active journal"
+
+          release_copy << true
+          assert_equal :published, first.value
+          assert_equal :published, second.value
+        end
+      end
+    end
+
+    assert_equal [ "test content", "test content" ], destinations.map { |path| File.binread(path) }
+  ensure
+    release_copy << true if first&.alive?
+    first&.join
+    second&.join
+  end
+
+  test "DrvFS records aborted destination creation and permits a later publication" do
+    failed_destination = File.join(@dest_dir, "failed.txt")
+    retry_destination = File.join(@dest_dir, "retry.txt")
+    real_open = FileCopyService.method(:native_openat)
+    fail_creation = lambda do |directory_fd, basename, flags, mode|
+      if basename == File.basename(failed_destination) && (flags & File::CREAT) != 0
+        raise Errno::ENOSPC, "simulated full destination"
+      end
+
+      real_open.call(directory_fd, basename, flags, mode)
+    end
+
+    FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+        FileCopyService.stub(:native_openat, fail_creation) do
+          assert_raises(Errno::ENOSPC) do
+            FileCopyService.cp_noreplace(@src_file, failed_destination, root: @dest_dir)
+          end
+        end
+
+        journal = File.join(@dest_dir, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+        assert_match(/drvfs:aborted/, File.binread(journal))
+        assert_not File.exist?(failed_destination)
+
+        FileCopyService.cp_noreplace(@src_file, retry_destination, root: @dest_dir)
+      end
+    end
+
+    assert_equal "test content", File.binread(retry_destination)
+  end
+
+  test "DrvFS reuses one bounded journal across completed publications" do
+    FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+        3.times do |index|
+          FileCopyService.cp_noreplace(
+            @src_file,
+            File.join(@dest_dir, "completed-#{index}.txt"),
+            root: @dest_dir
+          )
+        end
+      end
+    end
+
+    internal_entries = Dir.children(@dest_dir).grep(/\A\.shelfarr/)
+    assert_equal [ FileCopyService::DRVFS_COPY_JOURNAL_BASENAME ], internal_entries
+    journal = File.join(@dest_dir, internal_entries.sole)
+    assert_match(/drvfs:complete/, File.binread(journal))
+    assert_operator File.size(journal), :<, 4096
   end
 
   test "DrvFS publication never overwrites an occupied destination" do
@@ -1155,6 +1264,8 @@ class FileCopyServiceTest < ActiveSupport::TestCase
 
     assert_equal "existing library bytes", File.binread(destination)
     assert_equal "test content", File.binread(@src_file)
+    journal = File.join(@dest_dir, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+    assert_match(/drvfs:conflict/, File.binread(journal))
   end
 
   test "DrvFS interruption retains the partial destination and blocks unsafe retry cleanup" do
@@ -1175,7 +1286,9 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_instance_of IOError, error.cause
     assert_match(/manual review/, error.message)
     assert_equal "partial", File.binread(destination)
-    assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
+    journal = File.join(@dest_dir, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+    assert File.file?(journal)
+    assert_match(/drvfs:copying/, File.binread(journal))
     retry_error = FileCopyService.stub(:hardlink_identity_unreliable?, true) do
       FileCopyService.stub(:drvfs_mount?, true) do
         assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -635,6 +635,176 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal [ "referenced.txt" ], Dir.children(@dest_dir)
   end
 
+  test "reference_noreplace resolves an absolute source symlink to its final regular file" do
+    staging = File.join(@tmp_dir, "staged-reference.txt")
+    target = File.join(@tmp_dir, "content", "final-reference.txt")
+    destination = File.join(@dest_dir, "absolute-reference.txt")
+    FileUtils.mkdir_p(File.dirname(target))
+    File.binwrite(target, "remote content")
+    File.symlink(target, staging)
+    snapshot = FileCopyService.snapshot_reference_source(staging, authorized_roots: [ @tmp_dir ])
+
+    FileCopyService.reference_noreplace(
+      staging,
+      destination,
+      root: @dest_dir,
+      source_root: nil,
+      source_snapshot: snapshot
+    )
+
+    assert File.symlink?(destination)
+    assert_equal Pathname(target).realpath.to_s, File.readlink(destination)
+    refute_equal Pathname(staging).expand_path.to_s, File.readlink(destination)
+    assert FileCopyService.reference_target_matches?(
+      staging,
+      destination,
+      root: @dest_dir,
+      source_snapshot: snapshot
+    )
+    File.unlink(staging)
+    assert_equal "remote content", File.binread(destination)
+  end
+
+  test "reference_noreplace resolves a relative source symlink against its pinned parent" do
+    staging_directory = File.join(@tmp_dir, "staging")
+    target = File.join(@tmp_dir, "content", "relative-reference.txt")
+    staging = File.join(staging_directory, "relative-reference.txt")
+    destination = File.join(@dest_dir, "relative-reference.txt")
+    FileUtils.mkdir_p([ staging_directory, File.dirname(target) ])
+    File.binwrite(target, "relative remote content")
+    File.symlink(File.join("..", "content", "relative-reference.txt"), staging)
+
+    FileCopyService.reference_noreplace(
+      staging,
+      destination,
+      root: @dest_dir,
+      source_root: nil,
+      authorized_roots: [ @tmp_dir ]
+    )
+
+    assert_equal Pathname(target).realpath.to_s, File.readlink(destination)
+    File.unlink(staging)
+    assert_equal "relative remote content", File.binread(destination)
+  end
+
+  test "reference_noreplace rejects an immediate symlink target outside authorized roots" do
+    authorized = File.join(@tmp_dir, "authorized")
+    outside = File.join(@tmp_dir, "outside")
+    staging = File.join(authorized, "escaped-reference.txt")
+    target = File.join(outside, "private.txt")
+    destination = File.join(@dest_dir, "escaped-reference.txt")
+    FileUtils.mkdir_p([ authorized, outside ])
+    File.binwrite(target, "private content")
+    File.symlink(target, staging)
+
+    assert_raises(FileCopyService::UnsafePathError) do
+      FileCopyService.reference_noreplace(
+        staging,
+        destination,
+        root: @dest_dir,
+        source_root: nil,
+        authorized_roots: [ authorized ]
+      )
+    end
+
+    assert_not File.exist?(destination)
+    assert_equal "private content", File.binread(target)
+  end
+
+  test "reference_noreplace rejects second-level links and non-regular final targets" do
+    authorized = File.join(@tmp_dir, "authorized-reference-targets")
+    FileUtils.mkdir_p(authorized)
+    regular = File.join(authorized, "regular.txt")
+    second_link = File.join(authorized, "second-link.txt")
+    directory = File.join(authorized, "directory")
+    fifo = File.join(authorized, "target.pipe")
+    File.binwrite(regular, "regular content")
+    File.symlink(regular, second_link)
+    FileUtils.mkdir_p(directory)
+    File.mkfifo(fifo)
+
+    {
+      "second-level" => second_link,
+      "dangling" => File.join(authorized, "missing.txt"),
+      "directory" => directory,
+      "fifo" => fifo
+    }.each do |name, target|
+      staging = File.join(authorized, "#{name}-staging")
+      destination = File.join(@dest_dir, "#{name}.txt")
+      File.symlink(target, staging)
+
+      assert_raises(SystemCallError, FileCopyService::UnsafePathError) do
+        FileCopyService.reference_noreplace(
+          staging,
+          destination,
+          root: @dest_dir,
+          source_root: nil,
+          authorized_roots: [ authorized ]
+        )
+      end
+      assert_not File.exist?(destination)
+    end
+  end
+
+  test "reference_noreplace rejects replacement of a snapshotted staging symlink" do
+    staging = File.join(@tmp_dir, "raced-reference.txt")
+    original = File.join(@tmp_dir, "original-reference.txt")
+    replacement = File.join(@tmp_dir, "replacement-reference.txt")
+    destination = File.join(@dest_dir, "raced-reference.txt")
+    File.binwrite(original, "original content")
+    File.binwrite(replacement, "replacement content")
+    File.symlink(original, staging)
+    snapshot = FileCopyService.snapshot_reference_source(staging, authorized_roots: [ @tmp_dir ])
+    real_symlinkat = FileCopyService.method(:native_symlinkat)
+    replacing_publication = lambda do |target, directory_fd, basename|
+      File.unlink(staging)
+      File.symlink(replacement, staging)
+      real_symlinkat.call(target, directory_fd, basename)
+    end
+
+    FileCopyService.stub(:native_symlinkat, replacing_publication) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.reference_noreplace(
+          staging,
+          destination,
+          root: @dest_dir,
+          source_root: nil,
+          source_snapshot: snapshot
+        )
+      end
+    end
+
+    assert_equal Pathname(original).realpath.to_s, File.readlink(destination)
+    assert_equal "original content", File.binread(destination)
+  end
+
+  test "copy move and hardlink modes continue to reject an immediate source symlink" do
+    staging = File.join(@tmp_dir, "mode-staging.txt")
+    target = File.join(@tmp_dir, "mode-target.txt")
+    File.binwrite(target, "mode content")
+    File.symlink(target, staging)
+
+    {
+      "copy" => ->(destination) { FileCopyService.cp_noreplace(staging, destination, root: @dest_dir) },
+      "move" => ->(destination) { FileCopyService.mv_noreplace(staging, destination, root: @dest_dir) },
+      "hardlink" => lambda do |destination|
+        FileCopyService.hardlink_noreplace(
+          staging,
+          destination,
+          root: @dest_dir,
+          source_root: nil
+        )
+      end
+    }.each do |mode, operation|
+      destination = File.join(@dest_dir, "#{mode}-symlink.txt")
+      assert_raises(FileCopyService::UnsafePathError) { operation.call(destination) }
+      assert_not File.exist?(destination)
+    end
+
+    assert File.symlink?(staging)
+    assert_equal "mode content", File.binread(target)
+  end
+
   test "reference_target_matches compares the exact normalized symlink target" do
     destination = File.join(@dest_dir, "referenced.txt")
     source_alias = File.join(@tmp_dir, "missing", "..", "source.txt")

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -1327,6 +1327,27 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     second&.join
   end
 
+  test "DrvFS publication stops waiting after the journal lock deadline" do
+    destination = File.join(@dest_dir, "timed-out.txt")
+    journal_path = File.join(@dest_dir, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+
+    File.open(journal_path, File::RDWR | File::CREAT, 0o600) do |holder|
+      assert holder.flock(File::LOCK_EX | File::LOCK_NB)
+
+      error = FileCopyService.stub(:drvfs_mount?, true) do
+        FileCopyService.stub(:drvfs_copy_lock_timeout, 0) do
+          assert_raises(FileCopyService::PublicationBusyError) do
+            FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+          end
+        end
+      end
+
+      assert_match(/retry this import later/, error.message)
+    end
+
+    assert_not File.exist?(destination)
+  end
+
   test "DrvFS records aborted destination creation and permits a later publication" do
     failed_destination = File.join(@dest_dir, "failed.txt")
     retry_destination = File.join(@dest_dir, "retry.txt")

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -1348,6 +1348,43 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_not File.exist?(destination)
   end
 
+  test "DrvFS publication with a heartbeat keeps waiting past the worker deadline" do
+    destination = File.join(@dest_dir, "heartbeat-waiter.txt")
+    journal_path = File.join(@dest_dir, FileCopyService::DRVFS_COPY_JOURNAL_BASENAME)
+    heartbeat_count = 0
+    result = nil
+
+    File.open(journal_path, File::RDWR | File::CREAT, 0o600) do |holder|
+      assert holder.flock(File::LOCK_EX | File::LOCK_NB)
+
+      waiter = Thread.new do
+        FileCopyService.stub(:drvfs_mount?, true) do
+          FileCopyService.stub(:drvfs_copy_lock_timeout, 0) do
+            FileCopyService.cp_noreplace(
+              @src_file,
+              destination,
+              root: @dest_dir,
+              heartbeat: -> { heartbeat_count += 1 }
+            )
+          end
+        end
+      rescue => error
+        error
+      end
+
+      Timeout.timeout(1) { sleep 0.01 until heartbeat_count.positive? }
+      assert waiter.alive?, "the heartbeat-aware publication should remain cancellably queued"
+      holder.flock(File::LOCK_UN)
+      result = waiter.value
+    ensure
+      holder.flock(File::LOCK_UN)
+      waiter&.join
+    end
+
+    assert_equal destination, result
+    assert_equal "test content", File.binread(destination)
+  end
+
   test "DrvFS records aborted destination creation and permits a later publication" do
     failed_destination = File.join(@dest_dir, "failed.txt")
     retry_destination = File.join(@dest_dir, "retry.txt")

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -778,6 +778,63 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal "original content", File.binread(destination)
   end
 
+  test "reference source root snapshots and publishes immediate symlink leaves" do
+    source_root = File.join(@tmp_dir, "decypharr-release")
+    nested = File.join(source_root, "disc")
+    target = File.join(@tmp_dir, "debrid-content", "chapter.m4b")
+    source = File.join(nested, "chapter.m4b")
+    destination = File.join(@dest_dir, "chapter.m4b")
+    FileUtils.mkdir_p([ nested, File.dirname(target) ])
+    File.binwrite(target, "mounted chapter")
+    File.symlink(File.join("..", "..", "debrid-content", "chapter.m4b"), source)
+
+    root_snapshot = FileCopyService.snapshot_reference_source_root(
+      source_root,
+      authorized_roots: [ @tmp_dir ]
+    )
+    source_snapshot = root_snapshot.reference_snapshots.fetch("disc/chapter.m4b")
+    FileCopyService.reference_noreplace(
+      source,
+      destination,
+      root: @dest_dir,
+      source_root: nil,
+      source_snapshot: source_snapshot
+    )
+
+    assert_equal :reference, root_snapshot.entries.fetch("disc/chapter.m4b")[2]
+    assert_equal Pathname(target).realpath.to_s, File.readlink(destination)
+    assert_equal "mounted chapter", File.binread(destination)
+  end
+
+  test "reference source root rejects a changed snapshotted leaf" do
+    source_root = File.join(@tmp_dir, "raced-reference-release")
+    original = File.join(@tmp_dir, "original-leaf.m4b")
+    replacement = File.join(@tmp_dir, "replacement-leaf.m4b")
+    source = File.join(source_root, "book.m4b")
+    destination = File.join(@dest_dir, "book.m4b")
+    FileUtils.mkdir_p(source_root)
+    File.binwrite(original, "original")
+    File.binwrite(replacement, "replacement")
+    File.symlink(original, source)
+    root_snapshot = FileCopyService.snapshot_reference_source_root(
+      source_root,
+      authorized_roots: [ @tmp_dir ]
+    )
+    File.unlink(source)
+    File.symlink(replacement, source)
+
+    assert_raises(Errno::ESTALE) do
+      FileCopyService.reference_noreplace(
+        source,
+        destination,
+        root: @dest_dir,
+        source_root: nil,
+        source_snapshot: root_snapshot.reference_snapshots.fetch("book.m4b")
+      )
+    end
+    assert_not File.exist?(destination)
+  end
+
   test "copy move and hardlink modes continue to reject an immediate source symlink" do
     staging = File.join(@tmp_dir, "mode-staging.txt")
     target = File.join(@tmp_dir, "mode-target.txt")

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -778,6 +778,86 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal "original content", File.binread(destination)
   end
 
+  test "reference_noreplace rejects a target parent swapped before target snapshot" do
+    authorized = File.join(@tmp_dir, "authorized-parent")
+    original_parent = File.join(authorized, "content")
+    displaced_parent = File.join(authorized, "content-original")
+    outside = File.join(@tmp_dir, "outside-parent")
+    staging = File.join(authorized, "staged-reference.txt")
+    destination = File.join(@dest_dir, "parent-raced-reference.txt")
+    FileUtils.mkdir_p([ original_parent, outside ])
+    File.binwrite(File.join(original_parent, "book.txt"), "authorized content")
+    File.binwrite(File.join(outside, "book.txt"), "outside content")
+    File.symlink(File.join(original_parent, "book.txt"), staging)
+    original_snapshot = FileCopyService.method(:snapshot_reference_target)
+    swapped = false
+    swap_parent = lambda do |target|
+      unless swapped
+        File.rename(original_parent, displaced_parent)
+        File.symlink(outside, original_parent)
+        swapped = true
+      end
+      original_snapshot.call(target)
+    end
+
+    FileCopyService.stub(:snapshot_reference_target, swap_parent) do
+      assert_raises(FileCopyService::UnsafePathError) do
+        snapshot = FileCopyService.snapshot_reference_source(
+          staging,
+          authorized_roots: [ authorized ]
+        )
+        FileCopyService.reference_noreplace(
+          staging,
+          destination,
+          root: @dest_dir,
+          source_root: nil,
+          source_snapshot: snapshot
+        )
+      end
+    end
+
+    assert swapped
+    assert_not File.exist?(destination)
+    assert_equal "outside content", File.binread(File.join(outside, "book.txt"))
+  end
+
+  test "reference_noreplace rejects an authorized root replaced during publication" do
+    authorized = File.join(@tmp_dir, "authorized-root")
+    displaced = File.join(@tmp_dir, "authorized-root-original")
+    content = File.join(authorized, "content")
+    staging = File.join(@tmp_dir, "root-raced-reference.txt")
+    target = File.join(content, "book.txt")
+    destination = File.join(@dest_dir, "root-raced-reference.txt")
+    FileUtils.mkdir_p(content)
+    File.binwrite(target, "authorized content")
+    File.symlink(target, staging)
+    snapshot = FileCopyService.snapshot_reference_source(staging, authorized_roots: [ authorized ])
+    real_symlinkat = FileCopyService.method(:native_symlinkat)
+    swapped = false
+    swap_root = lambda do |link_target, directory_fd, basename|
+      File.rename(authorized, displaced)
+      FileUtils.mkdir_p(authorized)
+      File.rename(File.join(displaced, "content"), content)
+      swapped = true
+      real_symlinkat.call(link_target, directory_fd, basename)
+    end
+
+    FileCopyService.stub(:native_symlinkat, swap_root) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.reference_noreplace(
+          staging,
+          destination,
+          root: @dest_dir,
+          source_root: nil,
+          source_snapshot: snapshot
+        )
+      end
+    end
+
+    assert swapped
+    assert_equal "authorized content", File.binread(destination)
+  end
+
   test "reference source root snapshots and publishes immediate symlink leaves" do
     source_root = File.join(@tmp_dir, "decypharr-release")
     nested = File.join(source_root, "disc")

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -987,6 +987,176 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_empty Dir.children(@dest_dir)
   end
 
+  test "detects only 9p mounts explicitly backed by DrvFS" do
+    skip "Linux mountinfo is required" unless RUBY_PLATFORM.include?("linux")
+
+    stat = File.stat(@dest_dir)
+    device = "#{stat.dev_major}:#{stat.dev_minor}"
+    mountpoint = @tmp_dir.gsub(" ", "\\040")
+    drvfs_mountinfo =
+      "2286 2276 #{device} / #{mountpoint} rw,noatime - 9p D:\\\\134 " \
+      "rw,aname=drvfs;path=D:\\\\;uid=1000;gid=1000;metadata,cache=5\n"
+    ordinary_9p_mountinfo =
+      "2286 2276 #{device} / #{mountpoint} rw,noatime - 9p hostshare rw,trans=virtio\n"
+    misleading_mountinfo =
+      "2286 2276 #{device} / #{mountpoint} rw,noatime - ext4 /dev/test rw,aname=drvfs\n"
+
+    File.stub(:binread, drvfs_mountinfo.b) do
+      assert FileCopyService.send(:drvfs_mount?, @dest_dir)
+      assert FileCopyService.send(:hardlink_identity_unreliable?, @dest_dir)
+    end
+    [ ordinary_9p_mountinfo, misleading_mountinfo ].each do |mountinfo|
+      File.stub(:binread, mountinfo.b) do
+        assert_not FileCopyService.send(:drvfs_mount?, @dest_dir)
+      end
+    end
+  end
+
+  test "DrvFS cleanup never quarantines an entry whose rename can change identity" do
+    target = File.join(@dest_dir, "drvfs-cleanup-target")
+    File.binwrite(target, "retain me")
+    identity = [ File.stat(target).dev, File.stat(target).ino ]
+
+    result = FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:native_renameat, ->(*) { flunk "DrvFS cleanup must not move an identity-ambiguous entry" }) do
+        FileCopyService.send(:with_pinned_destination_parent, target, root: @dest_dir) do |parent, basename, _|
+          FileCopyService.send(:remove_pinned_child_if_identity, parent, basename, identity)
+        end
+      end
+    end
+
+    assert_equal :retained, result
+    assert_equal "retain me", File.binread(target)
+    assert_empty Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*"))
+  end
+
+  test "publication preserves its primary atomic error when quarantine identity changes" do
+    destination = File.join(@dest_dir, "primary-error.txt")
+    real_rename = FileCopyService.method(:native_renameat)
+    real_identity = FileCopyService.method(:file_identity)
+    quarantined = false
+    moving_to_quarantine = lambda do |source_fd, source_name, destination_fd, destination_name|
+      result = real_rename.call(source_fd, source_name, destination_fd, destination_name)
+      quarantined = true if destination_name == FileCopyService::COPY_QUARANTINE_ENTRY
+      result
+    end
+    changed_after_rename = lambda do |stat|
+      identity = real_identity.call(stat)
+      quarantined && stat.file? ? [ identity.first, identity.last + 1 ] : identity
+    end
+    primary = FileCopyService::AtomicPublicationUnsupportedError.new("atomic publication unavailable")
+
+    error = FileCopyService.stub(:drvfs_mount?, false) do
+      FileCopyService.stub(:publish_private_child_atomically_noreplace!, ->(*) { raise primary }) do
+        FileCopyService.stub(:native_renameat, moving_to_quarantine) do
+          FileCopyService.stub(:native_rename_noreplace, false) do
+            FileCopyService.stub(:file_identity, changed_after_rename) do
+              assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+                FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    assert_same primary, error
+    assert quarantined
+    quarantine = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-quarantine-*")).sole
+    assert_equal "test content",
+      File.binread(File.join(quarantine, FileCopyService::COPY_QUARANTINE_ENTRY))
+    assert_not File.exist?(destination)
+  end
+
+  test "DrvFS publication uses an exclusive verified direct copy" do
+    destination = File.join(@dest_dir, "drvfs-compatible.txt")
+
+    FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:native_rename_noreplace, ->(*) { flunk "DrvFS publication must not rename" }) do
+        FileCopyService.stub(:native_linkat, ->(*) { flunk "DrvFS publication must not hardlink" }) do
+          FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+        end
+      end
+    end
+
+    assert_equal "test content", File.binread(destination)
+    assert_includes FileCopyService::LIBRARY_FILE_MODES, File.stat(destination).mode & 0o7777
+    locks = Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock"))
+    assert_equal 1, locks.size
+    assert_match(/drvfs:complete/, File.binread(locks.sole))
+  end
+
+  test "DrvFS publication never overwrites an occupied destination" do
+    destination = File.join(@dest_dir, "drvfs-occupied.txt")
+    File.binwrite(destination, "existing library bytes")
+
+    FileCopyService.stub(:drvfs_mount?, true) do
+      assert_raises(Errno::EEXIST) do
+        FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+      end
+    end
+
+    assert_equal "existing library bytes", File.binread(destination)
+    assert_equal "test content", File.binread(@src_file)
+  end
+
+  test "DrvFS interruption retains the partial destination and blocks unsafe retry cleanup" do
+    destination = File.join(@dest_dir, "drvfs-partial.txt")
+
+    error = FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:copy_source_io, lambda { |_source, target, **|
+        target.write("partial")
+        target.flush
+        raise IOError, "simulated interrupted direct copy"
+      }) do
+        assert_raises(FileCopyService::AmbiguousPublicationError) do
+          FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+        end
+      end
+    end
+
+    assert_instance_of IOError, error.cause
+    assert_match(/manual review/, error.message)
+    assert_equal "partial", File.binread(destination)
+    assert_equal 1, Dir.glob(File.join(@dest_dir, ".shelfarr-copy-*.lock")).size
+    retry_error = FileCopyService.stub(:hardlink_identity_unreliable?, true) do
+      FileCopyService.stub(:drvfs_mount?, true) do
+        assert_raises(FileCopyService::AtomicPublicationUnsupportedError) do
+          FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+        end
+      end
+    end
+    assert_match(/manual cleanup/, retry_error.message)
+    assert_equal "partial", File.binread(destination)
+  end
+
+  test "DrvFS verification retains both pathname entries after destination replacement" do
+    destination = File.join(@dest_dir, "drvfs-replaced.txt")
+    displaced = File.join(@dest_dir, "drvfs-created-entry.txt")
+    real_copy = FileCopyService.method(:copy_source_io)
+    replaced = false
+    replacing_copy = lambda do |source, target, heartbeat: nil|
+      real_copy.call(source, target, heartbeat: heartbeat)
+      File.rename(destination, displaced)
+      File.binwrite(destination, "replacement bytes")
+      replaced = true
+    end
+
+    error = FileCopyService.stub(:drvfs_mount?, true) do
+      FileCopyService.stub(:copy_source_io, replacing_copy) do
+        assert_raises(FileCopyService::AmbiguousPublicationError) do
+          FileCopyService.cp_noreplace(@src_file, destination, root: @dest_dir)
+        end
+      end
+    end
+
+    assert replaced
+    assert_match(/manual review/, error.message)
+    assert_equal "replacement bytes", File.binread(destination)
+    assert_equal "test content", File.binread(displaced)
+    assert_equal "test content", File.binread(@src_file)
+  end
+
   test "cp_noreplace classifies an unusable linked destination as ambiguous" do
     destination = File.join(@dest_dir, "ambiguous-link.txt")
     destination_basename = File.basename(destination)

--- a/test/services/file_copy_service_test.rb
+++ b/test/services/file_copy_service_test.rb
@@ -858,6 +858,52 @@ class FileCopyServiceTest < ActiveSupport::TestCase
     assert_equal "authorized content", File.binread(destination)
   end
 
+  test "reference_noreplace revalidates a regular source root during publication and retry" do
+    authorized = File.join(@tmp_dir, "regular-authorized-root")
+    content = File.join(authorized, "content")
+    displaced = File.join(@tmp_dir, "regular-authorized-root-original")
+    source = File.join(content, "book.txt")
+    destination = File.join(@dest_dir, "regular-root-raced-reference.txt")
+    FileUtils.mkdir_p(content)
+    File.binwrite(source, "authorized regular content")
+    source_snapshot = FileCopyService.snapshot_source_file(source)
+    root_snapshot = FileCopyService.snapshot_reference_root(authorized)
+    real_symlinkat = FileCopyService.method(:native_symlinkat)
+    swapped = false
+    swap_root = lambda do |link_target, directory_fd, basename|
+      File.rename(authorized, displaced)
+      FileUtils.mkdir_p(authorized)
+      File.rename(File.join(displaced, "content"), content)
+      swapped = true
+      real_symlinkat.call(link_target, directory_fd, basename)
+    end
+
+    FileCopyService.stub(:native_symlinkat, swap_root) do
+      assert_raises(Errno::ESTALE) do
+        FileCopyService.reference_noreplace(
+          source,
+          destination,
+          root: @dest_dir,
+          source_root: nil,
+          source_snapshot: source_snapshot,
+          authorized_root_snapshot: root_snapshot
+        )
+      end
+    end
+
+    assert swapped
+    assert_equal "authorized regular content", File.binread(destination)
+    assert_raises(Errno::ESTALE) do
+      FileCopyService.reference_target_matches?(
+        source,
+        destination,
+        root: @dest_dir,
+        source_snapshot: source_snapshot,
+        authorized_root_snapshot: root_snapshot
+      )
+    end
+  end
+
   test "reference source root snapshots and publishes immediate symlink leaves" do
     source_root = File.join(@tmp_dir, "decypharr-release")
     nested = File.join(source_root, "disc")

--- a/test/services/library_path_safety_test.rb
+++ b/test/services/library_path_safety_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LibraryPathSafetyTest < ActiveSupport::TestCase
+  test "all persisted upload destination validators reject internal namespaces" do
+    root = Pathname(Dir.mktmpdir("library-path-safety"))
+
+    LibraryPathSafety::INTERNAL_DIRECTORIES.each do |directory|
+      destination = root.join(directory, "Book", "book.epub")
+
+      assert_raises(UploadImportFileService::Error) do
+        UploadImportFileService.send(:validate_path_within_root!, destination, root)
+      end
+      assert_raises(UploadZipImportFileService::Error) do
+        UploadZipImportFileService.send(:validate_within_root!, destination, root)
+      end
+    end
+  ensure
+    FileUtils.rm_rf(root) if root
+  end
+end

--- a/test/services/metadata_collection_service_test.rb
+++ b/test/services/metadata_collection_service_test.rb
@@ -16,6 +16,7 @@ class MetadataCollectionServiceTest < ActiveSupport::TestCase
       series_name: "Saga",
       issue_number: "1",
       release_date: "2012-03-14",
+      series_start_year: 2012,
       content_kind: "book",
       collection_id: nil,
       collection_title: nil,
@@ -45,6 +46,7 @@ class MetadataCollectionServiceTest < ActiveSupport::TestCase
         assert_equal "collection", items.first.metadata_attrs[:request_scope]
         assert_equal "4050-99", items.first.metadata_attrs[:collection_id]
         assert_equal "Saga", items.first.metadata_attrs[:collection_title]
+        assert_equal 2012, items.first.metadata_attrs[:series_start_year]
         assert_equal "1", items.first.metadata_attrs[:series_position]
         assert_equal "graphic", items.first.metadata_attrs[:content_kind]
       end

--- a/test/services/metadata_search/result_normalizer_test.rb
+++ b/test/services/metadata_search/result_normalizer_test.rb
@@ -167,6 +167,7 @@ module MetadataSearch
         series_name: "Saga",
         issue_number: resource_type == "issue" ? "1" : nil,
         release_date: "2012-03-14",
+        series_start_year: 2012,
         content_kind: "graphic",
         collection_id: "4050-1",
         collection_title: "Saga",

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -409,6 +409,7 @@ class MetadataServiceTest < ActiveSupport::TestCase
       series_name: "Saga",
       issue_number: "1",
       release_date: "2012-03-14",
+      series_start_year: 2012,
       content_kind: "graphic",
       collection_id: "4050-99",
       collection_title: "Saga",
@@ -422,6 +423,7 @@ class MetadataServiceTest < ActiveSupport::TestCase
       assert_equal "Saga - #1", result.title
       assert_equal "Writer One", result.author
       assert_equal "graphic", result.content_kind
+      assert_equal 2012, result.series_start_year
     end
   end
 

--- a/test/services/owned_media_import_file_service_test.rb
+++ b/test/services/owned_media_import_file_service_test.rb
@@ -92,7 +92,7 @@ class OwnedMediaImportFileServiceTest < ActiveSupport::TestCase
           @media_import,
           StringIO.new("new bytes"),
           ".m4b",
-          root: Pathname(@output_root)
+          root: Pathname(@output_root).realpath
         )
       end
     end

--- a/test/services/owned_media_import_file_service_test.rb
+++ b/test/services/owned_media_import_file_service_test.rb
@@ -131,6 +131,24 @@ class OwnedMediaImportFileServiceTest < ActiveSupport::TestCase
     assert_equal 0o640, File.stat(destination).mode & 0o777
   end
 
+  test "a persisted reservation cannot be redirected into direct-download staging" do
+    service = persistent_service
+    internal_directory = File.join(
+      File.realpath(@output_root),
+      DirectDownloadFileService::STAGING_DIRECTORY,
+      "Injected"
+    )
+    @media_import.update!(
+      destination_path: File.join(internal_directory, "book.m4b"),
+      library_path: internal_directory
+    )
+
+    assert_raises(OwnedMediaImportFileService::Error) do
+      service.with_destination_lock { service.finalize! }
+    end
+    assert_not File.exist?(internal_directory)
+  end
+
   test "filesystem capability probe verifies locking hard links and library permissions" do
     assert OwnedMediaImportFileService.verify_filesystem_capabilities!
     assert_empty Dir.glob(File.join(@output_root, ".shelfarr-capability-*"))

--- a/test/services/path_template_service_test.rb
+++ b/test/services/path_template_service_test.rb
@@ -231,6 +231,23 @@ class PathTemplateServiceTest < ActiveSupport::TestCase
     assert_includes error, ".."
   end
 
+  test "rejects direct-download staging in configured and rendered paths" do
+    valid, error = PathTemplateService.validate_template(".shelfarr-staging-v2/{title}")
+
+    assert_not valid
+    assert_match(/internal staging/i, error)
+
+    @book.update!(author: DirectDownloadFileService::STAGING_DIRECTORY)
+    assert_raises(PathTemplateService::UnsafePathError) do
+      PathTemplateService.build_path(@book, "{author}/{title}")
+    end
+
+    @book.update!(author: DirectDownloadFileService::STAGING_DIRECTORY.upcase)
+    assert_raises(PathTemplateService::UnsafePathError) do
+      PathTemplateService.build_path(@book, "{author}/{title}")
+    end
+  end
+
   test "validate_template returns error for unknown variables" do
     valid, error = PathTemplateService.validate_template("{author}/{title}/{unknown}")
     assert_not valid

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -229,24 +229,114 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     assert_not conflicting_score.breakdown[:auto_select_allowed]
   end
 
-  test "does not reject a comic release containing an ambiguous issue range" do
+  test "requires an explicit comic run year to match the requested release year" do
+    book = Book.create!(
+      title: "Batman - #1 - The Legend of the Batman",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-438",
+      issue_number: "1",
+      series: "Batman",
+      release_date: Date.new(1940, 4, 1)
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    correct_titles = [
+      "Batman (1940) #001 English Comic CBZ",
+      "Batman #001 (1940) English Comic CBZ"
+    ]
+    conflicting_titles = [
+      "Batman (2016) #001 English Comic CBZ",
+      "Batman #001 (2016) English Comic CBZ"
+    ]
+
+    correct_titles.each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
+
+      assert_equal :exact, score.breakdown[:issue_match], title
+      assert score.breakdown[:auto_select_allowed], title
+    end
+    conflicting_titles.each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
+
+      assert_equal :unknown, score.breakdown[:issue_match], title
+      assert_operator score.total, :<, 50, title
+      assert_not score.breakdown[:auto_select_allowed], title
+    end
+  end
+
+  test "treats comic issue ranges and lists as ambiguous" do
     book = Book.create!(
       title: "Saga",
       book_type: :comicbook,
       content_kind: :graphic,
       comic_vine_id: "4000-439",
-      issue_number: "7",
+      issue_number: "1",
       series: "Saga"
     )
     request = Request.create!(book: book, user: @user, status: :pending, language: "en")
-    release = SearchResult.new(title: "Saga 1-12 English Comic CBZ", seeders: 50)
 
-    score = ReleaseScorer.score(release, request)
+    [
+      "Saga 1-12 English Comic CBZ",
+      "Saga #001-#006 English Comic CBZ",
+      "Saga #001,#002 English Comic CBZ",
+      "Saga #001 #002 English Comic CBZ"
+    ].each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
 
-    assert_equal :unknown, score.breakdown[:issue_match]
-    assert_operator score.total, :>, 0
-    assert_operator score.total, :<, 50
-    assert_not score.breakdown[:auto_select_allowed]
+      assert_equal :unknown, score.breakdown[:issue_match], title
+      assert_operator score.total, :>, 0, title
+      assert_operator score.total, :<, 50, title
+      assert_not score.breakdown[:auto_select_allowed], title
+    end
+  end
+
+  test "matches punctuated comic series without matching normalized lookalikes" do
+    spider_man = Book.create!(
+      title: "Spider-Man - #7",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "7",
+      series: "Spider-Man"
+    )
+    spider_man_request = Request.create!(book: spider_man, user: @user, status: :pending, language: "en")
+
+    exact = ReleaseScorer.score(SearchResult.new(title: "Spider-Man #7 English Comic CBZ", seeders: 50), spider_man_request)
+    lookalike = ReleaseScorer.score(SearchResult.new(title: "Spiderwoman #7 English Comic CBZ", seeders: 50), spider_man_request)
+
+    assert_equal :exact, exact.breakdown[:issue_match]
+    assert_equal :unknown, lookalike.breakdown[:issue_match]
+
+    x_series = Book.create!(
+      title: "X - #7",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "7",
+      series: "X"
+    )
+    x_request = Request.create!(book: x_series, user: @user, status: :pending, language: "en")
+
+    assert_equal :exact,
+      ReleaseScorer.score(SearchResult.new(title: "X #7 English Comic CBZ", seeders: 50), x_request).breakdown[:issue_match]
+    assert_equal :unknown,
+      ReleaseScorer.score(SearchResult.new(title: "10 #7 English Comic CBZ", seeders: 50), x_request).breakdown[:issue_match]
+  end
+
+  test "normalizes padded numeric stems in comic issue labels" do
+    [ [ "7A", "Saga 007A English Comic CBZ" ], [ "7.5", "Saga 007.5 English Comic CBZ" ] ].each do |issue, title|
+      book = Book.create!(
+        title: "Saga - ##{issue}",
+        book_type: :comicbook,
+        content_kind: :graphic,
+        issue_number: issue,
+        series: "Saga"
+      )
+      request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
+
+      assert_equal :exact, score.breakdown[:issue_match], title
+      assert score.breakdown[:auto_select_allowed], title
+    end
   end
 
   test "does not reject conflicting alphanumeric comic issue labels" do

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -307,6 +307,37 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     end
   end
 
+  test "treats explicitly marked year-shaped values as additional issues" do
+    book = Book.create!(
+      title: "2000 AD - #2000",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "2000",
+      series: "2000 AD"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    [
+      "2000.AD #2000 and #2012 English Comic CBZ",
+      "2000 AD #2000 plus issue 2012 English Comic CBZ",
+      "2000 AD #2000 with No. #2012 English Comic CBZ",
+      "2000 AD #2000 and number 2012 English Comic CBZ"
+    ].each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
+
+      assert_equal :unknown, score.breakdown[:issue_match], title
+      assert_not score.breakdown[:auto_select_allowed], title
+    end
+
+    unmarked_year = ReleaseScorer.score(
+      SearchResult.new(title: "2000 AD #2000 published 2012 English Comic CBZ", seeders: 50),
+      request
+    )
+
+    assert_equal :exact, unmarked_year.breakdown[:issue_match]
+    assert unmarked_year.breakdown[:auto_select_allowed]
+  end
+
   test "matches punctuated comic series without matching normalized lookalikes" do
     spider_man = Book.create!(
       title: "Spider-Man - #7",
@@ -354,6 +385,30 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       ReleaseScorer.score(SearchResult.new(title: "Area 52 #007 English Comic CBZ", seeders: 50), numeric_request).breakdown[:issue_match]
     assert_equal :unknown,
       ReleaseScorer.score(SearchResult.new(title: "Batman #52 - #007 English Comic CBZ", seeders: 50), numeric_request).breakdown[:issue_match]
+  end
+
+  test "does not consume issue markers as numeric series punctuation" do
+    [
+      [ "X-23", "7", "X-23 #007 English Comic CBZ", "X #23 #007 English Comic CBZ" ],
+      [ "Batman '66", "1", "Batman '66 #001 English Comic CBZ", "Batman #66 #001 English Comic CBZ" ]
+    ].each do |series, issue, exact_title, conflicting_title|
+      book = Book.create!(
+        title: "#{series} - ##{issue}",
+        book_type: :comicbook,
+        content_kind: :graphic,
+        issue_number: issue,
+        series: series
+      )
+      request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+      exact = ReleaseScorer.score(SearchResult.new(title: exact_title, seeders: 50), request)
+      conflicting = ReleaseScorer.score(SearchResult.new(title: conflicting_title, seeders: 50), request)
+
+      assert_equal :exact, exact.breakdown[:issue_match], exact_title
+      assert exact.breakdown[:auto_select_allowed], exact_title
+      assert_equal :unknown, conflicting.breakdown[:issue_match], conflicting_title
+      assert_not conflicting.breakdown[:auto_select_allowed], conflicting_title
+    end
   end
 
   test "requires the comic series to occupy the leading release identity segment" do

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -202,6 +202,95 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     assert_equal 100, result.breakdown[:title]
   end
 
+  test "rewards an exact comic issue and rejects a conflicting issue" do
+    book = Book.create!(
+      title: "Saga",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-437",
+      issue_number: "7",
+      series: "Saga",
+      series_position: "7"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+    exact = SearchResult.new(title: "Saga #7 English Comic CBZ", seeders: 50)
+    conflicting = SearchResult.new(title: "Saga #8 English Comic CBZ", seeders: 50)
+
+    exact_score = ReleaseScorer.score(exact, request)
+    conflicting_score = ReleaseScorer.score(conflicting, request)
+
+    assert_operator exact_score.total, :>, conflicting_score.total
+    assert_operator exact_score.total, :>=, 90
+    assert_equal :exact, exact_score.breakdown[:issue_match]
+    assert_equal "7", exact_score.breakdown[:detected_issue_number]
+    assert_equal :mismatch, conflicting_score.breakdown[:issue_match]
+    assert_equal 0, conflicting_score.total
+    assert_not conflicting_score.breakdown[:auto_select_allowed]
+  end
+
+  test "does not reject a comic release containing an ambiguous issue range" do
+    book = Book.create!(
+      title: "Saga",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-439",
+      issue_number: "7",
+      series: "Saga"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+    release = SearchResult.new(title: "Saga 1-12 English Comic CBZ", seeders: 50)
+
+    score = ReleaseScorer.score(release, request)
+
+    assert_equal :unknown, score.breakdown[:issue_match]
+    assert_operator score.total, :>, 0
+    assert_operator score.total, :<, 50
+    assert_not score.breakdown[:auto_select_allowed]
+  end
+
+  test "does not reject conflicting alphanumeric comic issue labels" do
+    book = Book.create!(
+      title: "Saga",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-440",
+      issue_number: "7A",
+      series: "Saga"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+    exact = SearchResult.new(title: "Saga #7A English Comic CBZ", seeders: 50)
+    conflicting = SearchResult.new(title: "Saga #7B English Comic CBZ", seeders: 50)
+
+    exact_score = ReleaseScorer.score(exact, request)
+    conflicting_score = ReleaseScorer.score(conflicting, request)
+
+    assert_equal :exact, exact_score.breakdown[:issue_match]
+    assert_equal :unknown, conflicting_score.breakdown[:issue_match]
+    assert_operator conflicting_score.total, :>, 0
+    assert_operator conflicting_score.total, :<, 50
+    assert_not conflicting_score.breakdown[:auto_select_allowed]
+  end
+
+  test "does not treat a Comic Vine volume position as an issue number" do
+    book = Book.create!(
+      title: "Saga Deluxe Volume",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4050-442",
+      issue_number: nil,
+      series: "Saga",
+      series_position: "7"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+    release = SearchResult.new(title: "Saga Deluxe Volume English Comic CBZ", seeders: 50)
+
+    score = ReleaseScorer.score(release, request)
+
+    assert_not score.breakdown.key?(:issue_match)
+    assert score.breakdown[:auto_select_allowed]
+  end
+
   test "scores health based on seeders" do
     search_result = @request.search_results.create!(
       guid: "test-9",

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -229,7 +229,32 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     assert_not conflicting_score.breakdown[:auto_select_allowed]
   end
 
-  test "requires an explicit comic run year to match the requested release year" do
+  test "accepts standard release delimiters after an exact comic issue" do
+    book = Book.create!(
+      title: "Saga",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-437-delimiters",
+      issue_number: "54",
+      series: "Saga",
+      series_position: "54"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    [
+      "Saga.#054.English.Comic.CBZ",
+      "Saga_#054_English_Comic_CBZ"
+    ].each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
+
+      assert_equal :exact, score.breakdown[:issue_match], title
+      assert_operator score.total, :>=, 80, title
+      assert score.breakdown[:auto_select_allowed], title
+    end
+  end
+
+  test "requires an explicit comic run year to match the series start year" do
     book = Book.create!(
       title: "Batman - #1 - The Legend of the Batman",
       book_type: :comicbook,
@@ -237,7 +262,8 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       comic_vine_id: "4000-438",
       issue_number: "1",
       series: "Batman",
-      release_date: Date.new(1940, 4, 1)
+      release_date: Date.new(2018, 4, 1),
+      series_start_year: 1940
     )
     request = Request.create!(book: book, user: @user, status: :pending, language: "en")
 
@@ -257,7 +283,8 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       "Batman [2016] #001 English Comic CBZ",
       "Batman #001 (2016) English Comic CBZ",
       "Batman #001 English Comic CBZ [2016]",
-      "Batman (1940) #001 English Comic CBZ [2016]"
+      "Batman (1940) #001 English Comic CBZ [2016]",
+      "Batman #001 English Comic CBZ [2018]"
     ]
 
     correct_titles.each do |title|
@@ -464,7 +491,8 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       content_kind: :graphic,
       issue_number: "1",
       series: "Batman",
-      release_date: Date.new(1940, 4, 1)
+      release_date: Date.new(2018, 4, 1),
+      series_start_year: 1940
     )
     batman_request = Request.create!(book: batman, user: @user, status: :pending, language: "en")
 

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -242,12 +242,22 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     request = Request.create!(book: book, user: @user, status: :pending, language: "en")
 
     correct_titles = [
+      "(1940) Batman #001 English Comic CBZ",
+      "[1940] Batman #001 English Comic CBZ",
       "Batman (1940) #001 English Comic CBZ",
-      "Batman #001 (1940) English Comic CBZ"
+      "Batman [1940] #001 English Comic CBZ",
+      "Batman #001 (1940) English Comic CBZ",
+      "Batman #001 English Comic CBZ [1940]",
+      "(1940) Batman #001 English Comic CBZ [1940]"
     ]
     conflicting_titles = [
+      "(2016) Batman #001 English Comic CBZ",
+      "[2016] Batman #001 English Comic CBZ",
       "Batman (2016) #001 English Comic CBZ",
-      "Batman #001 (2016) English Comic CBZ"
+      "Batman [2016] #001 English Comic CBZ",
+      "Batman #001 (2016) English Comic CBZ",
+      "Batman #001 English Comic CBZ [2016]",
+      "Batman (1940) #001 English Comic CBZ [2016]"
     ]
 
     correct_titles.each do |title|
@@ -280,7 +290,13 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       "Saga 1-12 English Comic CBZ",
       "Saga #001-#006 English Comic CBZ",
       "Saga #001,#002 English Comic CBZ",
-      "Saga #001 #002 English Comic CBZ"
+      "Saga #001 #002 English Comic CBZ",
+      "Saga #001/#002 English Comic CBZ",
+      "Saga.#001.#002.English.Comic.CBZ",
+      "Saga #001; #002 English Comic CBZ",
+      "Saga #001 thru #006 English Comic CBZ",
+      "Saga #001 through 006 English Comic CBZ",
+      "Saga #001 (Digital) #002 English Comic CBZ"
     ].each do |title|
       score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
 
@@ -320,6 +336,24 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       ReleaseScorer.score(SearchResult.new(title: "X #7 English Comic CBZ", seeders: 50), x_request).breakdown[:issue_match]
     assert_equal :unknown,
       ReleaseScorer.score(SearchResult.new(title: "10 #7 English Comic CBZ", seeders: 50), x_request).breakdown[:issue_match]
+
+    numeric_series = Book.create!(
+      title: "52 - #7",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "7",
+      series: "52"
+    )
+    numeric_request = Request.create!(book: numeric_series, user: @user, status: :pending, language: "en")
+
+    assert_equal :exact,
+      ReleaseScorer.score(SearchResult.new(title: "52 #007 English Comic CBZ", seeders: 50), numeric_request).breakdown[:issue_match]
+    assert_equal :exact,
+      ReleaseScorer.score(SearchResult.new(title: "(1940) 52 #007 English Comic CBZ", seeders: 50), numeric_request).breakdown[:issue_match]
+    assert_equal :unknown,
+      ReleaseScorer.score(SearchResult.new(title: "Area 52 #007 English Comic CBZ", seeders: 50), numeric_request).breakdown[:issue_match]
+    assert_equal :unknown,
+      ReleaseScorer.score(SearchResult.new(title: "Batman #52 - #007 English Comic CBZ", seeders: 50), numeric_request).breakdown[:issue_match]
   end
 
   test "normalizes padded numeric stems in comic issue labels" do

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -483,6 +483,103 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     end
   end
 
+  test "requires a complete canonical comic issue label" do
+    plain_issue = Book.create!(
+      title: "Saga - #1",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "1",
+      series: "Saga"
+    )
+    plain_request = Request.create!(book: plain_issue, user: @user, status: :pending, language: "en")
+    suffixed_title = "Saga #1-A English Comic CBZ"
+
+    ambiguous = ReleaseScorer.score(SearchResult.new(title: suffixed_title, seeders: 50), plain_request)
+
+    assert_equal :unknown, ambiguous.breakdown[:issue_match]
+    assert_not ambiguous.breakdown[:auto_select_allowed]
+    assert_operator ambiguous.total, :<, 50
+
+    suffixed_issue = Book.create!(
+      title: "Saga - #1-A",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "1-A",
+      series: "Saga"
+    )
+    suffixed_request = Request.create!(book: suffixed_issue, user: @user, status: :pending, language: "en")
+    exact = ReleaseScorer.score(SearchResult.new(title: suffixed_title, seeders: 50), suffixed_request)
+
+    assert_equal :exact, exact.breakdown[:issue_match]
+    assert exact.breakdown[:auto_select_allowed]
+  end
+
+  test "does not interpret punctuation-extended series identities as unmarked issues" do
+    [
+      [ "X", "23", "X-23 English Comic CBZ" ],
+      [ "Batman", "66", "Batman-66 English Comic CBZ" ],
+      [ "52", "1", "52.1 English Comic CBZ" ]
+    ].each do |series, issue, title|
+      book = Book.create!(
+        title: "#{series} - ##{issue}",
+        book_type: :comicbook,
+        content_kind: :graphic,
+        issue_number: issue,
+        series: series
+      )
+      request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
+
+      assert_equal :unknown, score.breakdown[:issue_match], title
+      assert_not score.breakdown[:auto_select_allowed], title
+    end
+
+    batman = Book.create!(
+      title: "Batman - #1",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "1",
+      series: "Batman"
+    )
+    request = Request.create!(book: batman, user: @user, status: :pending, language: "en")
+    plain = ReleaseScorer.score(SearchResult.new(title: "Batman 001 English Comic CBZ", seeders: 50), request)
+
+    assert_equal :exact, plain.breakdown[:issue_match]
+    assert plain.breakdown[:auto_select_allowed]
+  end
+
+  test "treats any later standalone issue-shaped number as ambiguous" do
+    book = Book.create!(
+      title: "Saga - #1",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "1",
+      series: "Saga",
+      release_date: Date.new(2012, 3, 14)
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    [
+      "Saga #1 y 2 English Comic CBZ",
+      "Saga #1 et 2 English Comic CBZ",
+      "Saga #1 und 2 English Comic CBZ",
+      "Saga #1 plus 2 English Comic CBZ"
+    ].each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), request)
+
+      assert_equal :unknown, score.breakdown[:issue_match], title
+      assert_not score.breakdown[:auto_select_allowed], title
+    end
+
+    matching_year = ReleaseScorer.score(
+      SearchResult.new(title: "Saga #1 published 2012 English Comic CBZ", seeders: 50),
+      request
+    )
+
+    assert_equal :exact, matching_year.breakdown[:issue_match]
+    assert matching_year.breakdown[:auto_select_allowed]
+  end
+
   test "does not reject conflicting alphanumeric comic issue labels" do
     book = Book.create!(
       title: "Saga",

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -302,6 +302,35 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not trust an explicit comic run year before volume metadata is backfilled" do
+    book = Book.create!(
+      title: "Batman - #1 - The Legend of the Batman",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-105811",
+      issue_number: "1",
+      series: "Batman",
+      series_position: "1",
+      series_start_year: nil
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    yearless_score = ReleaseScorer.score(
+      SearchResult.new(title: "Batman #001 English Comic CBZ", seeders: 50),
+      request
+    )
+    unverified_year_score = ReleaseScorer.score(
+      SearchResult.new(title: "Batman #001 (2016) English Comic CBZ", seeders: 50),
+      request
+    )
+
+    assert_equal :exact, yearless_score.breakdown[:issue_match]
+    assert yearless_score.breakdown[:auto_select_allowed]
+    assert_equal :unknown, unverified_year_score.breakdown[:issue_match]
+    assert_operator unverified_year_score.total, :<, 50
+    assert_not unverified_year_score.breakdown[:auto_select_allowed]
+  end
+
   test "treats comic issue ranges and lists as ambiguous" do
     book = Book.create!(
       title: "Saga",

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -356,6 +356,116 @@ class ReleaseScorerTest < ActiveSupport::TestCase
       ReleaseScorer.score(SearchResult.new(title: "Batman #52 - #007 English Comic CBZ", seeders: 50), numeric_request).breakdown[:issue_match]
   end
 
+  test "requires the comic series to occupy the leading release identity segment" do
+    book = Book.create!(
+      title: "X - #7",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "7",
+      series: "X"
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    score = ReleaseScorer.score(
+      SearchResult.new(title: "Generation X #007 English Comic CBZ", seeders: 50),
+      request
+    )
+
+    assert_equal :unknown, score.breakdown[:issue_match]
+    assert_operator score.total, :<, 50
+    assert_not score.breakdown[:auto_select_allowed]
+  end
+
+  test "treats whitespace-separated issues as ambiguous but not a standalone year" do
+    book = Book.create!(
+      title: "Saga - #1",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "1",
+      series: "Saga",
+      release_date: Date.new(2012, 3, 14)
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    pack_score = ReleaseScorer.score(
+      SearchResult.new(title: "Saga #001 002 English Comic CBZ", seeders: 50),
+      request
+    )
+    year_score = ReleaseScorer.score(
+      SearchResult.new(title: "Saga #001 2012 English Comic CBZ", seeders: 50),
+      request
+    )
+
+    assert_equal :unknown, pack_score.breakdown[:issue_match]
+    assert_not pack_score.breakdown[:auto_select_allowed]
+    assert_equal :exact, year_score.breakdown[:issue_match]
+    assert year_score.breakdown[:auto_select_allowed]
+  end
+
+  test "validates standalone release years outside the matched series and issue spans" do
+    batman = Book.create!(
+      title: "Batman - #1",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "1",
+      series: "Batman",
+      release_date: Date.new(1940, 4, 1)
+    )
+    batman_request = Request.create!(book: batman, user: @user, status: :pending, language: "en")
+
+    conflicting_titles = [
+      "2016 Batman #001 English Comic CBZ",
+      "Batman #001 English Comic CBZ 2016"
+    ]
+    matching_titles = [
+      "1940 Batman #001 English Comic CBZ",
+      "Batman #001 English Comic CBZ 1940"
+    ]
+
+    conflicting_titles.each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), batman_request)
+
+      assert_equal :unknown, score.breakdown[:issue_match], title
+      assert_not score.breakdown[:auto_select_allowed], title
+    end
+    matching_titles.each do |title|
+      score = ReleaseScorer.score(SearchResult.new(title: title, seeders: 50), batman_request)
+
+      assert_equal :exact, score.breakdown[:issue_match], title
+      assert score.breakdown[:auto_select_allowed], title
+    end
+
+    numbered_series = Book.create!(
+      title: "2000 AD - #7",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "7",
+      series: "2000 AD",
+      release_date: Date.new(1977, 3, 5)
+    )
+    numbered_request = Request.create!(book: numbered_series, user: @user, status: :pending, language: "en")
+    numbered_score = ReleaseScorer.score(
+      SearchResult.new(title: "2000.AD #007 English Comic CBZ", seeders: 50),
+      numbered_request
+    )
+    assert_equal :exact, numbered_score.breakdown[:issue_match]
+
+    high_issue = Book.create!(
+      title: "Saga - #2000",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      issue_number: "2000",
+      series: "Saga",
+      release_date: Date.new(2024, 1, 1)
+    )
+    high_issue_request = Request.create!(book: high_issue, user: @user, status: :pending, language: "en")
+    high_issue_score = ReleaseScorer.score(
+      SearchResult.new(title: "Saga #2000 English Comic CBZ", seeders: 50),
+      high_issue_request
+    )
+    assert_equal :exact, high_issue_score.breakdown[:issue_match]
+  end
+
   test "normalizes padded numeric stems in comic issue labels" do
     [ [ "7A", "Saga 007A English Comic CBZ" ], [ "7.5", "Saga 007.5 English Comic CBZ" ] ].each do |issue, title|
       book = Book.create!(

--- a/test/services/request_creation_service_test.rb
+++ b/test/services/request_creation_service_test.rb
@@ -359,6 +359,7 @@ class RequestCreationServiceTest < ActiveSupport::TestCase
           author: "Writer One",
           content_kind: "comic",
           issue_number: "1",
+          series_start_year: 2012,
           series: "Saga",
           series_position: "1",
           request_scope: "collection",
@@ -375,6 +376,7 @@ class RequestCreationServiceTest < ActiveSupport::TestCase
           author: "Writer One",
           content_kind: "comic",
           issue_number: "2",
+          series_start_year: 2012,
           series: "Saga",
           series_position: "2",
           request_scope: "collection",
@@ -416,6 +418,7 @@ class RequestCreationServiceTest < ActiveSupport::TestCase
     assert requests.all? { |request| request.request_scope == "collection" }
     assert_equal [ "4000-102", "4000-101" ], requests.map { |request| request.book.comic_vine_id }
     assert_equal [ "Saga", "Saga" ], requests.map(&:collection_title)
+    assert_equal [ 2012, 2012 ], requests.map { |request| request.book.series_start_year }
     assert requests.all? { |request| request.book.content_graphic? }
   end
 

--- a/test/services/safe_library_deletion_service_test.rb
+++ b/test/services/safe_library_deletion_service_test.rb
@@ -121,16 +121,18 @@ class SafeLibraryDeletionServiceTest < ActiveSupport::TestCase
   end
 
   test "never authorizes Shelfarr internal staging paths as books" do
-    internal_directory = File.join(@root, OwnedMediaImportFileService::STAGING_DIRECTORY)
-    FileUtils.mkdir_p(internal_directory)
-    internal_path = File.join(internal_directory, "staged.m4b")
-    File.binwrite(internal_path, "staged bytes")
-    @book.update!(file_path: internal_path)
+    LibraryPathSafety::INTERNAL_DIRECTORIES.each do |directory|
+      internal_directory = File.join(@root, directory)
+      FileUtils.mkdir_p(internal_directory)
+      internal_path = File.join(internal_directory, "staged.m4b")
+      File.binwrite(internal_path, "staged bytes")
+      @book.update!(file_path: internal_path)
 
-    assert_raises(SafeLibraryDeletionService::Error) do
-      SafeLibraryDeletionService.new(@book).delete!
+      assert_raises(SafeLibraryDeletionService::Error) do
+        SafeLibraryDeletionService.new(@book).delete!
+      end
+      assert_equal "staged bytes", File.binread(internal_path)
     end
-    assert_equal "staged bytes", File.binread(internal_path)
   end
 
   test "supports the configured comic library root" do

--- a/test/services/safe_library_deletion_service_test.rb
+++ b/test/services/safe_library_deletion_service_test.rb
@@ -40,6 +40,24 @@ class SafeLibraryDeletionServiceTest < ActiveSupport::TestCase
     assert_equal "download bytes", File.binread(source)
   end
 
+  test "unlinks a final-target reference after its staging symlink is gone" do
+    download_root = Dir.mktmpdir("reference-download")
+    target = File.join(download_root, "content", "book.epub")
+    staging = File.join(download_root, "staged.epub")
+    FileUtils.mkdir_p(File.dirname(target))
+    File.binwrite(target, "remote download bytes")
+    File.symlink(target, staging)
+    FileUtils.rm_f(@path)
+    File.symlink(Pathname(target).realpath.to_s, @path)
+    File.unlink(staging)
+
+    assert SafeLibraryDeletionService.new(@book).delete!
+    assert_not File.symlink?(@path)
+    assert_equal "remote download bytes", File.binread(target)
+  ensure
+    FileUtils.rm_rf(download_root)
+  end
+
   test "recovers an interrupted reference symlink quarantine" do
     source = File.join(@root, "download-source.epub")
     File.binwrite(source, "download bytes")

--- a/test/services/upload_import_file_service_test.rb
+++ b/test/services/upload_import_file_service_test.rb
@@ -179,6 +179,23 @@ class UploadImportFileServiceTest < ActiveSupport::TestCase
     assert_not reserved_destination.start_with?(File.realpath(@other_library_root))
   end
 
+  test "a persisted reservation cannot be redirected into internal staging" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+    internal_directory = File.join(
+      File.realpath(@library_root),
+      DirectDownloadFileService::STAGING_DIRECTORY,
+      "Injected"
+    )
+    @upload.update_columns(
+      destination_path: File.join(internal_directory, "book.epub"),
+      library_path: internal_directory
+    )
+
+    assert_raises(UploadImportFileService::Error) { service.publish! }
+    assert_not File.exist?(internal_directory)
+  end
+
   test "destination-only recovery requires the persisted content digest" do
     service = UploadImportFileService.new(upload: @upload, book: @book)
     service.reserve!


### PR DESCRIPTION
## Summary

- respect Decypharr download-action configuration instead of forcing direct downloads
- search and score Comic Vine releases by strict series, issue, run-year, language, and format identity
- backfill missing Comic Vine run-year metadata and fail safe on explicit years until it is available
- label comics consistently as Comics & Manga across dashboard, request, and library surfaces
- support descriptor-pinned reference imports from top-level links and directories of symlink leaves
- persist immutable reference target boundaries for later download and deletion authorization
- move new direct downloads to a private v2 staging namespace without touching unsafe legacy state
- add bounded, serialized DrvFS publication and private-staging cleanup while preserving no-clobber guarantees
- reserve all internal staging namespaces across templates, uploads, imports, and deletion
- keep the Libation companion container smoke test portable across GNU/Linux and macOS date implementations
- update json, mail, net-imap, and sqlite3 to patched versions required by the security gate

## Test plan

- [x] Added regression tests that failed against main before each fix
- [x] Focused download/scoring regression suite: 38 tests, 230 assertions
- [x] Focused comic-label rendering suite: 187 tests, 883 assertions
- [x] Full bin/quality push in Ruby 3.3.6 with Chromium
- [x] Full Rails and system suites
- [x] Coverage: 91.19% line, 73.28% branch
- [x] bundler-audit --update: no vulnerabilities
- [x] CIFS serverino and noserverino filesystem contracts
- [x] Libation companion tests and container smoke test
- [x] Manual local UI validation: login, dashboard, request results, comic run-year scoring, completed request detail, and authorized EPUB download
- [x] Manual comic-label UI validation: dashboard recent items and requests, requests list, library grid, and library details
- [x] Browser console and page logs clean during the validated flows
- [x] Repeated adversarial review of the exact PR head with no remaining verified findings
- [x] All GitHub Actions and CodeQL checks green on e70eb5c491cbdb841f9f72e004cf98aef76c5513

Closes #444
Closes #441
Closes #437
Closes #429
Closes #401