### PR TITLE
feat: support qBittorrent API key authentication

### DIFF
--- a/app/controllers/admin/download_clients_controller.rb
+++ b/app/controllers/admin/download_clients_controller.rb
@@ -16,7 +16,7 @@ module Admin
     end
 
     def create
-      @download_client = DownloadClient.new(download_client_params)
+      @download_client = DownloadClient.new(download_client_params.except(:clear_api_key))
       @download_client.priority = next_priority_for(@download_client.client_type)
 
       if @download_client.save
@@ -33,15 +33,26 @@ module Admin
 
     def update
       update_params = download_client_params
+      original_api_key = @download_client.api_key
+      api_key_submitted = update_params[:api_key].present?
       # Don't overwrite password/api_key if left blank
       update_params = update_params.except(:password) if update_params[:password].blank?
-      update_params = update_params.except(:api_key) if update_params[:api_key].blank?
+      @clear_api_key = update_params.delete(:clear_api_key) == "1"
+      if @clear_api_key
+        update_params[:api_key] = nil
+      elsif update_params[:api_key].blank?
+        update_params = update_params.except(:api_key)
+      end
 
       if @download_client.update(update_params)
         run_download_client_health_check
         sync_download_monitor
         redirect_to admin_download_clients_path, notice: "Download client was successfully updated."
       else
+        @download_client.api_key = original_api_key
+        if api_key_submitted && !@clear_api_key
+          @download_client.errors.add(:api_key, "replacement was not saved; re-enter it after correcting the other errors")
+        end
         render :edit, status: :unprocessable_entity
       end
     end
@@ -82,7 +93,7 @@ module Admin
 
     def download_client_params
       params.require(:download_client).permit(
-        :name, :client_type, :url, :username, :password, :api_key, :category, :download_path, :enabled,
+        :name, :client_type, :url, :username, :password, :api_key, :clear_api_key, :category, :download_path, :enabled,
         :torrent_verification_max_attempts, :torrent_verification_wait_time
       )
     end

--- a/app/controllers/admin/download_clients_controller.rb
+++ b/app/controllers/admin/download_clients_controller.rb
@@ -33,7 +33,7 @@ module Admin
 
     def update
       update_params = download_client_params
-      original_api_key = @download_client.api_key
+      @api_key_saved = @download_client.api_key.present?
       api_key_submitted = update_params[:api_key].present?
       # Don't overwrite password/api_key if left blank
       update_params = update_params.except(:password) if update_params[:password].blank?
@@ -49,7 +49,9 @@ module Admin
         sync_download_monitor
         redirect_to admin_download_clients_path, notice: "Download client was successfully updated."
       else
-        @download_client.api_key = original_api_key
+        # The rejected replacement must not remain in controller/view state.
+        # The persisted encrypted value was never changed because the save failed.
+        @download_client.api_key = nil
         if api_key_submitted && !@clear_api_key
           @download_client.errors.add(:api_key, "replacement was not saved; re-enter it after correcting the other errors")
         end

--- a/app/models/download_client.rb
+++ b/app/models/download_client.rb
@@ -3,6 +3,9 @@
 require "uri"
 
 class DownloadClient < ApplicationRecord
+  QBITTORRENT_API_KEY_PREFIX = "qbt_"
+  QBITTORRENT_API_KEY_LENGTH = 32
+
   encrypts :password, :api_key
 
   enum :client_type, {
@@ -28,6 +31,7 @@ class DownloadClient < ApplicationRecord
     numericality: { only_integer: true, greater_than: 0 }
   validates :torrent_verification_wait_time,
     numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :qbittorrent_api_key_must_be_valid, if: :qbittorrent_api_key_requires_validation?
 
   scope :enabled, -> { where(enabled: true) }
   scope :by_priority, -> { order(priority: :asc) }
@@ -74,7 +78,21 @@ class DownloadClient < ApplicationRecord
     qbittorrent? || decypharr?
   end
 
+  def valid_qbittorrent_api_key?
+    api_key&.start_with?(QBITTORRENT_API_KEY_PREFIX) && api_key.length == QBITTORRENT_API_KEY_LENGTH
+  end
+
   private
+
+  def qbittorrent_api_key_requires_validation?
+    qbittorrent? && api_key.present? && (will_save_change_to_api_key? || will_save_change_to_client_type?)
+  end
+
+  def qbittorrent_api_key_must_be_valid
+    return if valid_qbittorrent_api_key?
+
+    errors.add(:api_key, "must start with qbt_ and contain 28 characters after the prefix")
+  end
 
   def normalize_url
     self.url = url.to_s.strip if url.present?

--- a/app/services/download_clients/decypharr.rb
+++ b/app/services/download_clients/decypharr.rb
@@ -11,5 +11,10 @@ module DownloadClients
     def default_session_cookie_name
       "sid"
     end
+
+    # Decypharr's qBittorrent compatibility API authenticates with its SID cookie.
+    def api_key
+      nil
+    end
   end
 end

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -7,7 +7,7 @@ require "stringio"
 
 module DownloadClients
   # qBittorrent WebUI API client
-  # https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)
+  # https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)
   class Qbittorrent < Base
     DEFAULT_TORRENT_VERIFICATION_MAX_ATTEMPTS = 10
     DEFAULT_TORRENT_VERIFICATION_WAIT_TIME = 2
@@ -389,7 +389,7 @@ module DownloadClients
         f.request :multipart
         f.request :url_encoded
         f.adapter Faraday.default_adapter
-        f.headers["Cookie"] = session_cookie_header if session_valid?
+        apply_authentication_headers(f.headers)
         f.headers["Referer"] = base_url
         f.headers["Origin"] = base_url
         f.options.timeout = 30
@@ -479,6 +479,8 @@ module DownloadClients
     end
 
     def ensure_authenticated!
+      return if api_key.present?
+
       authenticate! unless session_valid?
     end
 
@@ -539,12 +541,24 @@ module DownloadClients
       config.password
     end
 
+    def api_key
+      config.api_key if config.valid_qbittorrent_api_key?
+    end
+
+    def apply_authentication_headers(headers)
+      if api_key.present?
+        headers["Authorization"] = "Bearer #{api_key}"
+      elsif session_valid?
+        headers["Cookie"] = session_cookie_header
+      end
+    end
+
     def connection
       Faraday.new(url: base_url) do |f|
         f.request :url_encoded
         f.response :json, parser_options: { symbolize_names: false }
         f.adapter Faraday.default_adapter
-        f.headers["Cookie"] = session_cookie_header if session_valid?
+        apply_authentication_headers(f.headers)
         f.headers["Referer"] = base_url
         f.headers["Origin"] = base_url
         f.options.timeout = 15
@@ -558,8 +572,8 @@ module DownloadClients
         yield response.body
       when 401, 403
         clear_session!
-        Rails.logger.error "[Qbittorrent] Session expired or rejected (HTTP #{response.status}) for #{config.name} at #{base_url}"
-        raise Base::AuthenticationError, "qBittorrent session expired (HTTP #{response.status}) at #{base_url}"
+        Rails.logger.error "[Qbittorrent] Authentication rejected (HTTP #{response.status}) for #{config.name} at #{base_url}"
+        raise Base::AuthenticationError, "qBittorrent authentication failed (HTTP #{response.status}) at #{base_url}"
       else
         Rails.logger.error "[Qbittorrent] API error: HTTP #{response.status} from #{base_url} — #{response.body.to_s.truncate(200)}"
         raise Base::Error, "qBittorrent API error: #{response.status}"

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -143,7 +143,7 @@ module DownloadClients
         true
       when 401, 403
         clear_session!
-        raise Base::AuthenticationError, "qBittorrent session expired"
+        raise Base::AuthenticationError, "qBittorrent authentication failed (HTTP #{response.status}) at #{base_url}"
       else
         Rails.logger.error "[Qbittorrent] Failed to remove torrent: #{response.status}"
         false

--- a/app/views/admin/download_clients/_form.html.erb
+++ b/app/views/admin/download_clients/_form.html.erb
@@ -48,7 +48,7 @@
     </div>
   </div>
 
-  <div id="sabnzbd_fields" class="<%= 'hidden' unless download_client.sabnzbd? %>">
+  <div id="api_key_fields" class="<%= 'hidden' unless download_client.sabnzbd? || download_client.qbittorrent? %>">
     <div class="my-5">
       <%= form.label :api_key, "API Key", class: "block text-gray-300 font-medium" %>
       <div class="flex items-center gap-3 mt-2">
@@ -62,7 +62,13 @@
           </span>
         <% end %>
       </div>
-      <p class="mt-1 text-sm text-gray-500">Found in SABnzbd under Config > General > API Key</p>
+      <% if download_client.persisted? && download_client.api_key.present? %>
+        <label class="mt-3 flex items-center gap-2 text-sm text-gray-400">
+          <%= check_box_tag "download_client[clear_api_key]", "1", @clear_api_key == true, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
+          Clear saved API key
+        </label>
+      <% end %>
+      <p class="mt-1 text-sm text-gray-500">For qBittorrent 5.2+, create a key under Web UI > Preferences > Web UI. When set, it replaces username/password authentication. SABnzbd keys are under Config > General.</p>
     </div>
   </div>
 
@@ -113,10 +119,10 @@
   function initDownloadClientForm() {
     const clientTypeSelect = document.getElementById('client_type_select');
     const authenticationFields = document.getElementById('authentication_fields');
-    const sabnzbdFields = document.getElementById('sabnzbd_fields');
+    const apiKeyFields = document.getElementById('api_key_fields');
     const qbittorrentFields = document.getElementById('qbittorrent_fields');
 
-    if (!clientTypeSelect || !authenticationFields || !sabnzbdFields || !qbittorrentFields) return;
+    if (!clientTypeSelect || !authenticationFields || !apiKeyFields || !qbittorrentFields) return;
 
     function toggleFields() {
       const type = clientTypeSelect.value;
@@ -124,7 +130,7 @@
         'hidden',
         !['qbittorrent', 'decypharr', 'nzbget', 'deluge', 'transmission'].includes(type)
       );
-      sabnzbdFields.classList.toggle('hidden', type !== 'sabnzbd');
+      apiKeyFields.classList.toggle('hidden', !['sabnzbd', 'qbittorrent'].includes(type));
       qbittorrentFields.classList.toggle('hidden', type !== 'qbittorrent');
     }
 

--- a/app/views/admin/download_clients/_form.html.erb
+++ b/app/views/admin/download_clients/_form.html.erb
@@ -1,3 +1,4 @@
+<% api_key_saved = download_client.persisted? && (@api_key_saved.nil? ? download_client.api_key.present? : @api_key_saved) %>
 <%= form_with model: [:admin, download_client], class: "contents" do |form| %>
   <% if download_client.errors.any? %>
     <div class="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 font-medium rounded-lg mt-3">
@@ -52,8 +53,8 @@
     <div class="my-5">
       <%= form.label :api_key, "API Key", class: "block text-gray-300 font-medium" %>
       <div class="flex items-center gap-3 mt-2">
-        <%= form.password_field :api_key, placeholder: download_client.persisted? && download_client.api_key.present? ? "Leave blank to keep current" : "Enter API key", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 flex-grow" %>
-        <% if download_client.persisted? && download_client.api_key.present? %>
+        <%= form.password_field :api_key, placeholder: api_key_saved ? "Leave blank to keep current" : "Enter API key", class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 flex-grow" %>
+        <% if api_key_saved %>
           <span class="text-green-400 text-sm flex items-center gap-1 whitespace-nowrap">
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
@@ -62,7 +63,7 @@
           </span>
         <% end %>
       </div>
-      <% if download_client.persisted? && download_client.api_key.present? %>
+      <% if api_key_saved %>
         <label class="mt-3 flex items-center gap-2 text-sm text-gray-400">
           <%= check_box_tag "download_client[clear_api_key]", "1", @clear_api_key == true, class: "rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-900" %>
           Clear saved API key

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -552,7 +552,7 @@
               <tr><td class="key"><code>url</code></td><td><span class="req req-yes">Required</span></td><td class="desc">Base URL including protocol and port.</td></tr>
               <tr><td class="key"><code>username</code></td><td><span class="req req-no">Optional</span></td><td class="desc">Required by clients that use user/password authentication.</td></tr>
               <tr><td class="key"><code>password</code></td><td><span class="req req-no">Optional</span></td><td class="desc">Password for authenticated clients. Stored encrypted.</td></tr>
-              <tr><td class="key"><code>api_key</code></td><td><span class="req req-no">Optional</span></td><td class="desc">API key used by SABnzbd. Stored encrypted.</td></tr>
+              <tr><td class="key"><code>api_key</code></td><td><span class="req req-no">Optional</span></td><td class="desc">API key used by SABnzbd, or bearer API key for qBittorrent 5.2+. Stored encrypted.</td></tr>
               <tr><td class="key"><code>category</code></td><td><span class="req req-no">Optional</span></td><td class="desc">Category/tag applied in the download client, for routing and filtering.</td></tr>
               <tr><td class="key"><code>download_path</code></td><td><span class="req req-no">Optional</span></td><td class="desc">Client-specific completed download path override.</td></tr>
               <tr><td class="key"><code>enabled</code></td><td><span class="req req-yes">Required</span></td><td class="desc">When disabled, Shelfarr won't use the client for new downloads.</td></tr>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -350,7 +350,7 @@
             <li><strong>Torrent</strong> &mdash; qBittorrent, Deluge, Transmission, and Decypharr (a qBittorrent-compatible variant).</li>
             <li><strong>Usenet</strong> &mdash; SABnzbd, NZBGet.</li>
           </ul>
-          <p>Give each client a name, its URL, and credentials (username/password, or an API key for SABnzbd). A few things worth knowing:</p>
+          <p>Give each client a name, its URL, and credentials. qBittorrent supports username/password, while qBittorrent 5.2+ can instead use an API key from <strong>Web UI &rarr; Preferences &rarr; Web UI</strong>. Decypharr and other compatible clients continue to use username/password. SABnzbd uses an API key. A few things worth knowing:</p>
           <ul>
             <li><strong>Priority</strong> decides which client wins when several handle the same type &mdash; lower is preferred.</li>
             <li><strong>Category</strong> tags downloads in the client so you can keep Shelfarr's grabs separate.</li>

--- a/test/controllers/admin/download_clients_controller_test.rb
+++ b/test/controllers/admin/download_clients_controller_test.rb
@@ -162,6 +162,7 @@ class Admin::DownloadClientsControllerTest < ActionDispatch::IntegrationTest
     assert_equal QBITTORRENT_API_KEY, client.reload.api_key
     assert_select "div[class~='bg-red-500/10']", text: /API key replacement was not saved/
     assert_select "#api_key_fields", text: /Saved/
+    assert_select "input[type='password'][name='download_client[api_key]']:not([value])"
   end
 
   test "update renders errors for invalid client" do

--- a/test/controllers/admin/download_clients_controller_test.rb
+++ b/test/controllers/admin/download_clients_controller_test.rb
@@ -3,6 +3,9 @@
 require "test_helper"
 
 class Admin::DownloadClientsControllerTest < ActionDispatch::IntegrationTest
+  QBITTORRENT_API_KEY = "qbt_aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  REPLACEMENT_QBITTORRENT_API_KEY = "qbt_bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
   setup do
     @admin = users(:two)
     sign_in_as(@admin)
@@ -65,10 +68,11 @@ class Admin::DownloadClientsControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference -> { DownloadClient.count } do
       post admin_download_clients_url, params: {
         download_client: {
-          name: "",
-          client_type: "qbittorrent",
-          url: "",
-          torrent_verification_max_attempts: "0",
+            name: "",
+            client_type: "qbittorrent",
+            url: "",
+            clear_api_key: "1",
+            torrent_verification_max_attempts: "0",
           torrent_verification_wait_time: "-1"
         }
       }
@@ -85,6 +89,79 @@ class Admin::DownloadClientsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "form[action='#{admin_download_client_path(client)}']"
+  end
+
+  test "edit exposes API key for qBittorrent" do
+    client = create_download_client(api_key: QBITTORRENT_API_KEY)
+
+    get edit_admin_download_client_url(client)
+
+    assert_response :success
+    assert_select "#api_key_fields:not(.hidden)"
+    assert_select "input[type='password'][name='download_client[api_key]']"
+    assert_select "input[type='checkbox'][name='download_client[clear_api_key]']"
+    assert_select "#api_key_fields", text: /qBittorrent 5\.2\+/
+  end
+
+  test "edit does not offer API key authentication for Decypharr" do
+    client = create_download_client(client_type: "decypharr")
+
+    get edit_admin_download_client_url(client)
+
+    assert_response :success
+    assert_select "#api_key_fields.hidden"
+  end
+
+  test "update can clear API key and restore cookie authentication" do
+    client = create_download_client(api_key: QBITTORRENT_API_KEY)
+
+    VCR.turned_off do
+      stub_qbittorrent_connection(client.url)
+
+      patch admin_download_client_url(client), params: {
+        download_client: {
+          api_key: "",
+          clear_api_key: "1"
+        }
+      }
+
+      assert_redirected_to admin_download_clients_path
+      assert_nil client.reload.api_key
+      assert_requested(:post, "#{client.url}/api/v2/auth/login")
+    end
+  end
+
+  test "failed update retains saved API key and clear selection" do
+    client = create_download_client(api_key: QBITTORRENT_API_KEY)
+
+    patch admin_download_client_url(client), params: {
+      download_client: {
+        name: "",
+        api_key: "",
+        clear_api_key: "1"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal QBITTORRENT_API_KEY, client.reload.api_key
+    assert_select "#api_key_fields", text: /Saved/
+    assert_select "input[type='checkbox'][name='download_client[clear_api_key]'][checked]"
+  end
+
+  test "failed update restores saved API key and requires replacement re-entry" do
+    client = create_download_client(api_key: QBITTORRENT_API_KEY)
+
+    patch admin_download_client_url(client), params: {
+      download_client: {
+        name: "",
+        api_key: REPLACEMENT_QBITTORRENT_API_KEY
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal QBITTORRENT_API_KEY, client.reload.api_key
+    assert_select "div[class~='bg-red-500/10']", text: /API key replacement was not saved/
+    assert_select "#api_key_fields", text: /Saved/
   end
 
   test "update renders errors for invalid client" do

--- a/test/integration/beta_upgrade_compatibility_test.rb
+++ b/test/integration/beta_upgrade_compatibility_test.rb
@@ -17,9 +17,9 @@ class BetaUpgradeCompatibilityTest < ActiveSupport::TestCase
       client_type: "qbittorrent",
       url: "https://downloads.example",
       username: "legacy-reader",
-      password: "legacy-password",
-      api_key: "legacy-client-api-key"
+      password: "legacy-password"
     )
+    download_client.update_column(:api_key, "legacy-client-api-key")
     acquisition_provider = AcquisitionProvider.create!(
       name: "Upgrade compatibility provider",
       url: "https://provider.example",

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -179,17 +179,16 @@ class DownloadClientTest < ActiveSupport::TestCase
   end
 
   test "encrypts api_key" do
-    plaintext_api_key = "secret-api-key"
     client = DownloadClient.create!(
       name: "Test",
       client_type: "sabnzbd",
       url: "http://localhost:8080",
-      api_key: plaintext_api_key
+      api_key: "secret-api-key"
     )
     client.reload
-    assert_equal plaintext_api_key, client.api_key
-    assert_not_equal plaintext_api_key, client.api_key_before_type_cast
-    assert_not_includes client.api_key_before_type_cast, plaintext_api_key
+    assert_equal "secret-api-key", client.api_key
+    assert_not_equal "secret-api-key", client.api_key_before_type_cast
+    assert_not_includes client.api_key_before_type_cast, "secret-api-key"
   end
 
   test "requires qBittorrent API keys to match the upstream key shape" do

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -179,14 +179,17 @@ class DownloadClientTest < ActiveSupport::TestCase
   end
 
   test "encrypts api_key" do
+    plaintext_api_key = "secret-api-key"
     client = DownloadClient.create!(
       name: "Test",
       client_type: "sabnzbd",
       url: "http://localhost:8080",
-      api_key: "secret-api-key"
+      api_key: plaintext_api_key
     )
     client.reload
-    assert_equal "secret-api-key", client.api_key
+    assert_equal plaintext_api_key, client.api_key
+    assert_not_equal plaintext_api_key, client.api_key_before_type_cast
+    assert_not_includes client.api_key_before_type_cast, plaintext_api_key
   end
 
   test "requires qBittorrent API keys to match the upstream key shape" do

--- a/test/models/download_client_test.rb
+++ b/test/models/download_client_test.rb
@@ -188,4 +188,31 @@ class DownloadClientTest < ActiveSupport::TestCase
     client.reload
     assert_equal "secret-api-key", client.api_key
   end
+
+  test "requires qBittorrent API keys to match the upstream key shape" do
+    client = DownloadClient.new(
+      name: "qBittorrent API key",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080",
+      api_key: "legacy-client-api-key"
+    )
+
+    assert_not client.valid?
+    assert_includes client.errors[:api_key], "must start with qbt_ and contain 28 characters after the prefix"
+
+    client.api_key = "qbt_aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    assert client.valid?
+  end
+
+  test "allows existing legacy qBittorrent API keys on unrelated updates" do
+    client = DownloadClient.create!(
+      name: "Legacy qBittorrent API key",
+      client_type: "qbittorrent",
+      url: "http://localhost:8080"
+    )
+    client.update_column(:api_key, "legacy-client-api-key")
+
+    assert client.reload.update(name: "Renamed legacy qBittorrent")
+    assert_equal "legacy-client-api-key", client.reload.api_key
+  end
 end

--- a/test/services/download_clients/decypharr_test.rb
+++ b/test/services/download_clients/decypharr_test.rb
@@ -18,8 +18,10 @@ class DownloadClients::DecypharrTest < ActiveSupport::TestCase
     Thread.current[:qbittorrent_sessions] = {}
   end
 
-  test "authenticates with lowercase sid cookie" do
+  test "authenticates with lowercase sid cookie when generic API key is stored" do
     VCR.turned_off do
+      @client_record.update!(api_key: "not_supported_by_qbit_compatibility_api")
+
       stub_request(:post, "http://localhost:8282/api/v2/auth/login")
         .to_return(
           status: 200,

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -545,6 +545,23 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
     end
   end
 
+  test "remove_torrent reports a rejected bearer API key as an authentication failure" do
+    VCR.turned_off do
+      @client_record.update!(api_key: QBITTORRENT_API_KEY)
+
+      stub_request(:post, "http://localhost:8080/api/v2/torrents/delete")
+        .with(headers: { "Authorization" => "Bearer #{QBITTORRENT_API_KEY}" })
+        .to_return(status: 403, body: "Forbidden")
+
+      error = assert_raises(DownloadClients::Base::AuthenticationError) do
+        @client.remove_torrent("rejected-hash")
+      end
+
+      assert_equal "qBittorrent authentication failed (HTTP 403) at http://localhost:8080", error.message
+      assert_not_requested(:post, "http://localhost:8080/api/v2/auth/login")
+    end
+  end
+
   test "test_connection retains cookie login for a legacy malformed API key" do
     VCR.turned_off do
       @client_record.update_column(:api_key, "legacy-client-api-key")

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
+  QBITTORRENT_API_KEY = "qbt_aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
   setup do
     @client_record = DownloadClient.create!(
       name: "Test qBittorrent",
@@ -506,6 +508,62 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
         .to_return(status: 200, body: "v4.6.0")
 
       assert @client.test_connection
+    end
+  end
+
+  test "test_connection uses bearer API key without cookie login" do
+    VCR.turned_off do
+      @client_record.update!(api_key: QBITTORRENT_API_KEY)
+      Thread.current[:qbittorrent_sessions][@client_record.id] = {
+        cookie_name: "SID",
+        cookie_value: "stale_session_id"
+      }
+
+      version_stub = stub_request(:get, "http://localhost:8080/api/v2/app/version")
+        .with do |request|
+          request.headers["Authorization"] == "Bearer #{QBITTORRENT_API_KEY}" &&
+            request.headers["Cookie"].nil?
+        end
+        .to_return(status: 200, body: "v5.2.0")
+
+      assert @client.test_connection
+      assert_requested version_stub
+      assert_not_requested(:post, "http://localhost:8080/api/v2/auth/login")
+    end
+  end
+
+  test "test_connection does not fall back to cookie login when bearer API key is rejected" do
+    VCR.turned_off do
+      @client_record.update!(api_key: QBITTORRENT_API_KEY)
+
+      stub_request(:get, "http://localhost:8080/api/v2/app/version")
+        .with(headers: { "Authorization" => "Bearer #{QBITTORRENT_API_KEY}" })
+        .to_return(status: 403, body: "Forbidden")
+
+      assert_not @client.test_connection
+      assert_not_requested(:post, "http://localhost:8080/api/v2/auth/login")
+    end
+  end
+
+  test "test_connection retains cookie login for a legacy malformed API key" do
+    VCR.turned_off do
+      @client_record.update_column(:api_key, "legacy-client-api-key")
+      @client = @client_record.reload.adapter
+
+      login_stub = stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      version_stub = stub_request(:get, "http://localhost:8080/api/v2/app/version")
+        .with(headers: { "Cookie" => "SID=test_session_id" })
+        .to_return(status: 200, body: "v4.6.0")
+
+      assert @client.test_connection
+      assert_requested login_stub
+      assert_requested version_stub
     end
   end
 
@@ -1017,6 +1075,52 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
       assert_equal expected_hash, result
       assert_requested(add_stub)
       assert_requested(:get, "http://prowlarr:9696/api/v1/indexer/download/123", times: 1)
+    end
+  end
+
+  test "add_torrent authenticates multipart API requests with bearer API key" do
+    VCR.turned_off do
+      @client_record.update!(api_key: QBITTORRENT_API_KEY)
+      info_dict = {
+        "name" => "API Key Book.epub",
+        "piece length" => 16384,
+        "pieces" => "s" * 20,
+        "length" => 512
+      }
+      torrent_data = { "info" => info_dict }.bencode
+      expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+      download_stub = stub_request(:get, "http://prowlarr:9696/api/v1/indexer/download/api-key")
+        .with { |request| request.headers["Authorization"].nil? }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/x-bittorrent" },
+          body: torrent_data
+        )
+
+      add_stub = stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .with do |request|
+          request.headers["Authorization"] == "Bearer #{QBITTORRENT_API_KEY}" &&
+            request.headers["Cookie"].nil? &&
+            request.headers["Content-Type"]&.include?("multipart/form-data")
+        end
+        .to_return(status: 200, body: "Ok.")
+
+      verification_stub = stub_request(:get, "http://localhost:8080/api/v2/torrents/info?hashes=#{expected_hash}")
+        .with(headers: { "Authorization" => "Bearer #{QBITTORRENT_API_KEY}" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "hash" => expected_hash, "name" => "API Key Book.epub", "progress" => 0, "state" => "downloading", "size" => 512, "content_path" => "/downloads" } ].to_json
+        )
+
+      result = @client.add_torrent("http://prowlarr:9696/api/v1/indexer/download/api-key")
+
+      assert_equal expected_hash, result
+      assert_requested download_stub
+      assert_requested add_stub
+      assert_requested verification_stub
+      assert_not_requested(:post, "http://localhost:8080/api/v2/auth/login")
     end
   end
 


### PR DESCRIPTION
## Summary
- add qBittorrent 5.2+ bearer API-key authentication for standard and multipart WebAPI requests
- preserve SID cookie authentication for older qBittorrent releases, legacy malformed keys, and Decypharr
- validate new qBittorrent keys against the upstream `qbt_` plus 28-character format and allow administrators to clear saved keys
- keep bearer credentials isolated from source-torrent downloads and report rejected keys as authentication failures
- recover failed form submissions without retaining or rendering decrypted API-key values
- verify the Rails encryption boundary keeps stored API-key ciphertext distinct from plaintext
- update download-client guidance and add regression coverage for authentication, secret isolation, compatibility, and form recovery

## Test plan
- `bin/quality push` — passed after rebasing onto current `main`
- affected suite: 99 tests, 276 assertions
- live admin UI: conditional qBittorrent/Decypharr fields, saved-secret state, and failed-edit secret recovery; rejected and stored values remained absent from the password input
- verified protocol and key-validation behavior against qBittorrent `release-5.2.0` at `b2270f7f6fec1b10117564f642b961621ae0058a`

Closes #453
