### PR TITLE
feat: require assigned issues for pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Assigned issue
+
+Closes #
+
+<!--
+Pull requests are accepted only when the author is assigned to the linked,
+open Shelfarr issue by the maintainer. Unassigned pull requests are closed
+automatically. See CONTRIBUTING.md before submitting.
+-->
+
+## What changed
+
+<!-- Describe the focused change and why this implementation fits Shelfarr. -->
+
+## Verification
+
+<!-- List the exact automated and manual checks you ran. -->
+
+## Screenshots or recordings
+
+<!-- Required for visible or interactive changes. Remove if not applicable. -->
+
+## Checklist
+
+- [ ] The maintainer assigned the linked issue to me before I started implementation
+- [ ] This pull request stays within the assigned issue's scope
+- [ ] I added or updated tests for the behavior I changed
+- [ ] I ran the relevant local quality checks
+- [ ] I updated documentation for user-visible changes

--- a/.github/workflows/pr-authorization.yml
+++ b/.github/workflows/pr-authorization.yml
@@ -1,0 +1,261 @@
+name: PR authorization
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+  issues:
+    types: [unassigned, closed]
+  workflow_dispatch:
+    inputs:
+      enforce:
+        description: Close unauthorized open pull requests instead of reporting them
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: pr-authorization-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce assigned issue policy
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const marker = "<!-- shelfarr-pr-authorization -->";
+            const approvedBots = new Set([
+              "dependabot[bot]",
+              "github-actions[bot]",
+            ]);
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const repositoryName = `${owner}/${repo}`.toLowerCase();
+            const manualEnforcement = context.payload.inputs?.enforce;
+            const enforce =
+              context.eventName !== "workflow_dispatch" ||
+              manualEnforcement === true ||
+              manualEnforcement === "true";
+
+            async function collectPullNumbers() {
+              if (context.eventName === "pull_request_target") {
+                return [context.payload.pull_request.number];
+              }
+
+              if (context.eventName === "issues") {
+                const result = await github.graphql(
+                  `query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      issue(number: $number) {
+                        timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
+                          nodes {
+                            ... on CrossReferencedEvent {
+                              source {
+                                ... on PullRequest {
+                                  number
+                                  state
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }`,
+                  {
+                    owner,
+                    repo,
+                    number: context.payload.issue.number,
+                  },
+                );
+
+                const sources = result.repository.issue?.timelineItems.nodes ?? [];
+                return [
+                  ...new Set(
+                    sources
+                      .map((event) => event.source)
+                      .filter((source) => source?.state === "OPEN")
+                      .map((source) => source.number),
+                  ),
+                ];
+              }
+
+              const pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100,
+              });
+              return pulls.map((pull) => pull.number);
+            }
+
+            async function loadPull(number) {
+              const result = await github.graphql(
+                `query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      number
+                      state
+                      author {
+                        login
+                      }
+                      closingIssuesReferences(first: 20) {
+                        nodes {
+                          number
+                          state
+                          repository {
+                            nameWithOwner
+                          }
+                          assignees(first: 20) {
+                            nodes {
+                              login
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                { owner, repo, number },
+              );
+
+              return result.repository.pullRequest;
+            }
+
+            async function findPolicyComment(number) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner,
+                  repo,
+                  issue_number: number,
+                  per_page: 100,
+                },
+              );
+              return comments.find((comment) => comment.body?.includes(marker));
+            }
+
+            async function upsertPolicyComment(number, body) {
+              const existing = await findPolicyComment(number);
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body,
+              });
+            }
+
+            async function authorize(number) {
+              const pull = await loadPull(number);
+              if (!pull || pull.state !== "OPEN") {
+                core.info(`Skipping PR #${number}; it is not open.`);
+                return;
+              }
+
+              const author = pull.author?.login ?? "";
+              const normalizedAuthor = author.toLowerCase();
+              if (
+                normalizedAuthor === owner.toLowerCase() ||
+                approvedBots.has(normalizedAuthor)
+              ) {
+                core.info(`PR #${number}: @${author} is exempt from issue assignment.`);
+                return;
+              }
+
+              const shelfarrIssues = pull.closingIssuesReferences.nodes.filter(
+                (issue) => issue.repository.nameWithOwner.toLowerCase() === repositoryName,
+              );
+              const unauthorizedIssues = shelfarrIssues.filter((issue) => {
+                const assignees = issue.assignees.nodes.map(({ login }) =>
+                  login.toLowerCase(),
+                );
+                return issue.state !== "OPEN" || !assignees.includes(normalizedAuthor);
+              });
+              const authorized =
+                shelfarrIssues.length > 0 && unauthorizedIssues.length === 0;
+
+              if (authorized) {
+                const existing = await findPolicyComment(number);
+                if (existing && enforce) {
+                  const issueList = shelfarrIssues
+                    .map((issue) => `#${issue.number}`)
+                    .join(", ");
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existing.id,
+                    body: `${marker}\nAuthorization confirmed: @${author} is assigned to ${issueList}.`,
+                  });
+                }
+                core.info(`PR #${number}: @${author} is authorized by issue assignment.`);
+                return;
+              }
+
+              let reason;
+              if (shelfarrIssues.length === 0) {
+                reason = "The PR does not link an open Shelfarr issue with a closing keyword.";
+              } else {
+                reason = unauthorizedIssues
+                  .map((issue) => {
+                    if (issue.state !== "OPEN") return `#${issue.number} is not open`;
+                    return `#${issue.number} is not assigned to @${author}`;
+                  })
+                  .join("; ");
+                reason += ".";
+              }
+
+              if (!enforce) {
+                core.warning(`DRY RUN: PR #${number} from @${author} is unauthorized: ${reason}`);
+                return;
+              }
+
+              const defaultBranch = context.payload.repository.default_branch;
+              const contributingUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/CONTRIBUTING.md`;
+              const body = [
+                marker,
+                "Thanks for taking the time to contribute. Shelfarr only accepts implementation pull requests for work explicitly assigned by the maintainer.",
+                "",
+                `This pull request was automatically closed because no valid assignment was found: ${reason}`,
+                "",
+                "Before reopening this pull request:",
+                "",
+                "1. Discuss the bug or proposal in a Shelfarr issue.",
+                "2. Wait for the maintainer to assign that issue to you.",
+                "3. Add `Closes #123`, `Fixes #123`, or `Resolves #123` to the pull request description.",
+                "",
+                `Once those conditions are met, you may reopen the pull request. See the [contribution policy](${contributingUrl}) for the complete requirements.`,
+              ].join("\n");
+
+              await upsertPolicyComment(number, body);
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: number,
+                state: "closed",
+              });
+              core.info(`Closed unauthorized PR #${number} from @${author}.`);
+            }
+
+            const pullNumbers = await collectPullNumbers();
+            for (const number of pullNumbers) {
+              await authorize(number);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Shelfarr
+
+Shelfarr is a maintainer-directed hobby project. Bug reports, feature ideas,
+and focused technical proposals are welcome through GitHub Issues. Opening an
+issue does not commit the project to an implementation or timeline.
+
+## Implementation requires assignment
+
+Do not open an implementation pull request unless the maintainer has assigned
+you an open Shelfarr issue for that work. Assignment is the explicit approval
+to implement that issue's agreed scope; it is not a general invitation to add
+other changes and does not guarantee that a pull request will be merged.
+
+Every external pull request must:
+
+1. Link at least one open Shelfarr issue using `Closes #123`, `Fixes #123`, or
+   `Resolves #123` in the pull request description.
+2. Be authored by a person assigned to every Shelfarr issue it claims to close.
+3. Stay focused on the assigned scope.
+4. Include appropriate tests, documentation, and verification evidence.
+
+Pull requests that do not meet the assignment requirements are closed
+automatically. After the maintainer assigns the issue and the pull request
+description links it correctly, the author may reopen the pull request.
+
+## Before requesting review
+
+- Rebase once onto the current `main` branch when the implementation is ready.
+- Run `bin/quality push` and resolve its failures.
+- Explain what changed, why it belongs in Shelfarr, and how it was verified.
+- Include screenshots or recordings for visible or interactive changes.
+- Avoid unrelated cleanup, broad rewrites, and speculative feature expansion.
+
+The maintainer may close an implementation that is too costly to review or
+maintain, even when its underlying idea is useful. In that case, the issue can
+remain as the durable record of the problem or proposal.
+
+## Security reports
+
+Do not report vulnerabilities in a public issue. Follow [SECURITY.md](SECURITY.md)
+instead.

--- a/test/config/docker_workflow_test.rb
+++ b/test/config/docker_workflow_test.rb
@@ -113,7 +113,7 @@ class DockerWorkflowTest < ActiveSupport::TestCase
   end
 
   test "all workflow actions use immutable commit references" do
-    %w[ci.yml docker.yml].each do |filename|
+    %w[ci.yml docker.yml pr-authorization.yml].each do |filename|
       workflow = YAML.safe_load_file(
         Rails.root.join(".github/workflows", filename),
         aliases: true

--- a/test/config/pr_authorization_workflow_test.rb
+++ b/test/config/pr_authorization_workflow_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "yaml"
+
+class PrAuthorizationWorkflowTest < ActiveSupport::TestCase
+  setup do
+    @workflow = YAML.safe_load_file(
+      Rails.root.join(".github/workflows/pr-authorization.yml"),
+      aliases: true
+    )
+    @triggers = @workflow["on"] || @workflow.fetch(true)
+    @job = @workflow.dig("jobs", "authorize")
+    @step = @job.fetch("steps").sole
+    @script = @step.dig("with", "script")
+  end
+
+  test "rechecks pull requests when their authorization can change" do
+    assert_equal %w[opened reopened edited synchronize ready_for_review],
+      @triggers.dig("pull_request_target", "types")
+    assert_equal %w[unassigned closed], @triggers.dig("issues", "types")
+    assert_equal false, @triggers.dig("workflow_dispatch", "inputs", "enforce", "default")
+  end
+
+  test "uses narrow permissions and never checks out contributor code" do
+    assert_equal "read", @workflow.dig("permissions", "contents")
+    assert_equal "write", @workflow.dig("permissions", "issues")
+    assert_equal "write", @workflow.dig("permissions", "pull-requests")
+    assert_equal "actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd",
+      @step.fetch("uses")
+    refute @job.fetch("steps").any? { |step| step.fetch("uses", "").start_with?("actions/checkout@") }
+  end
+
+  test "requires every linked Shelfarr issue to be open and assigned to the author" do
+    assert_includes @script, "closingIssuesReferences"
+    assert_includes @script, "issue.repository.nameWithOwner.toLowerCase() === repositoryName"
+    assert_includes @script, 'issue.state !== "OPEN" || !assignees.includes(normalizedAuthor)'
+    assert_includes @script, "shelfarrIssues.length > 0 && unauthorizedIssues.length === 0"
+  end
+
+  test "exempts only the owner and approved automation" do
+    assert_includes @script, 'normalizedAuthor === owner.toLowerCase()'
+    assert_includes @script, '"dependabot[bot]"'
+    assert_includes @script, '"github-actions[bot]"'
+    refute_includes @script, "author_association"
+  end
+
+  test "explains and closes unauthorized pull requests idempotently" do
+    assert_includes @script, "<!-- shelfarr-pr-authorization -->"
+    assert_includes @script, "findPolicyComment"
+    assert_includes @script, "upsertPolicyComment"
+    assert_includes @script, 'core.warning(`DRY RUN:'
+    assert_includes @script, 'state: "closed"'
+    assert_includes @script, "Before reopening this pull request"
+  end
+end


### PR DESCRIPTION
## Summary

- require external pull requests to link open Shelfarr issues assigned to every claimed PR author
- close unauthorized pull requests with an idempotent explanation while exempting the repository owner and approved automation
- recheck connected PRs when issues are unassigned or closed and provide a safe manual dry-run audit
- document the maintainer-directed contribution policy and add an assigned-issue PR template
- protect the security-critical workflow configuration with regression tests and immutable Action references

## Test plan

- [x] 14 focused workflow tests, 198 assertions
- [x] Embedded GitHub Script JavaScript syntax check
- [x] actionlint
- [x] bin/quality push
- [x] bin/quality commit --staged
- [x] pre-commit and pre-push hooks