### PR TITLE
fix: preserve Hardcover single-provider search results

### DIFF
--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -125,8 +125,6 @@ class MetadataService
         priority: provider_priority,
         requested_content_kind: requested_content_kind
       )
-      min_confidence = SettingsService.get(:min_match_confidence).to_i
-      candidates = candidates.select { |candidate| candidate.confidence >= min_confidence }
       candidates = filter_candidates_for_content(candidates, requested_content_kind)
       sort_candidates(candidates, requested_content_kind: requested_content_kind).first(limit || default_search_limit)
     end

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -551,20 +551,41 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert_equal %w[hardcover openlibrary google_books], results.map(&:source)
   end
 
-  test "aggregate_provider_results filters candidates below min_match_confidence" do
+  test "aggregate_provider_results preserves a hardcover-only candidate when min_match_confidence exceeds its score" do
     SettingsService.set(:min_match_confidence, 80)
 
     provider_results = [
-      metadata_provider_result(source: "openlibrary", source_id: "OL_LOW", title: "Low Confidence"),
-      metadata_provider_result(source: "openlibrary", source_id: "OL_HIGH_A", title: "High Confidence", year: 1965),
-      metadata_provider_result(source: "google_books", source_id: "GB_HIGH_B", title: "High Confidence", year: 1966)
+      metadata_provider_result(source: "hardcover", source_id: "HC_ONLY", title: "Hardcover Only")
     ]
 
     results = MetadataService.aggregate_provider_results(provider_results)
 
     assert_equal 1, results.size
-    assert_equal "High Confidence", results.first.title
-    assert_equal 90, results.first.confidence
+    assert_equal "Hardcover Only", results.first.title
+    assert_equal [ "hardcover" ], results.first.sources.pluck(:source)
+    assert_equal 70, results.first.confidence
+  end
+
+  test "aggregate_provider_results preserves hardcover-only candidate alongside corroborated candidate" do
+    SettingsService.set(:min_match_confidence, 80)
+    SettingsService.set(:metadata_provider_priority, "hardcover,openlibrary,google_books")
+
+    provider_results = [
+      metadata_provider_result(source: "hardcover", source_id: "HC_ONLY", title: "Hardcover Only"),
+      metadata_provider_result(source: "openlibrary", source_id: "OL_MATCH", title: "Corroborated", year: 1965),
+      metadata_provider_result(source: "google_books", source_id: "GB_MATCH", title: "Corroborated", year: 1966)
+    ]
+
+    results = MetadataService.aggregate_provider_results(provider_results)
+
+    assert_equal [ "Hardcover Only", "Corroborated" ], results.map(&:title)
+    hardcover_candidate = results.first
+    assert_equal [ "hardcover" ], hardcover_candidate.sources.pluck(:source)
+    assert_equal 70, hardcover_candidate.confidence
+
+    corroborated_candidate = results.second
+    assert_equal %w[openlibrary google_books], corroborated_candidate.sources.pluck(:source)
+    assert_equal 90, corroborated_candidate.confidence
   end
 
   test "bounded web aggregation remains untruncated until pagination after deduplication" do


### PR DESCRIPTION
## Assigned issue

Closes #450

## What changed

Remove the `min_match_confidence` selection from metadata-provider aggregation so a candidate does not require corroboration from another metadata source to reach the UI. Preserve the existing requested-content-kind filter, provider-priority ordering, deduplication, aggregate limit, and candidate confidence values; confidence remains useful metadata, but the indexer-specific threshold no longer decides whether a metadata candidate exists. Replace the test that codifies threshold filtering with regression coverage using a threshold above the singleton score: verify a Hardcover-only candidate survives, and verify it also remains visible alongside a separately corroborated Open Library/Google Books candidate.

Hardcover returns valid parsed hits for the reported titles, but `MetadataService.aggregate_provider_results` can remove them before the search response is rendered. The aggregator assigns a valid single-provider candidate confidence 70 and multi-provider matches 90 or 100, while the service compares those corroboration scores with `min_match_confidence`, a setting documented for category-less indexer release searches. Consequently, a configured threshold above 70 treats a valid Hardcover-only result as if it were invalid, both when Hardcover is the only working provider and when other providers return unrelated, higher-confidence matches. The controller and Turbo stream are downstream of this empty candidate list and do not need changes.

## Verification

With `min_match_confidence` set above 70 and one normalized Hardcover result, aggregation returns that candidate with its Hardcover source and confidence intact instead of an empty array.
With the same high threshold, one Hardcover-only title plus a different title matched by Open Library and Google Books returns both candidates, proving a successful second source is not required for the Hardcover title and does not suppress it.
Existing requested-content-kind tests continue to exclude strongly conflicting book/graphic candidates, and existing ordering, deduplication, and aggregate-limit tests remain unchanged.

## Screenshots or recordings

No user-visible surface changes in this PR, so there is nothing to show.

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [ ] I ran the relevant local quality checks
- [ ] I updated documentation for user-visible changes
