### PR TITLE
Fix non-English language search to use scene tokens instead of English names

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -745,16 +745,17 @@ class SearchJob < ApplicationJob
     language = request.effective_language
     return false if language.blank? || language == "en"
 
-    # Only add if we have a known language name
+    # Only add if we have a known language flag
     info = ReleaseParserService.language_info(language)
     info.present?
   end
 
-  # Get the language name for search query
+  # Prefer the short tokens commonly used in release names (for example DE,
+  # FR, and ES) over English display names such as "German" or "French".
   def language_search_term(request)
     language = request.effective_language
     info = ReleaseParserService.language_info(language)
-    info[:name]
+    info[:flag]
   end
 
   def merge_indexer_results(*result_groups)
@@ -923,6 +924,9 @@ class SearchJob < ApplicationJob
       attempts = issue_queries.map do |query|
         build_search_attempt(:comic_issue, [ query, language_hint ])
       end
+      if language_hint.present?
+        attempts.concat(issue_queries.map { |query| build_search_attempt(:comic_issue, [ query ]) })
+      end
       return deduplicate_search_attempts(attempts)
     end
 
@@ -939,7 +943,15 @@ class SearchJob < ApplicationJob
 
     numeric_title_variants(book.title).each do |title_variant|
       attempts << build_search_attempt(:number_variant, [ title_variant, language_hint ])
-      attempts << build_search_attempt(:number_variant, [ title_variant, book.author, language_hint ])
+      attempts << build_search_attempt(:number_variant, [ title_variant, book.author, language_hint ]) if book.author.present?
+    end
+
+    # For non-English requests, add hint-free fallback attempts after all language-tagged attempts.
+    # Scene releases may be untagged or use different language markers than the hint,
+    # and matches_language already accepts untagged results ([lang, nil]).
+    if language_hint.present?
+      attempts << build_search_attempt(:exact_title, [ book.title ])
+      attempts << build_search_attempt(:title_author, [ book.title, book.author ])
     end
 
     deduplicate_search_attempts(attempts)

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -839,31 +839,122 @@ class SearchJobTest < ActiveJob::TestCase
     end
   end
 
-  test "includes language in search query for non-English requests" do
-    # Set request language to French
-    @request.update!(language: "fr")
+  test "uses scene language codes instead of English names for non-English requests" do
+    # Set request language to German
+    @request.update!(language: "de")
+    SettingsService.set(:indexer_search_scope, "strict")
 
     VCR.turned_off do
-      # Prowlarr book search should keep language as free text while title/author are structured
+      # Structured book search with scene code
       stub_request(:get, %r{localhost:9696/api/v1/search})
         .with do |req|
           query = req.uri.query_values["query"]
           req.uri.query_values["type"] == "book" &&
-            query.include?("French") &&
-            query.include?("{title:#{@request.book.title}}") &&
-            query.include?("{author:#{@request.book.author}}")
+            query.include?("DE") &&
+            !query.include?("German")
         end
         .to_return(
           status: 200,
           headers: { "Content-Type" => "application/json" },
           body: [ prowlarr_result_payload ].to_json
         )
-      stub_prowlarr_generic_search_empty
 
-      assert_nothing_raised do
-        SearchJob.perform_now(@request.id)
+      # Accept all generic attempts, then assert the two required query shapes below.
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "search" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+
+      assert_requested :get, %r{localhost:9696/api/v1/search}, at_least_times: 1 do |req|
+        req.uri.query_values["type"] == "search" &&
+          req.uri.query_values["query"].split.include?("DE")
+      end
+      assert_requested :get, %r{localhost:9696/api/v1/search}, at_least_times: 1 do |req|
+        query_parts = req.uri.query_values["query"].split
+        req.uri.query_values["type"] == "search" &&
+          query_parts.exclude?("DE") && query_parts.exclude?("German")
+      end
+      assert_not_requested :get, %r{localhost:9696/api/v1/search} do |req|
+        req.uri.query_values["query"].to_s.include?("German")
       end
     end
+  end
+
+  test "tries hint-free fallback when language-tagged query returns no results" do
+    @request.update!(language: "de")
+    SettingsService.set(:indexer_search_scope, "strict")
+    hint_free_payload = prowlarr_result_payload.merge(
+      "guid" => "hint-free-result",
+      "title" => "#{@request.book.title} #{@request.book.author} EPUB"
+    )
+
+    VCR.turned_off do
+      structured_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req| req.uri.query_values["type"] == "book" }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      # All attempts with "DE" return empty
+      with_hint_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"].include?("DE")
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      # Hint-free attempt finds the result
+      hint_free_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with do |req|
+          req.uri.query_values["type"] == "search" &&
+            req.uri.query_values["query"] == @request.book.title &&
+            category_query_param?(req)
+        end
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ hint_free_payload ].to_json
+        )
+
+      SearchJob.perform_now(@request.id)
+      @request.reload
+
+      assert_requested structured_stub
+      assert_requested with_hint_stub, at_least_times: 1
+      assert_requested hint_free_stub
+      assert_equal hint_free_payload["title"], @request.search_results.first.title
+    end
+  end
+
+  test "adds language-tagged and hint-free attempts for non-English comic issues" do
+    book = Book.create!(
+      title: "Saga - #7 - The Chapter",
+      author: "Brian K. Vaughan",
+      book_type: :comicbook,
+      content_kind: :graphic,
+      comic_vine_id: "4000-language-issue",
+      issue_number: "7",
+      series: "Saga"
+    )
+    request = Request.create!(book: book, user: @request.user, status: :pending, language: "de")
+
+    attempts = SearchJob.new.send(:generic_indexer_attempts, request)
+
+    assert_equal(
+      [ "Saga 7 DE", "Saga #7 DE", "Saga 007 DE", "Saga 7", "Saga #7", "Saga 007" ],
+      attempts.map(&:query)
+    )
   end
 
   test "does not add language to search query for English requests" do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Assigned issue

Closes #456

## What changed

For non-English requests, `SearchJob` was appending the **English display name** (e.g., `"German"`) to all indexer queries. Scene releases use ISO/scene codes (`DE`, `.DE.`, `GER`), so these queries systematically returned zero results for non-English requests.

This implementation fixes the issue by:

1. **Using scene-compatible language codes**: Changed `language_search_term` to return `ReleaseParserService.language_info[:flag]` (e.g., `"DE"`) instead of `[:name]` (e.g., `"German"`)
2. **Adding hint-free fallback attempts**: For non-English requests, added hint-free `exact_title` and `title_author` attempts after all language-tagged attempts, since scene releases may be untagged or use different language markers
3. **Preserving existing behavior**: English requests remain hint-free (unchanged), and unknown language codes keep current skip behavior (unchanged via existing `info.present?` check)

The `matches_language` scope already accepts untagged results (`[lang, nil]`), so hint-free attempts correctly match both language-tagged and untagged releases.

## Verification

### Automated tests
- ✅ Replaced old test expecting English name "French" with new test verifying scene code "DE" is used and English name "German" is never used
- ✅ Added test verifying hint-free fallback attempts find results when language-tagged queries return empty
- ✅ Verified existing "English requests stay hint-free" test remains unchanged and passing

### Code changes
- `app/jobs/search_job.rb`:
  - Modified `language_search_term` to return `info[:flag]` instead of `info[:name]`
  - Modified `generic_indexer_attempts` to add hint-free fallback attempts for non-English requests
  - Added defensive check for `book.author.present?` in numeric variant generation
- `test/jobs/search_job_test.rb`:
  - Updated test to verify scene codes are used instead of English names
  - Added test for hint-free fallback behavior

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [x] I ran the relevant local quality checks
- [x] I updated documentation for user-visible changes (N/A - internal search logic change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edc2460a-dde2-49b7-8165-32f48acc601c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edc2460a-dde2-49b7-8165-32f48acc601c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

