### PR TITLE
Fix direct download reservation leak on failure

### DIFF
--- a/app/jobs/direct_download_recovery_job.rb
+++ b/app/jobs/direct_download_recovery_job.rb
@@ -4,11 +4,20 @@ class DirectDownloadRecoveryJob < ApplicationJob
   queue_as :default
 
   def perform
-    Download.where.not(direct_staging_path: nil).find_each do |download|
+    tracked_downloads = Download.where.not(direct_staging_path: nil)
+      .or(Download.where.not(direct_reservation_token: nil))
+    tracked_downloads.find_each do |download|
       DirectDownloadFileService.reconcile!(download)
     rescue => error
       Rails.logger.warn(
         "[DirectDownloadRecoveryJob] Could not reconcile download #{download.id}: #{error.class}"
+      )
+    end
+
+    cleared = DirectDownloadFileService.reconcile_orphaned_reservations!
+    if cleared.positive?
+      Rails.logger.info(
+        "[DirectDownloadRecoveryJob] Released #{cleared} orphaned direct-download reservations"
       )
     end
 

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -1294,30 +1294,23 @@ class DownloadJob < ApplicationJob
 
   def ensure_book_available_for_direct_download!(book)
     book.reload
-    
-    # Release stale reservations from failed downloads to allow retry
+
     if book.acquisition_reserved? && !book.acquired?
-      release_failed_download_reservation!(book)
+      DirectDownloadFileService.reconcile_reservation!(book)
       book.reload
     end
-    
+
     return unless book.acquisition_blocked?
 
+    message = if book.acquired?
+      "This title already has a library file; the existing file was preserved"
+    elsif book.acquisition_reservation_owner_type == "Download"
+      "A previous direct download still owns this title while its recovery state is being verified"
+    else
+      "Another acquisition still owns this title; no library file was replaced"
+    end
     raise BookAcquisitionConflictError,
-      "Another acquisition already claimed this title; its existing library file was preserved"
-  end
-  
-  def release_failed_download_reservation!(book)
-    return unless book.acquisition_reservation_owner_type == "Download"
-    
-    # Only release if the owning download has failed
-    owner_download = Download.find_by(id: book.acquisition_reservation_owner_id)
-    return unless owner_download&.failed?
-    
-    Rails.logger.info "[DownloadJob] Releasing stale reservation from failed download ##{owner_download.id} for book ##{book.id}"
-    DirectDownloadFileService.send(:release_reservation!, owner_download)
-  rescue => e
-    Rails.logger.warn "[DownloadJob] Could not release stale reservation for book ##{book.id}: #{e.message}"
+      message
   end
 
   def ensure_output_root!(base_path)

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -1293,10 +1293,31 @@ class DownloadJob < ApplicationJob
   end
 
   def ensure_book_available_for_direct_download!(book)
-    return unless book.reload.acquisition_blocked?
+    book.reload
+    
+    # Release stale reservations from failed downloads to allow retry
+    if book.acquisition_reserved? && !book.acquired?
+      release_failed_download_reservation!(book)
+      book.reload
+    end
+    
+    return unless book.acquisition_blocked?
 
     raise BookAcquisitionConflictError,
       "Another acquisition already claimed this title; its existing library file was preserved"
+  end
+  
+  def release_failed_download_reservation!(book)
+    return unless book.acquisition_reservation_owner_type == "Download"
+    
+    # Only release if the owning download has failed
+    owner_download = Download.find_by(id: book.acquisition_reservation_owner_id)
+    return unless owner_download&.failed?
+    
+    Rails.logger.info "[DownloadJob] Releasing stale reservation from failed download ##{owner_download.id} for book ##{book.id}"
+    DirectDownloadFileService.send(:release_reservation!, owner_download)
+  rescue => e
+    Rails.logger.warn "[DownloadJob] Could not release stale reservation for book ##{book.id}: #{e.message}"
   end
 
   def ensure_output_root!(base_path)

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -605,8 +605,10 @@ class DirectDownloadFileService
     end
 
     return false unless self.class.send(:valid_output_root_identity?, download)
-    return false if @publication_started && !error.is_a?(ConflictError)
-
+    
+    # Release the reservation on any error unless publication completed.
+    # Previously this skipped release when publication_started && !ConflictError,
+    # causing permanent reservation leaks on mid-publication failures.
     self.class.send(:release_reservation!, download)
     download.reload
     false

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -17,6 +17,20 @@ class DirectDownloadFileService
   ACTIVE_TIMEOUT = 30.minutes
   HEARTBEAT_INTERVAL = 10.seconds
   MANIFEST_MAX_BYTES = 10.megabytes
+  RECOVERY_PUBLICATION_ATTRIBUTES = %w[
+    direct_staging_path
+    direct_staging_device
+    direct_staging_inode
+    direct_staging_parent_device
+    direct_staging_parent_inode
+    direct_destination_path
+    direct_book_path
+    direct_output_root
+    direct_output_root_device
+    direct_output_root_inode
+    direct_publication_kind
+    direct_content_manifest
+  ].freeze
 
   class Error < StandardError; end
   class ConflictError < Error; end
@@ -48,6 +62,11 @@ class DirectDownloadFileService
         return cleanup_completed_state!(download.reload)
       end
 
+      if detached_failed_reservation?(download) && reservation_owned?(download)
+        release_reservation!(download)
+        return false
+      end
+
       # A monitor can mark an apparently stalled worker failed while that
       # worker is paused in the kernel or on slow storage. The status change
       # itself renews this lease, so recovery must not remove its staging tree
@@ -60,6 +79,33 @@ class DirectDownloadFileService
       false
     rescue ActiveRecord::RecordNotFound
       false
+    end
+
+    def reconcile_reservation!(book)
+      book.reload
+      return false if book.acquired? || !book.acquisition_reserved?
+      return false unless book.acquisition_reservation_owner_type == "Download"
+
+      owner = Download.find_by(id: book.acquisition_reservation_owner_id)
+      return clear_orphaned_reservation!(book) unless owner
+      return false unless owner.failed? && owner.download_type == "direct"
+
+      reconcile!(owner)
+      !book.reload.acquisition_reserved?
+    rescue ActiveRecord::RecordNotFound
+      false
+    end
+
+    def reconcile_orphaned_reservations!
+      cleared = 0
+      Book.acquisition_reserved
+        .where(acquisition_reservation_owner_type: "Download")
+        .find_each do |book|
+          next if Download.where(id: book.acquisition_reservation_owner_id).exists?
+
+          cleared += 1 if clear_orphaned_reservation!(book)
+        end
+      cleared
     end
 
     def cleanup_orphans!(root:, max_age: ORPHAN_MAX_AGE.ago)
@@ -185,6 +231,11 @@ class DirectDownloadFileService
         download.updated_at > ACTIVE_TIMEOUT.ago
     end
 
+    def detached_failed_reservation?(download)
+      download.failed? && download.download_type == "direct" &&
+        download.attributes.values_at(*RECOVERY_PUBLICATION_ATTRIBUTES).all?(&:blank?)
+    end
+
     def reservation_owned?(download)
       token = download.direct_reservation_token
       return false if token.blank?
@@ -243,6 +294,24 @@ class DirectDownloadFileService
         direct_reservation_token: nil,
         updated_at: Time.current
       )
+    end
+
+    def clear_orphaned_reservation!(book)
+      token = book.acquisition_reservation_token
+      owner_id = book.acquisition_reservation_owner_id
+      return false if token.blank? || owner_id.blank? || book.acquired?
+
+      Book.where(
+        id: book.id,
+        acquisition_reservation_token: token,
+        acquisition_reservation_owner_type: "Download",
+        acquisition_reservation_owner_id: owner_id
+      ).where("file_path IS NULL OR TRIM(file_path) = ''").update_all(
+        acquisition_reservation_token: nil,
+        acquisition_reservation_owner_type: nil,
+        acquisition_reservation_owner_id: nil,
+        updated_at: Time.current
+      ) == 1
     end
 
     def cleanup_completed_state!(download)
@@ -605,10 +674,8 @@ class DirectDownloadFileService
     end
 
     return false unless self.class.send(:valid_output_root_identity?, download)
-    
-    # Release the reservation on any error unless publication completed.
-    # Previously this skipped release when publication_started && !ConflictError,
-    # causing permanent reservation leaks on mid-publication failures.
+    return false if @publication_started && !error.is_a?(ConflictError)
+
     self.class.send(:release_reservation!, download)
     download.reload
     false

--- a/test/jobs/direct_download_recovery_job_test.rb
+++ b/test/jobs/direct_download_recovery_job_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class DirectDownloadRecoveryJobTest < ActiveJob::TestCase
-  test "reconciles every tracked direct download and sweeps each output root" do
+  test "reconciles tracked state and detached reservations then sweeps each output root" do
     request = requests(:pending_request)
     first = request.downloads.create!(
       name: "Tracked direct download",
@@ -11,19 +11,32 @@ class DirectDownloadRecoveryJobTest < ActiveJob::TestCase
       download_type: "direct",
       direct_staging_path: "/tmp/tracked-direct"
     )
+    detached = request.downloads.create!(
+      name: "Detached direct reservation",
+      status: :failed,
+      download_type: "direct",
+      direct_reservation_token: SecureRandom.hex(32)
+    )
     roots = [ "/ebooks-one", "/audiobooks-two" ]
     reconciled = []
     swept = []
+    orphan_sweeps = 0
 
     DirectDownloadFileService.stub(:reconcile!, ->(download) { reconciled << download.id }) do
-      DirectDownloadFileService.stub(:output_roots, roots) do
-        DirectDownloadFileService.stub(:cleanup_orphans!, ->(root:) { swept << root; 0 }) do
-          DirectDownloadRecoveryJob.perform_now
+      DirectDownloadFileService.stub(:reconcile_orphaned_reservations!, lambda {
+        orphan_sweeps += 1
+        0
+      }) do
+        DirectDownloadFileService.stub(:output_roots, roots) do
+          DirectDownloadFileService.stub(:cleanup_orphans!, ->(root:) { swept << root; 0 }) do
+            DirectDownloadRecoveryJob.perform_now
+          end
         end
       end
     end
 
-    assert_equal [ first.id ], reconciled
+    assert_equal [ first.id, detached.id ].sort, reconciled.sort
+    assert_equal 1, orphan_sweeps
     assert_equal roots, swept
   end
 end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -2118,6 +2118,99 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_equal [ "audio-lib" ], scanned
   end
 
+  test "failed direct download releases acquisition reservation allowing retry" do
+    Dir.mktmpdir do |dir|
+      setup_gutenberg_download(output_path: dir)
+      book = @gutenberg_request.book
+      
+      # Verify no reservation initially
+      assert_nil book.reload.acquisition_reservation_token
+      assert_not book.acquisition_blocked?
+
+      VCR.turned_off do
+        stub_request(:get, "https://www.gutenberg.org/ebooks/1342.epub3.images")
+          .with(query: hash_including("download" => "1"))
+          .to_return(
+            status: 200,
+            body: "PK\x03\x04" + ("test" * 256),
+            headers: { "Content-Type" => "application/epub+zip" }
+          )
+
+        # Simulate a failure during file publication (after reservation is made)
+        # This happens in publish_file_and_finalize! after reserve_book! succeeds
+        FileCopyService.stub(:cp_io_noreplace, ->(*_args, **_kwargs) {
+          raise IOError, "simulated disk failure during publication"
+        }) do
+          DownloadJob.perform_now(@gutenberg_download.id)
+        end
+      end
+
+      # Download should be failed
+      assert @gutenberg_download.reload.failed?
+      assert_nil @gutenberg_request.book.reload.file_path
+
+      # The reservation should be released, allowing retry
+      book.reload
+      assert_nil book.acquisition_reservation_token, "Expected reservation to be released after failure"
+      assert_nil book.acquisition_reservation_owner_type
+      assert_nil book.acquisition_reservation_owner_id
+      assert_not book.acquisition_blocked?, "Expected book to not be blocked after reservation release"
+
+      # Verify a retry is possible by checking the book is available
+      assert_not book.acquisition_reserved?
+    end
+  end
+
+  test "stale reservation from failed download is released when retrying" do
+    Dir.mktmpdir do |dir|
+      setup_gutenberg_download(output_path: dir)
+      book = @gutenberg_request.book
+      
+      # Simulate a stale reservation from a failed download
+      # (e.g., job was killed before error handling could release it)
+      token = SecureRandom.hex(32)
+      failed_download = @gutenberg_request.downloads.create!(
+        name: "Failed Download",
+        status: :failed,
+        download_type: "direct",
+        direct_reservation_token: token
+      )
+      book.update!(
+        acquisition_reservation_token: token,
+        acquisition_reservation_owner_type: "Download",
+        acquisition_reservation_owner_id: failed_download.id
+      )
+      
+      # Verify the book is blocked initially
+      assert book.reload.acquisition_blocked?
+      assert book.acquisition_reserved?
+
+      VCR.turned_off do
+        stub_request(:get, "https://www.gutenberg.org/ebooks/1342.epub3.images")
+          .with(query: hash_including("download" => "1"))
+          .to_return(
+            status: 200,
+            body: "PK\x03\x04" + ("test" * 256),
+            headers: { "Content-Type" => "application/epub+zip" }
+          )
+
+        # The new download should succeed by releasing the stale reservation
+        DownloadJob.perform_now(@gutenberg_download.id)
+      end
+
+      # The new download should succeed
+      assert @gutenberg_download.reload.completed?
+      assert_equal File.dirname(gutenberg_destination_path(dir)), @gutenberg_request.book.reload.file_path
+
+      # The reservation should be released
+      book.reload
+      assert_nil book.acquisition_reservation_token
+      assert_nil book.acquisition_reservation_owner_type
+      assert_nil book.acquisition_reservation_owner_id
+      assert_not book.acquisition_blocked?
+    end
+  end
+
   private
 
   def setup_zlibrary_download

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -2118,14 +2118,10 @@ class DownloadJobTest < ActiveJob::TestCase
     assert_equal [ "audio-lib" ], scanned
   end
 
-  test "failed direct download releases acquisition reservation allowing retry" do
+  test "failed publication retains its reservation until verified recovery" do
     Dir.mktmpdir do |dir|
       setup_gutenberg_download(output_path: dir)
       book = @gutenberg_request.book
-      
-      # Verify no reservation initially
-      assert_nil book.reload.acquisition_reservation_token
-      assert_not book.acquisition_blocked?
 
       VCR.turned_off do
         stub_request(:get, "https://www.gutenberg.org/ebooks/1342.epub3.images")
@@ -2136,8 +2132,6 @@ class DownloadJobTest < ActiveJob::TestCase
             headers: { "Content-Type" => "application/epub+zip" }
           )
 
-        # Simulate a failure during file publication (after reservation is made)
-        # This happens in publish_file_and_finalize! after reserve_book! succeeds
         FileCopyService.stub(:cp_io_noreplace, ->(*_args, **_kwargs) {
           raise IOError, "simulated disk failure during publication"
         }) do
@@ -2145,19 +2139,18 @@ class DownloadJobTest < ActiveJob::TestCase
         end
       end
 
-      # Download should be failed
       assert @gutenberg_download.reload.failed?
       assert_nil @gutenberg_request.book.reload.file_path
+      assert book.reload.acquisition_reserved?
+      staging = @gutenberg_download.direct_staging_path
+      assert File.directory?(staging)
 
-      # The reservation should be released, allowing retry
-      book.reload
-      assert_nil book.acquisition_reservation_token, "Expected reservation to be released after failure"
-      assert_nil book.acquisition_reservation_owner_type
-      assert_nil book.acquisition_reservation_owner_id
-      assert_not book.acquisition_blocked?, "Expected book to not be blocked after reservation release"
+      @gutenberg_download.update_columns(updated_at: 1.hour.ago)
+      assert_not DirectDownloadFileService.reconcile!(@gutenberg_download)
 
-      # Verify a retry is possible by checking the book is available
-      assert_not book.acquisition_reserved?
+      assert_not book.reload.acquisition_reserved?
+      assert_nil @gutenberg_download.reload.direct_staging_path
+      assert_not File.exist?(staging)
     end
   end
 
@@ -2165,9 +2158,7 @@ class DownloadJobTest < ActiveJob::TestCase
     Dir.mktmpdir do |dir|
       setup_gutenberg_download(output_path: dir)
       book = @gutenberg_request.book
-      
-      # Simulate a stale reservation from a failed download
-      # (e.g., job was killed before error handling could release it)
+
       token = SecureRandom.hex(32)
       failed_download = @gutenberg_request.downloads.create!(
         name: "Failed Download",
@@ -2180,8 +2171,7 @@ class DownloadJobTest < ActiveJob::TestCase
         acquisition_reservation_owner_type: "Download",
         acquisition_reservation_owner_id: failed_download.id
       )
-      
-      # Verify the book is blocked initially
+
       assert book.reload.acquisition_blocked?
       assert book.acquisition_reserved?
 
@@ -2194,21 +2184,60 @@ class DownloadJobTest < ActiveJob::TestCase
             headers: { "Content-Type" => "application/epub+zip" }
           )
 
-        # The new download should succeed by releasing the stale reservation
         DownloadJob.perform_now(@gutenberg_download.id)
       end
 
-      # The new download should succeed
       assert @gutenberg_download.reload.completed?
       assert_equal File.dirname(gutenberg_destination_path(dir)), @gutenberg_request.book.reload.file_path
 
-      # The reservation should be released
       book.reload
       assert_nil book.acquisition_reservation_token
       assert_nil book.acquisition_reservation_owner_type
       assert_nil book.acquisition_reservation_owner_id
-      assert_not book.acquisition_blocked?
+      assert book.acquired?
     end
+  end
+
+  test "retry explains when failed publication state must remain reserved" do
+    book = @request.book
+    token = SecureRandom.hex(32)
+    failed_download = @request.downloads.create!(
+      name: "Failed direct publication",
+      status: :failed,
+      download_type: "direct",
+      direct_reservation_token: token,
+      direct_destination_path: "/ebooks/recovery/book.epub"
+    )
+    book.update!(
+      acquisition_reservation_token: token,
+      acquisition_reservation_owner_type: "Download",
+      acquisition_reservation_owner_id: failed_download.id
+    )
+
+    error = assert_raises(DownloadJob::BookAcquisitionConflictError) do
+      DownloadJob.new.send(:ensure_book_available_for_direct_download!, book)
+    end
+
+    assert_match(/recovery state is being verified/, error.message)
+    assert_no_match(/existing library file/, error.message)
+    assert book.reload.acquisition_reserved?
+  end
+
+  test "direct retry does not describe another acquisition reservation as a library file" do
+    book = @request.book
+    book.update!(
+      acquisition_reservation_token: SecureRandom.hex(32),
+      acquisition_reservation_owner_type: "Upload",
+      acquisition_reservation_owner_id: 91_001
+    )
+
+    error = assert_raises(DownloadJob::BookAcquisitionConflictError) do
+      DownloadJob.new.send(:ensure_book_available_for_direct_download!, book)
+    end
+
+    assert_match(/Another acquisition still owns this title/, error.message)
+    assert_no_match(/existing library file/, error.message)
+    assert book.reload.acquisition_reserved?
   end
 
   private

--- a/test/services/direct_download_file_service_test.rb
+++ b/test/services/direct_download_file_service_test.rb
@@ -221,6 +221,74 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert_nil @download.reload.direct_staging_path
   end
 
+  test "recovery releases a failed reservation with no publication state" do
+    token = SecureRandom.hex(32)
+    @book.update!(
+      acquisition_reservation_token: token,
+      acquisition_reservation_owner_type: "Download",
+      acquisition_reservation_owner_id: @download.id
+    )
+    @download.update!(
+      status: :failed,
+      direct_reservation_token: token
+    )
+
+    assert_not DirectDownloadFileService.reconcile!(@download)
+
+    assert_not @book.reload.acquisition_reserved?
+    assert_nil @download.reload.direct_reservation_token
+  end
+
+  test "recovery retains a failed reservation with ambiguous publication state" do
+    token = SecureRandom.hex(32)
+    @book.update!(
+      acquisition_reservation_token: token,
+      acquisition_reservation_owner_type: "Download",
+      acquisition_reservation_owner_id: @download.id
+    )
+    @download.update!(
+      status: :failed,
+      direct_reservation_token: token,
+      direct_destination_path: @destination
+    )
+
+    assert_not DirectDownloadFileService.reconcile!(@download)
+
+    assert @book.reload.acquisition_reserved?
+    assert_equal token, @download.reload.direct_reservation_token
+    assert_equal @destination, @download.direct_destination_path
+  end
+
+  test "reservation recovery releases an ownerless failed-download reservation" do
+    token = SecureRandom.hex(32)
+    missing_download_id = Download.maximum(:id).to_i + 10_000
+    @book.update!(
+      acquisition_reservation_token: token,
+      acquisition_reservation_owner_type: "Download",
+      acquisition_reservation_owner_id: missing_download_id
+    )
+
+    assert DirectDownloadFileService.reconcile_reservation!(@book)
+
+    assert_not @book.reload.acquisition_reserved?
+    assert_nil @book.acquisition_reservation_owner_type
+    assert_nil @book.acquisition_reservation_owner_id
+  end
+
+  test "orphan recovery preserves reservations attached to acquired books" do
+    token = SecureRandom.hex(32)
+    @book.update!(
+      file_path: File.dirname(@destination),
+      acquisition_reservation_token: token,
+      acquisition_reservation_owner_type: "Download",
+      acquisition_reservation_owner_id: Download.maximum(:id).to_i + 10_000
+    )
+
+    assert_equal 0, DirectDownloadFileService.reconcile_orphaned_reservations!
+
+    assert_equal token, @book.reload.acquisition_reservation_token
+  end
+
   test "a conflicting file is preserved and does not strand a reservation" do
     staging = @service.create_staging!
     FileUtils.mkdir_p(File.dirname(@destination))


### PR DESCRIPTION
## Assigned issue

Closes #468

## What changed

- Reaps failed direct-download reservations that have no publication or staging state.
- Lets retries invoke the same public, safety-checked reconciliation path.
- Extends the recurring recovery job to inspect reservation-only downloads and reservations whose owner row no longer exists.
- Distinguishes an existing library file from a reservation still held for recovery.

## Safety review

A failure after publication begins is deliberately **not** released immediately. The final path may contain a complete or partial publication, so ownership remains until the existing descriptor- and identity-checked recovery path can verify/finalize it or safely remove its exact staging tree.

Only failed direct downloads with no persisted publication state are released directly. Ambiguous state, fresh recovery leases, changed roots, replacement staging paths, non-Download owners, and acquired books are retained.

## Verification

- `test/services/direct_download_file_service_test.rb`
- `test/jobs/direct_download_recovery_job_test.rb`
- `test/jobs/download_job_test.rb`
- 129 tests, 552 assertions, 0 failures/errors
- RuboCop: 6 files inspected, no offenses
- `git diff --check`: clean

## Screenshots or recordings

Not applicable; recovery/backend behavior only.

## Checklist

- [x] The maintainer assigned the linked issue before implementation
- [x] The pull request stays within the assigned issue scope
- [x] Tests cover the changed behavior and adversarial recovery cases
- [x] Relevant local quality checks pass
- [x] No documentation change is needed for this internal recovery fix