### PR TITLE
Fix misleading 'could not lock' error for publication failures

### DIFF
--- a/app/services/owned_media_import_file_service.rb
+++ b/app/services/owned_media_import_file_service.rb
@@ -232,30 +232,11 @@ class OwnedMediaImportFileService
     end
 
     def with_lock(root, key)
-      lock_directory = Pathname(root).join(STAGING_DIRECTORY, LOCKS_DIRECTORY)
-      shard = Digest::SHA256.hexdigest(key.to_s).to_i(16) % LOCK_SHARDS
-      secure_directory!(lock_directory) do |locks|
-        descriptor = class_native_openat(
-          locks.fileno,
-          format("lock-%04d", shard),
-          flags: File::RDWR | File::CREAT | File::NOFOLLOW | File::NONBLOCK,
-          mode: 0o600
-        )
-        lock = File.for_fd(descriptor, "r+", autoclose: true)
-        begin
-          raise Error, "Shelfarr's audiobook lock is not a regular file" unless lock.stat.file?
-
-          class_native_fchmod(lock.fileno, 0o600)
-          unless lock.flock(File::LOCK_EX)
-            raise Error, "The audiobook filesystem does not support Shelfarr's required lock"
-          end
-          yield
-        ensure
-          lock.close unless lock.closed?
-        end
-      end
-    rescue Errno::ELOOP, Errno::EACCES, Errno::ENOENT => e
-      raise Error, "Shelfarr could not lock the audiobook destination: #{e.message}"
+      lock = nil
+      lock = acquire_audiobook_lock(root, key)
+      yield
+    ensure
+      lock&.close unless lock&.closed?
     end
 
     # Audible backups rely on an advisory filesystem lock and a same-volume
@@ -300,6 +281,34 @@ class OwnedMediaImportFileService
     end
 
     private
+
+    def acquire_audiobook_lock(root, key)
+      lock = nil
+      lock_directory = Pathname(root).join(STAGING_DIRECTORY, LOCKS_DIRECTORY)
+      shard = Digest::SHA256.hexdigest(key.to_s).to_i(16) % LOCK_SHARDS
+      secure_directory!(lock_directory) do |locks|
+        descriptor = class_native_openat(
+          locks.fileno,
+          format("lock-%04d", shard),
+          flags: File::RDWR | File::CREAT | File::NOFOLLOW | File::NONBLOCK,
+          mode: 0o600
+        )
+        lock = File.for_fd(descriptor, "r+", autoclose: true)
+        raise Error, "Shelfarr's audiobook lock is not a regular file" unless lock.stat.file?
+
+        class_native_fchmod(lock.fileno, 0o600)
+        unless lock.flock(File::LOCK_EX)
+          raise Error, "The audiobook filesystem does not support Shelfarr's required lock"
+        end
+        return lock
+      end
+    rescue Errno::ELOOP, Errno::EACCES, Errno::ENOENT => e
+      lock&.close unless lock&.closed?
+      raise Error, "Shelfarr could not lock the audiobook destination: #{e.message}"
+    rescue
+      lock&.close unless lock&.closed?
+      raise
+    end
 
     def staging_components(raw_path)
       return if raw_path.blank?

--- a/app/services/upload_import_file_service.rb
+++ b/app/services/upload_import_file_service.rb
@@ -303,26 +303,11 @@ class UploadImportFileService
     end
 
     def with_lock(root, key)
-      canonical_root = Pathname(root).realpath
-      with_pinned_absolute_directory(canonical_root) do |root_directory|
-        relative = Pathname(PRIVATE_DIRECTORY).join(database_fingerprint, LOCKS_DIRECTORY)
-        with_pinned_relative_directory(root_directory, relative, create: true, mode: 0o700) do |locks|
-          shard = Digest::SHA256.hexdigest(key.to_s).to_i(16) % LOCK_SHARDS
-          descriptor = open_or_create_lock(locks, format("lock-%04d", shard))
-          lock = File.for_fd(descriptor, "r+", autoclose: true)
-          begin
-            raise Error, "Upload recovery lock is not a regular file" unless lock.stat.file?
-            native_fchmod(lock.fileno, 0o600)
-            raise Error, "Upload recovery lock could not be acquired" unless lock.flock(File::LOCK_EX)
-
-            yield
-          ensure
-            lock.close unless lock.closed?
-          end
-        end
-      end
-    rescue Errno::ELOOP, Errno::EACCES, Errno::ENOENT, Errno::ENOTDIR => error
-      raise Error, "Shelfarr could not lock the upload destination: #{error.message}"
+      lock = nil
+      lock = acquire_upload_lock(root, key)
+      yield
+    ensure
+      lock&.close unless lock&.closed?
     end
 
     # Resolve the longest existing configured prefix once, then create only the
@@ -373,6 +358,29 @@ class UploadImportFileService
     end
 
     private
+
+    def acquire_upload_lock(root, key)
+      lock = nil
+      canonical_root = Pathname(root).realpath
+      with_pinned_absolute_directory(canonical_root) do |root_directory|
+        relative = Pathname(PRIVATE_DIRECTORY).join(database_fingerprint, LOCKS_DIRECTORY)
+        with_pinned_relative_directory(root_directory, relative, create: true, mode: 0o700) do |locks|
+          shard = Digest::SHA256.hexdigest(key.to_s).to_i(16) % LOCK_SHARDS
+          descriptor = open_or_create_lock(locks, format("lock-%04d", shard))
+          lock = File.for_fd(descriptor, "r+", autoclose: true)
+          raise Error, "Upload recovery lock is not a regular file" unless lock.stat.file?
+          native_fchmod(lock.fileno, 0o600)
+          raise Error, "Upload recovery lock could not be acquired" unless lock.flock(File::LOCK_EX)
+          return lock
+        end
+      end
+    rescue Errno::ELOOP, Errno::EACCES, Errno::ENOENT, Errno::ENOTDIR => error
+      lock&.close unless lock&.closed?
+      raise Error, "Shelfarr could not lock the upload destination: #{error.message}"
+    rescue
+      lock&.close unless lock&.closed?
+      raise
+    end
 
     def open_or_create_lock(directory, basename)
       loop do

--- a/test/services/owned_media_import_file_service_test.rb
+++ b/test/services/owned_media_import_file_service_test.rb
@@ -603,6 +603,37 @@ class OwnedMediaImportFileServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "publication filesystem errors are not reported as audiobook lock failures" do
+    error = assert_raises(Errno::EACCES) do
+      OwnedMediaImportFileService.with_lock(@output_root, "publication-error") do
+        raise Errno::EACCES, "Permission denied - publication mkdirat"
+      end
+    end
+
+    assert_match(/publication mkdirat/i, error.message)
+    assert_no_match(/lock/, error.message.downcase)
+  end
+
+  test "lock acquisition failure retains audiobook lock context" do
+    original_openat = OwnedMediaImportFileService.method(:class_native_openat)
+    failing_lock_open = lambda do |directory_fd, basename, flags:, mode: 0|
+      if basename.start_with?("lock-")
+        raise Errno::EACCES, "Permission denied - lock openat"
+      end
+
+      original_openat.call(directory_fd, basename, flags: flags, mode: mode)
+    end
+
+    error = OwnedMediaImportFileService.stub(:class_native_openat, failing_lock_open) do
+      assert_raises(OwnedMediaImportFileService::Error) do
+        OwnedMediaImportFileService.with_lock(@output_root, "failing-lock") { flunk }
+      end
+    end
+
+    assert_match(/could not lock the audiobook destination/i, error.message)
+    assert_match(/lock openat/i, error.message)
+  end
+
   test "concurrent first use safely shares staging directory initialization" do
     fresh_root = Dir.mktmpdir("owned-media-concurrent-stage")
     FileUtils.rm_rf(File.join(fresh_root, OwnedMediaImportFileService::STAGING_DIRECTORY))

--- a/test/services/upload_import_file_service_test.rb
+++ b/test/services/upload_import_file_service_test.rb
@@ -575,6 +575,50 @@ class UploadImportFileServiceTest < ActiveSupport::TestCase
     assert_operator locks.length, :<=, UploadImportFileService::LOCK_SHARDS
   end
 
+  test "mkdirat failure during publication reports accurate error not lock failure" do
+    service = UploadImportFileService.new(upload: @upload, book: @book)
+    service.reserve!
+
+    # Stub mkdirat to fail with EACCES when creating the destination parent directory.
+    # This happens during publication (inside the yielded block of with_lock),
+    # not during lock acquisition itself.
+    original_mkdirat = UploadImportFileService.method(:native_mkdirat)
+    destination_parent_name = File.basename(File.dirname(@upload.reload.destination_path))
+    interposed_mkdirat = lambda do |directory_fd, basename, mode|
+      if basename == destination_parent_name
+        raise Errno::EACCES, "Permission denied - mkdirat"
+      end
+      original_mkdirat.call(directory_fd, basename, mode)
+    end
+
+    error = UploadImportFileService.stub(:native_mkdirat, interposed_mkdirat) do
+      assert_raises(Errno::EACCES) { service.publish! }
+    end
+
+    assert_match(/Permission denied/, error.message)
+    assert_no_match(/lock/, error.message.downcase)
+  end
+
+  test "lock acquisition failure retains upload lock context" do
+    original_openat = UploadImportFileService.method(:native_openat)
+    failing_lock_open = lambda do |directory_fd, basename, flags:, mode: 0|
+      if basename.start_with?("lock-")
+        raise Errno::EACCES, "Permission denied - lock openat"
+      end
+
+      original_openat.call(directory_fd, basename, flags: flags, mode: mode)
+    end
+
+    error = UploadImportFileService.stub(:native_openat, failing_lock_open) do
+      assert_raises(UploadImportFileService::Error) do
+        UploadImportFileService.with_lock(@library_root, "failing-lock") { flunk }
+      end
+    end
+
+    assert_match(/could not lock the upload destination/i, error.message)
+    assert_match(/lock openat/i, error.message)
+  end
+
   private
 
   def build_upload(path)


### PR DESCRIPTION
## Related issue

Related to #469. This PR fixes the misleading diagnostic described there; it does **not** claim to fix the underlying queued-worker-versus-inline EACCES behavior, which was not reproducible locally. The issue should remain open until that root cause is identified.

## What changed

Lock acquisition is now isolated in private helpers for both ordinary uploads and owned-media imports. Only errors raised while creating/opening/chmodding/flocking the lock are normalized as lock failures. Filesystem errors raised by the publication block retain their original exception class and message, so an EACCES from mkdirat is no longer mislabeled as “could not lock.”

Lock files are still descriptor-pinned, sharded, chmodded to 0600, held across the complete publication block, and closed on every success or failure path.

## Verification

- Upload publication EACCES remains Errno::EACCES and retains the mkdirat diagnostic.
- Upload lock-open EACCES is reported with upload-lock context.
- Owned-media publication EACCES remains Errno::EACCES.
- Owned-media lock-open EACCES retains audiobook-lock context.
- Focused service suites: 62 tests, 257 assertions, all passing.
- Upload-processing, recovery, owned-media backup, and library-path suites: 96 tests, 471 assertions, all passing.
- Focused quality checks pass.

## Checklist

- [x] Change is scoped to accurate diagnostics and lock lifetime.
- [x] Publication exception classes/messages are preserved.
- [x] Lock-acquisition failures remain actionable.
- [x] Regression and adversarial coverage added.
- [x] Root-cause issue intentionally remains open.
