### PR TITLE
Fix: Rescue Faraday transport errors in BookMetadataLookupService

### DIFF
--- a/app/services/book_metadata_lookup_service.rb
+++ b/app/services/book_metadata_lookup_service.rb
@@ -112,6 +112,9 @@ class BookMetadataLookupService
       errors = [ HardcoverClient::Error, GoogleBooksClient::Error, OpenLibraryClient::Error, ComicVineClient::Error, MetadataService::Error, ArgumentError ]
       errors << VCR::Errors::UnhandledHTTPRequestError if defined?(VCR::Errors::UnhandledHTTPRequestError)
       errors << WebMock::NetConnectNotAllowedError if defined?(WebMock::NetConnectNotAllowedError)
+      if defined?(Faraday)
+        errors << Faraday::ConnectionFailed << Faraday::TimeoutError << Faraday::SSLError
+      end
       errors
     end
   end

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -1145,6 +1145,24 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_nil book.series
   end
 
+  test "create falls back to request params when metadata transport fails" do
+    MetadataService.stub(:book_details, ->(*) { raise Faraday::ConnectionFailed, "connection refused" }) do
+      assert_difference [ "Book.count", "Request.count" ], 1 do
+        post requests_path, params: {
+          work_id: "openlibrary:OL_FARADAY_FALLBACK_123W",
+          title: "Offline Fallback Book",
+          author: "Offline Fallback Author",
+          book_type: "ebook"
+        }
+      end
+    end
+
+    book = Book.last
+    assert_equal "Offline Fallback Book", book.title
+    assert_equal "Offline Fallback Author", book.author
+    assert_redirected_to request_path(Request.last)
+  end
+
   test "create enqueues request_created webhook event" do
     SettingsService.set(:webhook_enabled, true)
     SettingsService.set(:webhook_url, "http://localhost:4567/webhook")

--- a/test/services/book_metadata_lookup_service_test.rb
+++ b/test/services/book_metadata_lookup_service_test.rb
@@ -97,6 +97,81 @@ class BookMetadataLookupServiceTest < ActiveSupport::TestCase
     )
   end
 
+  test "rescues Faraday ConnectionFailed and continues with alternate identifiers" do
+    alternate = metadata_details(
+      source: "google_books",
+      source_id: "gb-123",
+      title: "Recovered title",
+      description: "Recovered description"
+    )
+    lookup = lambda do |work_id|
+      raise Faraday::ConnectionFailed, "Connection refused" if work_id == "hardcover:123"
+
+      alternate
+    end
+
+    metadata = MetadataService.stub(:book_details, lookup) do
+      BookMetadataLookupService.call([ "hardcover:123", "google_books:gb-123" ])
+    end
+
+    assert_equal "Recovered title", metadata[:title]
+    assert_equal "Recovered description", metadata[:description]
+  end
+
+  test "rescues Faraday TimeoutError and continues with alternate identifiers" do
+    alternate = metadata_details(
+      source: "google_books",
+      source_id: "gb-123",
+      title: "Recovered title",
+      description: "Recovered description"
+    )
+    lookup = lambda do |work_id|
+      raise Faraday::TimeoutError, "Request timed out" if work_id == "hardcover:123"
+
+      alternate
+    end
+
+    metadata = MetadataService.stub(:book_details, lookup) do
+      BookMetadataLookupService.call([ "hardcover:123", "google_books:gb-123" ])
+    end
+
+    assert_equal "Recovered title", metadata[:title]
+    assert_equal "Recovered description", metadata[:description]
+  end
+
+  test "rescues Faraday SSLError and continues with alternate identifiers" do
+    alternate = metadata_details(
+      source: "google_books",
+      source_id: "gb-123",
+      title: "Recovered title",
+      description: "Recovered description"
+    )
+    lookup = lambda do |work_id|
+      raise Faraday::SSLError, "SSL verification failed" if work_id == "hardcover:123"
+
+      alternate
+    end
+
+    metadata = MetadataService.stub(:book_details, lookup) do
+      BookMetadataLookupService.call([ "hardcover:123", "google_books:gb-123" ])
+    end
+
+    assert_equal "Recovered title", metadata[:title]
+    assert_equal "Recovered description", metadata[:description]
+  end
+
+  test "does not rescue unrelated exceptions" do
+    lookup = lambda do |_work_id|
+      raise RuntimeError, "Unrelated programming error"
+    end
+
+    assert_raises(RuntimeError) do
+      MetadataService.stub(:book_details, lookup) do
+        BookMetadataLookupService.call([ "hardcover:123" ])
+      end
+    end
+  end
+
   private
 
   def metadata_details(source:, source_id:, title:, description:)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Assigned issue

Closes #470

## What changed

This PR adds Faraday transport errors (`ConnectionFailed`, `TimeoutError`, `SSLError`) to the list of rescued exceptions in `BookMetadataLookupService.fetch_details`.

Previously, the service rescued provider-specific errors (e.g., `HardcoverClient::Error`, `GoogleBooksClient::Error`) and `MetadataService::Error`, but not Faraday's low-level transport exceptions. When a Faraday transport error occurred during synchronous metadata enrichment (e.g., network timeout, SSL verification failure, connection refused), the error would propagate up and cause request creation to fail with HTTP 500, even though the title and author submitted by the user were sufficient to create the request.

The fix treats Faraday transport errors the same way as provider errors: log a warning and return `nil`, allowing the service to continue with fallback metadata or alternate work IDs. Programming errors (non-transport exceptions) continue to propagate normally.

## Verification

- Added regression tests for `Faraday::ConnectionFailed`, `Faraday::TimeoutError`, and `Faraday::SSLError` to verify they are rescued and allow recovery with alternate identifiers
- Added a test to verify unrelated exceptions are not swallowed
- Ran `bundle exec rails test test/services/book_metadata_lookup_service_test.rb` - all 8 tests pass

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [x] I ran the relevant local quality checks
- [x] I updated documentation for user-visible changes (N/A - internal error handling)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bec6111-aa3a-43ae-befe-2fd9435c2f71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bec6111-aa3a-43ae-befe-2fd9435c2f71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

