### PR TITLE
Fix system health card to only count degraded/down services and make it clickable

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -77,7 +77,7 @@
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <div class="bg-gray-800 rounded-lg shadow p-6 border border-gray-700">
+    <div id="system-health" class="bg-gray-800 rounded-lg shadow p-6 border border-gray-700">
       <div class="flex items-center justify-between mb-4">
         <h2 class="font-bold text-xl text-white">System Health</h2>
         <%= button_to "Run Check", admin_run_health_check_path, method: :post, class: "px-3 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 rounded" %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -76,8 +76,8 @@
     <% end %>
 
     <%# System Status %>
-    <% unhealthy_count = @system_health.values.count { |h| !h.healthy? } %>
-    <div class="bg-gray-900 rounded-xl border border-gray-800 p-5 hover:border-gray-700 transition">
+    <% unhealthy_count = @system_health.values.count { |h| h.degraded? || h.down? } %>
+    <% system_card_content = capture do %>
       <div class="flex items-center gap-4">
         <div class="p-3 rounded-lg <%= unhealthy_count > 0 ? 'bg-red-500/20' : 'bg-green-500/20' %>">
           <% if unhealthy_count > 0 %>
@@ -97,7 +97,16 @@
           <div class="text-sm text-gray-500">System</div>
         </div>
       </div>
-    </div>
+    <% end %>
+    <% if Current.user&.admin? %>
+      <%= link_to admin_root_path(anchor: "system-health"), class: "bg-gray-900 rounded-xl border border-gray-800 p-5 hover:border-gray-700 transition block", data: { system_health_card: true } do %>
+        <%= system_card_content %>
+      <% end %>
+    <% else %>
+      <div class="bg-gray-900 rounded-xl border border-gray-800 p-5" data-system-health-card>
+        <%= system_card_content %>
+      </div>
+    <% end %>
   </div>
 
   <%# Recently Added to Library %>

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -26,4 +26,42 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{request_path(request)}'] span[class*='bg-emerald-500/90']",
       text: "Comics & Manga"
   end
+
+  test "system card only counts degraded and down services as issues, not not_configured" do
+    SystemHealth.delete_all
+
+    SystemHealth.create!(service: "indexer", status: :healthy)
+    SystemHealth.create!(service: "download_client", status: :not_configured)
+    SystemHealth.create!(service: "download_paths", status: :degraded)
+    SystemHealth.create!(service: "output_paths", status: :down)
+    SystemHealth.create!(service: "audiobookshelf", status: :not_configured)
+
+    get root_path
+
+    assert_response :success
+    assert_select "[data-system-health-card] .text-2xl", text: "2 Issues"
+    assert_select "a[data-system-health-card]", count: 0
+  end
+
+  test "system card is clickable for admins" do
+    admin = users(:two)
+    sign_in_as(admin)
+
+    get root_path
+
+    assert_response :success
+    assert_select "a[data-system-health-card][href='#{admin_root_path(anchor: "system-health")}']", text: /System/
+  end
+
+  test "system card shows Healthy when no degraded or down services" do
+    SystemHealth.delete_all
+
+    SystemHealth.create!(service: "indexer", status: :healthy)
+    SystemHealth.create!(service: "download_client", status: :not_configured)
+
+    get root_path
+
+    assert_response :success
+    assert_select "[data-system-health-card] .text-2xl", text: "Healthy"
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Assigned issue

Closes #459

## What changed

Fixed the Home dashboard System card to properly count and display system health issues:

1. **Changed the issue count logic**: Now only counts `degraded` and `down` services as "Issues", excluding `not_configured` services. This uses the existing `.unhealthy` scope logic (checking `h.degraded? || h.down?`) instead of the previous `!h.healthy?` which incorrectly counted `not_configured` as issues.

2. **Made the card clickable for admins**: Admin users can now click the System card to navigate to the admin dashboard's System Health section where they can see detailed status and messages for each service. Non-admin users see the same card but without the link.

This implementation follows the pattern of other dashboard cards (Pending, Completed, etc.) which are also clickable links.

## Verification

**Automated tests:**
- Added test to verify `not_configured` services are not counted as issues
- Added test to verify the System card is clickable for admins  
- Added test to verify "Healthy" is displayed when no degraded/down services exist
- All new tests pass
- Existing test suite passes (pre-existing failures in unrelated image processing tests remain)

**Manual testing:**
```bash
bin/rails test test/controllers/dashboard_controller_test.rb
# 4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

## Screenshots or recordings

N/A - UI change is minor (adds clickability and changes count logic)

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [x] I ran the relevant local quality checks
- [ ] I updated documentation for user-visible changes (not needed - internal behavior fix)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3115160-40cd-457f-a883-54e318f6a661?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3115160-40cd-457f-a883-54e318f6a661&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

