### PR TITLE
Fix HealthCheckJob duplicate chain issue

### DIFF
--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -14,7 +14,6 @@ class HealthCheckJob < ApplicationJob
       check_output_paths
       check_audiobookshelf
       check_hardcover
-      schedule_next_run
     end
   end
 
@@ -227,10 +226,5 @@ class HealthCheckJob < ApplicationJob
   rescue => e
     health.check_failed!(message: "Error: #{e.message}")
     Rails.logger.error "[HealthCheckJob] Hardcover check failed: #{e.message}"
-  end
-
-  def schedule_next_run
-    interval = SettingsService.get(:health_check_interval, default: 300)
-    HealthCheckJob.set(wait: interval.seconds).perform_later
   end
 end

--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -4,10 +4,41 @@
 class HealthCheckJob < ApplicationJob
   queue_as :default
 
-  def perform(service: nil)
+  class << self
+    def discard_legacy_scheduled_chains!
+      discarded = 0
+      legacy_scheduled_jobs.find_each do |job|
+        next unless full_health_check_arguments?(job.arguments)
+        next unless job.status.in?([ :ready, :scheduled ])
+
+        job.discard
+        discarded += 1
+      rescue SolidQueue::Execution::UndiscardableError, ActiveRecord::RecordNotFound
+        next
+      end
+      discarded
+    end
+
+    private
+
+    def legacy_scheduled_jobs
+      SolidQueue::Job
+        .where(class_name: name, finished_at: nil)
+        .where('"solid_queue_jobs"."scheduled_at" > "solid_queue_jobs"."created_at"')
+        .where.missing(:recurring_execution, :claimed_execution, :failed_execution)
+    end
+
+    def full_health_check_arguments?(payload)
+      payload.is_a?(Hash) && Array(payload["arguments"]).empty?
+    end
+  end
+
+  def perform(service: nil, scheduled: false)
     if service.present?
       run_check_for(service)
     else
+      return if scheduled && !scheduled_health_check_due?
+
       check_indexer
       check_download_clients
       check_download_paths
@@ -18,6 +49,19 @@ class HealthCheckJob < ApplicationJob
   end
 
   private
+
+  def scheduled_health_check_due?
+    health_records = SystemHealth.where(service: SystemHealth::SERVICES)
+    return true if health_records.count < SystemHealth::SERVICES.length
+    return true if health_records.where(last_check_at: nil).exists?
+
+    interval = SettingsService.get(:health_check_interval, default: 300).to_i
+    interval = [ interval, SettingsService::MIN_HEALTH_CHECK_INTERVAL ].max
+    interval_minutes = (interval / 1.minute.to_f).ceil
+    last_full_check = health_records.minimum(:last_check_at)
+
+    last_full_check.beginning_of_minute <= interval_minutes.minutes.ago.beginning_of_minute
+  end
 
   def run_check_for(service)
     case service.to_s

--- a/app/services/settings_service.rb
+++ b/app/services/settings_service.rb
@@ -1,4 +1,6 @@
 class SettingsService
+  MIN_HEALTH_CHECK_INTERVAL = 60
+
   MANUAL_SAVE_SETTING_GROUPS = {
     indexer: %w[
       indexer_provider prowlarr_url prowlarr_api_key jackett_url jackett_api_key
@@ -160,7 +162,7 @@ class SettingsService
     comic_vine_search_limit: { type: "integer", default: 10, category: "comic_vine", description: "Maximum number of Comic Vine search results to return" },
 
     # Health Monitoring
-    health_check_interval: { type: "integer", default: 300, category: "health", description: "Seconds between system health checks (default: 5 minutes)" },
+    health_check_interval: { type: "integer", default: 300, category: "health", description: "Seconds between system health checks (minimum: 60; default: 300)" },
 
     # Auto-Selection
     auto_select_enabled: { type: "boolean", default: false, category: "auto_select", description: "Automatically select the best search result without admin intervention" },
@@ -383,6 +385,8 @@ class SettingsService
       if key == :completed_download_import_mode
         return COMPLETED_DOWNLOAD_IMPORT_MODES.include?(value) ? value : "copy"
       end
+
+      return [ value.to_i, MIN_HEALTH_CHECK_INTERVAL ].max if key == :health_check_interval && !value.nil?
       return value unless value.nil?
 
       definition = DEFINITIONS[key]
@@ -400,6 +404,14 @@ class SettingsService
         value = value.to_s
         unless COMPLETED_DOWNLOAD_IMPORT_MODES.include?(value)
           raise ArgumentError, "#{label_for(key)} must be one of: #{COMPLETED_DOWNLOAD_IMPORT_MODES.join(', ')}"
+        end
+      end
+
+      if key == :health_check_interval
+        value = Integer(value, exception: false)
+        if value.nil? || value < MIN_HEALTH_CHECK_INTERVAL
+          raise ArgumentError,
+            "#{label_for(key)} must be at least #{MIN_HEALTH_CHECK_INTERVAL} seconds"
         end
       end
 

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -106,7 +106,11 @@
                         </label>
                         <% end %>
                       <% when "integer" %>
-                        <% integer_constraints = key.to_s == "ebooks_com_search_limit" ? { min: 1, max: EbooksComClient::MAX_RESULTS } : {} %>
+                        <% integer_constraints = case key.to_s
+                        when "ebooks_com_search_limit" then { min: 1, max: EbooksComClient::MAX_RESULTS }
+                        when "health_check_interval" then { min: SettingsService::MIN_HEALTH_CHECK_INTERVAL }
+                        else {}
+                        end %>
                         <%= form.number_field "settings[#{key}]", value: data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" }, **integer_constraints %>
                       <% when "json" %>
                         <%= form.text_field "settings[#{key}]", value: data[:value].is_a?(Array) ? data[:value].join(', ') : data[:value], id: "settings_#{key}", class: "w-full rounded-md border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-3 py-2", data: { action: "change->settings-form#autoSave" } %>

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -17,19 +17,16 @@ Rails.application.config.after_initialize do
       Rails.logger.warn "[Shelfarr] Could not seed SystemHealth records: #{e.message}"
     end
 
-    # Clean up leftover pending HealthCheckJob rows from the self-rescheduling chain bug
-    # This allows existing installs to heal on next deploy
     begin
-      deleted_count = SolidQueue::Job.where(
-        class_name: "HealthCheckJob",
-        finished_at: nil
-      ).delete_all
+      discarded_count = HealthCheckJob.discard_legacy_scheduled_chains!
 
-      if deleted_count > 0
-        Rails.logger.info "[Shelfarr] Cleaned up #{deleted_count} pending HealthCheckJob(s) from previous install"
+      if discarded_count.positive?
+        Rails.logger.info(
+          "[Shelfarr] Discarded #{discarded_count} legacy scheduled HealthCheckJob chain entries"
+        )
       end
     rescue => e
-      Rails.logger.warn "[Shelfarr] Could not clean up pending HealthCheckJob rows: #{e.message}"
+      Rails.logger.warn "[Shelfarr] Could not clean up legacy HealthCheckJob chains: #{e.message}"
     end
   end
 rescue => e

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Initialize health check records and start the health check job chain when the application boots
+# Initialize health check records when the application boots
 Rails.application.config.after_initialize do
-  # Only start in server mode, not in console or rake tasks
+  # Only run in server mode, not in console or rake tasks
   if defined?(Rails::Server)
     # Ensure SystemHealth records exist for all services so the dashboard
     # never shows a blank "Not checked" state
@@ -17,10 +17,21 @@ Rails.application.config.after_initialize do
       Rails.logger.warn "[Shelfarr] Could not seed SystemHealth records: #{e.message}"
     end
 
-    Rails.logger.info "[Shelfarr] Starting HealthCheckJob chain"
-    HealthCheckJob.perform_later
+    # Clean up leftover pending HealthCheckJob rows from the self-rescheduling chain bug
+    # This allows existing installs to heal on next deploy
+    begin
+      deleted_count = SolidQueue::Job.where(
+        class_name: "HealthCheckJob",
+        finished_at: nil
+      ).delete_all
+
+      if deleted_count > 0
+        Rails.logger.info "[Shelfarr] Cleaned up #{deleted_count} pending HealthCheckJob(s) from previous install"
+      end
+    rescue => e
+      Rails.logger.warn "[Shelfarr] Could not clean up pending HealthCheckJob rows: #{e.message}"
+    end
   end
 rescue => e
-  # Don't crash the app if there's an issue starting the health check
-  Rails.logger.error "[Shelfarr] Failed to start HealthCheckJob: #{e.message}"
+  Rails.logger.error "[Shelfarr] Failed to initialize health check: #{e.message}"
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -45,7 +45,9 @@ default: &default
   health_check:
     class: HealthCheckJob
     queue: default
-    schedule: every 5 minutes
+    args:
+      - scheduled: true
+    schedule: every minute
 
 development:
   <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -42,6 +42,10 @@ default: &default
     class: OwnedLibraryAutomationJob
     queue: default
     schedule: every 5 minutes
+  health_check:
+    class: HealthCheckJob
+    queue: default
+    schedule: every 5 minutes
 
 development:
   <<: *default

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -868,7 +868,7 @@
           <table>
             <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
             <tbody>
-              <tr><td class="key"><code>health_check_interval</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>300</code></td><td class="desc">Seconds between system health checks (default: 5 minutes).</td></tr>
+              <tr><td class="key"><code>health_check_interval</code></td><td><span class="badge t-integer">integer</span></td><td class="default"><code>300</code></td><td class="desc">Seconds between system health checks (minimum: 60; default: 300). Scheduled checks are evaluated once per minute.</td></tr>
               <tr><td class="key"><code>github_repo</code></td><td><span class="badge t-string">string</span></td><td class="default"><code>Pedro-Revez-Silva/shelfarr</code></td><td class="desc">Repository used for update-availability checks.</td></tr>
             </tbody>
           </table>

--- a/test/config/recurring_config_test.rb
+++ b/test/config/recurring_config_test.rb
@@ -53,4 +53,14 @@ class RecurringConfigTest < ActiveSupport::TestCase
     assert_equal "default", recovery_job["queue"]
     assert_equal "every 5 minutes", recovery_job["schedule"]
   end
+
+  test "runs health check every five minutes" do
+    config = YAML.safe_load_file(Rails.root.join("config/recurring.yml"), aliases: true)
+
+    health_check_job = config.fetch("default").fetch("health_check")
+
+    assert_equal "HealthCheckJob", health_check_job["class"]
+    assert_equal "default", health_check_job["queue"]
+    assert_equal "every 5 minutes", health_check_job["schedule"]
+  end
 end

--- a/test/config/recurring_config_test.rb
+++ b/test/config/recurring_config_test.rb
@@ -54,13 +54,14 @@ class RecurringConfigTest < ActiveSupport::TestCase
     assert_equal "every 5 minutes", recovery_job["schedule"]
   end
 
-  test "runs health check every five minutes" do
+  test "checks whether configured health monitoring is due every minute" do
     config = YAML.safe_load_file(Rails.root.join("config/recurring.yml"), aliases: true)
 
     health_check_job = config.fetch("default").fetch("health_check")
 
     assert_equal "HealthCheckJob", health_check_job["class"]
     assert_equal "default", health_check_job["queue"]
-    assert_equal "every 5 minutes", health_check_job["schedule"]
+    assert_equal [ { "scheduled" => true } ], health_check_job["args"]
+    assert_equal "every minute", health_check_job["schedule"]
   end
 end

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -44,6 +44,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_select "#settings-tabs noscript", text: /Use Save All/
     assert_select "#settings-tabs noscript style", count: 0
     assert_select "#settings-tabs [data-settings-tabs-target='tablist'].hidden [role='tablist']", count: 1
+    assert_select "input[name='settings[health_check_interval]'][min='#{SettingsService::MIN_HEALTH_CHECK_INTERVAL}']"
   end
 
   test "index shows telegram group authorization only in integrations tab" do

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -9,23 +9,48 @@ class HealthCheckJobTest < ActiveJob::TestCase
     Thread.current[:qbittorrent_sessions] = {}
   end
 
-  test "schedules next run after checking" do
-    assert_enqueued_with(job: HealthCheckJob) do
+  test "does not schedule next run after checking (recurring job handles scheduling)" do
+    assert_no_enqueued_jobs(only: HealthCheckJob) do
       HealthCheckJob.perform_now
     end
   end
 
-  test "uses configurable interval for next run" do
-    Setting.find_or_create_by(key: "health_check_interval").update!(
-      value: "600",
-      value_type: "integer",
-      category: "health"
+  test "cleans up leftover pending HealthCheckJob rows from self-rescheduling chains" do
+    # Connect to the queue database for this test
+    SolidQueue::Record.establish_connection(:queue)
+
+    # Simulate multiple pending HealthCheckJob rows from the old self-rescheduling chain bug
+    job1 = SolidQueue::Job.create!(
+      class_name: "HealthCheckJob",
+      queue_name: "default",
+      arguments: [].to_json,
+      scheduled_at: 5.minutes.from_now
+    )
+    job2 = SolidQueue::Job.create!(
+      class_name: "HealthCheckJob",
+      queue_name: "default",
+      arguments: [].to_json,
+      scheduled_at: 10.minutes.from_now
+    )
+    job3 = SolidQueue::Job.create!(
+      class_name: "HealthCheckJob",
+      queue_name: "default",
+      arguments: [].to_json,
+      scheduled_at: 15.minutes.from_now
     )
 
-    HealthCheckJob.perform_now
+    # Verify we have 3 pending jobs
+    assert_equal 3, SolidQueue::Job.where(class_name: "HealthCheckJob", finished_at: nil).count
 
-    enqueued = enqueued_jobs.find { |j| j[:job] == HealthCheckJob }
-    assert enqueued
+    # Run the cleanup logic from the initializer
+    deleted_count = SolidQueue::Job.where(
+      class_name: "HealthCheckJob",
+      finished_at: nil
+    ).delete_all
+
+    # Verify all pending jobs were cleaned up
+    assert_equal 3, deleted_count
+    assert_equal 0, SolidQueue::Job.where(class_name: "HealthCheckJob", finished_at: nil).count
   end
 
   # Single service check

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -6,6 +6,7 @@ class HealthCheckJobTest < ActiveJob::TestCase
   setup do
     SystemHealth.destroy_all
     DownloadClient.destroy_all
+    Setting.where(key: "health_check_interval").delete_all
     Thread.current[:qbittorrent_sessions] = {}
   end
 
@@ -15,42 +16,69 @@ class HealthCheckJobTest < ActiveJob::TestCase
     end
   end
 
-  test "cleans up leftover pending HealthCheckJob rows from self-rescheduling chains" do
-    # Connect to the queue database for this test
+  test "cleanup discards only identifiable legacy delayed full-check jobs" do
     SolidQueue::Record.establish_connection(:queue)
-
-    # Simulate multiple pending HealthCheckJob rows from the old self-rescheduling chain bug
-    job1 = SolidQueue::Job.create!(
-      class_name: "HealthCheckJob",
-      queue_name: "default",
-      arguments: [].to_json,
-      scheduled_at: 5.minutes.from_now
+    legacy = create_queue_health_job(scheduled_at: 5.minutes.from_now)
+    manual = create_queue_health_job(scheduled_at: Time.current)
+    targeted = create_queue_health_job(
+      scheduled_at: 5.minutes.from_now,
+      arguments: { service: "hardcover" }
     )
-    job2 = SolidQueue::Job.create!(
-      class_name: "HealthCheckJob",
-      queue_name: "default",
-      arguments: [].to_json,
-      scheduled_at: 10.minutes.from_now
+    recurring = create_queue_health_job(
+      scheduled_at: 5.minutes.from_now,
+      arguments: { scheduled: true }
     )
-    job3 = SolidQueue::Job.create!(
-      class_name: "HealthCheckJob",
-      queue_name: "default",
-      arguments: [].to_json,
-      scheduled_at: 15.minutes.from_now
+    SolidQueue::RecurringExecution.create!(
+      job: recurring,
+      task_key: "health_check",
+      run_at: 5.minutes.from_now
     )
+    claimed = create_queue_health_job(scheduled_at: 5.minutes.from_now)
+    claimed.scheduled_execution.destroy!
+    process = SolidQueue::Process.register(
+      kind: "Worker",
+      name: "health-check-cleanup-test-#{SecureRandom.hex(4)}",
+      pid: Process.pid,
+      hostname: "test",
+      metadata: {}
+    )
+    SolidQueue::ClaimedExecution.create!(job: claimed, process: process)
 
-    # Verify we have 3 pending jobs
-    assert_equal 3, SolidQueue::Job.where(class_name: "HealthCheckJob", finished_at: nil).count
+    assert_equal 1, HealthCheckJob.discard_legacy_scheduled_chains!
 
-    # Run the cleanup logic from the initializer
-    deleted_count = SolidQueue::Job.where(
-      class_name: "HealthCheckJob",
-      finished_at: nil
-    ).delete_all
+    assert_not SolidQueue::Job.exists?(legacy.id)
+    [ manual, targeted, recurring, claimed ].each do |preserved|
+      assert SolidQueue::Job.exists?(preserved.id), "expected job #{preserved.id} to be preserved"
+    end
+  end
 
-    # Verify all pending jobs were cleaned up
-    assert_equal 3, deleted_count
-    assert_equal 0, SolidQueue::Job.where(class_name: "HealthCheckJob", finished_at: nil).count
+  test "scheduled checks honor the configured interval on minute boundaries" do
+    SettingsService.set(:health_check_interval, 600)
+
+    travel_to Time.zone.parse("2026-08-26 12:00:00") do
+      SystemHealth::SERVICES.each do |service|
+        SystemHealth.create!(
+          service: service,
+          status: :not_configured,
+          last_check_at: 9.minutes.ago
+        )
+      end
+
+      job = HealthCheckJob.new
+      assert_not job.send(:scheduled_health_check_due?)
+
+      SystemHealth.update_all(last_check_at: 10.minutes.ago)
+      assert job.send(:scheduled_health_check_due?)
+    end
+  end
+
+  test "scheduled checks run when a service has never been checked" do
+    SystemHealth::SERVICES.each do |service|
+      SystemHealth.create!(service: service, status: :not_configured, last_check_at: 1.minute.ago)
+    end
+    SystemHealth.find_by!(service: "hardcover").update_column(:last_check_at, nil)
+
+    assert HealthCheckJob.new.send(:scheduled_health_check_due?)
   end
 
   # Single service check
@@ -498,6 +526,17 @@ class HealthCheckJobTest < ActiveJob::TestCase
   end
 
   private
+
+  def create_queue_health_job(scheduled_at:, arguments: {})
+    active_job = arguments.empty? ? HealthCheckJob.new : HealthCheckJob.new(**arguments)
+    SolidQueue::Job.create!(
+      active_job_id: active_job.job_id,
+      class_name: "HealthCheckJob",
+      queue_name: "default",
+      arguments: active_job.serialize,
+      scheduled_at: scheduled_at
+    )
+  end
 
   def create_download_client(name: "Test Client", url: "http://localhost:8080")
     DownloadClient.create!(

--- a/test/services/settings_service_test.rb
+++ b/test/services/settings_service_test.rb
@@ -21,6 +21,7 @@ class SettingsServiceTest < ActiveSupport::TestCase
       oidc_enabled oidc_auto_redirect oidc_provider_name oidc_issuer oidc_client_id oidc_client_secret oidc_scopes
       oidc_link_existing_users oidc_auto_create_users oidc_default_role
       webhook_enabled webhook_url webhook_token webhook_events webhook_topic
+      health_check_interval
     ]).delete_all
   end
 
@@ -183,6 +184,19 @@ class SettingsServiceTest < ActiveSupport::TestCase
     )
 
     assert_equal "copy", SettingsService.get(:completed_download_import_mode)
+  end
+
+  test "health check interval accepts safe values and rejects unsafe values" do
+    assert_equal 600, SettingsService.set(:health_check_interval, "600")
+
+    [ 59, 0, "invalid" ].each do |value|
+      error = assert_raises(ArgumentError) do
+        SettingsService.set(:health_check_interval, value)
+      end
+      assert_equal "Health Check Interval must be at least 60 seconds", error.message
+    end
+
+    assert_equal 600, SettingsService.get(:health_check_interval)
   end
 
   test "split audiobook bundle imports defaults to disabled" do


### PR DESCRIPTION
## Assigned issue

Closes #464

## What changed

- Replaced the boot-created, self-rescheduling HealthCheckJob chain with one Solid Queue recurring task.
- Runs a lightweight scheduler tick every minute and performs external checks only when the configured health_check_interval is due.
- Enforces and documents a 60-second minimum while preserving live setting changes and longer custom intervals.
- Keeps SystemHealth seeding at server boot.
- On upgrade, discards only identifiable legacy delayed full-check jobs.

## Safety review

Upgrade cleanup requires all of the legacy-chain signals: an unfinished HealthCheckJob, no arguments, a delayed scheduled_at timestamp, no recurring execution, no failed execution, no claimed/running execution, and a ready or scheduled state.

Manual full checks, service-specific checks, recurring executions, failed jobs, and claimed/running jobs are preserved. Any legacy job that cannot be identified safely may run once, but it cannot recreate a chain because self-rescheduling has been removed.

Solid Queue's recurring execution uniqueness prevents duplicate scheduler processes from enqueueing the same recurring occurrence. The due check uses all six SystemHealth records, so a manual single-service check cannot postpone the regular full check.

## Verification

- 253 focused tests, 1,110 assertions, 0 failures/errors
- Complete Admin::SettingsController suite: 164 tests, 803 assertions
- Solid Queue recurring configuration validation passes
- RuboCop and git diff --check pass
- Full bin/quality push gate passes
- Live authenticated UI check: Queue & System renders value 300, min=60, and the updated help text

## Screenshots or recordings

Live UI was inspected at desktop size; no layout regression found.

## Checklist

- [x] The maintainer assigned the linked issue before implementation
- [x] The pull request stays within the assigned issue scope
- [x] Tests cover duplicate cleanup, protected queue states, recurring configuration, and interval behavior
- [x] Relevant local and full quality checks pass
- [x] User-visible setting behavior is documented