### PR TITLE
Fix: Remove -nostdin flag from ffprobe command

### DIFF
--- a/app/services/audiobook_probe_service.rb
+++ b/app/services/audiobook_probe_service.rb
@@ -38,7 +38,6 @@ class AudiobookProbeService
       Tempfile.create([ "shelfarr-ffprobe-", ".json" ]) do |output|
         pid = Process.spawn(
           "ffprobe",
-          "-nostdin",
           "-v", "error",
           "-protocol_whitelist", "file,pipe",
           "-probesize", MAX_PROBE_BYTES.to_s,
@@ -47,6 +46,7 @@ class AudiobookProbeService
           "-show_entries", "stream=codec_type,duration:format=duration",
           "-of", "json",
           "-i", path.to_s,
+          in: File::NULL,
           out: output.path,
           err: File::NULL,
           pgroup: true,

--- a/test/services/audiobook_probe_service_test.rb
+++ b/test/services/audiobook_probe_service_test.rb
@@ -25,6 +25,24 @@ class AudiobookProbeServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "works with real ffprobe on a valid audio file" do
+    skip "ffprobe not available" unless system("ffprobe", "-version", out: File::NULL, err: File::NULL)
+    skip "ffmpeg not available" unless system("ffmpeg", "-version", out: File::NULL, err: File::NULL)
+
+    Dir.mktmpdir do |dir|
+      audio_file = File.join(dir, "test.mp3")
+      generated = system(
+        "ffmpeg", "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+        "-c:a", "libmp3lame", "-b:a", "64k", audio_file, "-y",
+        in: File::NULL, out: File::NULL, err: File::NULL
+      )
+
+      assert generated, "Test audio file should be created"
+      assert AudiobookProbeService.valid?(audio_file),
+             "AudiobookProbeService should validate a real audio file with the actual ffprobe binary"
+    end
+  end
+
   private
 
   def with_fake_ffprobe(payload)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Assigned issue

Closes #466

## What changed

Removed the `-nostdin` flag from the ffprobe command in `AudiobookProbeService#probe_file`. 

The `-nostdin` flag is not supported by ffprobe - it's an ffmpeg-specific flag. When passed to ffprobe, it interprets the next argument (`-v`) as the value for `nostdin`, causing ffprobe to exit with error code 1. This was preventing all direct downloads from being verified, even when they contained valid audio files.

The fix simply removes the flag. Since ffprobe is invoked with an explicit input file via `-i`, it doesn't read from stdin anyway, making the flag unnecessary.

## Verification

- Added a new test `test_works_with_real_ffprobe_on_a_valid_audio_file` that creates a real MP3 file and verifies ffprobe can successfully probe it with the actual command-line arguments used by the service
- The test fails before the fix (ffprobe returns exit code 1)
- The test passes after the fix (ffprobe successfully probes the audio file)
- All existing AudiobookProbeService tests pass (4 tests, 5 assertions)
- Verified manually that ffprobe 5.1.9 (Debian bookworm) and 6.1.1 (Ubuntu) both reject the `-nostdin` flag

## Screenshots or recordings

Not applicable - internal fix for audio file validation.

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [x] I ran the relevant local quality checks
- [ ] I updated documentation for user-visible changes (not applicable - no user-visible changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-677fc12e-9db1-40b3-bc03-5c3604ffbbce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-677fc12e-9db1-40b3-bc03-5c3604ffbbce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

