### PR TITLE
feat: support maintainer-adopted pull requests

### DIFF
--- a/.github/workflows/pr-authorization.yml
+++ b/.github/workflows/pr-authorization.yml
@@ -2,7 +2,7 @@ name: PR authorization
 
 on:
   pull_request_target:
-    types: [opened, reopened, edited, synchronize, ready_for_review]
+    types: [opened, reopened, edited, synchronize, ready_for_review, labeled, unlabeled]
   issues:
     types: [unassigned, closed]
   workflow_dispatch:
@@ -36,6 +36,7 @@ jobs:
               "dependabot[bot]",
               "github-actions[bot]",
             ]);
+            const maintainerAdoptedLabel = "maintainer-adopted";
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -108,6 +109,11 @@ jobs:
                       author {
                         login
                       }
+                      labels(first: 100) {
+                        nodes {
+                          name
+                        }
+                      }
                       closingIssuesReferences(first: 20) {
                         nodes {
                           number
@@ -178,6 +184,21 @@ jobs:
                 approvedBots.has(normalizedAuthor)
               ) {
                 core.info(`PR #${number}: @${author} is exempt from issue assignment.`);
+                return;
+              }
+
+              const labels = pull.labels.nodes.map(({ name }) => name.toLowerCase());
+              if (labels.includes(maintainerAdoptedLabel)) {
+                const existing = await findPolicyComment(number);
+                if (existing && enforce) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existing.id,
+                    body: `${marker}\nAuthorization confirmed: this pull request was adopted by a Shelfarr maintainer.`,
+                  });
+                }
+                core.info(`PR #${number}: explicitly adopted by a maintainer.`);
                 return;
               }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,21 @@ Pull requests that do not meet the assignment requirements are closed
 automatically. After the maintainer assigns the issue and the pull request
 description links it correctly, the author may reopen the pull request.
 
+## Maintainer adoption
+
+Occasionally, a maintainer may choose to finish an existing external pull
+request rather than ask its author to repeat integration work. The maintainer
+will apply the `maintainer-adopted` label and explain the handoff in the pull
+request. That label is explicit approval for the pull request to remain open
+without an assigned issue while the maintainer rebases, adjusts, tests, or
+finishes it.
+
+Adoption does not transfer ownership of the contributor's work. Original
+commits retain their authorship, and substantial rewrites or squashed commits
+must preserve credit with a `Co-authored-by` trailer. Once a pull request is
+adopted, its author does not need to take further action unless the maintainer
+asks for input.
+
 ## Before requesting review
 
 - Rebase once onto the current `main` branch when the implementation is ready.

--- a/test/config/pr_authorization_workflow_test.rb
+++ b/test/config/pr_authorization_workflow_test.rb
@@ -16,7 +16,7 @@ class PrAuthorizationWorkflowTest < ActiveSupport::TestCase
   end
 
   test "rechecks pull requests when their authorization can change" do
-    assert_equal %w[opened reopened edited synchronize ready_for_review],
+    assert_equal %w[opened reopened edited synchronize ready_for_review labeled unlabeled],
       @triggers.dig("pull_request_target", "types")
     assert_equal %w[unassigned closed], @triggers.dig("issues", "types")
     assert_equal false, @triggers.dig("workflow_dispatch", "inputs", "enforce", "default")
@@ -38,10 +38,14 @@ class PrAuthorizationWorkflowTest < ActiveSupport::TestCase
     assert_includes @script, "shelfarrIssues.length > 0 && unauthorizedIssues.length === 0"
   end
 
-  test "exempts only the owner and approved automation" do
+  test "exempts the owner, approved automation, and maintainer-adopted pull requests" do
     assert_includes @script, 'normalizedAuthor === owner.toLowerCase()'
     assert_includes @script, '"dependabot[bot]"'
     assert_includes @script, '"github-actions[bot]"'
+    assert_includes @script, 'const maintainerAdoptedLabel = "maintainer-adopted"'
+    assert_includes @script, "labels(first: 100)"
+    assert_includes @script, "labels.includes(maintainerAdoptedLabel)"
+    assert_includes @script, "explicitly adopted by a maintainer"
     refute_includes @script, "author_association"
   end
 


### PR DESCRIPTION
## Summary

- allow explicitly adopted external pull requests to bypass assigned-issue authorization with the maintainer-controlled `maintainer-adopted` label
- recheck authorization when the label is added or removed
- preserve and document contributor attribution during maintainer handoff
- extend workflow regression coverage for the new authorization path

## Test plan

- [x] 14 focused workflow tests, 206 assertions
- [x] Embedded GitHub Script JavaScript syntax check
- [x] Full local `bin/quality push` with two workers
- [x] GitHub CI, CodeQL, filesystem contracts, companion tests, security, and container build
- [x] `git diff --check`