### PR TITLE
Fix false-positive fuzzy matches for books in same series by same author

### DIFF
--- a/app/services/book_matcher_service.rb
+++ b/app/services/book_matcher_service.rb
@@ -24,7 +24,17 @@ class BookMatcherService
   # This prevents false positives when books share author + series text but have different core titles
   # Example: "Harry Potter und die Kammer des Schreckens" vs "Harry Potter und der Gefangene von Askaban"
   # should not match despite sharing author and series metadata
-  MIN_TITLE_SIMILARITY = 65
+  MIN_TITLE_SIMILARITY = FUZZY_THRESHOLD
+  SEQUENCE_MARKER_PATTERN = /\b(book|part|vol|volume)\s*(\d+|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten)\b/
+  SEQUENCE_NUMBER_WORDS = {
+    "one" => 1, "two" => 2, "three" => 3, "four" => 4, "five" => 5,
+    "six" => 6, "seven" => 7, "eight" => 8, "nine" => 9, "ten" => 10
+  }.freeze
+  ROMAN_DIGIT_VALUES = { "i" => 1, "v" => 5, "x" => 10, "l" => 50, "c" => 100, "d" => 500, "m" => 1_000 }.freeze
+  TITLE_ALIAS_METADATA_WORDS = %w[
+    a an anniversary audiobook biography book deluxe edition ebook illustrated
+    memoir novel novella part revised special the unabridged updated vol volume
+  ].freeze
 
   class << self
     # Find best matching book for the given title/author and book type
@@ -85,7 +95,10 @@ class BookMatcherService
     end
 
     def calculate_match_score(query_title:, query_author:, book_title:, book_author:)
-      title_score = string_similarity(normalize(query_title), normalize(book_title))
+      normalized_query_title = normalize(query_title)
+      normalized_book_title = normalize(book_title)
+      title_score = string_similarity(normalized_query_title, normalized_book_title)
+      return 0 if conflicting_sequence_markers?(normalized_query_title, normalized_book_title)
 
       # If no author in query, weight title more heavily
       if query_author.blank?
@@ -102,7 +115,8 @@ class BookMatcherService
       # Require minimum title similarity to prevent false positives when
       # books share author + series/edition text but have different core titles
       # (e.g., "Harry Potter und die Kammer des Schreckens" vs "Harry Potter und der Gefangene von Askaban")
-      if title_score < MIN_TITLE_SIMILARITY
+      if title_score < MIN_TITLE_SIMILARITY &&
+          !title_alias?(query_title, book_title)
         return title_score
       end
 
@@ -110,12 +124,85 @@ class BookMatcherService
       (title_score * 0.6 + author_score * 0.4).round
     end
 
+    # A colon or dash-delimited subtitle/series label can lower trigram
+    # similarity even when one side is still the complete core title. Require
+    # that structural boundary instead of accepting arbitrary containment,
+    # which would conflate sequels such as "The Cat in the Hat" and "The Cat
+    # in the Hat Comes Back".
+    def title_alias?(left, right)
+      normalized_left = normalize(left)
+      normalized_right = normalize(right)
+      shorter, longer = [ normalized_left, normalized_right ].sort_by(&:length)
+      return false if shorter.length < 8
+
+      if longer.start_with?("#{shorter} ")
+        suffix = longer.delete_prefix("#{shorter} ")
+        return true if title_metadata_suffix?(suffix)
+      end
+
+      raw_longer = normalized_left == longer ? left : right
+      segments = raw_longer.to_s
+        .split(/\s*(?::|[()\u2013\u2014]|\s-\s)\s*/)
+        .filter_map { |segment| normalize(segment).presence }
+      return false if segments.size < 2
+
+      # A complete title may follow a series label, as in "Mistborn: The Final
+      # Empire". Text following the complete title is safe only when it is
+      # edition metadata; otherwise it may be a distinct sequel subtitle.
+      return true if segments.last == shorter
+      return false unless segments.first == shorter
+
+      title_metadata_suffix?(segments.drop(1).join(" "))
+    end
+
+    def title_metadata_suffix?(suffix)
+      return false if suffix.match?(/\A(?:and|or|versus|vs)\b/)
+      return true if suffix.match?(
+        /\b(?:anniversary|audiobook|book|classics?|collection|deluxe|edition|ebook|illustrated|part|revised|series|special|unabridged|updated|vol|volume)\b/
+      )
+
+      suffix.split.all? { |word| word.in?(TITLE_ALIAS_METADATA_WORDS) }
+    end
+
+    def conflicting_sequence_markers?(left, right)
+      left_markers = left.scan(SEQUENCE_MARKER_PATTERN).to_h
+      right_markers = right.scan(SEQUENCE_MARKER_PATTERN).to_h
+
+      (left_markers.keys & right_markers.keys).any? do |marker|
+        left_markers.fetch(marker) != right_markers.fetch(marker)
+      end
+    end
+
+    def normalize_sequence_marker(marker)
+      marker.in?(%w[vol volume]) ? "volume" : marker
+    end
+
+    def normalize_sequence_number(value)
+      return value.to_i.to_s if value.match?(/\A\d+\z/)
+      return SEQUENCE_NUMBER_WORDS.fetch(value).to_s if SEQUENCE_NUMBER_WORDS.key?(value)
+
+      total = 0
+      previous = 0
+      value.reverse.each_char do |character|
+        current = ROMAN_DIGIT_VALUES.fetch(character)
+        total += current < previous ? -current : current
+        previous = [ previous, current ].max
+      end
+      total.to_s
+    end
+
     def normalize(text)
       return "" if text.blank?
 
       text
         .downcase
+        .gsub("&", " and ")
         .gsub(/[^a-z0-9\s]/, "")  # Remove special characters
+        .gsub(SEQUENCE_MARKER_PATTERN) do
+          marker = normalize_sequence_marker(Regexp.last_match(1))
+          number = normalize_sequence_number(Regexp.last_match(2))
+          "#{marker} #{number}"
+        end
         .gsub(/\s+/, " ")         # Collapse whitespace
         .strip
     end

--- a/app/services/book_matcher_service.rb
+++ b/app/services/book_matcher_service.rb
@@ -20,6 +20,12 @@ class BookMatcherService
   # Minimum score to consider a fuzzy match
   FUZZY_THRESHOLD = 70
 
+  # Minimum title-only similarity required before author similarity can contribute to score
+  # This prevents false positives when books share author + series text but have different core titles
+  # Example: "Harry Potter und die Kammer des Schreckens" vs "Harry Potter und der Gefangene von Askaban"
+  # should not match despite sharing author and series metadata
+  MIN_TITLE_SIMILARITY = 65
+
   class << self
     # Find best matching book for the given title/author and book type
     # Returns Result with matched book (or nil), score, and match type
@@ -92,6 +98,13 @@ class BookMatcherService
       end
 
       author_score = string_similarity(normalize(query_author), normalize(book_author))
+
+      # Require minimum title similarity to prevent false positives when
+      # books share author + series/edition text but have different core titles
+      # (e.g., "Harry Potter und die Kammer des Schreckens" vs "Harry Potter und der Gefangene von Askaban")
+      if title_score < MIN_TITLE_SIMILARITY
+        return title_score
+      end
 
       # Weight: 60% title, 40% author
       (title_score * 0.6 + author_score * 0.4).round

--- a/test/services/book_matcher_service_test.rb
+++ b/test/services/book_matcher_service_test.rb
@@ -115,4 +115,44 @@ class BookMatcherServiceTest < ActiveSupport::TestCase
 
     assert result.no_match?
   end
+
+  test "does not match different books in same series by same author" do
+    # Create a book from the German Harry Potter series (Chamber of Secrets)
+    existing_book = Book.create!(
+      title: "Harry Potter und die Kammer des Schreckens (Die Harry-Potter-Buchreihe) (German Edition)",
+      author: "J.K. Rowling",
+      book_type: :ebook
+    )
+
+    # Try to match a different book in the same series (Prisoner of Azkaban)
+    result = BookMatcherService.match(
+      title: "Harry Potter und der Gefangene von Askaban (Die Harry-Potter-Buchreihe) (German Edition)",
+      author: "J.K. Rowling",
+      book_type: :ebook
+    )
+
+    # Should not match - these are different books despite sharing author and series text
+    assert result.no_match?, "Different books in the same series should not match (got #{result.match_type} with score #{result.score})"
+    assert_nil result.book
+  end
+
+  test "does not match books with shared series suffix but different titles" do
+    # Create a book with a series tag
+    existing_book = Book.create!(
+      title: "The Shadow Rising (The Wheel of Time Book 4)",
+      author: "Robert Jordan",
+      book_type: :ebook
+    )
+
+    # Try to match a different book in the same series
+    result = BookMatcherService.match(
+      title: "The Fires of Heaven (The Wheel of Time Book 5)",
+      author: "Robert Jordan",
+      book_type: :ebook
+    )
+
+    # Should not match - these are different books
+    assert result.no_match?, "Different books in the same series should not match (got #{result.match_type} with score #{result.score})"
+    assert_nil result.book
+  end
 end

--- a/test/services/book_matcher_service_test.rb
+++ b/test/services/book_matcher_service_test.rb
@@ -155,4 +155,208 @@ class BookMatcherServiceTest < ActiveSupport::TestCase
     assert result.no_match?, "Different books in the same series should not match (got #{result.match_type} with score #{result.score})"
     assert_nil result.book
   end
+
+  test "matches a complete title with a subtitle extension" do
+    existing_book = Book.create!(
+      title: "Project Hail Mary: A Novel",
+      author: "Andy Weir",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "Project Hail Mary",
+      author: "Andy Weir",
+      book_type: :ebook
+    )
+
+    assert result.fuzzy?
+    assert_equal existing_book, result.book
+  end
+
+  test "matches an unseparated generic subtitle extension" do
+    existing_book = Book.create!(
+      title: "Project Hail Mary Novel",
+      author: "Andy Weir",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "Project Hail Mary",
+      author: "Andy Weir",
+      book_type: :ebook
+    )
+
+    assert result.fuzzy?
+    assert_equal existing_book, result.book
+  end
+
+  test "normalizes ampersands as and" do
+    existing_book = Book.create!(
+      title: "War and Peace",
+      author: "Leo Tolstoy",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "War & Peace",
+      author: "Leo Tolstoy",
+      book_type: :ebook
+    )
+
+    assert result.exact?
+    assert_equal existing_book, result.book
+  end
+
+  test "matches a complete title after a series prefix" do
+    existing_book = Book.create!(
+      title: "Mistborn: The Final Empire",
+      author: "Brandon Sanderson",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "The Final Empire",
+      author: "Brandon Sanderson",
+      book_type: :ebook
+    )
+
+    assert result.fuzzy?
+    assert_equal existing_book, result.book
+  end
+
+  test "matches a complete title before a numbered series suffix" do
+    existing_book = Book.create!(
+      title: "The Fellowship of the Ring (The Lord of the Rings, Book 1)",
+      author: "J.R.R. Tolkien",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "The Fellowship of the Ring",
+      author: "J.R.R. Tolkien",
+      book_type: :ebook
+    )
+
+    assert result.fuzzy?
+    assert_equal existing_book, result.book
+  end
+
+  test "matches a short complete title before a generic subtitle" do
+    existing_book = Book.create!(
+      title: "The Martian: A Novel",
+      author: "Andy Weir",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "The Martian",
+      author: "Andy Weir",
+      book_type: :ebook
+    )
+
+    assert result.fuzzy?
+    assert_equal existing_book, result.book
+  end
+
+  test "matches a complete title before publisher edition metadata" do
+    existing_book = Book.create!(
+      title: "Pride and Prejudice: Penguin Classics",
+      author: "Jane Austen",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "Pride and Prejudice",
+      author: "Jane Austen",
+      book_type: :ebook
+    )
+
+    assert result.fuzzy?
+    assert_equal existing_book, result.book
+  end
+
+  test "does not treat an unseparated sequel title as an alias" do
+    Book.create!(
+      title: "The Cat in the Hat Comes Back",
+      author: "Dr. Seuss",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "The Cat in the Hat",
+      author: "Dr. Seuss",
+      book_type: :ebook
+    )
+
+    assert result.no_match?
+    assert_nil result.book
+  end
+
+  test "does not treat a colon-delimited sequel subtitle as edition metadata" do
+    Book.create!(
+      title: "The Dark Tower: The Gunslinger",
+      author: "Stephen King",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "The Dark Tower",
+      author: "Stephen King",
+      book_type: :ebook
+    )
+
+    assert result.no_match?
+    assert_nil result.book
+  end
+
+  test "does not match a derivative title by the same credited author" do
+    Book.create!(
+      title: "Pride and Prejudice and Zombies",
+      author: "Jane Austen",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "Pride and Prejudice",
+      author: "Jane Austen",
+      book_type: :ebook
+    )
+
+    assert result.no_match?
+    assert_nil result.book
+  end
+
+  test "does not match different numbered volumes" do
+    Book.create!(
+      title: "Attack on Titan Vol 2",
+      author: "Hajime Isayama",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "Attack on Titan Vol 1",
+      author: "Hajime Isayama",
+      book_type: :ebook
+    )
+
+    assert result.no_match?
+    assert_nil result.book
+  end
+
+  test "matches equivalent volume marker formats" do
+    existing_book = Book.create!(
+      title: "Attack on Titan Volume 1",
+      author: "Hajime Isayama",
+      book_type: :ebook
+    )
+
+    result = BookMatcherService.match(
+      title: "Attack on Titan Vol. I",
+      author: "Hajime Isayama",
+      book_type: :ebook
+    )
+
+    assert result.exact?
+    assert_equal existing_book, result.book
+  end
 end


### PR DESCRIPTION
## Assigned issue

Refs #483

## What changed

- Prevent same-author books with structurally different titles or conflicting series sequence markers from being treated as fuzzy matches.
- Preserve safe title aliases such as subtitles, edition labels, ampersand variants, and equivalent volume markers.
- Add regression coverage for known false positives and legitimate matches.

This fixes the automatic matching portion of #483. The requested manual match and recovery workflow is separate and remains open.

## Verification

- [x] Fuzzy matcher tests: 23 runs, 46 assertions, 0 failures/errors
- [x] Upload matching path tests: 2 runs, 7 assertions, 0 failures/errors
- [x] Adversarial matrix covers same-series collisions, conflicting volumes, translations, subtitles, edition labels, and Roman/word/number volume equivalents
- [x] RuboCop passes for the changed files

## Screenshots or recordings

Not applicable; this changes backend matching decisions without adding UI.

## Checklist

- [x] The change is focused and avoids unrelated refactors.
- [x] I added or updated tests for the behavior I changed.
- [x] I ran the relevant test suite and linting locally.
- [x] I did not commit secrets or local environment files.
- [x] The PR description explains any user-visible behavior changes.
