### PR TITLE
Fix false-positive health check for .shelfarr-staging with owned-media dirs

### DIFF
--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -159,7 +159,9 @@ class DirectDownloadFileService
         # and locks/ subdirectories. Only warn if there are other entries that
         # could be leftover direct-download data.
         children = Dir.children(legacy)
-        owned_media_structure = children.all? { |name| name.in?([ "uploads", "locks" ]) }
+        owned_media_structure = children.all? do |name|
+          name.in?([ "uploads", "locks" ]) && File.lstat(legacy.join(name)).directory?
+        end
         return if owned_media_structure
 
         return "legacy direct-download staging contains retained entries; new downloads use " \

--- a/app/services/direct_download_file_service.rb
+++ b/app/services/direct_download_file_service.rb
@@ -154,6 +154,14 @@ class DirectDownloadFileService
       if stat.directory? && mode == 0o700
         return if Dir.empty?(legacy)
 
+        # Check if the directory only contains current owned-media structure.
+        # OwnedMediaImportFileService still uses .shelfarr-staging with uploads/
+        # and locks/ subdirectories. Only warn if there are other entries that
+        # could be leftover direct-download data.
+        children = Dir.children(legacy)
+        owned_media_structure = children.all? { |name| name.in?([ "uploads", "locks" ]) }
+        return if owned_media_structure
+
         return "legacy direct-download staging contains retained entries; new downloads use " \
           "#{STAGING_DIRECTORY}, and the legacy entry requires manual review"
       end

--- a/test/services/direct_download_file_service_test.rb
+++ b/test/services/direct_download_file_service_test.rb
@@ -123,6 +123,51 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert_not_includes chmod_identities, legacy_identity
   end
 
+  test "legacy staging diagnostic recognizes current owned-media directories" do
+    legacy = File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+    uploads = File.join(legacy, "uploads")
+    locks = File.join(legacy, "locks")
+    FileUtils.mkdir_p(uploads)
+    FileUtils.mkdir_p(locks)
+    File.chmod(0o700, legacy)
+    File.chmod(0o700, uploads)
+    File.chmod(0o700, locks)
+
+    # Create nested structure that owned-media uses
+    database_fingerprint = Digest::SHA256.hexdigest(
+      ActiveRecord::Base.connection_db_config.database.to_s
+    ).first(12)
+    upload_staging = File.join(uploads, database_fingerprint)
+    FileUtils.mkdir_p(upload_staging)
+    File.chmod(0o700, upload_staging)
+
+    # Should not warn when only uploads/ and locks/ are present
+    assert_nil DirectDownloadFileService.legacy_staging_diagnostic(root: @output_root)
+  end
+
+  test "legacy staging diagnostic accepts only uploads directory" do
+    legacy = File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+    uploads = File.join(legacy, "uploads")
+    FileUtils.mkdir_p(uploads)
+    File.chmod(0o700, legacy)
+
+    # Should not warn when only uploads/ is present (locks/ is optional)
+    assert_nil DirectDownloadFileService.legacy_staging_diagnostic(root: @output_root)
+  end
+
+  test "legacy staging diagnostic warns about actual leftover direct-download data" do
+    legacy = File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+    uploads = File.join(legacy, "uploads")
+    direct_downloads = File.join(legacy, "direct-downloads")
+    FileUtils.mkdir_p(uploads)
+    FileUtils.mkdir_p(direct_downloads)
+    File.chmod(0o700, legacy)
+
+    # Should warn when there are entries other than uploads/locks
+    diagnostic = DirectDownloadFileService.legacy_staging_diagnostic(root: @output_root)
+    assert_match(/contains retained entries/, diagnostic)
+  end
+
   test "rejects destinations in every internal library namespace" do
     LibraryPathSafety::INTERNAL_DIRECTORIES.each do |directory|
       internal = File.join(@output_root, directory, "book.epub")

--- a/test/services/direct_download_file_service_test.rb
+++ b/test/services/direct_download_file_service_test.rb
@@ -168,6 +168,29 @@ class DirectDownloadFileServiceTest < ActiveSupport::TestCase
     assert_match(/contains retained entries/, diagnostic)
   end
 
+  test "legacy staging diagnostic rejects an allowed basename that is a file" do
+    legacy = File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+    FileUtils.mkdir_p(legacy)
+    File.write(File.join(legacy, "uploads"), "retained data")
+    File.chmod(0o700, legacy)
+
+    diagnostic = DirectDownloadFileService.legacy_staging_diagnostic(root: @output_root)
+
+    assert_match(/contains retained entries/, diagnostic)
+  end
+
+  test "legacy staging diagnostic rejects an allowed basename that is a symlink" do
+    legacy = File.join(@output_root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+    target = File.join(@output_root, "external-locks")
+    FileUtils.mkdir_p([ legacy, target ])
+    File.symlink(target, File.join(legacy, "locks"))
+    File.chmod(0o700, legacy)
+
+    diagnostic = DirectDownloadFileService.legacy_staging_diagnostic(root: @output_root)
+
+    assert_match(/contains retained entries/, diagnostic)
+  end
+
   test "rejects destinations in every internal library namespace" do
     LibraryPathSafety::INTERNAL_DIRECTORIES.each do |directory|
       internal = File.join(@output_root, directory, "book.epub")


### PR DESCRIPTION
## Assigned issue

Closes #487

## What changed

- Treat Shelfarr-owned media directories inside `.shelfarr-staging` as healthy expected contents.
- Require every allowlisted staging entry to be a real directory.
- Reject regular files and symlinks that merely reuse an allowlisted basename.
- Add coverage for expected directories, unexpected entries, files, and symlinks.

## Verification

- [x] Relevant tests: 63 runs, 267 assertions, 0 failures/errors
- [x] RuboCop passes for the changed files
- [x] Adversarial filesystem review covers basename spoofing and symlink cases

## Screenshots or recordings

Not applicable; this changes filesystem health-check behavior.

## Checklist

- [x] The change is focused and avoids unrelated refactors.
- [x] I added or updated tests for the behavior I changed.
- [x] I ran the relevant test suite and linting locally.
- [x] I did not commit secrets or local environment files.
- [x] The PR description explains any user-visible behavior changes.
