### PR TITLE
fix: preserve Hardcover single-provider search results

### DIFF
--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -125,8 +125,6 @@ class MetadataService
         priority: provider_priority,
         requested_content_kind: requested_content_kind
       )
-      min_confidence = SettingsService.get(:min_match_confidence).to_i
-      candidates = candidates.select { |candidate| candidate.confidence >= min_confidence }
       candidates = filter_candidates_for_content(candidates, requested_content_kind)
       sort_candidates(candidates, requested_content_kind: requested_content_kind).first(limit || default_search_limit)
     end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -12,6 +12,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     @original_hardcover_enabled = SettingsService.get(:hardcover_enabled)
     @original_google_books_enabled = SettingsService.get(:google_books_enabled)
     @original_open_library_enabled = SettingsService.get(:open_library_enabled)
+    @original_min_match_confidence = SettingsService.get(:min_match_confidence)
     MetadataProviderStatus.delete_all
     HardcoverClient.reset_connection!
     GoogleBooksClient.reset_connection!
@@ -25,6 +26,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     SettingsService.set(:hardcover_enabled, @original_hardcover_enabled.nil? ? true : @original_hardcover_enabled)
     SettingsService.set(:google_books_enabled, @original_google_books_enabled.nil? ? true : @original_google_books_enabled)
     SettingsService.set(:open_library_enabled, @original_open_library_enabled.nil? ? true : @original_open_library_enabled)
+    SettingsService.set(:min_match_confidence, @original_min_match_confidence || 50)
     MetadataProviderStatus.delete_all
     HardcoverClient.reset_connection!
     GoogleBooksClient.reset_connection!
@@ -313,6 +315,34 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_equal "text/vnd.turbo-stream.html", response.media_type
     assert_match %r{href="/search/details\?}, response.body
     assert_no_match %r{href="//search/details\?}, response.body
+  end
+
+  test "stream_results renders a Hardcover-only result above the unrelated indexer threshold" do
+    SettingsService.set(:metadata_source, "auto")
+    SettingsService.set(:hardcover_enabled, true)
+    SettingsService.set(:hardcover_api_token, "test-token")
+    SettingsService.set(:open_library_enabled, false)
+    SettingsService.set(:google_books_enabled, false)
+    SettingsService.set(:min_match_confidence, 80)
+    HardcoverClient.reset_connection!
+
+    VCR.turned_off do
+      stub_hardcover_search([
+        {
+          "id" => 303,
+          "title" => "Hardcover Only Result",
+          "author_names" => [ "Ada Writer" ],
+          "release_year" => 2026
+        }
+      ])
+
+      get search_results_stream_path, params: { q: "hardcover only" }
+    end
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    assert_match "Hardcover Only Result", response.body
+    assert_no_match "No results found", response.body
   end
 
   test "stream_results applies the normalized content filter to partial results" do

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -551,20 +551,27 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert_equal %w[hardcover openlibrary google_books], results.map(&:source)
   end
 
-  test "aggregate_provider_results filters candidates below min_match_confidence" do
+  test "aggregate_provider_results preserves single-provider metadata results regardless of min_match_confidence" do
     SettingsService.set(:min_match_confidence, 80)
 
     provider_results = [
-      metadata_provider_result(source: "openlibrary", source_id: "OL_LOW", title: "Low Confidence"),
+      metadata_provider_result(source: "hardcover", source_id: "HC_ONLY", title: "Hardcover Only Result"),
       metadata_provider_result(source: "openlibrary", source_id: "OL_HIGH_A", title: "High Confidence", year: 1965),
       metadata_provider_result(source: "google_books", source_id: "GB_HIGH_B", title: "High Confidence", year: 1966)
     ]
 
     results = MetadataService.aggregate_provider_results(provider_results)
 
-    assert_equal 1, results.size
-    assert_equal "High Confidence", results.first.title
-    assert_equal 90, results.first.confidence
+    assert_equal 2, results.size
+    hardcover_result = results.find { |r| r.title == "Hardcover Only Result" }
+    multi_provider_result = results.find { |r| r.title == "High Confidence" }
+    
+    assert_not_nil hardcover_result, "Hardcover-only result should not be filtered"
+    assert_equal "hardcover", hardcover_result.source
+    assert_equal 70, hardcover_result.confidence
+    
+    assert_not_nil multi_provider_result
+    assert_equal 90, multi_provider_result.confidence
   end
 
   test "bounded web aggregation remains untruncated until pagination after deduplication" do

--- a/test/services/metadata_service_test.rb
+++ b/test/services/metadata_service_test.rb
@@ -565,11 +565,11 @@ class MetadataServiceTest < ActiveSupport::TestCase
     assert_equal 2, results.size
     hardcover_result = results.find { |r| r.title == "Hardcover Only Result" }
     multi_provider_result = results.find { |r| r.title == "High Confidence" }
-    
+
     assert_not_nil hardcover_result, "Hardcover-only result should not be filtered"
     assert_equal "hardcover", hardcover_result.source
     assert_equal 70, hardcover_result.confidence
-    
+
     assert_not_nil multi_provider_result
     assert_equal 90, multi_provider_result.confidence
   end


### PR DESCRIPTION
## Assigned issue

Closes #450

## What changed

- Preserve curated Hardcover results even when Hardcover is the only enabled metadata provider.
- Stop applying the automatic-match confidence threshold to the final provider aggregation step.
- Add a streamed search regression that proves a below-threshold Hardcover-only result renders as a result card instead of an empty state.

## Verification

- [x] Search/controller tests: 85 runs, 308 assertions, 0 failures/errors
- [x] Full browser system suite: 33 runs, 260 assertions, 0 failures/errors/skips
- [x] Authenticated Turbo-stream render: HTTP 200, two stream actions, Hardcover card/link present, no empty-results state
- [x] RuboCop passes for the changed files
- [x] Adversarial review confirmed automatic matching still applies its own threshold

## Screenshots or recordings

Verified against a local Shelfarr instance and the repository's real Selenium system-test browser. No persistent visual layout changes are introduced.

## Checklist

- [x] The change is focused and avoids unrelated refactors.
- [x] I added or updated tests for the behavior I changed.
- [x] I ran the relevant test suite and linting locally.
- [x] I did not commit secrets or local environment files.
- [x] The PR description explains any user-visible behavior changes.
