### PR TITLE
Fix Hardcover API quota exhaustion

### DIFF
--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -258,13 +258,32 @@ class HealthCheckJob < ApplicationJob
       return
     end
 
+    # Skip health check if we've exceeded or are approaching the daily quota
+    if HardcoverClient.quota_exceeded?
+      daily_count = HardcoverClient.daily_request_count
+      health.check_failed!(
+        message: "Daily API quota exceeded (#{daily_count}/#{HardcoverClient::FREE_PLAN_DAILY_LIMIT})",
+        degraded: false
+      )
+      return
+    elsif HardcoverClient.should_backoff?
+      daily_count = HardcoverClient.daily_request_count
+      Rails.logger.info "[HealthCheckJob] Skipping Hardcover health check (approaching quota: #{daily_count}/#{HardcoverClient::FREE_PLAN_DAILY_LIMIT})"
+      # Don't fail the health check, just skip it
+      return
+    end
+
     if HardcoverClient.test_connection
       health.check_succeeded!(message: "Connection successful")
     else
       health.check_failed!(message: "Failed to connect to Hardcover")
     end
+  rescue HardcoverClient::QuotaExceededError => e
+    health.check_failed!(message: "API quota exceeded", degraded: false)
   rescue HardcoverClient::AuthenticationError => e
     health.check_failed!(message: "Authentication failed: #{e.message}")
+  rescue HardcoverClient::RateLimitError => e
+    health.check_failed!(message: "Rate limit exceeded", degraded: true)
   rescue HardcoverClient::ConnectionError => e
     health.check_failed!(message: "Connection error: #{e.message}")
   rescue => e

--- a/app/services/hardcover_client.rb
+++ b/app/services/hardcover_client.rb
@@ -5,11 +5,19 @@
 class HardcoverClient
   BASE_URL = "https://api.hardcover.app/v1/graphql"
 
+  # Hardcover free plan limits (as of 2026)
+  FREE_PLAN_REQUESTS_PER_MINUTE = 60
+  FREE_PLAN_DAILY_LIMIT = 5000
+  RATE_LIMIT_CACHE_KEY = "hardcover_client_rate_limit"
+  DAILY_QUOTA_CACHE_KEY = "hardcover_client_daily_quota"
+  RATE_LIMIT_BACKOFF_SECONDS = 65 # Wait just over 1 minute to reset the per-minute limit
+
   # Custom error classes
   class Error < StandardError; end
   class ConnectionError < Error; end
   class AuthenticationError < Error; end
   class RateLimitError < Error; end
+  class QuotaExceededError < RateLimitError; end
   class NotFoundError < Error; end
   class NotConfiguredError < Error; end
 
@@ -44,6 +52,50 @@ class HardcoverClient
   class << self
     def configured?
       SettingsService.hardcover_configured?
+    end
+
+    # Check if we've hit the daily quota limit
+    def quota_exceeded?
+      daily_count = Rails.cache.read(DAILY_QUOTA_CACHE_KEY).to_i
+      daily_count >= FREE_PLAN_DAILY_LIMIT
+    end
+
+    # Get current daily request count
+    def daily_request_count
+      Rails.cache.read(DAILY_QUOTA_CACHE_KEY).to_i
+    end
+
+    # Track an API request for rate limiting and quota purposes
+    def track_request!
+      now = Time.current
+      today_key = "#{DAILY_QUOTA_CACHE_KEY}:#{now.to_date.iso8601}"
+      
+      # Increment daily counter
+      daily_count = Rails.cache.read(today_key).to_i
+      Rails.cache.write(today_key, daily_count + 1, expires_in: 25.hours)
+
+      # Also track in a rolling counter for monitoring
+      Rails.cache.write(DAILY_QUOTA_CACHE_KEY, daily_count + 1, expires_in: 25.hours)
+      
+      # Track per-minute rate limit
+      minute_key = "#{RATE_LIMIT_CACHE_KEY}:#{now.beginning_of_minute.to_i}"
+      minute_count = Rails.cache.read(minute_key).to_i
+      Rails.cache.write(minute_key, minute_count + 1, expires_in: 90.seconds)
+
+      Rails.logger.info "[HardcoverClient] Request tracked: daily #{daily_count + 1}, minute #{minute_count + 1}"
+    end
+
+    # Check if we should back off due to approaching limits
+    def should_backoff?
+      daily_count = daily_request_count
+      
+      # Back off if we're close to the daily limit (90% threshold)
+      if daily_count >= (FREE_PLAN_DAILY_LIMIT * 0.9)
+        Rails.logger.warn "[HardcoverClient] Approaching daily quota: #{daily_count}/#{FREE_PLAN_DAILY_LIMIT}"
+        return true
+      end
+
+      false
     end
 
     # Search for books by query
@@ -217,7 +269,17 @@ class HardcoverClient
       raise NotConfiguredError, "Hardcover API token not configured" unless configured?
     end
 
+    def check_quota_and_track!
+      if quota_exceeded?
+        raise QuotaExceededError, "Daily API quota exceeded (#{FREE_PLAN_DAILY_LIMIT} requests/day)"
+      end
+
+      track_request!
+    end
+
     def execute_query(query, variables)
+      check_quota_and_track!
+      
       response = connection.post do |req|
         req.body = { query: query, variables: variables }.to_json
       end
@@ -264,8 +326,9 @@ class HardcoverClient
         Rails.logger.error "[HardcoverClient] Authentication failed (status #{response.status})"
         raise AuthenticationError, "Invalid API token"
       when 429
-        Rails.logger.warn "[HardcoverClient] Rate limit exceeded"
-        raise RateLimitError, "Rate limit exceeded (60 requests/minute)"
+        daily_count = daily_request_count
+        Rails.logger.warn "[HardcoverClient] Rate limit exceeded (daily: #{daily_count}/#{FREE_PLAN_DAILY_LIMIT})"
+        raise RateLimitError, "Rate limit exceeded (60 requests/minute, #{FREE_PLAN_DAILY_LIMIT}/day limit)"
       else
         Rails.logger.error "[HardcoverClient] API error (status #{response.status})"
         raise Error, "API request failed with status #{response.status}"

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -201,7 +201,7 @@ class MetadataService
     def provider_errors(provider)
       errors = case provider.to_s
       when "hardcover"
-        [ HardcoverClient::Error ]
+        [ HardcoverClient::Error, HardcoverClient::QuotaExceededError ]
       when "google_books"
         [ GoogleBooksClient::Error ]
       when "openlibrary"

--- a/test/services/hardcover_client_test.rb
+++ b/test/services/hardcover_client_test.rb
@@ -6,11 +6,14 @@ class HardcoverClientTest < ActiveSupport::TestCase
   setup do
     @original_token = SettingsService.get(:hardcover_api_token)
     HardcoverClient.reset_connection!
+    # Clear quota cache before each test
+    Rails.cache.clear
   end
 
   teardown do
     SettingsService.set(:hardcover_api_token, @original_token || "")
     HardcoverClient.reset_connection!
+    Rails.cache.clear
   end
 
   test "configured? returns false without token" do
@@ -281,6 +284,69 @@ class HardcoverClientTest < ActiveSupport::TestCase
     )
 
     assert_equal "hardcover:12345", result.work_id
+  end
+
+  test "tracks API requests for quota monitoring" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      stub_hardcover_search("test", [])
+
+      initial_count = HardcoverClient.daily_request_count
+      HardcoverClient.search("test")
+      
+      assert_equal initial_count + 1, HardcoverClient.daily_request_count,
+        "Should increment daily request counter"
+    end
+  end
+
+  test "blocks requests when daily quota is exceeded" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    # Simulate quota exceeded
+    today_key = "#{HardcoverClient::DAILY_QUOTA_CACHE_KEY}:#{Time.current.to_date.iso8601}"
+    Rails.cache.write(today_key, HardcoverClient::FREE_PLAN_DAILY_LIMIT + 1)
+    Rails.cache.write(HardcoverClient::DAILY_QUOTA_CACHE_KEY, HardcoverClient::FREE_PLAN_DAILY_LIMIT + 1)
+
+    VCR.turned_off do
+      assert_raises HardcoverClient::QuotaExceededError do
+        HardcoverClient.search("test")
+      end
+    end
+  end
+
+  test "quota_exceeded? returns true when over limit" do
+    today_key = "#{HardcoverClient::DAILY_QUOTA_CACHE_KEY}:#{Time.current.to_date.iso8601}"
+    Rails.cache.write(today_key, HardcoverClient::FREE_PLAN_DAILY_LIMIT + 1)
+    Rails.cache.write(HardcoverClient::DAILY_QUOTA_CACHE_KEY, HardcoverClient::FREE_PLAN_DAILY_LIMIT + 1)
+
+    assert HardcoverClient.quota_exceeded?
+  end
+
+  test "quota_exceeded? returns false when under limit" do
+    today_key = "#{HardcoverClient::DAILY_QUOTA_CACHE_KEY}:#{Time.current.to_date.iso8601}"
+    Rails.cache.write(today_key, 100)
+    Rails.cache.write(HardcoverClient::DAILY_QUOTA_CACHE_KEY, 100)
+
+    assert_not HardcoverClient.quota_exceeded?
+  end
+
+  test "should_backoff? returns true when approaching quota" do
+    # Set to 91% of daily limit
+    approaching_limit = (HardcoverClient::FREE_PLAN_DAILY_LIMIT * 0.91).to_i
+    today_key = "#{HardcoverClient::DAILY_QUOTA_CACHE_KEY}:#{Time.current.to_date.iso8601}"
+    Rails.cache.write(today_key, approaching_limit)
+    Rails.cache.write(HardcoverClient::DAILY_QUOTA_CACHE_KEY, approaching_limit)
+
+    assert HardcoverClient.should_backoff?
+  end
+
+  test "should_backoff? returns false when well under quota" do
+    today_key = "#{HardcoverClient::DAILY_QUOTA_CACHE_KEY}:#{Time.current.to_date.iso8601}"
+    Rails.cache.write(today_key, 100)
+    Rails.cache.write(HardcoverClient::DAILY_QUOTA_CACHE_KEY, 100)
+
+    assert_not HardcoverClient.should_backoff?
   end
 
   private

--- a/test/services/hardcover_quota_test.rb
+++ b/test/services/hardcover_quota_test.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Test that Hardcover API calls stay within reasonable quota limits
+# to avoid burning through the free plan's ~5000 daily requests
+class HardcoverQuotaTest < ActiveSupport::TestCase
+  setup do
+    @original_token = SettingsService.get(:hardcover_api_token)
+    SettingsService.set(:hardcover_api_token, "test_token")
+    HardcoverClient.reset_connection!
+    
+    @api_call_count = 0
+    
+    # Track all API calls made to Hardcover
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return do |request|
+        @api_call_count += 1
+        {
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "data" => { "me" => [ { "id" => 123 } ] } }.to_json
+        }
+      end
+  end
+
+  teardown do
+    SettingsService.set(:hardcover_api_token, @original_token || "")
+    HardcoverClient.reset_connection!
+  end
+
+  test "search respects the configured search limit setting" do
+    limit = 5
+    SettingsService.set(:hardcover_search_limit, limit)
+
+    # Stub a search that would return many results if limit wasn't enforced
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          "data" => {
+            "search" => {
+              "results" => {
+                "hits" => Array.new(limit) do |i|
+                  {
+                    "document" => {
+                      "id" => i + 1,
+                      "title" => "Book #{i + 1}",
+                      "author_names" => [ "Author #{i + 1}" ]
+                    }
+                  }
+                end
+              }
+            }
+          }
+        }.to_json
+      )
+
+    results = HardcoverClient.search("test query")
+
+    # Should return exactly limit results, not more
+    assert_equal limit, results.size, "Search should respect the configured limit"
+
+    # Verify the API request included the correct limit parameter
+    assert_requested(:post, HardcoverClient::BASE_URL) do |req|
+      body = JSON.parse(req.body)
+      body.dig("variables", "perPage") == limit
+    end
+  end
+
+  test "search does not make multiple API calls per result" do
+    limit = 10
+    SettingsService.set(:hardcover_search_limit, limit)
+
+    stub_hardcover_search_response(limit)
+
+    initial_count = @api_call_count
+    HardcoverClient.search("test query")
+    calls_made = @api_call_count - initial_count
+
+    # Should make exactly ONE API call for a search, not one per result
+    assert_equal 1, calls_made, 
+      "Search should make only 1 API call total, not one per result"
+  end
+
+  test "health check test_connection makes only one API call" do
+    initial_count = @api_call_count
+    HardcoverClient.test_connection
+    calls_made = @api_call_count - initial_count
+
+    assert_equal 1, calls_made,
+      "test_connection should make exactly 1 API call"
+  end
+
+  test "MetadataService search does not call Hardcover per provider result" do
+    SettingsService.set(:hardcover_search_limit, 10)
+    
+    # Enable only Hardcover
+    SettingsService.set(:metadata_providers, [ "hardcover" ])
+
+    stub_hardcover_search_response(10)
+
+    initial_count = @api_call_count
+    MetadataService.search("test query")
+    calls_made = @api_call_count - initial_count
+
+    # Should make exactly ONE call to Hardcover for the search
+    assert_equal 1, calls_made,
+      "MetadataService search should make only 1 Hardcover API call"
+  end
+
+  test "repeated health checks respect the configured interval" do
+    SettingsService.set(:health_check_interval, 300) # 5 minutes
+    
+    # Create initial health record
+    health = SystemHealth.for_service("hardcover")
+    health.update!(last_check_at: 10.minutes.ago)
+
+    # First check should run (interval has passed)
+    initial_count = @api_call_count
+    HealthCheckJob.perform_now(scheduled: true)
+    assert_equal 1, @api_call_count - initial_count,
+      "First health check should call Hardcover API"
+
+    health.reload
+    first_check_time = health.last_check_at
+
+    # Second check immediately after should NOT run (interval hasn't passed)
+    HealthCheckJob.perform_now(scheduled: true)
+    assert_equal 1, @api_call_count - initial_count,
+      "Second immediate health check should not call Hardcover API (interval not elapsed)"
+
+    health.reload
+    assert_equal first_check_time, health.last_check_at,
+      "Health check timestamp should not change when interval hasn't elapsed"
+  end
+
+  test "handles 429 rate limit response gracefully" do
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return(status: 429, body: '{"error": "Rate limit exceeded"}')
+
+    assert_raises HardcoverClient::RateLimitError do
+      HardcoverClient.search("test")
+    end
+  end
+
+  test "book details lookup makes only one API call" do
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          "data" => {
+            "books" => [
+              {
+                "id" => 12345,
+                "title" => "Test Book",
+                "contributions" => [ { "author" => { "name" => "Test Author" } } ]
+              }
+            ]
+          }
+        }.to_json
+      )
+
+    initial_count = @api_call_count
+    HardcoverClient.book(12345)
+    calls_made = @api_call_count - initial_count
+
+    assert_equal 1, calls_made,
+      "Book details lookup should make exactly 1 API call"
+  end
+
+  test "series_books makes only one API call" do
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          "data" => {
+            "series" => [
+              {
+                "id" => 987,
+                "name" => "Test Series",
+                "book_series" => [
+                  {
+                    "position" => 1,
+                    "book" => {
+                      "id" => 111,
+                      "title" => "Book 1",
+                      "contributions" => [ { "author" => { "name" => "Author" } } ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }.to_json
+      )
+
+    initial_count = @api_call_count
+    HardcoverClient.series_books(987)
+    calls_made = @api_call_count - initial_count
+
+    assert_equal 1, calls_made,
+      "Series books lookup should make exactly 1 API call"
+  end
+
+  private
+
+  def stub_hardcover_search_response(result_count)
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          "data" => {
+            "search" => {
+              "results" => {
+                "hits" => Array.new(result_count) do |i|
+                  {
+                    "document" => {
+                      "id" => i + 1,
+                      "title" => "Book #{i + 1}",
+                      "author_names" => [ "Author #{i + 1}" ],
+                      "cached_image" => "https://example.com/cover#{i + 1}.jpg"
+                    }
+                  }
+                end
+              }
+            }
+          }
+        }.to_json
+      )
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Assigned issue

Closes #492

## What changed

Added comprehensive API quota tracking and rate limiting to HardcoverClient to prevent burning through the free plan's daily request limit (5000/day):

- **Daily quota tracking**: Track all API requests in Rails cache and block when limit reached
- **Rate limiting**: Monitor per-minute (60 req/min) and daily (5000 req/day) limits
- **Health check protection**: Skip health checks when quota exceeded or approaching limit (90%)
- **Better error handling**: New QuotaExceededError with usage information
- **Improved logging**: Show current quota usage in all rate limit messages

The root cause was untracked API usage from health checks running every minute, potentially multiplied by duplicate recurring task instances similar to previous bugs (#464, #488).

## Verification

**Automated tests added:**
- `test/services/hardcover_quota_test.rb` - Comprehensive quota enforcement tests:
  - Search respects configured limit setting
  - Only one API call per search (not one per result)
  - Health checks respect configured intervals
  - Rate limit and quota exceeded handling
  - All methods make exactly one API call

- `test/services/hardcover_client_test.rb` - Added quota tracking tests:
  - Request tracking functionality
  - Quota exceeded detection
  - Backoff behavior when approaching limit

**Manual verification plan:**
1. Monitor Hardcover API usage in dashboard
2. Verify health checks skip when approaching quota
3. Confirm searches still work normally under quota
4. Check rate limit errors are handled gracefully

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [ ] I ran the relevant local quality checks (Ruby not available in build environment)
- [ ] I updated documentation for user-visible changes (not user-visible)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0b360e7-1fdb-4f97-9e06-8d352b7f911e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0b360e7-1fdb-4f97-9e06-8d352b7f911e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

