### PR TITLE
Fix Hardcover daily quota exhaustion

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -195,6 +195,10 @@ module Admin
         health.check_failed!(message: "Failed to connect to Hardcover")
         respond_with_flash(alert: "Hardcover connection failed.")
       end
+    rescue HardcoverClient::RateLimitError => e
+      MetadataProviderStatus.for_provider("hardcover").record_failure!(e)
+      health&.check_failed!(message: e.message, degraded: true)
+      respond_with_flash(alert: "Hardcover is rate limited. #{e.message}")
     rescue HardcoverClient::Error => e
       health&.check_failed!(message: e.message)
       respond_with_flash(alert: "Hardcover error: #{e.message}")

--- a/app/jobs/book_metadata_backfill_job.rb
+++ b/app/jobs/book_metadata_backfill_job.rb
@@ -4,19 +4,53 @@
 # Safe by default: only fills blank fields and skips books without a work_id.
 class BookMetadataBackfillJob < ApplicationJob
   queue_as :default
+  limits_concurrency to: 1,
+    key: "book-metadata-backfill",
+    duration: 2.hours
+
+  SCHEDULED_BATCH_SIZE = 100
+  RECHECK_INTERVAL = 30.days
 
   def perform(book_ids: nil)
-    books_for_backfill(book_ids).find_each do |book|
-      work_id = book.unified_work_id
-      next if work_id.blank?
+    unavailable_sources = []
+    unavailable_sources << "hardcover" unless HardcoverClient.configured?
 
-      BookMetadataBackfillService.apply!(book, work_id: work_id)
-    rescue StandardError => e
-      Rails.logger.warn("[BookMetadataBackfillJob] Failed for book #{book.id}: #{e.message}")
+    each_book_for_backfill(book_ids, unavailable_sources: unavailable_sources) do |book|
+      result = backfill_book(book)
+      unavailable_sources << "hardcover" if result == :hardcover_unavailable
     end
   end
 
   private
+
+  def each_book_for_backfill(book_ids, unavailable_sources:)
+    books = books_for_backfill(book_ids)
+    if book_ids.present?
+      ordered_for_backfill(books).each do |book|
+        yield book unless source_unavailable?(book, unavailable_sources)
+      end
+      return
+    end
+
+    processed_ids = []
+    processed_count = 0
+    while processed_count < SCHEDULED_BATCH_SIZE
+      candidates = exclude_unavailable_sources(books, unavailable_sources)
+      candidates = candidates.where.not(id: processed_ids) if processed_ids.any?
+      candidates = ordered_for_backfill(candidates)
+        .limit(SCHEDULED_BATCH_SIZE - processed_count)
+        .to_a
+      break if candidates.empty?
+
+      candidates.each do |book|
+        processed_ids << book.id
+        next if source_unavailable?(book, unavailable_sources)
+
+        yield book
+        processed_count += 1
+      end
+    end
+  end
 
   def books_for_backfill(book_ids)
     return Book.where(id: book_ids) if book_ids.present?
@@ -26,6 +60,62 @@ class BookMetadataBackfillJob < ApplicationJob
       .where(series_start_year: nil)
       .where("comic_vine_id LIKE ?", "4000-%")
 
-    missing_series.or(missing_comic_run_year)
+    missing_metadata = missing_series.or(missing_comic_run_year)
+    missing_metadata.where(
+      "metadata_backfill_checked_at IS NULL OR metadata_backfill_checked_at <= ?",
+      RECHECK_INTERVAL.ago
+    )
+  end
+
+  def mark_checked!(book)
+    book.update_column(:metadata_backfill_checked_at, Time.current)
+  end
+
+  def backfill_book(book)
+    work_id = book.unified_work_id
+    if work_id.blank?
+      mark_checked!(book)
+      return :processed
+    end
+
+    BookMetadataBackfillService.apply!(
+      book,
+      work_id: work_id,
+      raise_lookup_errors: true
+    )
+    mark_checked!(book)
+    :processed
+  rescue HardcoverClient::NotFoundError
+    mark_checked!(book)
+    :processed
+  rescue HardcoverClient::RateLimitError,
+         HardcoverClient::AuthenticationError,
+         HardcoverClient::ConnectionError => e
+    MetadataProviderStatus.for_provider("hardcover").record_failure!(e)
+    Rails.logger.warn("[BookMetadataBackfillJob] Skipping Hardcover after provider error: #{e.message}")
+    :hardcover_unavailable
+  rescue StandardError => e
+    Rails.logger.warn("[BookMetadataBackfillJob] Failed for book #{book.id}: #{e.message}")
+    :processed
+  end
+
+  def ordered_for_backfill(books)
+    books.order(
+      Arel.sql("metadata_backfill_checked_at IS NOT NULL ASC"),
+      metadata_backfill_checked_at: :asc,
+      id: :asc
+    )
+  end
+
+  def exclude_unavailable_sources(books, unavailable_sources)
+    if unavailable_sources.include?("hardcover")
+      books = books.where(hardcover_id: [ nil, "" ])
+    end
+    books
+  end
+
+  def source_unavailable?(book, unavailable_sources)
+    source, = Book.parse_work_id(book.unified_work_id)
+    unavailable_sources.include?(source)
   end
 end

--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -259,10 +259,14 @@ class HealthCheckJob < ApplicationJob
     end
 
     if HardcoverClient.test_connection
+      MetadataProviderStatus.for_provider("hardcover").record_success!
       health.check_succeeded!(message: "Connection successful")
     else
       health.check_failed!(message: "Failed to connect to Hardcover")
     end
+  rescue HardcoverClient::RateLimitError => e
+    MetadataProviderStatus.for_provider("hardcover").record_failure!(e)
+    health.check_failed!(message: e.message, degraded: true)
   rescue HardcoverClient::AuthenticationError => e
     health.check_failed!(message: "Authentication failed: #{e.message}")
   rescue HardcoverClient::ConnectionError => e

--- a/app/models/metadata_provider_status.rb
+++ b/app/models/metadata_provider_status.rb
@@ -72,9 +72,14 @@ class MetadataProviderStatus < ApplicationRecord
   end
 
   def record_failure!(error)
+    retry_at = backoff_until_for(error)
+    if rate_limit_error?(error)
+      retry_at = [ rate_limited_until, retry_at ].compact.max
+    end
+
     update!(
       status: status_for(error),
-      rate_limited_until: backoff_until_for(error),
+      rate_limited_until: retry_at,
       last_error: error.message,
       last_failure_at: Time.current,
       failure_count: failure_count.to_i + 1
@@ -93,6 +98,9 @@ class MetadataProviderStatus < ApplicationRecord
 
   def backoff_until_for(error)
     return nil if auth_error?(error)
+
+    server_retry_at = error.retry_at if rate_limit_error?(error) && error.respond_to?(:retry_at)
+    return server_retry_at if server_retry_at&.future?
 
     seconds = if rate_limit_error?(error)
       15.minutes.to_i

--- a/app/services/book_metadata_backfill_service.rb
+++ b/app/services/book_metadata_backfill_service.rb
@@ -4,11 +4,19 @@
 # without overwriting values that are already present.
 class BookMetadataBackfillService
   class << self
-    def apply!(book, work_id:, source_work_ids: [], fallback_attrs: {}, lookup_details: true)
+    def apply!(
+      book,
+      work_id:,
+      source_work_ids: [],
+      fallback_attrs: {},
+      lookup_details: true,
+      raise_lookup_errors: false
+    )
       metadata = if lookup_details
         BookMetadataLookupService.call(
           [ work_id, *Array(source_work_ids) ],
-          fallback: fallback_attrs
+          fallback: fallback_attrs,
+          raise_lookup_errors: raise_lookup_errors
         )
       else
         {}

--- a/app/services/book_metadata_lookup_service.rb
+++ b/app/services/book_metadata_lookup_service.rb
@@ -23,15 +23,21 @@ class BookMetadataLookupService
   }.freeze
 
   class << self
-    def call(work_ids, fallback: {})
+    def call(work_ids, fallback: {}, raise_lookup_errors: false)
       work_ids = normalize_work_ids(work_ids)
       return {} if work_ids.empty?
 
       metadata = {}
-      merge_details!(metadata, fetch_details(work_ids.first), work_ids.first)
+      merge_details!(
+        metadata,
+        fetch_details(work_ids.first, raise_lookup_errors: raise_lookup_errors),
+        work_ids.first
+      )
       return metadata if work_ids.one? || essential_metadata_complete?(metadata, fallback)
 
-      work_ids.drop(1).zip(fetch_concurrently(work_ids.drop(1))).each do |work_id, details|
+      alternate_ids = work_ids.drop(1)
+      alternate_details = fetch_concurrently(alternate_ids, raise_lookup_errors: raise_lookup_errors)
+      alternate_ids.zip(alternate_details).each do |work_id, details|
         merge_details!(metadata, details, work_id)
       end
       metadata
@@ -55,19 +61,23 @@ class BookMetadataLookupService
 
     private
 
-    def fetch_concurrently(work_ids)
+    def fetch_concurrently(work_ids, raise_lookup_errors:)
       work_ids.map do |work_id|
         Thread.new do
           Rails.application.executor.wrap do
-            ActiveRecord::Base.connection_pool.with_connection { fetch_details(work_id) }
+            ActiveRecord::Base.connection_pool.with_connection do
+              fetch_details(work_id, raise_lookup_errors: raise_lookup_errors)
+            end
           end
         end
       end.map(&:value)
     end
 
-    def fetch_details(work_id)
+    def fetch_details(work_id, raise_lookup_errors:)
       MetadataService.book_details(work_id)
     rescue *metadata_lookup_errors => e
+      raise if raise_lookup_errors
+
       Rails.logger.warn("[BookMetadataLookupService] Metadata lookup failed for #{work_id}: #{e.message}")
       nil
     end

--- a/app/services/hardcover_client.rb
+++ b/app/services/hardcover_client.rb
@@ -1,17 +1,44 @@
 # frozen_string_literal: true
 
+require "digest"
+require "securerandom"
+require "time"
+require "timeout"
+
 # Client for interacting with the Hardcover GraphQL API
 # https://hardcover.app/account/api
 class HardcoverClient
   BASE_URL = "https://api.hardcover.app/v1/graphql"
+  RATE_LIMIT_CACHE_VERSION = 1
+  RATE_LIMIT_BUCKETS = %i[retry minute daily].freeze
+  DEFAULT_RATE_LIMIT_COOLDOWN = 60
+  MIN_RATE_LIMIT_COOLDOWN = 1
+  MAX_RATE_LIMIT_COOLDOWN = 25.hours.to_i
+  MAX_RATE_LIMIT_HEADER_BYTES = 4.kilobytes
+  RATE_LIMIT_STATE_MUTEX = Mutex.new
+  REQUEST_MUTEX = Mutex.new
+  HARD_REQUEST_TIMEOUT = 35.seconds
+  REQUEST_LOCK_TTL = HARD_REQUEST_TIMEOUT + 10.seconds
+  REQUEST_LOCK_WAIT = REQUEST_LOCK_TTL + 1.second
+  REQUEST_LOCK_POLL_INTERVAL = 0.05
 
   # Custom error classes
   class Error < StandardError; end
   class ConnectionError < Error; end
   class AuthenticationError < Error; end
-  class RateLimitError < Error; end
+  class RateLimitError < Error
+    attr_reader :retry_after, :retry_at
+
+    def initialize(message, retry_after: nil)
+      @retry_after = retry_after
+      @retry_at = Time.current + retry_after if retry_after
+      super(message)
+    end
+  end
   class NotFoundError < Error; end
   class NotConfiguredError < Error; end
+
+  Credential = Data.define(:authorization_header, :digest)
 
   # Data structures for API responses
   SearchResult = Data.define(
@@ -43,7 +70,7 @@ class HardcoverClient
 
   class << self
     def configured?
-      SettingsService.hardcover_configured?
+      SettingsService.get(:hardcover_enabled, default: true) && SettingsService.hardcover_configured?
     end
 
     # Search for books by query
@@ -202,13 +229,31 @@ class HardcoverClient
 
       Rails.logger.info "[HardcoverClient] Connection test: #{result ? 'passed' : 'failed'}"
       result
+    rescue RateLimitError
+      raise
     rescue Error => e
       Rails.logger.error "[HardcoverClient] Connection test failed: #{e.message}"
       false
     end
 
     def reset_connection!
-      @connection = nil
+      REQUEST_MUTEX.synchronize do
+        @connection = nil
+        @connection_credential_digest = nil
+      end
+    end
+
+    def rate_limited?
+      active_rate_limit_retry_after(current_credential.digest).present?
+    end
+
+    # Test/maintenance hook. Normal request paths must retain the
+    # server-advertised cooldown instead of bypassing it.
+    def reset_rate_limit_state!
+      credential_digest = current_credential.digest
+      cache_keys = RATE_LIMIT_BUCKETS.map { |bucket| rate_limit_cache_key(bucket, credential_digest) }
+      RATE_LIMIT_STATE_MUTEX.synchronize { @local_rate_limit_deadlines = {} }
+      cache_keys.each { |key| safe_cache_delete(key) }
     end
 
     private
@@ -218,39 +263,63 @@ class HardcoverClient
     end
 
     def execute_query(query, variables)
-      response = connection.post do |req|
-        req.body = { query: query, variables: variables }.to_json
-      end
+      credential = current_credential
+      with_rate_limit_request_lock(credential.digest) do
+        ensure_not_rate_limited!(credential.digest)
 
-      handle_response(response)
+        response = Timeout.timeout(
+          HARD_REQUEST_TIMEOUT,
+          ConnectionError,
+          "Hardcover request timed out"
+        ) do
+          connection(credential).post do |req|
+            req.body = { query: query, variables: variables }.to_json
+          end
+        end
+
+        handle_response(response, credential.digest)
+      end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
       Rails.logger.error "[HardcoverClient] Connection error: #{e.message}"
       raise ConnectionError, "Failed to connect to Hardcover: #{e.message}"
     end
 
-    def connection
-      @connection ||= Faraday.new(url: BASE_URL) do |f|
+    def connection(credential = current_credential)
+      return @connection if @connection && @connection_credential_digest == credential.digest
+
+      @connection = Faraday.new(url: BASE_URL) do |f|
         f.request :json
         f.response :json, parser_options: { symbolize_names: false }
         f.adapter Faraday.default_adapter
         f.headers["Content-Type"] = "application/json"
-        f.headers["Authorization"] = authorization_header
+        f.headers["Authorization"] = credential.authorization_header
         f.headers["User-Agent"] = "Shelfarr/1.0"
         f.options.timeout = 30
         f.options.open_timeout = 10
       end
+      @connection_credential_digest = credential.digest
+      @connection
     end
 
     def api_token
       SettingsService.get(:hardcover_api_token)
     end
 
-    def authorization_header
-      token = api_token.to_s.strip
-      token.match?(/\ABearer\s+/i) ? token : "Bearer #{token}"
+    def current_credential
+      token = api_token.to_s.strip.sub(/\ABearer\s+/i, "").strip
+      Credential.new(
+        authorization_header: "Bearer #{token}",
+        digest: Digest::SHA256.hexdigest(token)
+      )
     end
 
-    def handle_response(response)
+    def handle_response(response, credential_digest)
+      if response.status == 429
+        handle_rate_limit_response!(response, credential_digest)
+      else
+        observe_rate_limit_headers(response.headers, credential_digest)
+      end
+
       case response.status
       when 200
         body = response.body
@@ -263,13 +332,328 @@ class HardcoverClient
       when 401, 403
         Rails.logger.error "[HardcoverClient] Authentication failed (status #{response.status})"
         raise AuthenticationError, "Invalid API token"
-      when 429
-        Rails.logger.warn "[HardcoverClient] Rate limit exceeded"
-        raise RateLimitError, "Rate limit exceeded (60 requests/minute)"
       else
         Rails.logger.error "[HardcoverClient] API error (status #{response.status})"
         raise Error, "API request failed with status #{response.status}"
       end
+    end
+
+    def handle_rate_limit_response!(response, credential_digest)
+      retry_after = retry_after_seconds(response_header(response.headers, "Retry-After"), fallback: nil)
+
+      if retry_after
+        # Retry-After is authoritative for a 429. Discard older bucket hints so
+        # a stale RateLimit value cannot silently extend or shorten it.
+        clear_rate_limit_buckets!(credential_digest)
+        remember_rate_limit!(:retry, retry_after, credential_digest)
+      else
+        observe_rate_limit_headers(response.headers, credential_digest)
+        retry_after = active_rate_limit_retry_after(credential_digest) || DEFAULT_RATE_LIMIT_COOLDOWN
+        remember_rate_limit!(:retry, retry_after, credential_digest) unless active_rate_limit_retry_after(credential_digest)
+      end
+
+      effective_retry_after = active_rate_limit_retry_after(credential_digest) || retry_after
+      Rails.logger.warn "[HardcoverClient] Rate limited; retry in #{effective_retry_after} seconds"
+      raise RateLimitError.new(
+        "Hardcover rate limit exceeded; retry in #{effective_retry_after} seconds",
+        retry_after: effective_retry_after
+      )
+    end
+
+    def ensure_not_rate_limited!(credential_digest)
+      retry_after = active_rate_limit_retry_after(credential_digest)
+      return unless retry_after
+
+      raise RateLimitError.new(
+        "Hardcover rate limit cooldown active; retry in #{retry_after} seconds",
+        retry_after: retry_after
+      )
+    end
+
+    def observe_rate_limit_headers(headers, credential_digest)
+      states = parse_rate_limit_entries(response_header(headers, "RateLimit"))
+      policies = parse_rate_limit_entries(response_header(headers, "RateLimit-Policy"))
+      usable_states = states.select { |entry| integer_parameter(entry, "r") }
+
+      if usable_states.any?
+        usable_states.each do |state|
+          next unless integer_parameter(state, "r") <= 0
+
+          policy = matching_rate_limit_policy(state, policies)
+          bucket = rate_limit_bucket(state, policy)
+          reset_after = cooldown_seconds(integer_parameter(state, "t"), fallback: DEFAULT_RATE_LIMIT_COOLDOWN)
+          remember_rate_limit!(bucket, reset_after, credential_digest)
+        end
+        return
+      end
+
+      observe_legacy_rate_limit_headers(headers, credential_digest)
+    end
+
+    def observe_legacy_rate_limit_headers(headers, credential_digest)
+      daily_remaining = header_integer(headers, "X-RateLimit-Daily-Remaining")
+      if daily_remaining && daily_remaining <= 0
+        reset_after = seconds_until_epoch(header_integer(headers, "X-RateLimit-Daily-Reset"))
+        remember_rate_limit!(:daily, reset_after || DEFAULT_RATE_LIMIT_COOLDOWN, credential_digest)
+      end
+
+      remaining = header_integer(headers, "X-RateLimit-Remaining")
+      return unless remaining && remaining <= 0
+
+      reset_after = seconds_until_epoch(header_integer(headers, "X-RateLimit-Reset"))
+      remember_rate_limit!(:minute, reset_after || DEFAULT_RATE_LIMIT_COOLDOWN, credential_digest)
+    end
+
+    def parse_rate_limit_entries(value)
+      split_rate_limit_entries(value).filter_map do |raw_entry|
+        identifier, *raw_parameters = raw_entry.split(";")
+        identifier = identifier.to_s.strip
+        identifier = identifier.delete_prefix(%(")).delete_suffix(%(")).strip
+        next if identifier.blank?
+
+        parameters = raw_parameters.each_with_object({}) do |raw_parameter, parsed|
+          key, raw_value = raw_parameter.split("=", 2)
+          next if raw_value.nil?
+
+          parsed[key.to_s.strip.downcase] = raw_value.to_s.strip.delete_prefix(%(")).delete_suffix(%(")).strip
+        end
+        { identifier: identifier, parameters: parameters }
+      end
+    end
+
+    def split_rate_limit_entries(value)
+      input = value.to_s.byteslice(0, MAX_RATE_LIMIT_HEADER_BYTES).to_s
+      entries = []
+      current = +""
+      quoted = false
+      escaped = false
+
+      input.each_char do |character|
+        if character == "," && !quoted
+          entries << current.strip
+          current = +""
+          next
+        end
+
+        current << character
+        if character == "\\" && quoted
+          escaped = !escaped
+        elsif character == '"' && !escaped
+          quoted = !quoted
+        else
+          escaped = false
+        end
+      end
+      entries << current.strip unless current.blank?
+      entries
+    end
+
+    def matching_rate_limit_policy(state, policies)
+      policies.find do |policy|
+        policy[:identifier].casecmp?(state[:identifier])
+      end
+    end
+
+    def rate_limit_bucket(state, policy)
+      window = integer_parameter(policy, "w")
+      return :daily if state[:identifier].casecmp?("daily")
+      return :daily if window && window >= 1.hour.to_i
+
+      :minute
+    end
+
+    def integer_parameter(entry, name)
+      return unless entry
+
+      bounded_integer(entry[:parameters][name])
+    end
+
+    def header_integer(headers, name)
+      bounded_integer(response_header(headers, name))
+    end
+
+    def bounded_integer(value)
+      raw_value = value.to_s.byteslice(0, 64).to_s.strip
+      Integer(raw_value, exception: false)
+    end
+
+    def retry_after_seconds(value, fallback: DEFAULT_RATE_LIMIT_COOLDOWN)
+      raw_value = value.to_s.byteslice(0, 128).to_s.strip
+      seconds = bounded_integer(raw_value)
+      seconds ||= (Time.httpdate(raw_value) - Time.current).ceil if raw_value.present?
+      cooldown_seconds(seconds, fallback: fallback)
+    rescue ArgumentError
+      cooldown_seconds(nil, fallback: fallback)
+    end
+
+    def cooldown_seconds(seconds, fallback:)
+      seconds = fallback unless seconds&.positive?
+      return unless seconds
+
+      seconds.clamp(MIN_RATE_LIMIT_COOLDOWN, MAX_RATE_LIMIT_COOLDOWN)
+    end
+
+    def seconds_until_epoch(epoch)
+      return unless epoch
+
+      cooldown_seconds(epoch - Time.current.to_i, fallback: nil)
+    end
+
+    def response_header(headers, name)
+      value = headers[name]
+      value = value.join(", ") if value.is_a?(Array)
+      value
+    end
+
+    # Solid Cache makes this lease shared across Puma and job processes. The
+    # mutex preserves the same safety under NullStore and during cache outages.
+    def with_rate_limit_request_lock(credential_digest)
+      REQUEST_MUTEX.synchronize do
+        token = SecureRandom.hex(16)
+        deadline = monotonic_time + REQUEST_LOCK_WAIT
+
+        loop do
+          lease_started_at = monotonic_time
+          if acquire_request_lock(token, credential_digest)
+            begin
+              return yield
+            ensure
+              release_request_lock(token, credential_digest, acquired_at: lease_started_at)
+            end
+          end
+
+          if monotonic_time >= deadline
+            raise ConnectionError, "Hardcover API is busy; try again shortly"
+          end
+
+          sleep REQUEST_LOCK_POLL_INTERVAL
+        end
+      end
+    end
+
+    def acquire_request_lock(token, credential_digest)
+      key = request_lock_cache_key(credential_digest)
+      written = Rails.cache.write(
+        key,
+        token,
+        expires_in: REQUEST_LOCK_TTL,
+        unless_exist: true
+      )
+      return true if written
+      return false if Rails.cache.read(key).present?
+
+      !cache_operational?(credential_digest)
+    rescue StandardError
+      true
+    end
+
+    def release_request_lock(token, credential_digest, acquired_at:)
+      # Never let an owner whose lease already expired inspect or delete a
+      # successor's entry. The hard request timeout keeps normal requests well
+      # inside this boundary.
+      return false if monotonic_time - acquired_at >= REQUEST_LOCK_TTL
+
+      key = request_lock_cache_key(credential_digest)
+      Rails.cache.delete(key) if Rails.cache.read(key) == token
+    rescue StandardError
+      false
+    end
+
+    def cache_operational?(credential_digest)
+      token = SecureRandom.hex(16)
+      key = "#{request_lock_cache_key(credential_digest)}:probe:#{token}"
+      written = Rails.cache.write(key, token, expires_in: 5.seconds)
+      written && Rails.cache.read(key) == token
+    ensure
+      Rails.cache.delete(key) if key
+    end
+
+    def active_rate_limit_retry_after(credential_digest)
+      retry_after = active_bucket_retry_after(:retry, credential_digest)
+      return retry_after if retry_after
+
+      RATE_LIMIT_BUCKETS.excluding(:retry).filter_map do |bucket|
+        active_bucket_retry_after(bucket, credential_digest)
+      end.max
+    end
+
+    def active_bucket_retry_after(bucket, credential_digest)
+      key = rate_limit_cache_key(bucket, credential_digest)
+      local_remaining = local_rate_limit_remaining(key)
+      cached_deadline = safe_cache_read(key)
+      cached_remaining = cached_deadline - Time.current.to_f if cached_deadline
+      remaining = [ local_remaining, cached_remaining ].compact.select(&:positive?).max
+      cooldown_seconds(remaining&.ceil, fallback: nil)
+    end
+
+    def local_rate_limit_remaining(key)
+      RATE_LIMIT_STATE_MUTEX.synchronize do
+        deadline = local_rate_limit_deadlines[key]
+        next unless deadline
+
+        remaining = deadline - monotonic_time
+        local_rate_limit_deadlines.delete(key) unless remaining.positive?
+        remaining if remaining.positive?
+      end
+    end
+
+    def remember_rate_limit!(bucket, seconds, credential_digest)
+      seconds = cooldown_seconds(seconds, fallback: DEFAULT_RATE_LIMIT_COOLDOWN)
+      key = rate_limit_cache_key(bucket, credential_digest)
+
+      RATE_LIMIT_STATE_MUTEX.synchronize do
+        deadline = monotonic_time + seconds
+        existing = local_rate_limit_deadlines[key]
+        local_rate_limit_deadlines[key] = [ existing, deadline ].compact.max
+      end
+
+      wall_deadline = Time.current.to_f + seconds
+      existing_deadline = safe_cache_read(key)
+      wall_deadline = [ existing_deadline, wall_deadline ].compact.max
+      safe_cache_write(key, wall_deadline, expires_in: (wall_deadline - Time.current.to_f).ceil)
+    end
+
+    def clear_rate_limit_buckets!(credential_digest)
+      keys = RATE_LIMIT_BUCKETS.map { |bucket| rate_limit_cache_key(bucket, credential_digest) }
+      RATE_LIMIT_STATE_MUTEX.synchronize do
+        keys.each { |key| local_rate_limit_deadlines.delete(key) }
+      end
+      keys.each { |key| safe_cache_delete(key) }
+    end
+
+    def local_rate_limit_deadlines
+      @local_rate_limit_deadlines ||= {}
+    end
+
+    def rate_limit_cache_key(bucket, credential_digest)
+      "hardcover:v#{RATE_LIMIT_CACHE_VERSION}:rate-limit:#{credential_digest}:#{bucket}"
+    end
+
+    def request_lock_cache_key(credential_digest)
+      "hardcover:v#{RATE_LIMIT_CACHE_VERSION}:request-lock:#{credential_digest}"
+    end
+
+    def safe_cache_read(key)
+      value = Float(Rails.cache.read(key), exception: false)
+      value if value&.finite?
+    rescue StandardError
+      nil
+    end
+
+    def safe_cache_write(key, value, expires_in:)
+      Rails.cache.write(key, value, expires_in: expires_in)
+    rescue StandardError
+      false
+    end
+
+    def safe_cache_delete(key)
+      Rails.cache.delete(key)
+    rescue StandardError
+      false
+    end
+
+    def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def parse_search_result(result)

--- a/db/migrate/20260828230000_add_metadata_backfill_checked_at_to_books.rb
+++ b/db/migrate/20260828230000_add_metadata_backfill_checked_at_to_books.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMetadataBackfillCheckedAtToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :metadata_backfill_checked_at, :datetime
+    add_index :books, :metadata_backfill_checked_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_230000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -80,6 +80,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
     t.string "isbn"
     t.string "issue_number"
     t.string "language", default: "en"
+    t.datetime "metadata_backfill_checked_at"
     t.string "metadata_source", default: "openlibrary"
     t.string "narrator"
     t.string "open_library_edition_id"
@@ -100,6 +101,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
     t.index ["google_books_id"], name: "index_books_on_google_books_id"
     t.index ["hardcover_id"], name: "index_books_on_hardcover_id"
     t.index ["isbn"], name: "index_books_on_isbn"
+    t.index ["metadata_backfill_checked_at"], name: "index_books_on_metadata_backfill_checked_at"
     t.index ["open_library_edition_id"], name: "index_books_on_open_library_edition_id"
     t.index ["open_library_work_id"], name: "index_books_on_open_library_work_id"
     t.index ["series_position"], name: "index_books_on_series_position"

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -2201,6 +2201,25 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     assert_match /hard boom/, flash[:alert]
   end
 
+  test "test_hardcover reports rate limiting as degraded and preserves the retry deadline" do
+    SettingsService.set(:hardcover_enabled, true)
+    SettingsService.set(:hardcover_api_token, "token")
+    MetadataProviderStatus.where(provider: "hardcover").delete_all
+    SystemHealth.where(service: "hardcover").delete_all
+    error = HardcoverClient::RateLimitError.new("retry later", retry_after: 120)
+
+    HardcoverClient.stub(:test_connection, -> { raise error }) do
+      post test_hardcover_admin_settings_url
+    end
+
+    assert_redirected_to admin_settings_path
+    assert_match(/rate limited/i, flash[:alert])
+    assert SystemHealth.for_service("hardcover").degraded?
+    provider = MetadataProviderStatus.for_provider("hardcover")
+    assert_equal "rate_limited", provider.status
+    assert_in_delta error.retry_at, provider.rate_limited_until, 1.second
+  end
+
   test "test_google_books fails when disabled" do
     SettingsService.set(:google_books_enabled, false)
 

--- a/test/jobs/book_metadata_backfill_job_test.rb
+++ b/test/jobs/book_metadata_backfill_job_test.rb
@@ -3,6 +3,12 @@
 require "test_helper"
 
 class BookMetadataBackfillJobTest < ActiveJob::TestCase
+  setup do
+    Book.update_all(metadata_backfill_checked_at: Time.current)
+    SettingsService.set(:hardcover_enabled, true)
+    SettingsService.set(:hardcover_api_token, "backfill-test-token")
+  end
+
   test "processes books with blank series metadata or missing Comic Vine run years by default" do
     blank_series = Book.create!(
       title: "Blank Series",
@@ -39,8 +45,9 @@ class BookMetadataBackfillJobTest < ActiveJob::TestCase
 
     processed = []
 
-    BookMetadataBackfillService.stub(:apply!, lambda { |book, work_id:, fallback_attrs: {}|
+    BookMetadataBackfillService.stub(:apply!, lambda { |book, work_id:, fallback_attrs: {}, raise_lookup_errors:|
       processed << [ book.id, work_id, fallback_attrs ]
+      assert raise_lookup_errors
       true
     }) do
       BookMetadataBackfillJob.perform_now
@@ -129,8 +136,9 @@ class BookMetadataBackfillJobTest < ActiveJob::TestCase
 
     processed = []
 
-    BookMetadataBackfillService.stub(:apply!, lambda { |book, work_id:, fallback_attrs: {}|
+    BookMetadataBackfillService.stub(:apply!, lambda { |book, work_id:, fallback_attrs: {}, raise_lookup_errors:|
       processed << work_id
+      assert raise_lookup_errors
       raise "boom" if book.id == first_book.id
 
       book.update!(series: "Recovered Series", series_position: "4")
@@ -144,5 +152,274 @@ class BookMetadataBackfillJobTest < ActiveJob::TestCase
     assert_nil first_book.reload.series
     assert_equal "Recovered Series", second_book.reload.series
     assert_equal "4", second_book.reload.series_position
+  end
+
+  test "records a successful negative lookup so standalone books are not retried daily" do
+    book = Book.create!(
+      title: "Standalone Hardcover Book",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "301",
+      series: nil,
+      series_position: nil
+    )
+    calls = 0
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |_book, work_id:, raise_lookup_errors:, **|
+      calls += 1
+      assert_equal "hardcover:301", work_id
+      assert raise_lookup_errors
+      false
+    }) do
+      BookMetadataBackfillJob.perform_now
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert_equal 1, calls
+    assert_in_delta Time.current, book.reload.metadata_backfill_checked_at, 1.second
+  end
+
+  test "scheduled runs process at most one bounded batch" do
+    books = 101.times.map do |index|
+      Book.create!(
+        title: "Batch Book #{index}",
+        author: "Author",
+        book_type: :ebook,
+        hardcover_id: (10_000 + index).to_s,
+        series: nil,
+        series_position: nil
+      )
+    end
+    processed = []
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |book, **|
+      processed << book.id
+      false
+    }) do
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert_equal BookMetadataBackfillJob::SCHEDULED_BATCH_SIZE, processed.size
+    assert_equal books.first(100).map(&:id), processed
+    assert books.first.reload.metadata_backfill_checked_at.present?
+    assert_nil books.last.reload.metadata_backfill_checked_at
+  end
+
+  test "stops probing Hardcover after the first rate limit" do
+    first_book = Book.create!(
+      title: "First Limited Book",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "401",
+      series: nil,
+      series_position: nil
+    )
+    second_book = Book.create!(
+      title: "Second Limited Book",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "402",
+      series: nil,
+      series_position: nil
+    )
+    processed = []
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |book, **|
+      processed << book.id
+      raise HardcoverClient::RateLimitError.new("limited", retry_after: 120)
+    }) do
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert_equal [ first_book.id ], processed
+    assert_nil first_book.reload.metadata_backfill_checked_at
+    assert_nil second_book.reload.metadata_backfill_checked_at
+  end
+
+  test "continues other providers after Hardcover becomes unavailable" do
+    hardcover_books = 100.times.map do |index|
+      Book.create!(
+        title: "Limited Hardcover Book #{index}",
+        author: "Author",
+        book_type: :ebook,
+        hardcover_id: (20_000 + index).to_s,
+        series: nil,
+        series_position: nil
+      )
+    end
+    openlibrary_book = Book.create!(
+      title: "Open Library Book",
+      author: "Author",
+      book_type: :ebook,
+      open_library_work_id: "OL-MIXED-W",
+      series: nil,
+      series_position: nil
+    )
+    processed = []
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |_book, work_id:, **|
+      processed << work_id
+      if work_id.start_with?("hardcover:")
+        raise HardcoverClient::RateLimitError.new("limited", retry_after: 120)
+      end
+
+      false
+    }) do
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert_equal [ "hardcover:#{hardcover_books.first.hardcover_id}", "openlibrary:OL-MIXED-W" ], processed
+    assert_nil hardcover_books.first.reload.metadata_backfill_checked_at
+    assert openlibrary_book.reload.metadata_backfill_checked_at.present?
+  end
+
+  test "prioritizes never checked books ahead of stale low ids" do
+    stale_books = 100.times.map do |index|
+      Book.create!(
+        title: "Stale Book #{index}",
+        author: "Author",
+        book_type: :ebook,
+        hardcover_id: (30_000 + index).to_s,
+        series: nil,
+        series_position: nil,
+        metadata_backfill_checked_at: 31.days.ago
+      )
+    end
+    never_checked = Book.create!(
+      title: "Never Checked",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "30999",
+      series: nil,
+      series_position: nil
+    )
+    processed = []
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |book, **|
+      processed << book.id
+      false
+    }) do
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert_equal BookMetadataBackfillJob::SCHEDULED_BATCH_SIZE, processed.size
+    assert_equal never_checked.id, processed.first
+    assert_includes processed, never_checked.id
+    assert_not_includes processed, stale_books.last.id
+  end
+
+  test "disabling Hardcover prevents automated Hardcover calls without blocking other providers" do
+    SettingsService.set(:hardcover_enabled, false)
+    hardcover_book = Book.create!(
+      title: "Disabled Hardcover Book",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "32001",
+      series: nil,
+      series_position: nil
+    )
+    openlibrary_book = Book.create!(
+      title: "Enabled Open Library Book",
+      author: "Author",
+      book_type: :ebook,
+      open_library_work_id: "OL-ENABLED-W",
+      series: nil,
+      series_position: nil
+    )
+    processed = []
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |_book, work_id:, **|
+      processed << work_id
+      false
+    }) do
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert_equal [ "openlibrary:OL-ENABLED-W" ], processed
+    assert_nil hardcover_book.reload.metadata_backfill_checked_at
+    assert openlibrary_book.reload.metadata_backfill_checked_at.present?
+  end
+
+  test "leaves transient failures eligible for the next scheduled run" do
+    book = Book.create!(
+      title: "Transient Failure",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "501",
+      series: nil,
+      series_position: nil
+    )
+    calls = 0
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |_book, **|
+      calls += 1
+      raise OpenLibraryClient::ConnectionError, "timeout" if calls == 1
+
+      false
+    }) do
+      BookMetadataBackfillJob.perform_now
+      assert_nil book.reload.metadata_backfill_checked_at
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert_equal 2, calls
+    assert book.reload.metadata_backfill_checked_at.present?
+  end
+
+  test "explicit book ids bypass the scheduled staleness filter" do
+    book = Book.create!(
+      title: "Explicit Refresh",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "601",
+      series: nil,
+      series_position: nil,
+      metadata_backfill_checked_at: Time.current
+    )
+    processed = []
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |candidate, **|
+      processed << candidate.id
+      false
+    }) do
+      BookMetadataBackfillJob.perform_now(book_ids: [ book.id ])
+    end
+
+    assert_equal [ book.id ], processed
+  end
+
+  test "books without a provider id are marked checked so they cannot starve the batch" do
+    book = Book.create!(
+      title: "No Provider ID",
+      author: "Author",
+      book_type: :ebook,
+      series: nil,
+      series_position: nil
+    )
+
+    BookMetadataBackfillService.stub(:apply!, ->(*) { flunk "backfill should not be called" }) do
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert book.reload.metadata_backfill_checked_at.present?
+  end
+
+  test "not found responses are recorded as a completed check" do
+    book = Book.create!(
+      title: "Removed Upstream Book",
+      author: "Author",
+      book_type: :ebook,
+      hardcover_id: "701",
+      series: nil,
+      series_position: nil
+    )
+
+    BookMetadataBackfillService.stub(:apply!, lambda { |*|
+      raise HardcoverClient::NotFoundError, "not found"
+    }) do
+      BookMetadataBackfillJob.perform_now
+    end
+
+    assert book.reload.metadata_backfill_checked_at.present?
   end
 end

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class HealthCheckJobTest < ActiveJob::TestCase
   setup do
     SystemHealth.destroy_all
+    MetadataProviderStatus.destroy_all
     DownloadClient.destroy_all
     Setting.where(key: "health_check_interval").delete_all
     Thread.current[:qbittorrent_sessions] = {}
@@ -523,6 +524,40 @@ class HealthCheckJobTest < ActiveJob::TestCase
       health = SystemHealth.for_service("audiobookshelf")
       assert health.down?
     end
+  end
+
+  test "records a successful Hardcover health check for provider availability" do
+    HardcoverClient.stub(:configured?, true) do
+      HardcoverClient.stub(:test_connection, true) do
+        HealthCheckJob.perform_now(service: "hardcover")
+      end
+    end
+
+    health = SystemHealth.for_service("hardcover")
+    provider = MetadataProviderStatus.for_provider("hardcover")
+    assert health.healthy?
+    assert health.last_check_at.present?
+    assert_equal "healthy", provider.status
+    assert provider.last_success_at.present?
+  end
+
+  test "reports Hardcover rate limiting without treating the token as invalid" do
+    error = HardcoverClient::RateLimitError.new("limited for 2 minutes", retry_after: 120)
+
+    HardcoverClient.stub(:configured?, true) do
+      HardcoverClient.stub(:test_connection, -> { raise error }) do
+        HealthCheckJob.perform_now(service: "hardcover")
+      end
+    end
+
+    health = SystemHealth.for_service("hardcover")
+    provider = MetadataProviderStatus.for_provider("hardcover")
+    assert health.degraded?
+    assert health.last_check_at.present?
+    assert_includes health.message, "limited"
+    assert_equal "rate_limited", provider.status
+    assert_in_delta error.retry_at, provider.rate_limited_until, 1.second
+    assert_nil provider.last_success_at
   end
 
   private

--- a/test/models/metadata_provider_status_test.rb
+++ b/test/models/metadata_provider_status_test.rb
@@ -40,6 +40,31 @@ class MetadataProviderStatusTest < ActiveSupport::TestCase
     assert_not status.available?
   end
 
+  test "record_failure honors a server-provided rate limit deadline beyond generic backoff" do
+    status = MetadataProviderStatus.create!(provider: "hardcover", status: "healthy")
+    error = HardcoverClient::RateLimitError.new("daily quota exhausted", retry_after: 8.hours.to_i)
+
+    status.record_failure!(error)
+
+    assert_equal "rate_limited", status.status
+    assert_in_delta error.retry_at, status.rate_limited_until, 1.second
+  end
+
+  test "a repeated rate limit failure cannot shorten an existing cooldown" do
+    existing_deadline = 30.minutes.from_now
+    status = MetadataProviderStatus.create!(
+      provider: "hardcover",
+      status: "rate_limited",
+      rate_limited_until: existing_deadline
+    )
+    error = HardcoverClient::RateLimitError.new("still limited", retry_after: 60)
+
+    status.record_failure!(error)
+
+    assert_in_delta existing_deadline, status.rate_limited_until, 1.second
+    assert_equal 1, status.failure_count
+  end
+
   test "record_failure classifies auth errors without retry backoff" do
     status = MetadataProviderStatus.create!(provider: "hardcover", status: "healthy")
 

--- a/test/services/book_metadata_backfill_service_test.rb
+++ b/test/services/book_metadata_backfill_service_test.rb
@@ -200,4 +200,27 @@ class BookMetadataBackfillServiceTest < ActiveSupport::TestCase
 
     assert_equal "9", book.reload.series_position
   end
+
+  test "passes strict lookup handling through for quota-aware batch jobs" do
+    book = Book.new(book_type: :ebook)
+    error = HardcoverClient::RateLimitError.new("limited", retry_after: 120)
+    lookup = lambda do |work_ids, fallback:, raise_lookup_errors:|
+      assert_equal [ "hardcover:123" ], work_ids
+      assert_equal({}, fallback)
+      assert raise_lookup_errors
+      raise error
+    end
+
+    raised = assert_raises(HardcoverClient::RateLimitError) do
+      BookMetadataLookupService.stub(:call, lookup) do
+        BookMetadataBackfillService.apply!(
+          book,
+          work_id: "hardcover:123",
+          raise_lookup_errors: true
+        )
+      end
+    end
+
+    assert_same error, raised
+  end
 end

--- a/test/services/book_metadata_lookup_service_test.rb
+++ b/test/services/book_metadata_lookup_service_test.rb
@@ -172,6 +172,28 @@ class BookMetadataLookupServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "continues to swallow provider errors by default for interactive fallbacks" do
+    error = HardcoverClient::RateLimitError.new("limited", retry_after: 120)
+
+    metadata = MetadataService.stub(:book_details, ->(*) { raise error }) do
+      BookMetadataLookupService.call([ "hardcover:123" ])
+    end
+
+    assert_equal({}, metadata)
+  end
+
+  test "can surface provider errors so batch jobs know when to stop" do
+    error = HardcoverClient::RateLimitError.new("limited", retry_after: 120)
+
+    raised = assert_raises(HardcoverClient::RateLimitError) do
+      MetadataService.stub(:book_details, ->(*) { raise error }) do
+        BookMetadataLookupService.call([ "hardcover:123" ], raise_lookup_errors: true)
+      end
+    end
+
+    assert_same error, raised
+  end
+
   private
 
   def metadata_details(source:, source_id:, title:, description:)

--- a/test/services/hardcover_client_test.rb
+++ b/test/services/hardcover_client_test.rb
@@ -5,12 +5,20 @@ require "test_helper"
 class HardcoverClientTest < ActiveSupport::TestCase
   setup do
     @original_token = SettingsService.get(:hardcover_api_token)
+    @original_enabled = SettingsService.get(:hardcover_enabled, default: true)
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    SettingsService.set(:hardcover_enabled, true)
     HardcoverClient.reset_connection!
+    HardcoverClient.reset_rate_limit_state!
   end
 
   teardown do
+    HardcoverClient.reset_rate_limit_state!
     SettingsService.set(:hardcover_api_token, @original_token || "")
+    SettingsService.set(:hardcover_enabled, @original_enabled)
     HardcoverClient.reset_connection!
+    Rails.cache = @original_cache
   end
 
   test "configured? returns false without token" do
@@ -21,6 +29,13 @@ class HardcoverClientTest < ActiveSupport::TestCase
   test "configured? returns true with token" do
     SettingsService.set(:hardcover_api_token, "test_token")
     assert HardcoverClient.configured?
+  end
+
+  test "configured? returns false when Hardcover is disabled despite a saved token" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+    SettingsService.set(:hardcover_enabled, false)
+
+    assert_not HardcoverClient.configured?
   end
 
   test "search raises NotConfiguredError without token" do
@@ -223,6 +238,307 @@ class HardcoverClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "honors Retry-After and blocks another outbound request during the cooldown" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_request(:post, HardcoverClient::BASE_URL)
+        .to_return(
+          status: 429,
+          headers: { "Retry-After" => "120" },
+          body: '{"error": "Rate limit exceeded"}'
+        )
+
+      first_error = assert_raises(HardcoverClient::RateLimitError) do
+        HardcoverClient.search("test")
+      end
+      second_error = assert_raises(HardcoverClient::RateLimitError) do
+        HardcoverClient.search("test")
+      end
+
+      assert_equal 120, first_error.retry_after
+      assert_in_delta 120.seconds.from_now, first_error.retry_at, 1.second
+      assert_match(/cooldown active/, second_error.message)
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "Retry-After is authoritative over conflicting rate limit bucket headers" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_request(:post, HardcoverClient::BASE_URL)
+        .to_return(
+          status: 429,
+          headers: {
+            "Retry-After" => "30",
+            "RateLimit" => '"Free";r=0;t=60, "daily";r=0;t=80000',
+            "RateLimit-Policy" => '"Free";q=60;w=60;burst=10, "daily";q=5000;w=86400'
+          },
+          body: '{"error": "Rate limit exceeded"}'
+        )
+
+      error = assert_raises(HardcoverClient::RateLimitError) do
+        HardcoverClient.search("test")
+      end
+
+      assert_equal 30, error.retry_after
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "successful response at zero remaining blocks the next request" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_hardcover_response(
+        headers: {
+          "RateLimit" => '"Free";r=0;t=42, "daily";r=4231;t=51234',
+          "RateLimit-Policy" => '"Free";q=60;w=60;burst=10, "daily";q=5000;w=86400'
+        }
+      )
+
+      assert_empty HardcoverClient.search("test")
+      error = assert_raises(HardcoverClient::RateLimitError) do
+        HardcoverClient.search("test")
+      end
+
+      assert_in_delta 42, error.retry_after, 1
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "uses the longest exhausted server bucket without assuming a plan quota" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_hardcover_response(
+        headers: {
+          "RateLimit" => '"Custom";t=20;r=0, "daily";t=500;r=0',
+          "RateLimit-Policy" => '"Custom";burst=25;w=60;q=250, "daily";w=86400;q=75000'
+        }
+      )
+
+      assert_empty HardcoverClient.search("test")
+      error = assert_raises(HardcoverClient::RateLimitError) do
+        HardcoverClient.search("test")
+      end
+
+      assert_in_delta 500, error.retry_after, 1
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "does not block a supporter or custom policy while the server reports capacity" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_hardcover_response(
+        headers: {
+          "RateLimit" => '"Supporter";r=58;t=20, "daily";r=49000;t=500',
+          "RateLimit-Policy" => '"Supporter";q=60;w=60;burst=15, "daily";q=50000;w=86400'
+        }
+      )
+
+      2.times { assert_empty HardcoverClient.search("test") }
+
+      assert_requested request_stub, times: 2
+    end
+  end
+
+  test "falls back to legacy exhaustion headers when modern headers are unusable" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+    reset_at = 5.minutes.from_now.to_i
+
+    VCR.turned_off do
+      request_stub = stub_hardcover_response(
+        headers: {
+          "RateLimit" => '"Free";remaining=not-an-integer',
+          "X-RateLimit-Daily-Remaining" => "0",
+          "X-RateLimit-Daily-Reset" => reset_at.to_s
+        }
+      )
+
+      assert_empty HardcoverClient.search("test")
+      error = assert_raises(HardcoverClient::RateLimitError) do
+        HardcoverClient.search("test")
+      end
+
+      assert_in_delta 5.minutes.to_i, error.retry_after, 2
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "valid modern headers take precedence over stale legacy exhaustion headers" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_hardcover_response(
+        headers: {
+          "RateLimit" => '"Free";r=8;t=42, "daily";r=4231;t=51234',
+          "RateLimit-Policy" => '"Free";q=60;w=60;burst=10, "daily";q=5000;w=86400',
+          "X-RateLimit-Daily-Remaining" => "0",
+          "X-RateLimit-Daily-Reset" => 1.day.from_now.to_i.to_s
+        }
+      )
+
+      2.times { assert_empty HardcoverClient.search("test") }
+
+      assert_requested request_stub, times: 2
+    end
+  end
+
+  test "rate limit cooldown is isolated by normalized API token" do
+    SettingsService.set(:hardcover_api_token, "Bearer token-a")
+
+    VCR.turned_off do
+      first_token_stub = stub_request(:post, HardcoverClient::BASE_URL)
+        .with(headers: { "Authorization" => "Bearer token-a" })
+        .to_return(status: 429, headers: { "Retry-After" => "120" }, body: "{}")
+      second_token_stub = stub_request(:post, HardcoverClient::BASE_URL)
+        .with(headers: { "Authorization" => "Bearer token-b" })
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: empty_search_body
+        )
+
+      assert_raises(HardcoverClient::RateLimitError) { HardcoverClient.search("test") }
+
+      SettingsService.set(:hardcover_api_token, "token-b")
+      assert_empty HardcoverClient.search("test")
+
+      SettingsService.set(:hardcover_api_token, "token-a")
+      assert_raises(HardcoverClient::RateLimitError) { HardcoverClient.search("test") }
+
+      assert_requested first_token_stub, times: 1
+      assert_requested second_token_stub, times: 1
+    end
+  end
+
+  test "resetting the HTTP connection does not bypass the cooldown" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_request(:post, HardcoverClient::BASE_URL)
+        .to_return(status: 429, headers: { "Retry-After" => "120" }, body: "{}")
+
+      assert_raises(HardcoverClient::RateLimitError) { HardcoverClient.search("test") }
+      HardcoverClient.reset_connection!
+      assert_raises(HardcoverClient::RateLimitError) { HardcoverClient.search("test") }
+
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "concurrent callers observe exhaustion before a second request escapes" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      request_stub = stub_hardcover_response(
+        headers: {
+          "RateLimit" => '"Free";r=0;t=60',
+          "RateLimit-Policy" => '"Free";q=60;w=60;burst=10'
+        }
+      )
+      ready = Queue.new
+      start = Queue.new
+
+      workers = 2.times.map do
+        Thread.new do
+          ready << true
+          start.pop
+          HardcoverClient.search("test")
+        rescue StandardError => e
+          e
+        end
+      end
+      2.times { ready.pop }
+      2.times { start << true }
+      outcomes = workers.map(&:value)
+
+      assert_equal 1, outcomes.count { |outcome| outcome == [] }
+      assert_equal 1, outcomes.count { |outcome| outcome.is_a?(HardcoverClient::RateLimitError) }
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "rate limit parsing uses bounded fallbacks for malformed input" do
+    assert_equal HardcoverClient::DEFAULT_RATE_LIMIT_COOLDOWN,
+      HardcoverClient.send(:retry_after_seconds, "not-a-retry-date")
+    assert_equal HardcoverClient::MAX_RATE_LIMIT_COOLDOWN,
+      HardcoverClient.send(:retry_after_seconds, "9" * 10_000)
+
+    http_date = 2.minutes.from_now.httpdate
+    assert_in_delta 2.minutes.to_i, HardcoverClient.send(:retry_after_seconds, http_date), 1
+  end
+
+  test "local cooldown still protects requests when the cache store discards writes" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+    Rails.cache = ActiveSupport::Cache::NullStore.new
+    HardcoverClient.reset_rate_limit_state!
+
+    VCR.turned_off do
+      request_stub = stub_request(:post, HardcoverClient::BASE_URL)
+        .to_return(status: 429, headers: { "Retry-After" => "120" }, body: "{}")
+
+      assert_raises(HardcoverClient::RateLimitError) { HardcoverClient.search("test") }
+      assert_raises(HardcoverClient::RateLimitError) { HardcoverClient.search("test") }
+
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "cache write failures fall back immediately to the process lock" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+    Rails.cache = Class.new do
+      def write(*) = false
+      def read(*) = nil
+      def delete(*) = false
+    end.new
+    HardcoverClient.reset_rate_limit_state!
+
+    VCR.turned_off do
+      request_stub = stub_hardcover_response
+
+      assert_empty HardcoverClient.search("test")
+      assert_requested request_stub, times: 1
+    end
+  end
+
+  test "an expired lease owner cannot delete a successor lease" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+    credential = HardcoverClient.send(:current_credential)
+    key = HardcoverClient.send(:request_lock_cache_key, credential.digest)
+    Rails.cache.write(key, "successor", expires_in: 1.minute)
+    expired_at = HardcoverClient.send(:monotonic_time) - HardcoverClient::REQUEST_LOCK_TTL - 1
+
+    HardcoverClient.send(
+      :release_request_lock,
+      "expired-owner",
+      credential.digest,
+      acquired_at: expired_at
+    )
+
+    assert_equal "successor", Rails.cache.read(key)
+    assert_operator HardcoverClient::REQUEST_LOCK_TTL, :>, HardcoverClient::HARD_REQUEST_TIMEOUT
+  end
+
+  test "test_connection surfaces rate limiting to health monitoring" do
+    SettingsService.set(:hardcover_api_token, "test_token")
+
+    VCR.turned_off do
+      stub_request(:post, HardcoverClient::BASE_URL)
+        .to_return(status: 429, headers: { "Retry-After" => "120" }, body: "{}")
+
+      error = assert_raises(HardcoverClient::RateLimitError) do
+        HardcoverClient.test_connection
+      end
+
+      assert_equal 120, error.retry_after
+    end
+  end
+
   test "test_connection returns true on success" do
     SettingsService.set(:hardcover_api_token, "test_token")
 
@@ -284,6 +600,32 @@ class HardcoverClientTest < ActiveSupport::TestCase
   end
 
   private
+
+  def stub_hardcover_response(headers: {})
+    stub_request(:post, HardcoverClient::BASE_URL)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" }.merge(headers),
+        body: empty_search_body
+      )
+  end
+
+  def empty_search_body
+    {
+      "data" => {
+        "search" => {
+          "results" => {
+            "facet_counts" => [],
+            "found" => 0,
+            "hits" => [],
+            "request_params" => {},
+            "search_cutoff" => false,
+            "search_time_ms" => 1
+          }
+        }
+      }
+    }.to_json
+  end
 
   def stub_hardcover_search(query, results)
     typesense_response = {


### PR DESCRIPTION
## Assigned issue

Closes #492

## What changed

- Replace the rejected local-counter approach from #493 with server-authoritative handling of `Retry-After`, `RateLimit`, and `RateLimit-Policy`, plus compatible legacy-header fallback. Shelfarr does not assume Free, Supporter, or custom plan quotas.
- Persist token-scoped cooldown deadlines in Solid Cache, retain a process-local fallback, serialize the exhaustion boundary across web and job processes, and rebuild the HTTP connection automatically when credentials rotate.
- Make a saved-but-disabled Hardcover integration authoritative: automated searches, health checks, and backfills no longer contact Hardcover while it is disabled.
- Fix the actual quota-burning loop in the daily metadata backfill. Successful lookups with no series are recorded, rechecked after 30 days instead of every day, and scheduled work is capped at 100 books per run. Never-checked books are prioritized before stale rechecks.
- Stop further Hardcover probes after the first rate/auth/connection failure in a backfill run while continuing replacement candidates from Open Library, Google Books, and Comic Vine.
- Surface the exact server retry deadline through provider status, scheduled health checks, and the existing admin connection-test feedback.

Hardcover documents the current rate-limit headers and plan-dependent policies here: [Hardcover API rate limits](https://github.com/hardcoverapp/hardcover-docs/blob/e587ffc75ab0645a958c30f4d5f17860bb2a53f2/src/content/docs/api/Getting-Started.mdx#L153-L242).

## Verification

- [x] Full local gate: `bin/quality push` (RuboCop, Brakeman, complete Rails suite, Selenium system suite, and single-worker coverage)
- [x] Exact-head integration suite: 338 runs, 1,414 assertions, 0 failures/errors/skips
- [x] Exact-head backfill suite: 261 runs, 1,132 assertions, 0 failures/errors/skips
- [x] Exact-head Hardcover client suite: 33 runs, 97 assertions, 0 failures
- [x] Migration is applied in the test database; schema and migration syntax are clean
- [x] Three independent adversarial reviews pinned base `4f4e987ce16fa54898f9ff595394265ff8d9d11c` and signed head `685be60d784b7081bbfbf0e54a5dcd91f53f4f1b`; all returned with no blockers

## Screenshots or recordings

No persistent visual layout changes. Admin and health feedback use the existing UI states, and the complete Selenium system suite passes.

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue scope
- [x] I added or updated tests for the behavior I changed
- [x] I ran the relevant local quality checks
- [x] No user documentation update is required; the behavior is automatic and documented above
