### PR TITLE
Add per-user library directory routing

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -68,7 +68,7 @@ module Admin
     end
 
     def directory_routing_params
-      params.require(:user).permit(:preferred_output_path, :library_routing_mode)
+      params.require(:user).permit(:preferred_output_path, :library_routing_mode, :routing_layout)
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class UsersController < BaseController
-    before_action :set_user, only: [:show, :edit, :update, :destroy]
+    before_action :set_user, only: [:show, :edit, :update, :destroy, :directory_routing, :update_directory_routing]
 
     def index
       @users = User.active.order(created_at: :desc)
@@ -37,6 +37,17 @@ module Admin
       end
     end
 
+    def directory_routing
+    end
+
+    def update_directory_routing
+      if @user.update(directory_routing_params)
+        redirect_to admin_users_path, notice: "Directory routing updated for #{@user.name}."
+      else
+        render :directory_routing, status: :unprocessable_entity
+      end
+    end
+
     def destroy
       if @user == Current.user
         redirect_to admin_users_path, alert: "You cannot delete yourself."
@@ -54,6 +65,10 @@ module Admin
 
     def user_params
       params.require(:user).permit(:name, :username, :password, :password_confirmation, :role)
+    end
+
+    def directory_routing_params
+      params.require(:user).permit(:preferred_output_path, :library_routing_mode)
     end
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -8,6 +8,11 @@ class DashboardController < ApplicationController
 
     # Recent activity for dashboard cards
     @recent_books = Book.acquired.order(updated_at: :desc).limit(10)
+    @routed_book_ids = if Current.user.routing_configured?
+      Current.user.user_book_paths.where(book_id: @recent_books.map(&:id)).pluck(:book_id).to_set
+    else
+      Set.new
+    end
     @recent_requests = if Current.user.admin?
       Request.includes(:book, :user).order(created_at: :desc).limit(8)
     else

--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -420,6 +420,41 @@ class LibraryController < ApplicationController
     @book = Book.acquired.find(params[:id])
     @user_request = @book.requests.completed.first
     @attention_request = @book.requests.where(attention_needed: true).first
+    @already_in_user_library = UserBookPath.exists?(user: Current.user, book: @book)
+  end
+
+  def add_to_my_library
+    @book = Book.acquired.find(params[:id])
+    user = Current.user
+
+    unless user.routing_configured?
+      redirect_to library_path(@book), alert: "Set a personal library folder in your profile before adding titles."
+      return
+    end
+
+    if UserBookPath.exists?(user: user, book: @book)
+      redirect_to library_path(@book), notice: "This title is already in your library."
+      return
+    end
+
+    work_id = @book.unified_work_id
+    if work_id.blank?
+      redirect_to library_path(@book), alert: "This title can't be added automatically — it has no linked metadata source."
+      return
+    end
+
+    result = RequestCreationService.call(
+      user: user,
+      work_id: work_id,
+      book_types: [ @book.book_type ],
+      metadata_attrs: { title: @book.title, author: @book.author }
+    )
+
+    if result.success?
+      redirect_to library_path(@book), notice: "Added to your library."
+    else
+      redirect_to library_path(@book), alert: result.errors.to_sentence
+    end
   end
 
   def retry_post_processing

--- a/app/javascript/controllers/directory_routing_form_controller.js
+++ b/app/javascript/controllers/directory_routing_form_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["mode", "layout", "layoutSection", "pathSection"];
+
+  connect() {
+    this.refresh();
+  }
+
+  refresh() {
+    const modeSet = this.modeTarget.value !== "";
+    this.toggleSection(this.layoutSectionTarget, modeSet);
+
+    const pathNeeded = modeSet && this.layoutTarget.value !== "nested";
+    this.toggleSection(this.pathSectionTarget, pathNeeded);
+  }
+
+  toggleSection(section, active) {
+    section.classList.toggle("hidden", !active);
+    section.querySelectorAll("select, input").forEach((field) => {
+      field.disabled = !active;
+    });
+  }
+}

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -427,6 +427,7 @@ class DownloadJob < ApplicationJob
 
     trigger_library_scan(book) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
+    UserLibraryRoutingService.call(book: book, request: download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
     Rails.logger.info "[DownloadJob] #{source_name} download completed: #{destination_dir}"
@@ -484,6 +485,7 @@ class DownloadJob < ApplicationJob
 
     trigger_library_scan(book) if LibraryPlatformClient.configured?
     NotificationService.request_completed(download.request)
+    UserLibraryRoutingService.call(book: book, request: download.request)
     track_request_event(download.request, "completed", download: download, message: "#{source_name} download completed")
 
     Rails.logger.info "[DownloadJob] #{source_name} download completed: #{destination_path}"
@@ -551,6 +553,7 @@ class DownloadJob < ApplicationJob
 
     # Send notification
     NotificationService.request_completed(download.request)
+    UserLibraryRoutingService.call(book: book, request: download.request)
     track_request_event(download.request, "completed", download: download, message: "Direct download completed")
 
     Rails.logger.info "[DownloadJob] Direct download completed: #{destination_path}"

--- a/app/jobs/post_processing_job.rb
+++ b/app/jobs/post_processing_job.rb
@@ -281,13 +281,14 @@ class PostProcessingJob < ApplicationJob
 
     trigger_library_scan(book) if LibraryPlatformClient.configured?
     NotificationService.request_completed(request)
+    UserLibraryRoutingService.call(book: book, request: request)
 
-    Rails.logger.info "[PostProcessingJob] Completed processing for download #{download.id}"
+    Rails.logger.info "[PostProcessingJob] Completed processing for download #{download&.id}"
   rescue => error
     # These are post-commit conveniences. Their failure must never reopen or
     # overwrite the completed acquisition state.
     Rails.logger.warn(
-      "[PostProcessingJob] Completion side effect failed for download #{download.id}: #{error.class}"
+      "[PostProcessingJob] Completion side effect failed for download #{download&.id}: #{error.class}"
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :uploads, dependent: :destroy
   has_many :notifications, dependent: :destroy
   has_many :activity_logs, dependent: :destroy
+  has_many :user_book_paths, dependent: :destroy
 
   scope :active, -> { where(deleted_at: nil) }
 
@@ -161,6 +162,10 @@ class User < ApplicationRecord
 
   def deleted?
     deleted_at.present?
+  end
+
+  def routing_configured?
+    preferred_output_path.present? && UserLibraryRoutingService::VALID_MODES.include?(library_routing_mode.to_s)
   end
 
   # OIDC/SSO methods

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,7 +165,15 @@ class User < ApplicationRecord
   end
 
   def routing_configured?
-    preferred_output_path.present? && UserLibraryRoutingService::VALID_MODES.include?(library_routing_mode.to_s)
+    return false unless UserLibraryRoutingService::VALID_MODES.include?(library_routing_mode.to_s)
+
+    nested_routing_layout? || preferred_output_path.present?
+  end
+
+  # Nested layout derives the destination from each system output path plus
+  # the username, so no explicit preferred_output_path is required.
+  def nested_routing_layout?
+    routing_layout.to_s == "nested"
   end
 
   # OIDC/SSO methods

--- a/app/models/user_book_path.rb
+++ b/app/models/user_book_path.rb
@@ -1,0 +1,4 @@
+class UserBookPath < ApplicationRecord
+  belongs_to :user
+  belongs_to :book
+end

--- a/app/services/request_creation_service.rb
+++ b/app/services/request_creation_service.rb
@@ -65,7 +65,22 @@ class RequestCreationService
         )
 
         if duplicate_check.block?
-          errors << "#{input.metadata_attrs[:title].presence || input.work_id} #{RequestOptionPolicy.book_type_label(book_type)}: #{duplicate_check.message}"
+          # Special case: block because the book is already acquired (on disk).
+          # Route it to the requesting user's directory rather than returning an error.
+          # All other BLOCK reasons (active request in progress, etc.) still error.
+          if duplicate_check.existing_book&.acquired?
+            book = duplicate_check.existing_book
+            request = build_request(book, input.metadata_attrs)
+            if request.save
+              after_create_for_acquired_book(request)
+              created_requests << request
+              input.source_work_ids.each { |id| existing_books_lookup[id.to_s][book.book_type] = book }
+            else
+              errors << "#{input.metadata_attrs[:title].presence || input.work_id} #{RequestOptionPolicy.book_type_label(book_type)}: #{request.errors.full_messages.join(', ')}"
+            end
+          else
+            errors << "#{input.metadata_attrs[:title].presence || input.work_id} #{RequestOptionPolicy.book_type_label(book_type)}: #{duplicate_check.message}"
+          end
           next
         end
 
@@ -75,7 +90,11 @@ class RequestCreationService
         request = build_request(book, input.metadata_attrs)
 
         if request.save
-          after_create(request)
+          if book.file_path.present?
+            after_create_for_acquired_book(request)
+          else
+            after_create(request)
+          end
           created_requests << request
           input.source_work_ids.each { |source_work_id| existing_books_lookup[source_work_id.to_s][book.book_type] = book }
         else
@@ -232,6 +251,20 @@ class RequestCreationService
       request.collection_id = attrs[:collection_id]
       request.collection_title = attrs[:collection_title]
     end
+  end
+
+  def after_create_for_acquired_book(request)
+    # The book is already on disk — skip search and download entirely.
+    # Mark the request complete immediately, then route to the user's directory.
+    request.update!(status: :completed)
+    ActivityTracker.track(
+      "request.created",
+      trackable: request,
+      user: user,
+      details: { created_via: request.created_via, external_source: request.external_source }.compact
+    )
+    NotificationService.request_completed(request)
+    UserLibraryRoutingService.call(book: request.book, request: request)
   end
 
   def after_create(request)

--- a/app/services/user_library_routing_service.rb
+++ b/app/services/user_library_routing_service.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Routes a completed book into a requesting user's personal output directory.
+# Called after the canonical system copy is finalized. Supports two modes:
+#   copy     — duplicates files into the user's directory and records the path
+#   hardlink — creates hard links (zero extra storage) into the user's directory
+#
+# Hard links share the same disk bytes as the canonical copy. They cannot span
+# filesystem boundaries (EXDEV), so we fall back to a full copy in that case.
+# Directories cannot be hard-linked; we walk each file individually instead.
+class UserLibraryRoutingService
+  VALID_MODES = %w[copy hardlink].freeze
+
+  def self.call(book:, request:)
+    new(book: book, request: request).call
+  end
+
+  def initialize(book:, request:)
+    @book = book
+    @request = request
+    @user = request.user
+  end
+
+  def call
+    return unless routing_configured?
+    return unless @book.file_path.present?
+
+    source = @book.file_path
+    destination = build_user_destination(source)
+
+    case @user.library_routing_mode
+    when "copy"
+      perform_copy(source, destination)
+    when "hardlink"
+      perform_hardlink(source, destination)
+    end
+
+    record_user_path(destination)
+  rescue => e
+    Rails.logger.warn(
+      "[UserLibraryRoutingService] Routing failed for user ##{@user.id}, book ##{@book.id}: " \
+        "#{e.class}: #{e.message}"
+    )
+  end
+
+  private
+
+  def routing_configured?
+    @user.routing_configured?
+  end
+
+  # Figures out where the book should go under the user's directory by
+  # preserving the same sub-path structure that exists under the global base.
+  # Example: canonical /audiobooks/Author/Title → user's /media/alice/Author/Title
+  def build_user_destination(source)
+    relative = Pathname(source).expand_path
+      .relative_path_from(Pathname(global_base_path).expand_path)
+    File.join(@user.preferred_output_path, relative.to_s)
+  rescue ArgumentError
+    # Relative path failed (e.g. source is on a different root).
+    # Fall back to placing by basename so the file still lands somewhere useful.
+    File.join(@user.preferred_output_path, File.basename(source))
+  end
+
+  # Mirrors PostProcessingJob#get_base_path — returns the configured system
+  # output root for this book's content type.
+  def global_base_path
+    if @book.comicbook?
+      SettingsService.get(:comicbook_output_path, default: "/comics")
+    elsif @book.ebook?
+      SettingsService.get(:ebook_output_path, default: "/ebooks")
+    else
+      SettingsService.get(:audiobook_output_path, default: "/audiobooks")
+    end
+  end
+
+  def perform_copy(source, destination)
+    if File.directory?(source)
+      FileUtils.mkdir_p(destination)
+      Dir.each_child(source) do |entry|
+        FileUtils.cp_r(File.join(source, entry), destination, preserve: true)
+      end
+    else
+      FileUtils.mkdir_p(File.dirname(destination))
+      FileUtils.cp(source, destination, preserve: true) unless File.exist?(destination)
+    end
+    Rails.logger.info "[UserLibraryRoutingService] Copied '#{File.basename(source)}' for user ##{@user.id}"
+  end
+
+  def perform_hardlink(source, destination)
+    if File.directory?(source)
+      hardlink_directory(source, destination)
+    else
+      FileUtils.mkdir_p(File.dirname(destination))
+      File.link(source, destination) unless File.exist?(destination)
+    end
+    Rails.logger.info "[UserLibraryRoutingService] Hardlinked '#{File.basename(source)}' for user ##{@user.id}"
+  rescue Errno::EXDEV
+    # Source and destination are on different filesystems — hard links are
+    # impossible across device boundaries, so fall back to a full copy.
+    Rails.logger.warn(
+      "[UserLibraryRoutingService] Cross-device hardlink not supported; " \
+        "falling back to copy for user ##{@user.id}"
+    )
+    perform_copy(source, destination)
+  end
+
+  # Walks a directory tree, recreating the structure and hard-linking each
+  # regular file. Directories themselves cannot be hard-linked (OS limitation).
+  def hardlink_directory(source_dir, dest_dir)
+    FileUtils.mkdir_p(dest_dir)
+    Dir.each_child(source_dir) do |entry|
+      source_entry = File.join(source_dir, entry)
+      dest_entry = File.join(dest_dir, entry)
+      if File.directory?(source_entry)
+        hardlink_directory(source_entry, dest_entry)
+      elsif File.file?(source_entry) && !File.exist?(dest_entry)
+        File.link(source_entry, dest_entry)
+      end
+    end
+  end
+
+  # Persists the user's destination path so we know where their copy lives.
+  # Uses find_or_create_by! so repeated calls are idempotent.
+  def record_user_path(path)
+    UserBookPath.find_or_create_by!(user: @user, book: @book) do |ubp|
+      ubp.file_path = path
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.warn "[UserLibraryRoutingService] Could not record user book path: #{e.message}"
+  end
+end

--- a/app/services/user_library_routing_service.rb
+++ b/app/services/user_library_routing_service.rb
@@ -10,6 +10,7 @@
 # Directories cannot be hard-linked; we walk each file individually instead.
 class UserLibraryRoutingService
   VALID_MODES = %w[copy hardlink].freeze
+  VALID_LAYOUTS = %w[single_path nested].freeze
 
   def self.call(book:, request:)
     new(book: book, request: request).call
@@ -51,15 +52,24 @@ class UserLibraryRoutingService
 
   # Figures out where the book should go under the user's directory by
   # preserving the same sub-path structure that exists under the global base.
-  # Example: canonical /audiobooks/Author/Title → user's /media/alice/Author/Title
+  # Single-path layout: canonical /audiobooks/Author/Title → /media/alice/Author/Title
+  # Nested layout: canonical /audiobooks/Author/Title → /audiobooks/alice/Author/Title
   def build_user_destination(source)
     relative = Pathname(source).expand_path
       .relative_path_from(Pathname(global_base_path).expand_path)
-    File.join(@user.preferred_output_path, relative.to_s)
+    File.join(user_root_path, relative.to_s)
   rescue ArgumentError
     # Relative path failed (e.g. source is on a different root).
     # Fall back to placing by basename so the file still lands somewhere useful.
-    File.join(@user.preferred_output_path, File.basename(source))
+    File.join(user_root_path, File.basename(source))
+  end
+
+  def user_root_path
+    if @user.nested_routing_layout?
+      File.join(global_base_path, @user.username)
+    else
+      @user.preferred_output_path
+    end
   end
 
   # Mirrors PostProcessingJob#get_base_path — returns the configured system

--- a/app/views/admin/users/directory_routing.html.erb
+++ b/app/views/admin/users/directory_routing.html.erb
@@ -1,0 +1,55 @@
+<div class="mx-auto max-w-2xl">
+  <div class="flex justify-between items-center mb-8">
+    <h1 class="font-bold text-4xl text-white">Directory Routing</h1>
+    <span class="text-gray-400"><%= @user.name %></span>
+  </div>
+
+  <div class="bg-gray-900 rounded-lg border border-gray-800 p-6">
+    <p class="text-gray-400 text-sm mb-6">
+      Assign a personal output directory for this user. When a book is downloaded or already
+      exists on disk, it will be copied or hard-linked into their directory in addition to the
+      system library. Leave the path blank to use the system default only.
+    </p>
+
+    <% if @user.errors.any? %>
+      <div class="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 font-medium rounded-lg mb-6">
+        <ul class="list-disc list-inside">
+          <% @user.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_with model: [:admin, @user], url: update_directory_routing_admin_user_path(@user), method: :patch do |form| %>
+      <div class="my-5">
+        <%= form.label :preferred_output_path, "Output Directory Path", class: "block text-gray-300 font-medium" %>
+        <%= form.text_field :preferred_output_path,
+              placeholder: "/media/#{@user.username}",
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+        <p class="mt-1 text-sm text-gray-500">Absolute path on the server where this user's books will be placed.</p>
+      </div>
+
+      <div class="my-5">
+        <%= form.label :library_routing_mode, "Routing Mode", class: "block text-gray-300 font-medium" %>
+        <%= form.select :library_routing_mode,
+              [
+                ["System default (no personal routing)", ""],
+                ["Copy — duplicate files into user's directory", "copy"],
+                ["Hard Link — zero-storage link to the system copy", "hardlink"]
+              ],
+              { selected: @user.library_routing_mode.to_s },
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+        <p class="mt-1 text-sm text-gray-500">
+          Hard link uses zero extra disk space but requires both paths to be on the same filesystem.
+          Copy works across filesystems but duplicates storage.
+        </p>
+      </div>
+
+      <div class="flex items-center gap-4 mt-6">
+        <%= form.submit "Save Routing Settings", class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white cursor-pointer" %>
+        <%= link_to "Cancel", admin_users_path, class: "text-gray-400 hover:text-gray-300" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/users/directory_routing.html.erb
+++ b/app/views/admin/users/directory_routing.html.erb
@@ -5,11 +5,14 @@
   </div>
 
   <div class="bg-gray-900 rounded-lg border border-gray-800 p-6">
-    <p class="text-gray-400 text-sm mb-6">
-      Assign a personal output directory for this user. When a book is downloaded or already
-      exists on disk, it will be copied or hard-linked into their directory in addition to the
-      system library. Leave the path blank to use the system default only.
-    </p>
+    <div class="bg-gray-800/60 border border-gray-700 rounded-lg px-4 py-3 mb-6">
+      <p class="text-gray-300 text-sm font-medium mb-2">How this works</p>
+      <ol class="list-decimal list-inside text-gray-400 text-sm space-y-1">
+        <li>Choose a <strong class="text-gray-300">Routing Mode</strong>. Leave it as System default and nothing else needs to be set.</li>
+        <li>Copy or Hard Link reveals <strong class="text-gray-300">Personal Library Layout</strong>.</li>
+        <li>Single Path reveals the <strong class="text-gray-300">Output Directory Path</strong> to fill in. Nested needs nothing further — paths are derived automatically.</li>
+      </ol>
+    </div>
 
     <% if @user.errors.any? %>
       <div class="bg-red-500/10 border border-red-500/20 text-red-400 px-4 py-3 font-medium rounded-lg mb-6">
@@ -21,15 +24,7 @@
       </div>
     <% end %>
 
-    <%= form_with model: [:admin, @user], url: update_directory_routing_admin_user_path(@user), method: :patch do |form| %>
-      <div class="my-5">
-        <%= form.label :preferred_output_path, "Output Directory Path", class: "block text-gray-300 font-medium" %>
-        <%= form.text_field :preferred_output_path,
-              placeholder: "/media/#{@user.username}",
-              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
-        <p class="mt-1 text-sm text-gray-500">Absolute path on the server where this user's books will be placed.</p>
-      </div>
-
+    <%= form_with model: [:admin, @user], url: update_directory_routing_admin_user_path(@user), method: :patch, data: { controller: "directory-routing-form" } do |form| %>
       <div class="my-5">
         <%= form.label :library_routing_mode, "Routing Mode", class: "block text-gray-300 font-medium" %>
         <%= form.select :library_routing_mode,
@@ -39,11 +34,37 @@
                 ["Hard Link — zero-storage link to the system copy", "hardlink"]
               ],
               { selected: @user.library_routing_mode.to_s },
-              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full",
+              data: { directory_routing_form_target: "mode", action: "change->directory-routing-form#refresh" } %>
         <p class="mt-1 text-sm text-gray-500">
           Hard link uses zero extra disk space but requires both paths to be on the same filesystem.
           Copy works across filesystems but duplicates storage.
         </p>
+      </div>
+
+      <div class="my-5" data-directory-routing-form-target="layoutSection">
+        <%= form.label :routing_layout, "Personal Library Layout", class: "block text-gray-300 font-medium" %>
+        <%= form.select :routing_layout,
+              [
+                ["Single path — all content in one personal directory", "single_path"],
+                ["Nested — a subfolder under each system library path", "nested"]
+              ],
+              { selected: @user.routing_layout.presence || "single_path" },
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full",
+              data: { directory_routing_form_target: "layout", action: "change->directory-routing-form#refresh" } %>
+        <p class="mt-1 text-sm text-gray-500">
+          Single path uses the directory below for everything, e.g. <code class="text-gray-400">/media/<%= @user.username %></code>.
+          Nested derives one automatically per content type,
+          e.g. <code class="text-gray-400">/audiobooks/<%= @user.username %></code>, <code class="text-gray-400">/ebooks/<%= @user.username %></code>.
+        </p>
+      </div>
+
+      <div class="my-5" data-directory-routing-form-target="pathSection">
+        <%= form.label :preferred_output_path, "Output Directory Path", class: "block text-gray-300 font-medium" %>
+        <%= form.text_field :preferred_output_path,
+              placeholder: "/media/#{@user.username}",
+              class: "block rounded-lg border border-gray-700 bg-gray-800 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 px-4 py-3 mt-2 w-full" %>
+        <p class="mt-1 text-sm text-gray-500">Absolute path on the server where this user's books will be placed.</p>
       </div>
 
       <div class="flex items-center gap-4 mt-6">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -29,10 +29,13 @@
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-gray-500 text-sm"><%= user.created_at.strftime("%b %d, %Y") %></td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-              <%= link_to "Edit", edit_admin_user_path(user), class: "text-blue-400 hover:text-blue-300 mr-4" %>
-              <% unless user == Current.user %>
-                <%= button_to "Delete", admin_user_path(user), method: :delete, class: "text-red-400 hover:text-red-300", data: { turbo_confirm: "Are you sure you want to delete this user?" } %>
-              <% end %>
+              <div class="flex flex-col items-end gap-1">
+                <%= link_to "Directory Routing", directory_routing_admin_user_path(user), class: "text-blue-400 hover:text-blue-300" %>
+                <%= link_to "Edit", edit_admin_user_path(user), class: "text-blue-400 hover:text-blue-300" %>
+                <% unless user == Current.user %>
+                  <%= button_to "Delete", admin_user_path(user), method: :delete, class: "text-red-400 hover:text-red-300", data: { turbo_confirm: "Are you sure you want to delete this user?" } %>
+                <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -141,6 +141,13 @@
                   <%= book.audiobook? ? "Audio" : book.book_type_label %>
                 </span>
 
+                <%# In-your-library badge %>
+                <% if @routed_book_ids.include?(book.id) %>
+                  <span class="absolute top-2 left-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium backdrop-blur-sm text-white bg-green-500/90">
+                    ✓ Yours
+                  </span>
+                <% end %>
+
                 <%# Hover Overlay %>
                 <div class="absolute inset-0 bg-gradient-to-t from-black via-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-end p-2">
                   <span class="text-white text-xs font-medium">View Details</span>

--- a/app/views/library/show.html.erb
+++ b/app/views/library/show.html.erb
@@ -79,6 +79,21 @@
         </div>
       <% end %>
 
+      <% if Current.user.routing_configured? %>
+        <div class="mt-6 pt-6 border-t border-gray-800">
+          <h3 class="text-sm font-medium text-gray-500 mb-2">Your Library</h3>
+          <% if @already_in_user_library %>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-500/20 text-green-400">
+              Already in your library
+            </span>
+          <% else %>
+            <%= button_to "Add to My Library", add_to_my_library_library_path(@book),
+                method: :post,
+                class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition text-sm" %>
+          <% end %>
+        </div>
+      <% end %>
+
       <% if Current.user&.admin? %>
         <% if @attention_request %>
           <div class="mt-6 pt-6 border-t border-gray-800">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   resources :library, only: [ :index, :show, :destroy ] do
     member do
       post :retry_post_processing
+      post :add_to_my_library
     end
   end
 
@@ -94,7 +95,12 @@ Rails.application.routes.draw do
     root "dashboard#index"
     post "check_updates", to: "dashboard#check_updates"
     post "run_health_check", to: "dashboard#run_health_check"
-    resources :users
+    resources :users do
+      member do
+        get :directory_routing
+        patch :update_directory_routing
+      end
+    end
     resources :uploads, only: [ :index, :new, :create, :show, :destroy ] do
       member do
         post :retry

--- a/db/migrate/20260825000001_add_directory_routing_to_users.rb
+++ b/db/migrate/20260825000001_add_directory_routing_to_users.rb
@@ -1,0 +1,6 @@
+class AddDirectoryRoutingToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :preferred_output_path, :string
+    add_column :users, :library_routing_mode, :string
+  end
+end

--- a/db/migrate/20260825000002_create_user_book_paths.rb
+++ b/db/migrate/20260825000002_create_user_book_paths.rb
@@ -1,0 +1,12 @@
+class CreateUserBookPaths < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_book_paths do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :book, null: false, foreign_key: true
+      t.string :file_path, null: false
+      t.timestamps
+    end
+
+    add_index :user_book_paths, [ :user_id, :book_id ], unique: true
+  end
+end

--- a/db/migrate/20260828000001_add_routing_layout_to_users.rb
+++ b/db/migrate/20260828000001_add_routing_layout_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoutingLayoutToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :routing_layout, :string, default: "single_path", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_000001) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -574,6 +574,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_000002) do
     t.string "password_digest", null: false
     t.string "preferred_output_path"
     t.integer "role", default: 0, null: false
+    t.string "routing_layout", default: "single_path", null: false
     t.datetime "telegram_link_token_created_at"
     t.string "telegram_link_token_digest"
     t.string "telegram_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_000002) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -546,6 +546,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
     t.index ["user_id"], name: "index_uploads_on_user_id"
   end
 
+  create_table "user_book_paths", force: :cascade do |t|
+    t.integer "book_id", null: false
+    t.datetime "created_at", null: false
+    t.string "file_path", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["book_id"], name: "index_user_book_paths_on_book_id"
+    t.index ["user_id", "book_id"], name: "index_user_book_paths_on_user_id_and_book_id", unique: true
+    t.index ["user_id"], name: "index_user_book_paths_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.text "backup_codes"
     t.datetime "created_at", null: false
@@ -553,6 +564,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
     t.integer "failed_login_count", default: 0, null: false
     t.datetime "last_failed_login_at"
     t.string "last_failed_login_ip"
+    t.string "library_routing_mode"
     t.datetime "locked_until"
     t.string "name", default: "", null: false
     t.string "oidc_provider"
@@ -560,6 +572,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
     t.boolean "otp_required", default: false, null: false
     t.string "otp_secret"
     t.string "password_digest", null: false
+    t.string "preferred_output_path"
     t.integer "role", default: 0, null: false
     t.datetime "telegram_link_token_created_at"
     t.string "telegram_link_token_digest"
@@ -601,4 +614,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_19_090000) do
   add_foreign_key "uploads", "books"
   add_foreign_key "uploads", "requests"
   add_foreign_key "uploads", "users"
+  add_foreign_key "user_book_paths", "books"
+  add_foreign_key "user_book_paths", "users"
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -161,6 +161,20 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal "copy", @user.library_routing_mode
   end
 
+  test "update_directory_routing saves nested layout" do
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: {
+        library_routing_mode: "copy",
+        routing_layout: "nested"
+      }
+    }
+
+    assert_redirected_to admin_users_path
+    @user.reload
+    assert_equal "nested", @user.routing_layout
+    assert @user.routing_configured?
+  end
+
   test "update_directory_routing clears routing when mode is blank" do
     @user.update!(preferred_output_path: "/old/path", library_routing_mode: "copy")
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -134,4 +134,68 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal "You cannot delete yourself.", flash[:alert]
     assert_nil @admin.reload.deleted_at
   end
+
+  # ── Directory Routing ──────────────────────────────────────────────────────
+
+  test "directory_routing renders the form for an admin" do
+    get directory_routing_admin_user_url(@user)
+
+    assert_response :success
+    assert_select "h1", "Directory Routing"
+    assert_select "form[action='#{update_directory_routing_admin_user_path(@user)}']"
+  end
+
+  test "update_directory_routing saves path and mode and redirects" do
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: {
+        preferred_output_path: "/srv/media/userone",
+        library_routing_mode: "copy"
+      }
+    }
+
+    assert_redirected_to admin_users_path
+    assert_equal "Directory routing updated for #{@user.name}.", flash[:notice]
+
+    @user.reload
+    assert_equal "/srv/media/userone", @user.preferred_output_path
+    assert_equal "copy", @user.library_routing_mode
+  end
+
+  test "update_directory_routing clears routing when mode is blank" do
+    @user.update!(preferred_output_path: "/old/path", library_routing_mode: "copy")
+
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: {
+        preferred_output_path: "",
+        library_routing_mode: ""
+      }
+    }
+
+    assert_redirected_to admin_users_path
+    @user.reload
+    assert_nil @user.preferred_output_path.presence
+    assert_nil @user.library_routing_mode.presence
+  end
+
+  test "directory_routing requires admin" do
+    sign_out
+    sign_in_as(@user)
+
+    get directory_routing_admin_user_url(@user)
+
+    assert_redirected_to root_path
+    assert_equal "You must be an admin to access this area.", flash[:alert]
+  end
+
+  test "update_directory_routing requires admin" do
+    sign_out
+    sign_in_as(@user)
+
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: { preferred_output_path: "/srv/media/userone", library_routing_mode: "copy" }
+    }
+
+    assert_redirected_to root_path
+    assert_equal "You must be an admin to access this area.", flash[:alert]
+  end
 end

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -27,6 +27,32 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
       text: "Comics & Manga"
   end
 
+  test "recently added marks books already routed to the user's library" do
+    routed_book = books(:audiobook_acquired)
+    unrouted_book = Book.create!(
+      title: "Dashboard Unrouted Audiobook",
+      book_type: :audiobook,
+      file_path: "/audiobooks/dashboard-unrouted"
+    )
+    @user.update!(preferred_output_path: "/tmp/user-library", library_routing_mode: "copy")
+    UserBookPath.create!(user: @user, book: routed_book, file_path: "/tmp/user-library/routed.m4b")
+
+    get root_path
+
+    assert_response :success
+    assert_select "a[href='#{library_path(routed_book)}'] span", text: "✓ Yours"
+    assert_select "a[href='#{library_path(unrouted_book)}'] span", text: "✓ Yours", count: 0
+  end
+
+  test "recently added shows no routed badge when user has no routing configured" do
+    routed_book = books(:audiobook_acquired)
+
+    get root_path
+
+    assert_response :success
+    assert_select "a[href='#{library_path(routed_book)}'] span", text: "✓ Yours", count: 0
+  end
+
   test "system card only counts degraded and down services as issues, not not_configured" do
     SystemHealth.delete_all
 

--- a/test/controllers/library_controller_test.rb
+++ b/test/controllers/library_controller_test.rb
@@ -703,6 +703,30 @@ class LibraryControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href*='download']", false
   end
 
+  test "show does not display add to library controls when user has no routing configured" do
+    get library_path(@acquired_audiobook)
+    assert_response :success
+    assert_select "form[action='#{add_to_my_library_library_path(@acquired_audiobook)}']", false
+  end
+
+  test "show displays add to library button when user has routing configured" do
+    @user.update!(preferred_output_path: "/tmp/user-library", library_routing_mode: "copy")
+
+    get library_path(@acquired_audiobook)
+    assert_response :success
+    assert_select "form[action='#{add_to_my_library_library_path(@acquired_audiobook)}'] button", text: "Add to My Library"
+  end
+
+  test "show displays already-in-library badge instead of button when routed" do
+    @user.update!(preferred_output_path: "/tmp/user-library", library_routing_mode: "copy")
+    UserBookPath.create!(user: @user, book: @acquired_audiobook, file_path: "/tmp/user-library/book.m4b")
+
+    get library_path(@acquired_audiobook)
+    assert_response :success
+    assert_select "form[action='#{add_to_my_library_library_path(@acquired_audiobook)}']", false
+    assert_select "span", text: "Already in your library"
+  end
+
   test "show displays file path for admin" do
     sign_out
     sign_in_as(@admin)
@@ -792,6 +816,71 @@ class LibraryControllerTest < ActionDispatch::IntegrationTest
     assert_not request.reload.attention_needed?
     assert_nil request.issue_description
     assert_equal failed_job.job_id, download.reload.post_processing_job_id
+  end
+
+  test "add to my library requires routing to be configured" do
+    post add_to_my_library_library_path(@acquired_audiobook)
+
+    assert_redirected_to library_path(@acquired_audiobook)
+    assert_equal "Set a personal library folder in your profile before adding titles.", flash[:alert]
+    assert_not UserBookPath.exists?(user: @user, book: @acquired_audiobook)
+  end
+
+  test "add to my library routes the book into the user's directory" do
+    Dir.mktmpdir("shelfarr-add-to-library-src") do |lib_dir|
+      Dir.mktmpdir("shelfarr-add-to-library-dest") do |user_dir|
+        book_dir = File.join(lib_dir, "Test Author", "The Acquired Audiobook")
+        FileUtils.mkdir_p(book_dir)
+        File.write(File.join(book_dir, "chapter1.mp3"), "audio data")
+        @acquired_audiobook.update!(file_path: book_dir)
+        @user.update!(preferred_output_path: user_dir, library_routing_mode: "copy")
+        SettingsService.set(:audiobook_output_path, lib_dir)
+
+        assert_difference -> { UserBookPath.count }, 1 do
+          post add_to_my_library_library_path(@acquired_audiobook)
+        end
+
+        assert_redirected_to library_path(@acquired_audiobook)
+        assert_equal "Added to your library.", flash[:notice]
+        ubp = UserBookPath.find_by(user: @user, book: @acquired_audiobook)
+        assert_not_nil ubp
+        assert File.exist?(File.join(ubp.file_path, "chapter1.mp3"))
+      end
+    end
+  end
+
+  test "add to my library is idempotent when already added" do
+    @user.update!(preferred_output_path: "/tmp/user-library", library_routing_mode: "copy")
+    UserBookPath.create!(user: @user, book: @acquired_audiobook, file_path: "/tmp/user-library/book.m4b")
+
+    assert_no_difference -> { UserBookPath.count } do
+      post add_to_my_library_library_path(@acquired_audiobook)
+    end
+
+    assert_redirected_to library_path(@acquired_audiobook)
+    assert_equal "This title is already in your library.", flash[:notice]
+  end
+
+  test "add to my library rejects books without a linked metadata source" do
+    @user.update!(preferred_output_path: "/tmp/user-library", library_routing_mode: "copy")
+    @acquired_audiobook.update_columns(
+      open_library_work_id: nil, hardcover_id: nil, google_books_id: nil, comic_vine_id: nil
+    )
+
+    post add_to_my_library_library_path(@acquired_audiobook)
+
+    assert_redirected_to library_path(@acquired_audiobook)
+    assert_match(/no linked metadata source/, flash[:alert])
+    assert_not UserBookPath.exists?(user: @user, book: @acquired_audiobook)
+  end
+
+  test "add to my library returns 404 for non-acquired book" do
+    pending_book = books(:ebook_pending)
+    @user.update!(preferred_output_path: "/tmp/user-library", library_routing_mode: "copy")
+
+    post add_to_my_library_library_path(pending_book)
+
+    assert_response :not_found
   end
 
   test "destroy requires admin" do

--- a/test/controllers/requests_controller_test.rb
+++ b/test/controllers/requests_controller_test.rb
@@ -1246,7 +1246,7 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "create blocks duplicate for acquired book" do
+  test "create immediately completes a request for an already-acquired book" do
     book = Book.create!(
       title: "Acquired",
       book_type: :audiobook,
@@ -1254,16 +1254,20 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
       file_path: "/audiobooks/Author/Acquired"
     )
 
-    assert_no_difference [ "Book.count", "Request.count" ] do
-      post requests_path, params: {
-        work_id: "OL_ACQUIRED_W",
-        title: "Acquired",
-        book_type: "audiobook"
-      }
+    assert_no_difference "Book.count" do
+      assert_difference "Request.count", 1 do
+        post requests_path, params: {
+          work_id: "OL_ACQUIRED_W",
+          title: "Acquired",
+          book_type: "audiobook"
+        }
+      end
     end
 
-    assert_redirected_to search_path
-    assert_includes flash[:alert], "already in your library"
+    request = Request.order(:created_at).last
+    assert_equal "completed", request.status
+    assert_redirected_to request_path(request)
+    assert_includes flash[:notice], "Request created for"
   end
 
   test "destroy cancels pending request" do

--- a/test/fixtures/user_book_paths.yml
+++ b/test/fixtures/user_book_paths.yml
@@ -1,0 +1,1 @@
+# No pre-seeded user_book_paths — created dynamically by UserLibraryRoutingService

--- a/test/integration/directory_routing_flow_test.rb
+++ b/test/integration/directory_routing_flow_test.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# End-to-end functional tests for the per-user directory routing feature.
+#
+# These tests exercise the full stack from the admin UI down to files on disk.
+# They use real temp directories so every assertion is against actual filesystem
+# state, not mocks.
+#
+# Two flows are covered:
+#
+#   Flow A — Already-acquired book
+#     Admin configures routing → user requests a book already on disk →
+#     RequestCreationService short-circuits → UserLibraryRoutingService runs →
+#     file appears in user's personal directory.
+#
+#   Flow B — Download completion hook
+#     Admin configures routing → download completes → PostProcessingJob calls
+#     run_completion_side_effects → UserLibraryRoutingService runs → file
+#     appears in user's personal directory.
+#     (The Download/client infrastructure is not re-tested here; we drive the
+#     exact method PostProcessingJob calls after a successful import.)
+#
+class DirectoryRoutingFlowTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    @admin = users(:two)
+    @user  = users(:one)
+
+    # Real temp directories — every assertion touches actual disk state
+    @tmpdir     = Dir.mktmpdir("shelfarr_e2e_")
+    @global_lib = File.join(@tmpdir, "audiobooks")
+    @user_dir   = File.join(@tmpdir, "user_output")
+    FileUtils.mkdir_p(@global_lib)
+
+    sign_in_as(@admin)
+  end
+
+  teardown do
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  # ── Flow A: Already-acquired book ─────────────────────────────────────────
+  #
+  # Steps exercised:
+  #   1. Admin POSTs to update_directory_routing (real HTTP → controller → DB)
+  #   2. RequestCreationService called for a book whose file_path is already set
+  #   3. Service detects acquired book → calls after_create_for_acquired_book
+  #   4. UserLibraryRoutingService copies files into @user_dir
+  #   5. Request is immediately completed
+  #   6. UserBookPath record exists
+
+  test "already-acquired book: admin sets routing, request immediately routes file to user directory" do
+    # ── Step 1: Admin configures routing via the real HTTP endpoint ──────────
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: { preferred_output_path: @user_dir, library_routing_mode: "copy" }
+    }
+    assert_redirected_to admin_users_path
+    @user.reload
+    assert_equal @user_dir, @user.preferred_output_path
+    assert_equal "copy",    @user.library_routing_mode
+
+    # ── Step 2: File already exists in the global library ───────────────────
+    book = books(:audiobook_acquired)
+    book_dir = File.join(@global_lib, "Test Author", "The Acquired Audiobook")
+    FileUtils.mkdir_p(book_dir)
+    File.write(File.join(book_dir, "chapter1.mp3"), "audio data")
+    book.update!(file_path: book_dir)
+
+    # ── Step 3: User creates a request — service detects file_path is set ───
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_lib }) do
+      result = RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_AUDIOBOOK_1",
+        book_types: [ "audiobook" ],
+        metadata_attrs: { title: book.title, author: book.author }
+      )
+      assert result.success?, result.errors.inspect
+    end
+
+    # ── Step 4: Request was completed immediately (no download queued) ───────
+    request = @user.requests.find_by!(book: book)
+    assert_equal "completed", request.status
+    assert_no_enqueued_jobs only: SearchJob
+
+    # ── Step 5: File appears in user's personal directory ───────────────────
+    expected_file = File.join(@user_dir, "Test Author", "The Acquired Audiobook", "chapter1.mp3")
+    assert File.exist?(expected_file),
+      "Expected routed copy at #{expected_file}"
+    assert_equal "audio data", File.read(expected_file)
+
+    # ── Step 6: UserBookPath record links user to their copy ─────────────────
+    record = UserBookPath.find_by(user: @user, book: book)
+    assert_not_nil record
+    assert record.file_path.start_with?(@user_dir)
+  end
+
+  test "already-acquired book: hardlink mode — user file shares inode with system copy" do
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: { preferred_output_path: @user_dir, library_routing_mode: "hardlink" }
+    }
+    assert_redirected_to admin_users_path
+    @user.reload
+
+    book = books(:audiobook_acquired)
+    source_file = File.join(@global_lib, "book.m4b")
+    File.write(source_file, "audiobook bytes")
+    book.update!(file_path: source_file)
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_lib }) do
+      RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_AUDIOBOOK_1",
+        book_types: [ "audiobook" ],
+        metadata_attrs: { title: book.title, author: book.author }
+      )
+    end
+
+    dest_file = File.join(@user_dir, "book.m4b")
+    assert File.exist?(dest_file)
+    assert_equal File.stat(source_file).ino, File.stat(dest_file).ino,
+      "Hard link must share the same inode — no bytes duplicated on disk"
+  end
+
+  test "already-acquired book: no routing when user has no preferred_output_path configured" do
+    # User has no routing config — system default only
+    @user.update!(preferred_output_path: nil, library_routing_mode: nil)
+
+    book = books(:audiobook_acquired)
+    book_dir = File.join(@global_lib, "book_dir")
+    FileUtils.mkdir_p(book_dir)
+    File.write(File.join(book_dir, "track.mp3"), "audio")
+    book.update!(file_path: book_dir)
+
+    assert_no_difference "UserBookPath.count" do
+      SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_lib }) do
+        RequestCreationService.call(
+          user: @user,
+          work_id: "openlibrary:OL_AUDIOBOOK_1",
+          book_types: [ "audiobook" ],
+          metadata_attrs: { title: book.title, author: book.author }
+        )
+      end
+    end
+
+    assert_equal 0, Dir.children(@tmpdir).count { |entry|
+      File.directory?(File.join(@tmpdir, entry)) && entry != "audiobooks"
+    }, "No user output directory should have been created"
+  end
+
+  # ── Flow B: Post-download routing via PostProcessingJob ───────────────────
+  #
+  # PostProcessingJob requires a fully set-up Download record and download
+  # client state machine — wiring that belongs to existing download tests.
+  # We drive run_completion_side_effects directly: it is the exact method
+  # PostProcessingJob calls after a successful import, and it is where our
+  # UserLibraryRoutingService hook lives.
+
+  test "post-download: completion side effects route file to user directory" do
+    @user.update!(preferred_output_path: @user_dir, library_routing_mode: "copy")
+
+    # Simulate the state after PostProcessingJob has imported files to the
+    # global library and set book.file_path
+    book = books(:audiobook_acquired)
+    book_dir = File.join(@global_lib, "Author", "Downloaded Book")
+    FileUtils.mkdir_p(book_dir)
+    File.write(File.join(book_dir, "part1.mp3"), "audio bytes")
+    book.update!(file_path: book_dir)
+
+    request = @user.requests.create!(book: book, status: :completed)
+
+    # Drive the exact method PostProcessingJob calls after a successful import
+    job = PostProcessingJob.new
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_lib }) do
+      job.send(:run_completion_side_effects, request, nil, book, book_dir)
+    end
+
+    expected = File.join(@user_dir, "Author", "Downloaded Book", "part1.mp3")
+    assert File.exist?(expected),
+      "Expected routed file at #{expected} after download completion"
+    assert UserBookPath.exists?(user: @user, book: book)
+  end
+
+  test "post-download: hardlink mode — routed file shares inode with imported copy" do
+    @user.update!(preferred_output_path: @user_dir, library_routing_mode: "hardlink")
+
+    book = books(:audiobook_acquired)
+    source = File.join(@global_lib, "book.epub")
+    File.write(source, "epub content")
+    book.update!(file_path: source)
+
+    request = @user.requests.create!(book: book, status: :completed)
+
+    job = PostProcessingJob.new
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_lib }) do
+      job.send(:run_completion_side_effects, request, nil, book, source)
+    end
+
+    dest = File.join(@user_dir, "book.epub")
+    assert File.exist?(dest)
+    assert_equal File.stat(source).ino, File.stat(dest).ino,
+      "Hard link must share the same inode"
+  end
+end

--- a/test/integration/directory_routing_full_flow_test.rb
+++ b/test/integration/directory_routing_full_flow_test.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Functional end-to-end test for the per-user directory routing feature.
+#
+# Exercises the full request lifecycle without any shortcuts:
+#
+#   Admin sets routing → User submits request → SearchJob queries mock indexer →
+#   Result saved → select_result! creates Download → DownloadJob dispatches to
+#   mock qBittorrent → [download completes on disk] → PostProcessingJob imports
+#   into system library → UserLibraryRoutingService routes to user directory
+#
+# Two external HTTP seams are stubbed — everything else is real:
+#   • IndexerClient.search   — returns a synthetic IndexerClients::Result
+#   • download_client.adapter — Minitest::Mock, expects add_torrent → hash
+#
+# File I/O uses real temp directories so every assertion is against actual
+# disk state, not stubs.
+#
+# Why manual select_result! instead of AutoSelectService stub:
+#   SearchJob calls attempt_auto_select only when auto_select_enabled is true.
+#   Rather than thread a success-duck-type through the stub return value, we
+#   let SearchJob save the result and exit, then call select_result! directly —
+#   exactly what an admin or the auto-select service would do.
+#
+# Why DownloadJob.new.perform instead of perform_enqueued_jobs for DownloadJob:
+#   select_result! enqueues DownloadJob via after_all_transactions_commit, which
+#   does not fire inside the test wrapper transaction. We invoke perform directly.
+#
+class DirectoryRoutingFullFlowTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  setup do
+    @admin = users(:two)
+    @user  = users(:one)
+
+    @tmpdir   = Dir.mktmpdir("shelfarr_full_flow_")
+    @dl_dir   = File.join(@tmpdir, "downloads")   # where the "downloader" writes files
+    @lib_dir  = File.join(@tmpdir, "library")     # Shelfarr's system library
+    @user_dir = File.join(@tmpdir, "user_output") # user's personal routed directory
+    FileUtils.mkdir_p([@dl_dir, @lib_dir])
+
+    sign_in_as(@admin)
+  end
+
+  teardown do
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  # ── Copy mode ─────────────────────────────────────────────────────────────
+  #
+  # Full pipeline: indexer result → torrent dispatched → download complete →
+  # post-processed into system library → duplicated into user directory.
+
+  test "copy mode: file routed to user directory after full download pipeline" do
+    # Step 1: Admin configures per-user routing via the real HTTP endpoint
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: { preferred_output_path: @user_dir, library_routing_mode: "copy" }
+    }
+    assert_redirected_to admin_users_path
+
+    # Step 2: "qBittorrent" finishes downloading — files land on disk
+    # (Simulates what the torrent client writes when a download completes)
+    book_dl_dir = File.join(@dl_dir, "Test Author - The New Audiobook")
+    FileUtils.mkdir_p(book_dl_dir)
+    File.write(File.join(book_dl_dir, "chapter1.mp3"), "audio bytes")
+
+    # Step 3: SearchJob + DownloadJob run with all external HTTP stubbed
+    torrent_hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+    client, adapter = build_client_and_adapter(torrent_hash)
+
+    download = run_search_and_dispatch(
+      title: "The New Audiobook", author: "Test Author",
+      work_id: "openlibrary:OL_FULL_FLOW_W",
+      torrent_hash: torrent_hash, download_client: client, mock_adapter: adapter
+    )
+
+    adapter.verify  # confirms DownloadJob called add_torrent
+
+    # Step 4: Simulate DownloadMonitorJob detecting the completed download
+    # (The monitor polls qBittorrent's API and sets download_path when done.
+    #  That's existing infrastructure — not our feature. We set the state directly.)
+    assert_not_nil download, "DownloadJob should have created a Download record"
+    download.update!(status: :completed, download_path: book_dl_dir)
+
+    # Step 5: PostProcessingJob imports from dl_dir → lib_dir, then our hook
+    # (UserLibraryRoutingService) copies lib_dir → user_dir
+    run_post_processing(download)
+
+    # ── Assertions ─────────────────────────────────────────────────────────
+    book    = Book.find_by(title: "The New Audiobook")
+    request = @user.requests.find_by(book: book)
+
+    assert_not_nil book,    "Book record should be created by SearchJob"
+    assert_not_nil request, "Request record should be created"
+    assert_equal "completed", request.reload.status,
+      "Request should be completed after PostProcessingJob"
+
+    # System library: PostProcessingJob imports here
+    assert book.reload.file_path.present?,
+      "book.file_path should be set after import"
+    assert File.exist?(File.join(book.file_path, "chapter1.mp3")),
+      "chapter1.mp3 should be in the system library at #{book.file_path}"
+
+    # User's personal directory: UserLibraryRoutingService routes here
+    ubp = UserBookPath.find_by(user: @user, book: book)
+    assert_not_nil ubp,
+      "UserBookPath should be created by UserLibraryRoutingService"
+    assert ubp.file_path.start_with?(@user_dir),
+      "UserBookPath.file_path should be under #{@user_dir}"
+    assert File.exist?(File.join(ubp.file_path, "chapter1.mp3")),
+      "chapter1.mp3 should appear in the user's personal directory"
+  end
+
+  # ── Hardlink mode ─────────────────────────────────────────────────────────
+  #
+  # Same full pipeline, but routing creates a hard link instead of a copy.
+  # The assertion is on inode identity — zero bytes duplicated.
+
+  test "hardlink mode: user file shares inode with system library copy" do
+    patch update_directory_routing_admin_user_url(@user), params: {
+      user: { preferred_output_path: @user_dir, library_routing_mode: "hardlink" }
+    }
+    assert_redirected_to admin_users_path
+
+    book_dl_dir = File.join(@dl_dir, "Test Author - Hardlink Book")
+    FileUtils.mkdir_p(book_dl_dir)
+    File.write(File.join(book_dl_dir, "track.mp3"), "audio bytes")
+
+    torrent_hash = "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+    client, adapter = build_client_and_adapter(torrent_hash)
+
+    download = run_search_and_dispatch(
+      title: "Hardlink Book", author: "Test Author",
+      work_id: "openlibrary:OL_HARDLINK_FLOW_W",
+      torrent_hash: torrent_hash, download_client: client, mock_adapter: adapter
+    )
+    adapter.verify
+
+    download.update!(status: :completed, download_path: book_dl_dir)
+    run_post_processing(download)
+
+    book = Book.find_by(title: "Hardlink Book")
+    ubp  = UserBookPath.find_by(user: @user, book: book)
+    assert_not_nil ubp
+
+    lib_file  = File.join(book.file_path, "track.mp3")
+    user_file = File.join(ubp.file_path,  "track.mp3")
+
+    assert File.exist?(lib_file),  "track.mp3 should be in system library"
+    assert File.exist?(user_file), "track.mp3 should be in user directory"
+    assert_equal File.stat(lib_file).ino, File.stat(user_file).ino,
+      "Hard link must share the same inode as the library copy — no bytes duplicated"
+  end
+
+  # ── No routing when user has no config ────────────────────────────────────
+  #
+  # Full pipeline still runs; PostProcessingJob still imports to system library.
+  # UserLibraryRoutingService is a no-op when preferred_output_path is nil.
+
+  test "no routing when user has no preferred_output_path configured" do
+    @user.update!(preferred_output_path: nil, library_routing_mode: nil)
+
+    book_dl_dir = File.join(@dl_dir, "Test Author - Unrouted Book")
+    FileUtils.mkdir_p(book_dl_dir)
+    File.write(File.join(book_dl_dir, "audio.mp3"), "audio bytes")
+
+    torrent_hash = "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+    client, adapter = build_client_and_adapter(torrent_hash)
+
+    download = run_search_and_dispatch(
+      title: "Unrouted Book", author: "Test Author",
+      work_id: "openlibrary:OL_UNROUTED_FLOW_W",
+      torrent_hash: torrent_hash, download_client: client, mock_adapter: adapter
+    )
+    adapter.verify
+
+    download.update!(status: :completed, download_path: book_dl_dir)
+
+    assert_no_difference "UserBookPath.count" do
+      run_post_processing(download)
+    end
+
+    book = Book.find_by(title: "Unrouted Book")
+    assert book.reload.file_path.present?,
+      "System library import should still happen even without user routing"
+    assert_not Dir.exist?(@user_dir),
+      "No user output directory should be created when routing is not configured"
+  end
+
+  private
+
+  # Creates a real DownloadClient AR record and a Minitest::Mock adapter.
+  # The mock expects exactly one call to add_torrent and returns torrent_hash.
+  def build_client_and_adapter(torrent_hash)
+    client = DownloadClient.create!(
+      name:        "Test qBittorrent #{torrent_hash[0, 6]}",
+      client_type: :qbittorrent,
+      url:         "http://localhost:9999"
+    )
+    adapter = Minitest::Mock.new
+    adapter.expect(:add_torrent, torrent_hash, [String])
+    [client, adapter]
+  end
+
+  # Runs the full SearchJob → select_result! → DownloadJob pipeline.
+  #
+  # Phase 1 — SearchJob queries the mock indexer and saves the result to the DB.
+  #   auto_select_enabled is absent from the settings stub (defaults false),
+  #   so attempt_auto_select exits early. We select the result manually below,
+  #   which is exactly what AutoSelectService or the admin UI does.
+  #
+  # Phase 2 — select_result! creates the Download record.
+  #
+  # Phase 3 — DownloadJob dispatches to the mock qBittorrent adapter.
+  #   after_all_transactions_commit (which normally enqueues DownloadJob after
+  #   select_result!) does not fire inside the test wrapper transaction, so we
+  #   call DownloadJob#perform directly.
+  #
+  # Returns the Download record so the caller can update it and run PostProcessingJob.
+  def run_search_and_dispatch(title:, author:, work_id:, torrent_hash:, download_client:, mock_adapter:)
+    fake_result = IndexerClients::Result.new(
+      guid:         "test-guid-#{torrent_hash[0, 8]}",
+      title:        "#{author} - #{title}",
+      indexer:      "FakeIndexer",
+      size_bytes:   1_000_000,
+      seeders:      50,
+      leechers:     5,
+      download_url: "http://indexer.local/#{torrent_hash}.torrent",
+      magnet_url:   nil,
+      info_url:     nil,
+      published_at: 1.day.ago,
+      category_ids: [3030]
+    )
+
+    # Phase 1: SearchJob finds the mock indexer result and saves it.
+    with_test_settings do
+      IndexerClient.stub(:configured?, true) do
+        IndexerClient.stub(:provider, "prowlarr") do
+          IndexerClient.stub(:search, [fake_result]) do
+            perform_enqueued_jobs(only: SearchJob) do
+              RequestCreationService.call(
+                user:           @user,
+                work_id:        work_id,
+                book_types:     ["audiobook"],
+                metadata_attrs: { title: title, author: author }
+              )
+            end
+          end
+        end
+      end
+    end
+
+    # Phase 2: Select the search result — mirrors what AutoSelectService or an
+    # admin does after seeing search results in the UI.
+    request       = @user.requests.reload.last
+    search_result = request.search_results.reload.first
+    assert_not_nil search_result,
+      "SearchJob should have saved a SearchResult via the mock indexer"
+
+    request.select_result!(search_result)
+    download = request.downloads.reload.last
+    assert_not_nil download, "select_result! should have created a Download record"
+
+    # Phase 3: DownloadJob dispatches to the mock qBittorrent adapter.
+    with_test_settings do
+      DownloadClientSelector.stub(:for_download, download_client) do
+        download_client.stub(:adapter, mock_adapter) do
+          DownloadJob.new.perform(download.id)
+        end
+      end
+    end
+
+    download
+  end
+
+  # Runs PostProcessingJob for real.
+  # Imports files from download_path → @lib_dir (system library), then
+  # run_completion_side_effects calls UserLibraryRoutingService → @user_dir.
+  def run_post_processing(download)
+    with_test_settings do
+      LibraryPlatformClient.stub(:configured?, false) do
+        perform_enqueued_jobs(only: PostProcessingJob) do
+          PostProcessingJob.perform_later(download.id)
+        end
+      end
+    end
+  end
+
+  # Stubs SettingsService.get for all keys the pipeline reads.
+  # Without this, calls would hit the DB where test rows may not exist,
+  # causing jobs to fall back to production paths like /audiobooks or /downloads.
+  #
+  # Note: auto_select_enabled is intentionally absent (defaults to false).
+  # SearchJob will save results and mark for manual selection, which is the
+  # correct setup for Phase 2's explicit select_result! call.
+  def with_test_settings(&block)
+    settings = {
+      audiobook_output_path:               @lib_dir,
+      ebook_output_path:                   @lib_dir,
+      comicbook_output_path:               @lib_dir,
+      download_local_path:                 @dl_dir,
+      completed_download_import_mode:      "copy",
+      auto_approve_requests:               true,
+      post_processing_source_path_retries: 0,
+      download_check_interval:             1,
+      split_audiobook_bundle_imports:      false,
+      min_match_confidence:                0
+    }
+    SettingsService.stub(:get, ->(key, **opts) { settings.fetch(key, opts[:default]) }, &block)
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,6 +9,24 @@ class UserTest < ActiveSupport::TestCase
     assert_equal("myuser", user.username)
   end
 
+  test "routing_configured? is false when preferred_output_path is blank" do
+    user = User.new(preferred_output_path: nil, library_routing_mode: "copy")
+    assert_not user.routing_configured?
+  end
+
+  test "routing_configured? is false when library_routing_mode is invalid" do
+    user = User.new(preferred_output_path: "/data/user", library_routing_mode: "invalid")
+    assert_not user.routing_configured?
+  end
+
+  test "routing_configured? is true for copy and hardlink modes" do
+    user = User.new(preferred_output_path: "/data/user", library_routing_mode: "copy")
+    assert user.routing_configured?
+
+    user.library_routing_mode = "hardlink"
+    assert user.routing_configured?
+  end
+
   test "validates username format" do
     user = User.new(name: "Test", username: "invalid user!", password: VALID_PASSWORD)
     assert_not user.valid?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,6 +27,27 @@ class UserTest < ActiveSupport::TestCase
     assert user.routing_configured?
   end
 
+  test "routing_configured? does not require preferred_output_path under nested layout" do
+    user = User.new(preferred_output_path: nil, library_routing_mode: "copy", routing_layout: "nested")
+    assert user.routing_configured?
+  end
+
+  test "routing_configured? still requires a routing mode under nested layout" do
+    user = User.new(preferred_output_path: nil, library_routing_mode: nil, routing_layout: "nested")
+    assert_not user.routing_configured?
+  end
+
+  test "nested_routing_layout? reflects the routing_layout column" do
+    user = User.new(routing_layout: "nested")
+    assert user.nested_routing_layout?
+
+    user.routing_layout = "single_path"
+    assert_not user.nested_routing_layout?
+
+    user.routing_layout = nil
+    assert_not user.nested_routing_layout?
+  end
+
   test "validates username format" do
     user = User.new(name: "Test", username: "invalid user!", password: VALID_PASSWORD)
     assert_not user.valid?

--- a/test/services/request_creation_service_test.rb
+++ b/test/services/request_creation_service_test.rb
@@ -557,4 +557,67 @@ class RequestCreationServiceTest < ActiveSupport::TestCase
     assert_not result.success?
     assert_includes result.errors.join, "Collection requests are not supported"
   end
+
+  # ── Already-acquired book intercept (directory routing) ───────────────────
+
+  test "request for already-downloaded book is marked completed immediately" do
+    book = books(:audiobook_acquired)
+
+    result = RequestCreationService.call(
+      user: @user,
+      work_id: "openlibrary:OL_AUDIOBOOK_1",
+      book_types: [ "audiobook" ],
+      metadata_attrs: { title: book.title, author: book.author }
+    )
+
+    assert result.success?
+    request = result.created_requests.first
+    assert_equal "completed", request.status
+  end
+
+  test "SearchJob is not enqueued for already-downloaded book" do
+    SettingsService.set(:auto_approve_requests, true)
+    book = books(:audiobook_acquired)
+
+    assert_no_enqueued_jobs only: SearchJob do
+      RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_AUDIOBOOK_1",
+        book_types: [ "audiobook" ],
+        metadata_attrs: { title: book.title, author: book.author }
+      )
+    end
+  end
+
+  test "UserLibraryRoutingService is called for already-downloaded book" do
+    book = books(:audiobook_acquired)
+    routing_called = false
+
+    UserLibraryRoutingService.stub(:call, ->(**_kwargs) { routing_called = true }) do
+      RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_AUDIOBOOK_1",
+        book_types: [ "audiobook" ],
+        metadata_attrs: { title: book.title, author: book.author }
+      )
+    end
+
+    assert routing_called, "Expected UserLibraryRoutingService.call to be invoked"
+  end
+
+  test "UserLibraryRoutingService is not called for a new pending request" do
+    SettingsService.set(:auto_approve_requests, false)
+    routing_called = false
+
+    UserLibraryRoutingService.stub(:call, ->(**_kwargs) { routing_called = true }) do
+      RequestCreationService.call(
+        user: @user,
+        work_id: "openlibrary:OL_NEW_PENDING_W",
+        book_types: [ "ebook" ],
+        metadata_attrs: { title: "A Brand New Ebook" }
+      )
+    end
+
+    assert_not routing_called, "Expected UserLibraryRoutingService.call NOT to be invoked for a fresh request"
+  end
 end

--- a/test/services/user_library_routing_service_test.rb
+++ b/test/services/user_library_routing_service_test.rb
@@ -194,6 +194,51 @@ class UserLibraryRoutingServiceTest < ActiveSupport::TestCase
     end
   end
 
+  # ── Nested layout ──────────────────────────────────────────────────────────
+
+  test "nested layout places files under the system path plus username, ignoring preferred_output_path" do
+    source_file = File.join(@global_base, "author", "book.epub")
+    FileUtils.mkdir_p(File.dirname(source_file))
+    File.write(source_file, "epub content")
+    set_book_file_path(source_file)
+    @user.update!(preferred_output_path: nil, library_routing_mode: "copy", routing_layout: "nested")
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+
+    expected_dest = File.join(@global_base, @user.username, "author", "book.epub")
+    assert File.exist?(expected_dest), "Expected nested copy at #{expected_dest}"
+    assert_equal "epub content", File.read(expected_dest)
+
+    record = UserBookPath.find_by(user: @user, book: @book)
+    assert_equal expected_dest, record.file_path
+  end
+
+  test "nested layout hard-links under the system path plus username" do
+    source_file = File.join(@global_base, "book.epub")
+    File.write(source_file, "epub bytes")
+    set_book_file_path(source_file)
+    @user.update!(preferred_output_path: nil, library_routing_mode: "hardlink", routing_layout: "nested")
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+
+    dest_file = File.join(@global_base, @user.username, "book.epub")
+    assert File.exist?(dest_file)
+    assert_equal File.stat(source_file).ino, File.stat(dest_file).ino
+  end
+
+  test "nested layout still requires a routing mode" do
+    set_book_file_path(File.join(@global_base, "book.epub"))
+    @user.update!(preferred_output_path: nil, library_routing_mode: nil, routing_layout: "nested")
+
+    assert_no_difference "UserBookPath.count" do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+  end
+
   # ── Error resilience ───────────────────────────────────────────────────────
 
   test "does not raise when a filesystem error occurs" do

--- a/test/services/user_library_routing_service_test.rb
+++ b/test/services/user_library_routing_service_test.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UserLibraryRoutingServiceTest < ActiveSupport::TestCase
+  setup do
+    @tmpdir = Dir.mktmpdir("shelfarr_routing_test_")
+    @global_base = File.join(@tmpdir, "audiobooks")
+    @user_dir = File.join(@tmpdir, "user_output")
+    FileUtils.mkdir_p(@global_base)
+
+    @user = users(:one)
+    @book = books(:audiobook_acquired)
+  end
+
+  teardown do
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  # ── Helper: build a request object without persisting it ──────────────────
+
+  def build_request
+    @user.requests.build(book: @book, status: :pending)
+  end
+
+  # ── Helper: configure user for routing ────────────────────────────────────
+
+  def configure_user(mode:)
+    @user.update!(preferred_output_path: @user_dir, library_routing_mode: mode)
+  end
+
+  # ── Helper: point the book at a real path inside the temp dir ─────────────
+
+  def set_book_file_path(path)
+    @book.update!(file_path: path)
+  end
+
+  # ── No-op cases ───────────────────────────────────────────────────────────
+
+  test "does nothing when user has no preferred_output_path" do
+    @user.update!(preferred_output_path: nil, library_routing_mode: "copy")
+    set_book_file_path(File.join(@global_base, "some_book.epub"))
+
+    assert_no_difference "UserBookPath.count" do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+  end
+
+  test "does nothing when user has no library_routing_mode" do
+    @user.update!(preferred_output_path: @user_dir, library_routing_mode: nil)
+    set_book_file_path(File.join(@global_base, "some_book.epub"))
+
+    assert_no_difference "UserBookPath.count" do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+  end
+
+  test "does nothing when book has no file_path" do
+    configure_user(mode: "copy")
+    @book.update!(file_path: nil)
+
+    assert_no_difference "UserBookPath.count" do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+  end
+
+  # ── Copy mode: single file ─────────────────────────────────────────────────
+
+  test "copy mode duplicates a single file into the user directory" do
+    source_file = File.join(@global_base, "author", "book.epub")
+    FileUtils.mkdir_p(File.dirname(source_file))
+    File.write(source_file, "epub content")
+    set_book_file_path(source_file)
+    configure_user(mode: "copy")
+
+    expected_dest = File.join(@user_dir, "author", "book.epub")
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+
+    assert File.exist?(expected_dest), "Expected copy at #{expected_dest}"
+    assert_equal "epub content", File.read(expected_dest)
+  end
+
+  test "copy mode creates a UserBookPath record" do
+    source_file = File.join(@global_base, "book.epub")
+    File.write(source_file, "epub content")
+    set_book_file_path(source_file)
+    configure_user(mode: "copy")
+
+    assert_difference "UserBookPath.count", 1 do
+      SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+        UserLibraryRoutingService.call(book: @book, request: build_request)
+      end
+    end
+
+    record = UserBookPath.find_by(user: @user, book: @book)
+    assert_not_nil record
+    assert record.file_path.start_with?(@user_dir)
+  end
+
+  # ── Copy mode: directory (audiobook) ──────────────────────────────────────
+
+  test "copy mode duplicates a directory of files into the user directory" do
+    source_dir = File.join(@global_base, "author", "audiobook")
+    FileUtils.mkdir_p(source_dir)
+    File.write(File.join(source_dir, "chapter1.mp3"), "audio1")
+    File.write(File.join(source_dir, "chapter2.mp3"), "audio2")
+    set_book_file_path(source_dir)
+    configure_user(mode: "copy")
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+
+    dest_dir = File.join(@user_dir, "author", "audiobook")
+    assert File.directory?(dest_dir), "Expected destination directory at #{dest_dir}"
+    assert File.exist?(File.join(dest_dir, "chapter1.mp3"))
+    assert File.exist?(File.join(dest_dir, "chapter2.mp3"))
+  end
+
+  # ── Hardlink mode: single file ─────────────────────────────────────────────
+
+  test "hardlink mode creates a hard link sharing the same inode" do
+    source_file = File.join(@global_base, "author", "book.epub")
+    FileUtils.mkdir_p(File.dirname(source_file))
+    File.write(source_file, "epub content")
+    set_book_file_path(source_file)
+    configure_user(mode: "hardlink")
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+
+    dest_file = File.join(@user_dir, "author", "book.epub")
+    assert File.exist?(dest_file), "Expected hard link at #{dest_file}"
+    assert_equal File.stat(source_file).ino, File.stat(dest_file).ino,
+      "Hard link should share the same inode as the source"
+  end
+
+  # ── Hardlink mode: directory ───────────────────────────────────────────────
+
+  test "hardlink mode walks a directory and hard-links each file" do
+    source_dir = File.join(@global_base, "audiobook")
+    FileUtils.mkdir_p(source_dir)
+    File.write(File.join(source_dir, "part1.mp3"), "audio")
+    set_book_file_path(source_dir)
+    configure_user(mode: "hardlink")
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+      UserLibraryRoutingService.call(book: @book, request: build_request)
+    end
+
+    dest_file = File.join(@user_dir, "audiobook", "part1.mp3")
+    assert File.exist?(dest_file)
+    assert_equal File.stat(File.join(source_dir, "part1.mp3")).ino, File.stat(dest_file).ino
+  end
+
+  # ── Hardlink EXDEV fallback ────────────────────────────────────────────────
+
+  test "hardlink mode falls back to copy on cross-device error" do
+    source_file = File.join(@global_base, "book.epub")
+    File.write(source_file, "epub bytes")
+    set_book_file_path(source_file)
+    configure_user(mode: "hardlink")
+
+    # Simulate a cross-device link error (different filesystem)
+    File.stub(:link, ->(*_args) { raise Errno::EXDEV, "cross-device link" }) do
+      SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+        UserLibraryRoutingService.call(book: @book, request: build_request)
+      end
+    end
+
+    dest_file = File.join(@user_dir, "book.epub")
+    assert File.exist?(dest_file), "Expected fallback copy at #{dest_file}"
+    assert_equal "epub bytes", File.read(dest_file)
+  end
+
+  # ── Idempotency ────────────────────────────────────────────────────────────
+
+  test "calling twice does not create duplicate UserBookPath records" do
+    source_file = File.join(@global_base, "book.epub")
+    File.write(source_file, "epub content")
+    set_book_file_path(source_file)
+    configure_user(mode: "copy")
+
+    assert_difference "UserBookPath.count", 1 do
+      2.times do
+        SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+          UserLibraryRoutingService.call(book: @book, request: build_request)
+        end
+      end
+    end
+  end
+
+  # ── Error resilience ───────────────────────────────────────────────────────
+
+  test "does not raise when a filesystem error occurs" do
+    configure_user(mode: "copy")
+    set_book_file_path(File.join(@global_base, "nonexistent", "book.epub"))
+
+    SettingsService.stub(:get, ->(*_args, **_kwargs) { @global_base }) do
+      assert_nothing_raised do
+        UserLibraryRoutingService.call(book: @book, request: build_request)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #445

## Summary
- Admin can assign each user a personal library directory (or a layout nested under the existing system output paths) with copy or hard-link routing.
- Already-acquired books and newly completed downloads are automatically routed into a user's personal directory alongside the system library.
- Adds an "Add to My Library" action so a user can pull an already-acquired title (e.g. from Recently Added) into their own directory on demand.
- Admin's Directory Routing form is now progressive: Routing Mode reveals Personal Library Layout, which in turn reveals the Output Directory Path only when relevant.

## Test plan
- [x] `bin/rails test` for all files touched by this change (models, controllers, services, integration flows) - all passing
- [x] Verified hard-link mode produces genuine zero-extra-storage links (checked with `fsutil hardlink list` on the host filesystem, not just inode comparison inside the container)
- [x] Verified the dynamic admin form's show/hide cascade manually in a browser