### PR TITLE
Fix Z-Library connection test error reporting

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -258,11 +258,13 @@ module Admin
         return
       end
 
-      if ZLibraryClient.test_connection
+      if ZLibraryClient.test_connection!
         respond_with_flash(notice: "Z-Library connection successful!")
       else
         respond_with_flash(alert: "Z-Library connection failed.")
       end
+    rescue ZLibraryClient::Error => e
+      respond_with_flash(alert: "Z-Library error: #{e.message}")
     end
 
     def test_librivox

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -121,7 +121,11 @@ class ZLibraryClient
 
       @last_auth_from_cache = false
       auth = perform_login(signature, after_attempt: after_attempt)
-      raise AuthenticationError, "Z-Library login failed" unless auth
+
+      if auth.nil? || (auth.is_a?(Hash) && auth[:errors].present?)
+        error_details = auth.is_a?(Hash) && auth[:errors].present? ? " (#{auth[:errors].join('; ')})" : ""
+        raise AuthenticationError, "Z-Library login failed#{error_details}"
+      end
 
       auth
     end
@@ -129,22 +133,34 @@ class ZLibraryClient
     def perform_login(signature, after_attempt: nil)
       email = SettingsService.get(:zlibrary_email).to_s.strip
       password = SettingsService.get(:zlibrary_password).to_s
+      errors = []
 
       configured_uris.each do |uri|
         base_url = uri.to_s.delete_suffix("/")
         domain = uri.host
 
         auth = authenticate_uri(uri, after_attempt: after_attempt)
-        next unless auth
+
+        if auth.nil?
+          next
+        elsif auth.is_a?(Hash) && auth[:error].present?
+          errors << "#{domain}: #{auth[:error]}"
+          next
+        end
 
         Rails.logger.info "[ZLibraryClient] Login succeeded via #{domain}"
         cache_auth(signature, auth)
         return auth
       rescue JSON::ParserError, Faraday::Error => e
         Rails.logger.debug "[ZLibraryClient] Login failed on #{domain}: #{e.message}"
+        errors << "#{domain}: #{e.class.name.split('::').last}"
       end
 
-      nil
+      unless errors.empty?
+        Rails.logger.error "[ZLibraryClient] Login failed on all configured domains: #{errors.join('; ')}"
+      end
+
+      { errors: errors }
     end
 
     def authenticate_uri(uri, after_attempt: nil)
@@ -158,10 +174,18 @@ class ZLibraryClient
         end
       end
 
-      return unless response.status == 200
+      unless response.status == 200
+        Rails.logger.debug "[ZLibraryClient] Login failed on #{uri.host}: HTTP #{response.status}"
+        return { error: "HTTP #{response.status}" }
+      end
 
       data = parse_json_body(response)
-      return unless data["success"] == 1
+
+      unless data["success"] == 1
+        error_message = data["error"].presence || "login rejected"
+        Rails.logger.debug "[ZLibraryClient] Login failed on #{uri.host}: #{error_message}"
+        return { error: error_message }
+      end
 
       auth = {
         remix_userid: data.dig("user", "id")&.to_s,
@@ -170,7 +194,16 @@ class ZLibraryClient
         base_url: base_url
       }
 
-      auth if auth[:remix_userid].present? && auth[:remix_userkey].present?
+      unless auth[:remix_userid].present? && auth[:remix_userkey].present?
+        missing = []
+        missing << "user id" unless auth[:remix_userid].present?
+        missing << "remix_userkey" unless auth[:remix_userkey].present?
+        error_message = "incomplete response (missing #{missing.join(' and ')})"
+        Rails.logger.debug "[ZLibraryClient] Login failed on #{uri.host}: #{error_message}"
+        return { error: error_message }
+      end
+
+      auth
     end
 
     def cache_auth(signature, auth)
@@ -349,7 +382,7 @@ class ZLibraryClient
         next if base_url == current_auth[:base_url]
 
         auth = authenticate_uri(uri, after_attempt: after_attempt)
-        next unless auth
+        next if auth.nil? || (auth.is_a?(Hash) && auth[:error].present?)
 
         Rails.logger.info "[ZLibraryClient] Retrying eAPI via #{auth[:domain]}"
         cache_auth(signature, auth)

--- a/app/services/z_library_client.rb
+++ b/app/services/z_library_client.rb
@@ -27,6 +27,7 @@ class ZLibraryClient
 
   AUTH_TTL_SECONDS = 30.minutes
   ALLOWED_DOWNLOAD_SCHEMES = %w[http https].freeze
+  MAX_LOGIN_ERROR_LENGTH = 200
 
   class << self
     def configured?
@@ -34,11 +35,16 @@ class ZLibraryClient
     end
 
     def test_connection
-      ensure_configured!
-      login.present?
+      test_connection!
     rescue Error => e
       Rails.logger.error "[ZLibraryClient] Connection test failed: #{e.message}"
       false
+    end
+
+    def test_connection!
+      ensure_configured!
+      login
+      true
     end
 
     def search(query, file_types: %w[epub pdf], limit: 50, language: nil, after_attempt: nil)
@@ -122,7 +128,8 @@ class ZLibraryClient
       @last_auth_from_cache = false
       auth = perform_login(signature, after_attempt: after_attempt)
 
-      if auth.nil? || (auth.is_a?(Hash) && auth[:errors].present?)
+      login_failed = auth.nil? || (auth.is_a?(Hash) && auth.key?(:errors))
+      if login_failed
         error_details = auth.is_a?(Hash) && auth[:errors].present? ? " (#{auth[:errors].join('; ')})" : ""
         raise AuthenticationError, "Z-Library login failed#{error_details}"
       end
@@ -131,12 +138,9 @@ class ZLibraryClient
     end
 
     def perform_login(signature, after_attempt: nil)
-      email = SettingsService.get(:zlibrary_email).to_s.strip
-      password = SettingsService.get(:zlibrary_password).to_s
       errors = []
 
       configured_uris.each do |uri|
-        base_url = uri.to_s.delete_suffix("/")
         domain = uri.host
 
         auth = authenticate_uri(uri, after_attempt: after_attempt)
@@ -180,16 +184,21 @@ class ZLibraryClient
       end
 
       data = parse_json_body(response)
+      unless data.is_a?(Hash)
+        Rails.logger.debug "[ZLibraryClient] Login failed on #{uri.host}: invalid response"
+        return { error: "invalid response" }
+      end
 
       unless data["success"] == 1
-        error_message = data["error"].presence || "login rejected"
+        error_message = normalized_login_error(data["error"]) || "login rejected"
         Rails.logger.debug "[ZLibraryClient] Login failed on #{uri.host}: #{error_message}"
         return { error: error_message }
       end
 
+      user = data["user"].is_a?(Hash) ? data["user"] : {}
       auth = {
-        remix_userid: data.dig("user", "id")&.to_s,
-        remix_userkey: data.dig("user", "remix_userkey")&.to_s,
+        remix_userid: user["id"]&.to_s,
+        remix_userkey: user["remix_userkey"]&.to_s,
         domain: uri.host,
         base_url: base_url
       }
@@ -204,6 +213,11 @@ class ZLibraryClient
       end
 
       auth
+    end
+
+    def normalized_login_error(error)
+      error.to_s.scrub("?").gsub(/[[:cntrl:]]+/, " ").squish
+        .truncate(MAX_LOGIN_ERROR_LENGTH, omission: "...").presence
     end
 
     def cache_auth(signature, auth)
@@ -326,6 +340,9 @@ class ZLibraryClient
       case response.status
       when 200
         data = parse_json_body(response)
+        unless data.is_a?(Hash)
+          raise Error, "Z-Library #{context} returned an invalid response"
+        end
         if data["success"] == 0
           error_message = data["error"].presence || "unknown Z-Library error"
           raise Error, "Z-Library #{context} failed: #{error_message}"
@@ -341,7 +358,7 @@ class ZLibraryClient
     end
 
     def parse_json_body(response)
-      return response.body if response.body.is_a?(Hash)
+      return response.body unless response.body.is_a?(String)
 
       JSON.parse(response.body)
     end

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -1508,7 +1508,7 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     SettingsService.set(:zlibrary_email, "reader@example.com")
     SettingsService.set(:zlibrary_password, "secret")
 
-    ZLibraryClient.stub :test_connection, true do
+    ZLibraryClient.stub :test_connection!, true do
       post test_zlibrary_admin_settings_url
     end
 
@@ -1522,12 +1522,36 @@ class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
     SettingsService.set(:zlibrary_email, "reader@example.com")
     SettingsService.set(:zlibrary_password, "secret")
 
-    ZLibraryClient.stub :test_connection, false do
+    ZLibraryClient.stub :test_connection!, false do
       post test_zlibrary_admin_settings_url
     end
 
     assert_redirected_to admin_settings_path
     assert_match /failed/i, flash[:alert]
+  end
+
+  test "test_zlibrary shows the login failure returned by Z-Library" do
+    SettingsService.set(:zlibrary_enabled, true)
+    SettingsService.set(:zlibrary_url, "https://z-library.sk")
+    SettingsService.set(:zlibrary_email, "reader@example.com")
+    SettingsService.set(:zlibrary_password, "secret")
+
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .with(body: "email=reader%40example.com&password=secret")
+        .to_return(
+          status: 200,
+          body: { success: 0, error: "Invalid email or password" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      post test_zlibrary_admin_settings_url,
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    assert_response :success
+    assert_select "turbo-stream[target='flash']", count: 1
+    assert_includes response.body, "Invalid email or password"
   end
 
   test "test_librivox fails when disabled" do

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -479,7 +479,7 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     assert_not ZLibraryClient.test_connection
   end
 
-  test "test_connection surfaces specific error when Z-Library returns success: 0 with error message" do
+  test "test_connection! raises the specific error returned by Z-Library" do
     VCR.turned_off do
       stub_request(:post, "https://z-library.sk/eapi/user/login")
         .with(body: "email=reader%40example.com&password=secret")
@@ -489,7 +489,11 @@ class ZLibraryClientTest < ActiveSupport::TestCase
           headers: { "Content-Type" => "application/json" }
         )
 
-      assert_not ZLibraryClient.test_connection
+      error = assert_raises ZLibraryClient::AuthenticationError do
+        ZLibraryClient.test_connection!
+      end
+
+      assert_match /Invalid credentials/, error.message
     end
   end
 
@@ -526,6 +530,42 @@ class ZLibraryClientTest < ActiveSupport::TestCase
       end
 
       assert_match /incomplete|missing.*remix_userkey/i, error.message
+    end
+  end
+
+  test "test_connection! reports a non-object login response without crashing" do
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .to_return(
+          status: 200,
+          body: [ "unexpected" ].to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      error = assert_raises ZLibraryClient::AuthenticationError do
+        ZLibraryClient.test_connection!
+      end
+
+      assert_match /invalid response/, error.message
+    end
+  end
+
+  test "test_connection! bounds and normalizes an upstream login error" do
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .to_return(
+          status: 200,
+          body: { success: 0, error: "Invalid\ncredentials #{'x' * 300}" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      error = assert_raises ZLibraryClient::AuthenticationError do
+        ZLibraryClient.test_connection!
+      end
+
+      assert_includes error.message, "Invalid credentials"
+      assert_not_includes error.message, "\n"
+      assert_operator error.message.length, :<=, 260
     end
   end
 

--- a/test/services/z_library_client_test.rb
+++ b/test/services/z_library_client_test.rb
@@ -479,6 +479,56 @@ class ZLibraryClientTest < ActiveSupport::TestCase
     assert_not ZLibraryClient.test_connection
   end
 
+  test "test_connection surfaces specific error when Z-Library returns success: 0 with error message" do
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .with(body: "email=reader%40example.com&password=secret")
+        .to_return(
+          status: 200,
+          body: { success: 0, error: "Invalid credentials" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      assert_not ZLibraryClient.test_connection
+    end
+  end
+
+  test "login raises AuthenticationError with specific message when Z-Library returns error" do
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .with(body: "email=reader%40example.com&password=secret")
+        .to_return(
+          status: 200,
+          body: { success: 0, error: "Invalid email or password" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      error = assert_raises ZLibraryClient::AuthenticationError do
+        ZLibraryClient.send(:login)
+      end
+
+      assert_match /Invalid email or password/, error.message
+    end
+  end
+
+  test "login raises AuthenticationError when Z-Library returns incomplete user data" do
+    VCR.turned_off do
+      stub_request(:post, "https://z-library.sk/eapi/user/login")
+        .with(body: "email=reader%40example.com&password=secret")
+        .to_return(
+          status: 200,
+          body: { success: 1, user: { id: "12345" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      error = assert_raises ZLibraryClient::AuthenticationError do
+        ZLibraryClient.send(:login)
+      end
+
+      assert_match /incomplete|missing.*remix_userkey/i, error.message
+    end
+  end
+
   private
 
   def stub_zlibrary_login_success(domain = "z-library.sk")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #499 by improving Z-Library login error reporting to surface specific failure reasons instead of a generic "Z-Library login failed" message.

## Problem

The admin Z-Library connection test was failing with a generic "Z-Library login failed" message that didn't help users diagnose the actual problem. The `authenticate_uri` method would silently return `nil` when:
- HTTP 200 response with `success: 0` and an error message
- HTTP 200 response with incomplete user credentials (missing `remix_userid` or `remix_userkey`)
- Non-200 HTTP status codes

This made it impossible to distinguish between:
- Wrong credentials
- Z-Library service changes or outages
- Missing response fields
- HTTP errors

## Solution

Enhanced error handling throughout the authentication flow:

1. **`authenticate_uri`** now returns error details instead of `nil`:
   - HTTP status errors: `{ error: "HTTP 404" }`
   - Z-Library API errors: `{ error: "Invalid email or password" }`
   - Incomplete responses: `{ error: "incomplete response (missing remix_userkey)" }`

2. **`perform_login`** collects errors from all configured domains and returns them

3. **`login`** raises `AuthenticationError` with domain-specific error messages

4. **Improved logging** at debug and error levels for better troubleshooting

## Testing

Added three new test cases covering:
- Login failure with HTTP 200 and `success: 0` with error message
- Login failure with incomplete user data (missing `remix_userkey`)
- Connection test correctly returns false and logs specific errors

All existing tests continue to pass.

## Example Error Messages

Before:
```
[ZLibraryClient] Connection test failed: Z-Library login failed
```

After:
```
[ZLibraryClient] Connection test failed: Z-Library login failed (z-library.sk: Invalid email or password)
```

Or with multiple domains:
```
[ZLibraryClient] Connection test failed: Z-Library login failed (z-library.sk: HTTP 503; z-library.bz: Invalid credentials)
```

## Notes

This is a product bug fix - the client was hiding useful error information from Z-Library's API responses. No credentials or external services were tested during development; all tests use mocked HTTP responses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d97c796-2b3d-470d-9c06-0679a099b206?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d97c796-2b3d-470d-9c06-0679a099b206&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

