### PR TITLE
Retry transient indexer GET failures once

### DIFF
--- a/app/services/indexer_clients/base.rb
+++ b/app/services/indexer_clients/base.rb
@@ -49,6 +49,7 @@ module IndexerClients
       def request
         yield
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+        reset_connection!
         raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
       rescue InvalidUrlError => e
         # Preserve connection-error classification for malformed stored URLs so

--- a/app/services/indexer_clients/base.rb
+++ b/app/services/indexer_clients/base.rb
@@ -46,10 +46,22 @@ module IndexerClients
         raise NotConfiguredError, "#{display_name} is not configured" unless configured?
       end
 
-      def request
-        yield
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-        reset_connection!
+      def request(idempotent: false)
+        retried = false
+
+        begin
+          yield
+        rescue Faraday::SSLError => e
+          raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
+        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+          unless idempotent && !retried
+            raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
+          end
+
+          retried = true
+          retry
+        end
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
         raise ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
       rescue InvalidUrlError => e
         # Preserve connection-error classification for malformed stored URLs so

--- a/app/services/indexer_clients/jackett.rb
+++ b/app/services/indexer_clients/jackett.rb
@@ -27,7 +27,7 @@ module IndexerClients
         cats = categories || categories_for_type(book_type)
         params[:cat] = Array(cats).join(",") if cats.present?
 
-        response = request { connection.get(search_path, params) }
+        response = request(idempotent: true) { connection.get(search_path, params) }
         handle_response(response) { |body| parse_results(body, limit: limit) }
       end
 
@@ -38,10 +38,11 @@ module IndexerClients
       def test_connection
         ensure_configured!
 
-        response = connection.get(search_path, { apikey: api_key, t: "caps" })
+        response = request(idempotent: true) do
+          connection.get(search_path, { apikey: api_key, t: "caps" })
+        end
         response.status == 200
-      rescue IndexerClients::Base::Error, Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError
-        reset_connection!
+      rescue IndexerClients::Base::Error
         false
       end
 
@@ -87,9 +88,6 @@ module IndexerClients
         else
           raise Base::Error, "#{display_name} API error: #{response.status}"
         end
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-        reset_connection!
-        raise Base::ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
       end
 
       def parse_results(xml, limit:)

--- a/app/services/indexer_clients/jackett.rb
+++ b/app/services/indexer_clients/jackett.rb
@@ -41,6 +41,7 @@ module IndexerClients
         response = connection.get(search_path, { apikey: api_key, t: "caps" })
         response.status == 200
       rescue IndexerClients::Base::Error, Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError
+        reset_connection!
         false
       end
 
@@ -87,6 +88,7 @@ module IndexerClients
           raise Base::Error, "#{display_name} API error: #{response.status}"
         end
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+        reset_connection!
         raise Base::ConnectionError, "Failed to connect to #{display_name}: #{e.message}"
       end
 

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -33,7 +33,7 @@ module IndexerClients
       def indexers
         ensure_configured!
 
-        response = request { connection.get("api/v1/indexer") }
+        response = request(idempotent: true) { connection.get("api/v1/indexer") }
         handle_response(response) { |data| Array(data) }
       end
 
@@ -85,10 +85,9 @@ module IndexerClients
       def test_connection
         ensure_configured!
 
-        response = connection.get("api/v1/indexer")
+        response = request(idempotent: true) { connection.get("api/v1/indexer") }
         response.status == 200
-      rescue IndexerClients::Base::Error, Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError
-        reset_connection!
+      rescue IndexerClients::Base::Error
         false
       end
 
@@ -101,7 +100,7 @@ module IndexerClients
       def configured_tag_ids_for_names(tag_names)
         return [] if tag_names.empty?
 
-        response = request { connection.get("api/v1/tag") }
+        response = request(idempotent: true) { connection.get("api/v1/tag") }
         handle_response(response) do |tags|
           tag_lookup = {}
 
@@ -164,9 +163,6 @@ module IndexerClients
         else
           raise Base::Error, "Prowlarr API error: #{response.status}"
         end
-      rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-        reset_connection!
-        raise Base::ConnectionError, "Failed to connect to Prowlarr: #{e.message}"
       end
 
       def parse_result(item)
@@ -221,7 +217,7 @@ module IndexerClients
         params[:categories] = Array(categories) if categories.present?
         params[:indexerIds] = indexer_ids if indexer_ids.present?
 
-        response = request { connection.get("api/v1/search", params) }
+        response = request(idempotent: true) { connection.get("api/v1/search", params) }
 
         handle_response(response) { |data| Array(data) }
       end

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -88,6 +88,7 @@ module IndexerClients
         response = connection.get("api/v1/indexer")
         response.status == 200
       rescue IndexerClients::Base::Error, Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError
+        reset_connection!
         false
       end
 
@@ -164,6 +165,7 @@ module IndexerClients
           raise Base::Error, "Prowlarr API error: #{response.status}"
         end
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+        reset_connection!
         raise Base::ConnectionError, "Failed to connect to Prowlarr: #{e.message}"
       end
 

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -1822,7 +1822,7 @@ class SearchJobTest < ActiveJob::TestCase
 
       assert_requested structured_stub
       assert_requested categorized_generic_stub
-      assert_requested broad_stub
+      assert_requested broad_stub, times: 2
       assert_equal [ payload["title"] ], @request.search_results.pluck(:title)
     end
   end

--- a/test/services/indexer_clients/jackett_test.rb
+++ b/test/services/indexer_clients/jackett_test.rb
@@ -110,4 +110,21 @@ class IndexerClients::JackettTest < ActiveSupport::TestCase
       assert IndexerClients::Jackett.test_connection
     end
   end
+
+  test "search retries one transient connection failure" do
+    VCR.turned_off do
+      request = stub_request(:get, %r{localhost:9117/api/v2\.0/indexers/all/results/torznab/api})
+        .with(query: hash_including("apikey" => "jackett-api-key", "t" => "search"))
+        .to_raise(Faraday::ConnectionFailed.new("connection reset"))
+        .then
+        .to_return(
+          status: 200,
+          body: "<rss><channel></channel></rss>",
+          headers: { "Content-Type" => "application/xml" }
+        )
+
+      assert_equal [], IndexerClients::Jackett.search("test", book_type: :ebook)
+      assert_requested request, times: 2
+    end
+  end
 end

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -655,10 +655,11 @@ class ProwlarrClientTest < ActiveSupport::TestCase
   # SSL error handling tests
   test "test_connection returns false on SSL error" do
     VCR.turned_off do
-      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+      request = stub_request(:get, "http://localhost:9696/api/v1/indexer")
         .to_raise(Faraday::SSLError.new("SSL certificate verify failed"))
 
       assert_not ProwlarrClient.test_connection
+      assert_requested request, times: 1
     end
   end
 
@@ -673,77 +674,52 @@ class ProwlarrClientTest < ActiveSupport::TestCase
     end
   end
 
-  test "test_connection resets memoized connection on connection failure to allow recovery" do
+  test "test_connection retries one transient connection failure" do
     VCR.turned_off do
-      # First test_connection succeeds
-      stub_request(:get, "http://localhost:9696/api/v1/indexer")
-        .to_return(status: 200, body: "[]")
-
-      assert ProwlarrClient.test_connection, "Initial connection should succeed"
-
-      # Simulate remote closing the connection (e.g., Kestrel keep-alive idle timeout)
-      # The memoized Faraday connection becomes stale and raises ConnectionFailed
-      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+      request = stub_request(:get, "http://localhost:9696/api/v1/indexer")
         .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
-
-      # Without the fix, this would return false but leave the stale connection
-      assert_not ProwlarrClient.test_connection, "Connection failure should be detected"
-
-      # Now the remote is back online
-      stub_request(:get, "http://localhost:9696/api/v1/indexer")
-        .to_return(status: 200, body: "[]")
-
-      # With the fix, this should succeed because the stale connection was reset
-      # Without the fix, this would continue to fail because it reuses the dead connection
-      assert ProwlarrClient.test_connection, "Connection should recover after reset"
-    end
-  end
-
-  test "test_connection resets memoized connection on timeout to allow recovery" do
-    VCR.turned_off do
-      # First connection succeeds
-      stub_request(:get, "http://localhost:9696/api/v1/indexer")
-        .to_return(status: 200, body: "[]")
-
-      assert ProwlarrClient.test_connection, "Initial connection should succeed"
-
-      # Simulate timeout on the memoized connection
-      stub_request(:get, "http://localhost:9696/api/v1/indexer")
-        .to_raise(Faraday::TimeoutError.new("execution expired"))
-
-      assert_not ProwlarrClient.test_connection, "Timeout should be detected"
-
-      # Remote is responsive again
-      stub_request(:get, "http://localhost:9696/api/v1/indexer")
-        .to_return(status: 200, body: "[]")
-
-      # Should recover after timeout clears the memoized connection
-      assert ProwlarrClient.test_connection, "Connection should recover after timeout"
-    end
-  end
-
-  test "search resets memoized connection on connection error to allow recovery" do
-    VCR.turned_off do
-      # First search succeeds
-      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .then
         .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
 
-      assert_equal [], ProwlarrClient.search("test"), "Initial search should succeed"
+      assert ProwlarrClient.test_connection
+      assert_requested request, times: 2
+    end
+  end
 
-      # Connection fails
-      stub_request(:get, %r{localhost:9696/api/v1/search})
+  test "search retries one transient timeout" do
+    VCR.turned_off do
+      request = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_raise(Faraday::TimeoutError.new("execution expired"))
+        .then
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+      assert_equal [], ProwlarrClient.search("test")
+      assert_requested request, times: 2
+    end
+  end
+
+  test "search stops after one retry when connection failures persist" do
+    VCR.turned_off do
+      request = stub_request(:get, %r{localhost:9696/api/v1/search})
         .to_raise(Faraday::ConnectionFailed.new("Connection reset by peer"))
 
       assert_raises ProwlarrClient::ConnectionError do
         ProwlarrClient.search("test")
       end
+      assert_requested request, times: 2
+    end
+  end
 
-      # Remote is back online
-      stub_request(:get, %r{localhost:9696/api/v1/search})
-        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+  test "search does not retry API responses" do
+    VCR.turned_off do
+      request = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_return(status: 503, body: { error: "unavailable" }.to_json,
+          headers: { "Content-Type" => "application/json" })
 
-      # Should recover after connection error cleared the memoized connection
-      assert_equal [], ProwlarrClient.search("test"), "Search should recover after connection reset"
+      assert_raises ProwlarrClient::Error do
+        ProwlarrClient.search("test")
+      end
+      assert_requested request, times: 1
     end
   end
 

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -673,6 +673,80 @@ class ProwlarrClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "test_connection resets memoized connection on connection failure to allow recovery" do
+    VCR.turned_off do
+      # First test_connection succeeds
+      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+        .to_return(status: 200, body: "[]")
+
+      assert ProwlarrClient.test_connection, "Initial connection should succeed"
+
+      # Simulate remote closing the connection (e.g., Kestrel keep-alive idle timeout)
+      # The memoized Faraday connection becomes stale and raises ConnectionFailed
+      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+        .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+
+      # Without the fix, this would return false but leave the stale connection
+      assert_not ProwlarrClient.test_connection, "Connection failure should be detected"
+
+      # Now the remote is back online
+      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+        .to_return(status: 200, body: "[]")
+
+      # With the fix, this should succeed because the stale connection was reset
+      # Without the fix, this would continue to fail because it reuses the dead connection
+      assert ProwlarrClient.test_connection, "Connection should recover after reset"
+    end
+  end
+
+  test "test_connection resets memoized connection on timeout to allow recovery" do
+    VCR.turned_off do
+      # First connection succeeds
+      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+        .to_return(status: 200, body: "[]")
+
+      assert ProwlarrClient.test_connection, "Initial connection should succeed"
+
+      # Simulate timeout on the memoized connection
+      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+        .to_raise(Faraday::TimeoutError.new("execution expired"))
+
+      assert_not ProwlarrClient.test_connection, "Timeout should be detected"
+
+      # Remote is responsive again
+      stub_request(:get, "http://localhost:9696/api/v1/indexer")
+        .to_return(status: 200, body: "[]")
+
+      # Should recover after timeout clears the memoized connection
+      assert ProwlarrClient.test_connection, "Connection should recover after timeout"
+    end
+  end
+
+  test "search resets memoized connection on connection error to allow recovery" do
+    VCR.turned_off do
+      # First search succeeds
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+      assert_equal [], ProwlarrClient.search("test"), "Initial search should succeed"
+
+      # Connection fails
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_raise(Faraday::ConnectionFailed.new("Connection reset by peer"))
+
+      assert_raises ProwlarrClient::ConnectionError do
+        ProwlarrClient.search("test")
+      end
+
+      # Remote is back online
+      stub_request(:get, %r{localhost:9696/api/v1/search})
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+      # Should recover after connection error cleared the memoized connection
+      assert_equal [], ProwlarrClient.search("test"), "Search should recover after connection reset"
+    end
+  end
+
   private
 
   def stub_indexers(*indexers)


### PR DESCRIPTION
## Assigned issue

Refs #504

## What changed

Added one bounded retry for idempotent indexer GET requests when Faraday reports a transient connection failure or timeout.

- Prowlarr indexer discovery, tag lookup, search, and connection tests retry once.
- Jackett search and connection tests retry once; Newznab inherits the same paths.
- SSL failures, HTTP/API errors, malformed responses, invalid configuration, and non-idempotent requests are not retried.
- Persistent failures stop after the second attempt and retain the existing typed connection error.

The installed Faraday net_http adapter creates a fresh Net::HTTP transport for each request, so resetting the memoized Faraday configuration object did not repair a stale socket. Reissuing the safe GET is the behavior that provides transient recovery. This mitigates the reported health-check symptom, but the exact claim that a Kestrel idle socket remains pinned until restart was not reproducible; issue #504 should remain open until production diagnostics confirm its root cause.

## Verification

- Real TCP harnesses for Prowlarr, Jackett, and Newznab: the first connection is dropped and the second succeeds.
- Real read-timeout-then-success harness: exactly two connections.
- Persistent disconnects: exactly two attempts, then ConnectionError.
- Regression coverage for timeout recovery, retry cap, SSL no-retry, HTTP 503 no-retry, and broad-search failure handling.
- Full Rails suite: 3,276 tests and 12,608 assertions passed in the independent review; the local repeat encountered one unrelated DownloadMonitor scheduling flake that passed immediately in isolation.
- RuboCop and diff checks passed.

## Checklist

- [x] The maintainer assigned the linked issue before implementation
- [x] The change stays within the issue's resilience scope
- [x] Tests cover the changed behavior
- [x] Relevant local quality checks passed
- [x] No user-facing documentation change is required
