### PR TITLE
Handle combined-title search safely across providers

### DIFF
--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -18,6 +18,8 @@ class SearchJob < ApplicationJob
   # otherwise come back empty, so users see low-confidence candidates
   # instead of no results at all.
   LOW_CONFIDENCE_FALLBACK_LIMIT = 5
+  MAX_GENERIC_SEARCH_ATTEMPTS = 18
+  MAX_BROAD_SEARCH_ATTEMPTS = 6
 
   ROMAN_NUMERALS = {
     "I" => "1",
@@ -353,41 +355,33 @@ class SearchJob < ApplicationJob
     language_search_term(request)
   end
 
-  # Extract the appropriate search title from a book title that may contain
-  # combined localized/original titles (e.g., "La Nena / The Girl").
-  # Returns the first part before the slash separator to avoid sending
-  # the combined string as a literal search query.
+  # Prefer the localized component for providers that accept only one title.
+  # Generic indexer attempts retain every alias as a fallback.
   def search_title(book)
-    title = book.title.to_s
-    # Match pattern: "Text / Text" where the slash is surrounded by spaces
-    # and separates what appears to be a localized title from an English/original title
-    if title.match?(/\s+\/\s+/)
-      # Return the first part (localized title) for better search results
-      title.split(/\s+\/\s+/, 2).first.to_s.strip
-    else
-      title
-    end
+    search_titles(book).first.to_s
+  end
+
+  def search_titles(book)
+    SearchTitleVariantService.call(book.title)
   end
 
   def search_anna_archive(request, search_generation)
     book = request.book
-
-    query_parts = [ search_title(book) ]
-    query_parts << book.author if book.author.present?
-    query_parts << "audiobook" if book.audiobook?
-    query = query_parts.join(" ")
-
-    # Pass language to Anna's Archive for better filtering
     language = request.effective_language
     Rails.logger.debug "[SearchJob] Searching Anna's Archive for request ##{request.id}"
 
-    results = AnnaArchiveClient.search(
-      query,
-      file_types: book.audiobook? ? AnnaArchiveClient::AUDIOBOOK_FILE_TYPES : AnnaArchiveClient::EBOOK_FILE_TYPES,
-      content_types: book.audiobook? ? [] : AnnaArchiveClient::BOOK_CONTENT_TYPES,
-      language: language,
-      after_attempt: -> { heartbeat_search!(request, search_generation) }
-    )
+    results = first_title_variant_results(book) do |title|
+      query_parts = [ title ]
+      query_parts << book.author if book.author.present?
+      query_parts << "audiobook" if book.audiobook?
+      AnnaArchiveClient.search(
+        query_parts.join(" "),
+        file_types: book.audiobook? ? AnnaArchiveClient::AUDIOBOOK_FILE_TYPES : AnnaArchiveClient::EBOOK_FILE_TYPES,
+        content_types: book.audiobook? ? [] : AnnaArchiveClient::BOOK_CONTENT_TYPES,
+        language: language,
+        after_attempt: -> { heartbeat_search!(request, search_generation) }
+      )
+    end
 
     # Tag results with source
     results.map do |r|
@@ -407,15 +401,16 @@ class SearchJob < ApplicationJob
 
   def search_zlibrary(request, search_generation)
     book = request.book
-    query = [ search_title(book), book.author ].compact.join(" ")
     language = zlibrary_language_filter(request)
     Rails.logger.debug "[SearchJob] Searching Z-Library for request ##{request.id}"
 
-    ZLibraryClient.search(
-      query,
-      language: language,
-      after_attempt: -> { heartbeat_search!(request, search_generation) }
-    ).map do |result|
+    first_title_variant_results(book) do |title|
+      ZLibraryClient.search(
+        [ title, book.author ].compact.join(" "),
+        language: language,
+        after_attempt: -> { heartbeat_search!(request, search_generation) }
+      )
+    end.map do |result|
       { result: result, source: SearchResult::SOURCE_ZLIBRARY }
     end
   rescue ZLibraryClient::SearchCancelled
@@ -430,7 +425,9 @@ class SearchJob < ApplicationJob
     language = request.effective_language
     Rails.logger.debug "[SearchJob] Searching LibriVox for request ##{request.id}"
 
-    LibrivoxClient.search(title: search_title(book), author: book.author, language: language).map do |result|
+    first_title_variant_results(book) do |title|
+      LibrivoxClient.search(title: title, author: book.author, language: language)
+    end.map do |result|
       { result: result, source: SearchResult::SOURCE_LIBRIVOX }
     end
   rescue LibrivoxClient::Error => e
@@ -443,7 +440,9 @@ class SearchJob < ApplicationJob
     language = request.effective_language
     Rails.logger.debug "[SearchJob] Searching Project Gutenberg for request ##{request.id}"
 
-    GutenbergClient.search(title: search_title(book), author: book.author, language: language).map do |result|
+    first_title_variant_results(book) do |title|
+      GutenbergClient.search(title: title, author: book.author, language: language)
+    end.map do |result|
       { result: result, source: SearchResult::SOURCE_GUTENBERG }
     end
   rescue GutenbergClient::Error => e
@@ -462,12 +461,14 @@ class SearchJob < ApplicationJob
 
   def search_store_provider(request, provider)
     book = request.book
-    provider.client.search(
-      title: search_title(book),
-      author: book.author,
-      isbn: book.isbn,
-      language: request.effective_language
-    ).map do |result|
+    first_title_variant_results(book) do |title|
+      provider.client.search(
+        title: title,
+        author: book.author,
+        isbn: book.isbn,
+        language: request.effective_language
+      )
+    end.map do |result|
       { result: result, provider: provider }
     end
   rescue StoreProviderError => e
@@ -798,7 +799,7 @@ class SearchJob < ApplicationJob
   def supplement_with_broad_search(request, results)
     return results unless SettingsService.broad_indexer_search_scope?
 
-    attempts = generic_indexer_attempts(request)
+    attempts = broad_generic_indexer_attempts(request)
     return results if attempts.empty?
 
     Rails.logger.info "[SearchJob] Supplementing #{IndexerClient.display_name} search for request ##{request.id} without category restrictions"
@@ -946,32 +947,84 @@ class SearchJob < ApplicationJob
       return deduplicate_search_attempts(attempts)
     end
 
-    title = search_title(book)
-    attempts = [
-      build_search_attempt(:exact_title, [ title, language_hint ]),
-      build_search_attempt(:title_author, [ title, book.author, language_hint ])
-    ]
-
-    short_title = short_search_title(title)
-    attempts << build_search_attempt(:short_title, [ short_title, book.author, language_hint ]) if short_title.present?
-
-    attempts << build_search_attempt(:author_title, [ book.author, title, language_hint ])
-    attempts << build_search_attempt(:normalized_title, [ normalized_search_title(title), language_hint ])
-
-    numeric_title_variants(title).each do |title_variant|
-      attempts << build_search_attempt(:number_variant, [ title_variant, language_hint ])
-      attempts << build_search_attempt(:number_variant, [ title_variant, book.author, language_hint ]) if book.author.present?
+    titles = search_titles(book)
+    preferred_title = titles.first
+    attempts = titles.flat_map do |title|
+      [
+        build_search_attempt(:exact_title, [ title, language_hint ]),
+        build_search_attempt(:title_author, [ title, book.author, language_hint ])
+      ]
     end
 
-    # For non-English requests, add hint-free fallback attempts after all language-tagged attempts.
-    # Scene releases may be untagged or use different language markers than the hint,
-    # and matches_language already accepts untagged results ([lang, nil]).
+    # Untagged releases are common, so try every exact alias without the
+    # language hint before broadening or rewriting any one title.
     if language_hint.present?
-      attempts << build_search_attempt(:exact_title, [ title ])
-      attempts << build_search_attempt(:title_author, [ title, book.author ])
+      titles.each do |title|
+        attempts << build_search_attempt(:exact_title, [ title ])
+        attempts << build_search_attempt(:title_author, [ title, book.author ])
+      end
     end
 
-    deduplicate_search_attempts(attempts)
+    if preferred_title.present?
+      short_title = short_search_title(preferred_title)
+      if short_title.present?
+        attempts << build_search_attempt(:short_title, [ short_title, book.author, language_hint ])
+      end
+
+      attempts << build_search_attempt(:author_title, [ book.author, preferred_title, language_hint ])
+      attempts << build_search_attempt(:normalized_title, [ normalized_search_title(preferred_title), language_hint ])
+
+      numeric_title_variants(preferred_title).each do |title_variant|
+        attempts << build_search_attempt(:number_variant, [ title_variant, language_hint ])
+        if book.author.present?
+          attempts << build_search_attempt(:number_variant, [ title_variant, book.author, language_hint ])
+        end
+      end
+    end
+
+    deduplicate_search_attempts(attempts).first(MAX_GENERIC_SEARCH_ATTEMPTS)
+  end
+
+  def broad_generic_indexer_attempts(request)
+    book = request.book
+    language_hint = indexer_language_hint(request)
+    issue_queries = comic_issue_search_queries(book)
+    if issue_queries.any?
+      attempts = issue_queries.flat_map do |query|
+        values = [ build_search_attempt(:comic_issue, [ query, language_hint ]) ]
+        values << build_search_attempt(:comic_issue, [ query ]) if language_hint.present?
+        values
+      end
+      return deduplicate_search_attempts(attempts).first(MAX_BROAD_SEARCH_ATTEMPTS)
+    end
+
+    titles = search_titles(book)
+    attempts = []
+
+    # Category-free search is the last recall fallback. Interleave tagged and
+    # untagged exact aliases before applying the small cap so an untagged
+    # original-language release is never crowded out by expanded queries.
+    titles.each do |title|
+      attempts << build_search_attempt(:exact_title, [ title, language_hint ])
+      attempts << build_search_attempt(:exact_title, [ title ]) if language_hint.present?
+    end
+    titles.each do |title|
+      attempts << build_search_attempt(:title_author, [ title, book.author, language_hint ])
+      if language_hint.present?
+        attempts << build_search_attempt(:title_author, [ title, book.author ])
+      end
+    end
+
+    deduplicate_search_attempts(attempts).first(MAX_BROAD_SEARCH_ATTEMPTS)
+  end
+
+  def first_title_variant_results(book)
+    search_titles(book).each do |title|
+      results = Array(yield(title))
+      return results if results.any?
+    end
+
+    []
   end
 
   def comic_issue_search_queries(book)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -302,7 +302,7 @@ class SearchJob < ApplicationJob
     query = indexer_language_hint(request)
     categories = primary_indexer_categories(request)
     issue_queries = comic_issue_search_queries(book)
-    structured_title = issue_queries.second || book.title
+    structured_title = issue_queries.second || search_title(book)
     structured_author = issue_queries.any? ? nil : book.author
 
     Rails.logger.debug "[SearchJob] Searching #{IndexerClient.display_name} for request ##{request.id} (type: #{book.book_type})"
@@ -344,7 +344,7 @@ class SearchJob < ApplicationJob
   end
 
   def generic_indexer_query(request)
-    [ request.book.title, indexer_language_hint(request) ].reject(&:blank?).join(" ")
+    [ search_title(request.book), indexer_language_hint(request) ].reject(&:blank?).join(" ")
   end
 
   def indexer_language_hint(request)
@@ -353,10 +353,26 @@ class SearchJob < ApplicationJob
     language_search_term(request)
   end
 
+  # Extract the appropriate search title from a book title that may contain
+  # combined localized/original titles (e.g., "La Nena / The Girl").
+  # Returns the first part before the slash separator to avoid sending
+  # the combined string as a literal search query.
+  def search_title(book)
+    title = book.title.to_s
+    # Match pattern: "Text / Text" where the slash is surrounded by spaces
+    # and separates what appears to be a localized title from an English/original title
+    if title.match?(/\s+\/\s+/)
+      # Return the first part (localized title) for better search results
+      title.split(/\s+\/\s+/, 2).first.to_s.strip
+    else
+      title
+    end
+  end
+
   def search_anna_archive(request, search_generation)
     book = request.book
 
-    query_parts = [ book.title ]
+    query_parts = [ search_title(book) ]
     query_parts << book.author if book.author.present?
     query_parts << "audiobook" if book.audiobook?
     query = query_parts.join(" ")
@@ -391,7 +407,7 @@ class SearchJob < ApplicationJob
 
   def search_zlibrary(request, search_generation)
     book = request.book
-    query = [ book.title, book.author ].compact.join(" ")
+    query = [ search_title(book), book.author ].compact.join(" ")
     language = zlibrary_language_filter(request)
     Rails.logger.debug "[SearchJob] Searching Z-Library for request ##{request.id}"
 
@@ -414,7 +430,7 @@ class SearchJob < ApplicationJob
     language = request.effective_language
     Rails.logger.debug "[SearchJob] Searching LibriVox for request ##{request.id}"
 
-    LibrivoxClient.search(title: book.title, author: book.author, language: language).map do |result|
+    LibrivoxClient.search(title: search_title(book), author: book.author, language: language).map do |result|
       { result: result, source: SearchResult::SOURCE_LIBRIVOX }
     end
   rescue LibrivoxClient::Error => e
@@ -427,7 +443,7 @@ class SearchJob < ApplicationJob
     language = request.effective_language
     Rails.logger.debug "[SearchJob] Searching Project Gutenberg for request ##{request.id}"
 
-    GutenbergClient.search(title: book.title, author: book.author, language: language).map do |result|
+    GutenbergClient.search(title: search_title(book), author: book.author, language: language).map do |result|
       { result: result, source: SearchResult::SOURCE_GUTENBERG }
     end
   rescue GutenbergClient::Error => e
@@ -447,7 +463,7 @@ class SearchJob < ApplicationJob
   def search_store_provider(request, provider)
     book = request.book
     provider.client.search(
-      title: book.title,
+      title: search_title(book),
       author: book.author,
       isbn: book.isbn,
       language: request.effective_language
@@ -930,18 +946,19 @@ class SearchJob < ApplicationJob
       return deduplicate_search_attempts(attempts)
     end
 
+    title = search_title(book)
     attempts = [
-      build_search_attempt(:exact_title, [ book.title, language_hint ]),
-      build_search_attempt(:title_author, [ book.title, book.author, language_hint ])
+      build_search_attempt(:exact_title, [ title, language_hint ]),
+      build_search_attempt(:title_author, [ title, book.author, language_hint ])
     ]
 
-    short_title = short_search_title(book.title)
+    short_title = short_search_title(title)
     attempts << build_search_attempt(:short_title, [ short_title, book.author, language_hint ]) if short_title.present?
 
-    attempts << build_search_attempt(:author_title, [ book.author, book.title, language_hint ])
-    attempts << build_search_attempt(:normalized_title, [ normalized_search_title(book.title), language_hint ])
+    attempts << build_search_attempt(:author_title, [ book.author, title, language_hint ])
+    attempts << build_search_attempt(:normalized_title, [ normalized_search_title(title), language_hint ])
 
-    numeric_title_variants(book.title).each do |title_variant|
+    numeric_title_variants(title).each do |title_variant|
       attempts << build_search_attempt(:number_variant, [ title_variant, language_hint ])
       attempts << build_search_attempt(:number_variant, [ title_variant, book.author, language_hint ]) if book.author.present?
     end
@@ -950,8 +967,8 @@ class SearchJob < ApplicationJob
     # Scene releases may be untagged or use different language markers than the hint,
     # and matches_language already accepts untagged results ([lang, nil]).
     if language_hint.present?
-      attempts << build_search_attempt(:exact_title, [ book.title ])
-      attempts << build_search_attempt(:title_author, [ book.title, book.author ])
+      attempts << build_search_attempt(:exact_title, [ title ])
+      attempts << build_search_attempt(:title_author, [ title, book.author ])
     end
 
     deduplicate_search_attempts(attempts)

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -63,6 +63,7 @@ class ReleaseScorer
     format_score = calculate_format_score
     auto_select_allowed = @format_preferences.auto_select_allowed &&
       !explicit_format_conflict? &&
+      !ambiguous_title_alias_match? &&
       (@comic_issue_match.nil? || issue_status == :exact)
     breakdown = {
       title: calculate_title_score,
@@ -121,16 +122,37 @@ class ReleaseScorer
     return 100 if @comic_issue_match&.fetch(:status, nil) == :exact
 
     release_title = normalize_for_matching(@search_result.title)
-    book_title = normalize_for_matching(@book.title)
+    book_titles = SearchTitleVariantService.call(@book.title)
+      .map { |title| normalize_for_matching(title) }
+      .reject(&:blank?)
 
-    return 0 if release_title.blank? || book_title.blank?
+    return 0 if release_title.blank? || book_titles.empty?
 
-    # Check if book title appears in release title
-    if release_title.include?(book_title)
+    # Localized/original title aliases are equivalent only as complete phrases.
+    # Very short inferred titles are too collision-prone unless they lead the
+    # release name (for example, "It" must not match "The Institute").
+    if book_titles.any? { |title| exact_title_phrase_match?(release_title, title) }
       100
     else
-      trigram_similarity(release_title, book_title)
+      book_titles.map { |title| trigram_similarity(release_title, title) }.max
     end
+  end
+
+  def exact_title_phrase_match?(release_title, book_title)
+    phrase = /(?:\A|\s)#{Regexp.escape(book_title)}(?:\z|\s)/
+    return false unless release_title.match?(phrase)
+    return true if book_title.length >= 4
+
+    release_title == book_title || release_title.start_with?("#{book_title} ")
+  end
+
+  def ambiguous_title_alias_match?
+    variants = SearchTitleVariantService.call(@book.title)
+    return false if variants.length < 3
+
+    release_title = normalize_for_matching(@search_result.title)
+    full_title = normalize_for_matching(@book.title)
+    !exact_title_phrase_match?(release_title, full_title)
   end
 
   # Author matching score (0-100)

--- a/app/services/search_title_variant_service.rb
+++ b/app/services/search_title_variant_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Expands metadata titles that contain localized/original aliases separated by
+# a spaced slash. The first component remains the preferred provider query,
+# while the other component and original text remain available as fallbacks.
+class SearchTitleVariantService
+  SeparatorPattern = /\s+\/\s+/
+  private_constant :SeparatorPattern
+
+  def self.call(title)
+    full_title = title.to_s.squish
+    return [] if full_title.blank?
+    return [ full_title ] unless full_title.match?(SeparatorPattern)
+
+    first, second = full_title.split(SeparatorPattern, 2).map(&:squish)
+    [ first, second, full_title ].compact_blank.uniq
+  end
+end

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -2796,6 +2796,118 @@ class SearchJobTest < ActiveJob::TestCase
     }
   end
 
+  test "uses only localized title from combined title/original pattern in indexer search" do
+    VCR.turned_off do
+      # Create a book with a combined localized/original title
+      book = Book.create!(
+        title: "La Nena / The Girl",
+        author: "Carmen Mola",
+        book_type: :ebook
+      )
+      request = Request.create!(
+        book: book,
+        status: :pending,
+        requested_by: users(:default_user)
+      )
+
+      # Stub the indexer to capture the search query
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req|
+          # Verify the search query uses "La Nena" not "La Nena / The Girl"
+          query_params = req.uri.query_values
+          title_param = query_params["title"] || query_params["q"]
+          title_param&.include?("La Nena") && !title_param&.include?(" / ")
+        }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [
+            prowlarr_result_payload.merge(
+              "guid" => "combined-title-test",
+              "title" => "La Nena by Carmen Mola [EPUB]"
+            )
+          ].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+
+      # Verify the stub was called (search was made with correct title)
+      assert_requested search_stub, at_least_once: true
+
+      # Verify a result was found
+      request.reload
+      assert request.search_results.any?, "Expected search results to be found with localized title"
+    end
+  end
+
+  test "preserves original title when no slash separator is present" do
+    VCR.turned_off do
+      # Create a book with a normal title (no slash separator)
+      book = Book.create!(
+        title: "The Girl with the Dragon Tattoo",
+        author: "Stieg Larsson",
+        book_type: :ebook
+      )
+      request = Request.create!(
+        book: book,
+        status: :pending,
+        requested_by: users(:default_user)
+      )
+
+      # Stub the indexer to capture the search query
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req|
+          query_params = req.uri.query_values
+          title_param = query_params["title"] || query_params["q"]
+          title_param&.include?("The Girl with the Dragon Tattoo")
+        }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+
+      # Verify the stub was called (search was made with full title)
+      assert_requested search_stub, at_least_once: true
+    end
+  end
+
+  test "handles titles with slashes that are not combined title separators" do
+    VCR.turned_off do
+      # Create a book with a slash that's not a title separator (no spaces around it)
+      book = Book.create!(
+        title: "AC/DC: The Stories Behind the Songs",
+        author: "Susan Masino",
+        book_type: :ebook
+      )
+      request = Request.create!(
+        book: book,
+        status: :pending,
+        requested_by: users(:default_user)
+      )
+
+      # Stub the indexer to verify the full title is used (slash without spaces is kept)
+      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
+        .with { |req|
+          query_params = req.uri.query_values
+          title_param = query_params["title"] || query_params["q"]
+          title_param&.include?("AC/DC")
+        }
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [].to_json
+        )
+
+      SearchJob.perform_now(request.id)
+
+      # Verify the stub was called with full title including AC/DC
+      assert_requested search_stub, at_least_once: true
+    end
+  end
+
   def stub_prowlarr_indexers(indexers = STRUCTURED_INDEXERS)
     stub_request(:get, %r{localhost:9696/api/v1/indexer})
       .to_return(

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -1052,6 +1052,9 @@ class SearchJobTest < ActiveJob::TestCase
     assert_equal [ "Saga 7", "Saga #7", "Saga 007" ], attempts.map(&:query)
     assert attempts.none? { |attempt| attempt.query.include?(book.author) }
     assert_not_includes attempts.map(&:query), book.series
+
+    broad_attempts = SearchJob.new.send(:broad_generic_indexer_attempts, request)
+    assert_equal [ "Saga 7", "Saga #7", "Saga 007" ], broad_attempts.map(&:query)
   end
 
   test "falls back to series position only for confirmed Comic Vine issues" do
@@ -2797,115 +2800,92 @@ class SearchJobTest < ActiveJob::TestCase
   end
 
   test "uses only localized title from combined title/original pattern in indexer search" do
-    VCR.turned_off do
-      # Create a book with a combined localized/original title
-      book = Book.create!(
-        title: "La Nena / The Girl",
-        author: "Carmen Mola",
-        book_type: :ebook
-      )
-      request = Request.create!(
-        book: book,
-        status: :pending,
-        requested_by: users(:default_user)
-      )
+    book = Book.new(title: "La Nena / The Girl")
 
-      # Stub the indexer to capture the search query
-      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
-        .with { |req|
-          # Verify the search query uses "La Nena" not "La Nena / The Girl"
-          query_params = req.uri.query_values
-          title_param = query_params["title"] || query_params["q"]
-          title_param&.include?("La Nena") && !title_param&.include?(" / ")
-        }
-        .to_return(
-          status: 200,
-          headers: { "Content-Type" => "application/json" },
-          body: [
-            prowlarr_result_payload.merge(
-              "guid" => "combined-title-test",
-              "title" => "La Nena by Carmen Mola [EPUB]"
-            )
-          ].to_json
-        )
-
-      SearchJob.perform_now(request.id)
-
-      # Verify the stub was called (search was made with correct title)
-      assert_requested search_stub, at_least_once: true
-
-      # Verify a result was found
-      request.reload
-      assert request.search_results.any?, "Expected search results to be found with localized title"
-    end
+    assert_equal "La Nena", SearchJob.new.send(:search_title, book)
   end
 
   test "preserves original title when no slash separator is present" do
-    VCR.turned_off do
-      # Create a book with a normal title (no slash separator)
-      book = Book.create!(
-        title: "The Girl with the Dragon Tattoo",
-        author: "Stieg Larsson",
-        book_type: :ebook
-      )
-      request = Request.create!(
-        book: book,
-        status: :pending,
-        requested_by: users(:default_user)
-      )
+    book = Book.new(title: "The Girl with the Dragon Tattoo")
 
-      # Stub the indexer to capture the search query
-      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
-        .with { |req|
-          query_params = req.uri.query_values
-          title_param = query_params["title"] || query_params["q"]
-          title_param&.include?("The Girl with the Dragon Tattoo")
-        }
-        .to_return(
-          status: 200,
-          headers: { "Content-Type" => "application/json" },
-          body: [].to_json
-        )
-
-      SearchJob.perform_now(request.id)
-
-      # Verify the stub was called (search was made with full title)
-      assert_requested search_stub, at_least_once: true
-    end
+    assert_equal "The Girl with the Dragon Tattoo", SearchJob.new.send(:search_title, book)
   end
 
   test "handles titles with slashes that are not combined title separators" do
-    VCR.turned_off do
-      # Create a book with a slash that's not a title separator (no spaces around it)
-      book = Book.create!(
-        title: "AC/DC: The Stories Behind the Songs",
-        author: "Susan Masino",
-        book_type: :ebook
-      )
-      request = Request.create!(
-        book: book,
-        status: :pending,
-        requested_by: users(:default_user)
-      )
+    book = Book.new(title: "AC/DC: The Stories Behind the Songs")
 
-      # Stub the indexer to verify the full title is used (slash without spaces is kept)
-      search_stub = stub_request(:get, %r{localhost:9696/api/v1/search})
-        .with { |req|
-          query_params = req.uri.query_values
-          title_param = query_params["title"] || query_params["q"]
-          title_param&.include?("AC/DC")
-        }
-        .to_return(
-          status: 200,
-          headers: { "Content-Type" => "application/json" },
-          body: [].to_json
-        )
+    assert_equal "AC/DC: The Stories Behind the Songs", SearchJob.new.send(:search_title, book)
+  end
 
-      SearchJob.perform_now(request.id)
+  test "retains both components and the combined title in generic indexer fallback attempts" do
+    book = Book.create!(title: "La Nena / The Girl", author: "Carmen Mola", book_type: :ebook)
+    request = Request.create!(book: book, user: users(:one), status: :pending, language: "en")
 
-      # Verify the stub was called with full title including AC/DC
-      assert_requested search_stub, at_least_once: true
+    queries = SearchJob.new.send(:generic_indexer_attempts, request).map(&:query)
+
+    assert queries.any? { |query| query.include?("La Nena") && !query.include?(" / ") }
+    assert queries.any? { |query| query.include?("The Girl") && !query.include?(" / ") }
+    assert queries.any? { |query| query.include?("La Nena / The Girl") }
+  end
+
+  test "bounds combined-title indexer attempts and prioritizes exact aliases" do
+    book = Book.create!(
+      title: "Saga XII / Saga 12",
+      author: "Example Author",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending, language: "de")
+
+    attempts = SearchJob.new.send(:generic_indexer_attempts, request)
+
+    assert_operator attempts.size, :<=, SearchJob::MAX_GENERIC_SEARCH_ATTEMPTS
+    assert_equal(
+      [
+        "Saga XII DE",
+        "Saga XII Example Author DE",
+        "Saga 12 DE",
+        "Saga 12 Example Author DE",
+        "Saga XII / Saga 12 DE",
+        "Saga XII / Saga 12 Example Author DE"
+      ],
+      attempts.first(6).map(&:query)
+    )
+
+    broad_attempts = SearchJob.new.send(:broad_generic_indexer_attempts, request)
+    assert_operator broad_attempts.size, :<=, SearchJob::MAX_BROAD_SEARCH_ATTEMPTS
+    assert_includes broad_attempts.map(&:query), "Saga 12"
+  end
+
+  test "tries the original title with single-query providers after an empty localized result" do
+    book = Book.create!(
+      title: "La Nena / The Girl",
+      author: "Carmen Mola",
+      book_type: :audiobook
+    )
+    request = Request.create!(book: book, user: users(:one), status: :pending, language: "en")
+    result = LibrivoxClient::Result.new(
+      id: "combined-title",
+      title: "The Girl",
+      author: book.author,
+      language: "en",
+      year: "2022",
+      file_type: "audiobook zip",
+      download_url: "https://example.com/the-girl.zip",
+      info_url: "https://example.com/the-girl",
+      duration: "01:00:00"
+    )
+    searched_titles = []
+    search = lambda do |title:, **|
+      searched_titles << title
+      title == "The Girl" ? [ result ] : []
     end
+
+    tagged = LibrivoxClient.stub(:search, search) do
+      SearchJob.new.send(:search_librivox, request)
+    end
+
+    assert_equal [ "La Nena", "The Girl" ], searched_titles
+    assert_equal [ result ], tagged.map { |entry| entry[:result] }
   end
 
   def stub_prowlarr_indexers(indexers = STRUCTURED_INDEXERS)

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -153,6 +153,63 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     assert result.breakdown[:author] == 100
   end
 
+  test "scores localized and original components of a combined title as aliases" do
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    book = Book.create!(
+      title: "La Nena / The Girl",
+      author: "Carmen Mola",
+      book_type: :ebook
+    )
+    request = Request.create!(book: book, user: @user, status: :pending, language: "es")
+
+    localized = ReleaseScorer.score(
+      SearchResult.new(title: "La Nena - Carmen Mola - Spanish EPUB", seeders: 50),
+      request
+    )
+    original = ReleaseScorer.score(
+      SearchResult.new(title: "The Girl - Carmen Mola - Spanish EPUB", seeders: 50),
+      request
+    )
+
+    assert_equal 100, localized.breakdown[:title]
+    assert_equal 100, original.breakdown[:title]
+    assert_operator localized.total, :>=, 90
+    assert_operator original.total, :>=, 90
+    refute localized.breakdown[:auto_select_allowed]
+    refute original.breakdown[:auto_select_allowed]
+
+    combined = ReleaseScorer.score(
+      SearchResult.new(title: "La Nena The Girl - Carmen Mola - Spanish EPUB", seeders: 50),
+      request
+    )
+    assert combined.breakdown[:auto_select_allowed]
+  end
+
+  test "does not match a short combined-title alias inside another title" do
+    SettingsService.set(:ebook_approved_formats, [])
+    SettingsService.set(:ebook_rejected_formats, [])
+    SettingsService.set(:ebook_preferred_formats, [])
+    book = Book.create!(title: "Eso / It", author: "Stephen King", book_type: :ebook)
+    request = Request.create!(book: book, user: @user, status: :pending, language: "en")
+
+    unrelated = ReleaseScorer.score(
+      SearchResult.new(title: "The Institute - Stephen King - English EPUB", seeders: 50),
+      request
+    )
+    exact = ReleaseScorer.score(
+      SearchResult.new(title: "It - Stephen King - English EPUB", seeders: 50),
+      request
+    )
+
+    assert_operator unrelated.breakdown[:title], :<, 100
+    assert_equal 100, exact.breakdown[:title]
+    assert_operator unrelated.total, :<, SettingsService.get(:auto_select_confidence_threshold, default: 90)
+    refute unrelated.breakdown[:auto_select_allowed]
+    refute exact.breakdown[:auto_select_allowed]
+  end
+
   test "scores partial author match for last name only" do
     search_result = @request.search_results.create!(
       guid: "test-8",

--- a/test/services/search_title_variant_service_test.rb
+++ b/test/services/search_title_variant_service_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchTitleVariantServiceTest < ActiveSupport::TestCase
+  test "returns localized original and full combined title variants" do
+    assert_equal(
+      [ "La Nena", "The Girl", "La Nena / The Girl" ],
+      SearchTitleVariantService.call(" La Nena / The Girl ")
+    )
+  end
+
+  test "preserves ordinary and unspaced slash titles" do
+    assert_equal [ "The Girl" ], SearchTitleVariantService.call("The Girl")
+    assert_equal [ "AC/DC" ], SearchTitleVariantService.call("AC/DC")
+  end
+
+  test "returns no variants for a blank title" do
+    assert_empty SearchTitleVariantService.call(nil)
+    assert_empty SearchTitleVariantService.call("  ")
+  end
+end


### PR DESCRIPTION
## Assigned issue

Closes #507

## What changed

Searches for metadata titles such as `La Nena / The Girl` now treat the localized component, original component, and combined text as bounded fallback variants without changing the stored book title.

- Indexer attempts prioritize exact and title-plus-author queries for every variant, then broaden only the preferred title.
- Primary attempts are capped at 18 and category-free broad attempts at 6 so aliases and numeric rewrites cannot exceed the search lease.
- Broad searches interleave language-tagged and hint-free variants and preserve compact comic issue queries.
- Anna's Archive, Z-Library, LibriVox, Project Gutenberg, and store providers try the next variant only when the earlier one returns no results.
- Release scoring uses phrase boundaries, so short titles such as `It` do not match `The Institute`.
- Because a spaced slash can also describe an omnibus, component-only results remain available for manual review but cannot be auto-selected; a release containing the full combined title can still auto-select.

## Verification

- Adversarial autoselection checks for short aliases and ambiguous `Hamlet / Macbeth` metadata.
- Non-English category-free fallback proved an untagged original-title result is reached under the cap.
- Comic primary and broad searches both retain `Saga 7`, `Saga #7`, and `Saga 007` variants.
- Single-query providers stop after the first non-empty variant.
- Focused suite: 135 tests, 592 assertions, all passing.
- Full local quality gate passed, including system tests.
- RuboCop and diff checks passed.

## Screenshots or recordings

Not applicable; this changes backend query planning and scoring without changing rendered UI.

## Checklist

- [x] The maintainer assigned the linked issue before implementation
- [x] The change stays within the issue's scope
- [x] Regression tests cover the changed behavior
- [x] Relevant local quality checks passed
- [x] No user-facing documentation change is required
