### PR TITLE
Keep leftover staging warnings visible on output-path health checks

### DIFF
--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -215,6 +215,9 @@ class HealthCheckJob < ApplicationJob
     else
       health.check_failed!(message: issues.join("; "))
     end
+  rescue => e
+    health.check_failed!(message: "Error: #{e.message}")
+    Rails.logger.error "[HealthCheckJob] Output paths check failed: #{e.message}"
   end
 
   def check_path(name, path)

--- a/app/jobs/health_check_job.rb
+++ b/app/jobs/health_check_job.rb
@@ -199,34 +199,36 @@ class HealthCheckJob < ApplicationJob
 
   def check_output_paths
     health = SystemHealth.for_service("output_paths")
-    issues = []
+    findings = [
+      check_path("Audiobook", SettingsService.get(:audiobook_output_path)),
+      check_path("Ebook", SettingsService.get(:ebook_output_path))
+    ].compact
 
-    audiobook_path = SettingsService.get(:audiobook_output_path)
-    ebook_path = SettingsService.get(:ebook_output_path)
-
-    issues << check_path("Audiobook", audiobook_path)
-    issues << check_path("Ebook", ebook_path)
-    issues.compact!
-
-    if issues.empty?
+    if findings.empty?
       health.check_succeeded!(message: "All output paths accessible")
-    elsif issues.size == 1
-      health.check_failed!(message: issues.first, degraded: true)
-    else
-      health.check_failed!(message: issues.join("; "))
+      return
     end
-  rescue => e
-    health.check_failed!(message: "Error: #{e.message}")
-    Rails.logger.error "[HealthCheckJob] Output paths check failed: #{e.message}"
+
+    hard_failures = findings.count { |finding| finding[:severity] == :hard }
+    health.check_failed!(
+      message: findings.map { |finding| finding[:message] }.join("; "),
+      degraded: hard_failures == 0 || findings.size == 1
+    )
   end
 
   def check_path(name, path)
-    return "#{name} path not configured" if path.blank?
-    return "#{name} path does not exist" unless Dir.exist?(path)
-    return "#{name} path not writable" unless File.writable?(path)
+    return { severity: :hard, message: "#{name} path not configured" } if path.blank?
 
+    begin
+      return { severity: :hard, message: "#{name} path does not exist" } unless Dir.exist?(path)
+      return { severity: :hard, message: "#{name} path not writable" } unless File.writable?(path)
+    rescue SystemCallError => error
+      return { severity: :hard, message: "#{name} path could not be checked: #{error.message}" }
+    end
+
+    # Leave leftover-staging diagnostics intact; they already carry their own inspect failures.
     legacy_diagnostic = DirectDownloadFileService.legacy_staging_diagnostic(root: path)
-    return "#{name} #{legacy_diagnostic}" if legacy_diagnostic
+    return { severity: :legacy, message: "#{name} #{legacy_diagnostic}" } if legacy_diagnostic
 
     nil
   end

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -482,36 +482,152 @@ class HealthCheckJobTest < ActiveJob::TestCase
     assert_includes health.message, "not configured"
   end
 
-  test "marks output_paths as down when filesystem check raises an exception" do
-    Dir.mktmpdir do |valid_dir|
-      setup_output_paths(valid_dir, "/another/valid/path")
+  test "does not treat current owned-media staging as leftover on either output root" do
+    Dir.mktmpdir("owned-audiobooks") do |audiobook_dir|
+      Dir.mktmpdir("owned-ebooks") do |ebook_dir|
+        setup_output_paths(audiobook_dir, ebook_dir)
+        [ audiobook_dir, ebook_dir ].each do |root|
+          staging = File.join(root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+          FileUtils.mkdir_p(File.join(staging, "uploads"))
+          FileUtils.mkdir_p(File.join(staging, "locks"))
+          File.chmod(0o700, staging)
+        end
 
-      # Simulate a filesystem error during checks
-      Dir.stub(:exist?, -> (path) { raise Errno::EACCES, "Permission denied" }) do
         HealthCheckJob.perform_now(service: "output_paths")
 
         health = SystemHealth.for_service("output_paths")
-        assert health.down?
-        assert_includes health.message, "Error"
+        assert health.healthy?
+        assert_includes health.message, "accessible"
+        refute_includes health.message, "legacy"
       end
     end
   end
 
-  test "marks output_paths as down when legacy_staging_diagnostic raises an exception" do
-    Dir.mktmpdir do |audiobook_dir|
-      Dir.mktmpdir do |ebook_dir|
+  test "still reports leftover direct-download data beside owned-media staging" do
+    Dir.mktmpdir("owned-audiobooks") do |audiobook_dir|
+      Dir.mktmpdir("legacy-ebooks") do |ebook_dir|
         setup_output_paths(audiobook_dir, ebook_dir)
 
-        # Simulate an error in legacy_staging_diagnostic
-        DirectDownloadFileService.stub(:legacy_staging_diagnostic, -> (root:) {
-          raise Errno::EIO, "Input/output error"
+        owned = File.join(audiobook_dir, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+        FileUtils.mkdir_p(File.join(owned, "uploads"))
+        FileUtils.mkdir_p(File.join(owned, "locks"))
+        File.chmod(0o700, owned)
+
+        leftover = File.join(ebook_dir, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+        FileUtils.mkdir_p(File.join(leftover, "uploads"))
+        FileUtils.mkdir_p(File.join(leftover, "locks"))
+        FileUtils.mkdir_p(File.join(leftover, DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY))
+        File.chmod(0o700, leftover)
+
+        HealthCheckJob.perform_now(service: "output_paths")
+
+        health = SystemHealth.for_service("output_paths")
+        assert health.degraded?
+        assert_includes health.message, "Ebook legacy direct-download staging"
+        assert_includes health.message, "contains retained entries"
+        refute_includes health.message, "Audiobook legacy"
+        refute_includes health.message, ebook_dir
+      end
+    end
+  end
+
+  test "reports leftover staging on both roots as degraded without hiding either warning" do
+    Dir.mktmpdir("legacy-audiobooks") do |audiobook_dir|
+      Dir.mktmpdir("legacy-ebooks") do |ebook_dir|
+        setup_output_paths(audiobook_dir, ebook_dir)
+        [ audiobook_dir, ebook_dir ].each do |root|
+          leftover = File.join(root, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+          FileUtils.mkdir_p(File.join(leftover, DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY))
+          File.chmod(0o700, leftover)
+        end
+
+        HealthCheckJob.perform_now(service: "output_paths")
+
+        health = SystemHealth.for_service("output_paths")
+        assert health.degraded?
+        assert_includes health.message, "Audiobook legacy direct-download staging"
+        assert_includes health.message, "Ebook legacy direct-download staging"
+        assert_includes health.message, "contains retained entries"
+        assert_includes health.message, DirectDownloadFileService::STAGING_DIRECTORY
+        refute_includes health.message, audiobook_dir
+        refute_includes health.message, ebook_dir
+      end
+    end
+  end
+
+  test "keeps leftover staging text when the other output path cannot be checked" do
+    Dir.mktmpdir("legacy-audiobooks") do |audiobook_dir|
+      Dir.mktmpdir("legacy-ebooks") do |ebook_dir|
+        setup_output_paths(audiobook_dir, ebook_dir)
+        leftover = File.join(ebook_dir, DirectDownloadFileService::LEGACY_STAGING_DIRECTORY)
+        FileUtils.mkdir_p(File.join(leftover, DirectDownloadFileService::DIRECT_DOWNLOADS_DIRECTORY))
+        File.chmod(0o700, leftover)
+
+        exist = Dir.method(:exist?)
+        Dir.stub(:exist?, ->(path) {
+          raise Errno::EACCES, "Permission denied" if path == audiobook_dir
+
+          exist.call(path)
         }) do
           HealthCheckJob.perform_now(service: "output_paths")
-
-          health = SystemHealth.for_service("output_paths")
-          assert health.down?
-          assert_includes health.message, "Error"
         end
+
+        health = SystemHealth.for_service("output_paths")
+        assert health.down?
+        assert_includes health.message, "Audiobook path could not be checked"
+        assert_includes health.message, "Ebook legacy direct-download staging"
+        assert_includes health.message, "contains retained entries"
+        refute_includes health.message, "Error:"
+        refute_includes health.message, ebook_dir
+      end
+    end
+  end
+
+  test "records a filesystem error for one output path without failing the job" do
+    Dir.mktmpdir do |ebook_dir|
+      missing_audiobook = File.join(ebook_dir, "audiobooks")
+      setup_output_paths(missing_audiobook, ebook_dir)
+
+      exist = Dir.method(:exist?)
+      Dir.stub(:exist?, ->(path) {
+        raise Errno::EACCES, "Permission denied" if path == missing_audiobook
+
+        exist.call(path)
+      }) do
+        HealthCheckJob.perform_now(service: "output_paths")
+      end
+
+      health = SystemHealth.for_service("output_paths")
+      assert health.degraded?
+      assert_includes health.message, "Audiobook path could not be checked"
+      refute_includes health.message, "Error:"
+    end
+  end
+
+  test "keeps leftover inspect failures from the diagnostic instead of a generic error" do
+    Dir.mktmpdir("legacy-audiobooks") do |audiobook_dir|
+      Dir.mktmpdir("legacy-ebooks") do |ebook_dir|
+        setup_output_paths(audiobook_dir, ebook_dir)
+
+        original_lstat = File.method(:lstat)
+        File.stub(:lstat, ->(path) {
+          if File.basename(path.to_s) == DirectDownloadFileService::LEGACY_STAGING_DIRECTORY
+            raise Errno::EIO, "Input/output error"
+          end
+
+          original_lstat.call(path)
+        }) do
+          HealthCheckJob.perform_now(service: "output_paths")
+        end
+
+        health = SystemHealth.for_service("output_paths")
+        assert health.degraded?
+        assert_includes health.message, "Audiobook legacy direct-download staging"
+        assert_includes health.message, "Ebook legacy direct-download staging"
+        assert_includes health.message, "could not be safely inspected"
+        refute_includes health.message, "Error:"
+        refute_includes health.message, audiobook_dir
+        refute_includes health.message, ebook_dir
       end
     end
   end

--- a/test/jobs/health_check_job_test.rb
+++ b/test/jobs/health_check_job_test.rb
@@ -482,6 +482,40 @@ class HealthCheckJobTest < ActiveJob::TestCase
     assert_includes health.message, "not configured"
   end
 
+  test "marks output_paths as down when filesystem check raises an exception" do
+    Dir.mktmpdir do |valid_dir|
+      setup_output_paths(valid_dir, "/another/valid/path")
+
+      # Simulate a filesystem error during checks
+      Dir.stub(:exist?, -> (path) { raise Errno::EACCES, "Permission denied" }) do
+        HealthCheckJob.perform_now(service: "output_paths")
+
+        health = SystemHealth.for_service("output_paths")
+        assert health.down?
+        assert_includes health.message, "Error"
+      end
+    end
+  end
+
+  test "marks output_paths as down when legacy_staging_diagnostic raises an exception" do
+    Dir.mktmpdir do |audiobook_dir|
+      Dir.mktmpdir do |ebook_dir|
+        setup_output_paths(audiobook_dir, ebook_dir)
+
+        # Simulate an error in legacy_staging_diagnostic
+        DirectDownloadFileService.stub(:legacy_staging_diagnostic, -> (root:) {
+          raise Errno::EIO, "Input/output error"
+        }) do
+          HealthCheckJob.perform_now(service: "output_paths")
+
+          health = SystemHealth.for_service("output_paths")
+          assert health.down?
+          assert_includes health.message, "Error"
+        end
+      end
+    end
+  end
+
   # Audiobookshelf tests
   test "marks audiobookshelf as not_configured when not configured" do
     Setting.where(key: %w[audiobookshelf_url audiobookshelf_api_key]).destroy_all


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Assigned issue

Fixes #509

## What changed

The public screenshot for #509 is a completed output-paths check, not a crashed job. Both configured roots were marked **Down** with leftover `.shelfarr-staging` review text:

> Audiobook legacy direct-download staging contains retained entries…; Ebook legacy direct-download staging contains retained entries…

That message is emitted only when `.shelfarr-staging` is mode `0700`, nonempty, and has children other than current owned-media `uploads/` / `locks/` directories (the #487 / #489 case). The first patch wrapped the whole check in `rescue => e` and could replace those leftover strings with a generic `Error: …` if a later filesystem call raised.

This revision stays on the same check:

- Collect per-path findings instead of a single method-level rescue.
- Rescue only `SystemCallError` around `Dir.exist?` / `File.writable?`.
- Leave `legacy_staging_diagnostic` unwrapped so inspect failures keep their own “could not be safely inspected” leftover text.
- Leftover-only findings stay **degraded** even when both roots have retained staging. Missing, unwritable, or unconfigured paths are still hard failures. One hard failure plus a leftover warning is still **Down**, and the leftover sentence is kept.

Owned-media `uploads/` + `locks/` remains healthy. Real leftover `direct-downloads` (or any other non-owned-media child) is still reported.

## What the thin report could not prove

The issue body did not list the children under either `.shelfarr-staging`. The screenshot text matches leftover retained entries on **both** roots, not “path does not exist” or “path not writable”. This change does not delete or ignore leftover `direct-downloads` data.

## Verification

Added / replaced tests in `test/jobs/health_check_job_test.rb`:

- owned-media staging on both roots stays healthy
- leftover `direct-downloads` beside `uploads/` + `locks/` is still reported
- leftover warnings on both roots stay visible and are degraded, not Down
- a filesystem error on one root does not drop the other root’s leftover text
- leftover inspect failures stay as the diagnostic message, not `Error:`

Existing leftover, missing-path, and unconfigured-path tests are unchanged in intent.

CI on `b0571e9`: quality, security, companion, container, filesystem-contracts, and CodeQL all passed.

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [x] I ran the relevant local quality checks (CI quality passed)
- [x] I updated documentation for user-visible changes (not applicable)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d861af5d-d23d-4d81-ac57-13c0eb8658f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d861af5d-d23d-4d81-ac57-13c0eb8658f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

