### PR TITLE
Optimize AudiobookshelfLibraryMatcherService to eliminate O(N*M) text processing overhead

### DIFF
--- a/app/services/audiobookshelf_library_matcher_service.rb
+++ b/app/services/audiobookshelf_library_matcher_service.rb
@@ -17,10 +17,18 @@ class AudiobookshelfLibraryMatcherService
 
   FuzzyThreshold = 85
   MaxMatchTextLength = 500
+  TrigramCodepointBase = 0x110000
+  EmptyTrigrams = [].freeze
+  # A matcher can scan thousands of externally sourced records. Bound retained
+  # trigram entries so pathological metadata cannot turn this speed cache into
+  # a per-request memory spike; uncached entries still use identical scoring.
+  MaxCachedTrigrams = 1_000_000
+  private_constant :TrigramCodepointBase, :EmptyTrigrams, :MaxCachedTrigrams
 
   def initialize(cache_library_items: true)
     @cache_library_items = cache_library_items
     @prepared_items = {}
+    @cached_item_trigram_count = 0
   end
 
   def self.matches_for_many(results, limit_per_result: 3)
@@ -121,6 +129,8 @@ class AudiobookshelfLibraryMatcherService
   end
 
   def prepared_item(item)
+    return build_prepared_item(item, retain_trigrams: false) unless @cache_library_items
+
     key = item_prep_cache_key(item)
     return @prepared_items[key] if @prepared_items.key?(key)
 
@@ -131,7 +141,7 @@ class AudiobookshelfLibraryMatcherService
     [ item.id, item.title, item.subtitle, item.author ]
   end
 
-  def build_prepared_item(item)
+  def build_prepared_item(item, retain_trigrams: true)
     return nil if oversized_match_text?(item.title)
 
     item_title = normalize_text(item.title)
@@ -141,13 +151,43 @@ class AudiobookshelfLibraryMatcherService
     return nil if item_title.blank? && item_display_title.blank? && item_author.blank?
 
     titles = [ item_title, item_display_title ].uniq
+    title_trigrams_by_title, author_trigrams = if retain_trigrams
+      cacheable_item_trigrams(titles, item_author)
+    else
+      item_trigrams(titles, item_author)
+    end
     PreparedItem.new(
       title: item_title,
       titles: titles,
       author: item_author,
-      title_trigrams_by_title: titles.to_h { |title| [ title, title.present? ? trigrams(title) : Set.new ] },
-      author_trigrams: item_author.present? ? trigrams(item_author) : nil
+      title_trigrams_by_title: title_trigrams_by_title,
+      author_trigrams: author_trigrams
     )
+  end
+
+  def cacheable_item_trigrams(titles, author)
+    estimated_count = titles.sum { |title| estimated_trigram_count(title) } + estimated_trigram_count(author)
+    return [ nil, nil ] if @cached_item_trigram_count + estimated_count > max_cached_trigrams
+
+    title_trigrams, author_trigrams = item_trigrams(titles, author)
+    @cached_item_trigram_count += title_trigrams.sum { |_title, values| values.size }
+    @cached_item_trigram_count += author_trigrams.size if author_trigrams
+    [ title_trigrams, author_trigrams ]
+  end
+
+  def item_trigrams(titles, author)
+    [
+      titles.to_h { |title| [ title, title.present? ? trigrams(title) : EmptyTrigrams ] },
+      author.present? ? trigrams(author) : nil
+    ]
+  end
+
+  def estimated_trigram_count(text)
+    text.present? ? text.length + 2 : 0
+  end
+
+  def max_cached_trigrams
+    MaxCachedTrigrams
   end
 
   def match_score(query_title:, query_author:, item_titles:, item_author:,
@@ -204,14 +244,36 @@ class AudiobookshelfLibraryMatcherService
   end
 
   def trigram_overlap_size(left, right)
-    smaller, larger = left.size <= right.size ? [ left, right ] : [ right, left ]
-    smaller.count { |trigram| larger.include?(trigram) }
+    left_index = 0
+    right_index = 0
+    overlap = 0
+
+    while left_index < left.size && right_index < right.size
+      comparison = left[left_index] <=> right[right_index]
+      if comparison.negative?
+        left_index += 1
+      elsif comparison.positive?
+        right_index += 1
+      else
+        overlap += 1
+        left_index += 1
+        right_index += 1
+      end
+    end
+
+    overlap
   end
 
   def trigrams(text)
-    return Set.new if text.blank?
+    return EmptyTrigrams if text.blank?
 
-    padded = "  #{text}  "
-    (0..padded.length - 3).map { |i| padded[i, 3] }.to_set
+    codepoints = "  #{text}  ".codepoints
+    values = Array.new(codepoints.length - 2) do |index|
+      ((codepoints[index] * TrigramCodepointBase) + codepoints[index + 1]) * TrigramCodepointBase +
+        codepoints[index + 2]
+    end
+    values.sort!
+    values.uniq!
+    values.freeze
   end
 end

--- a/app/services/audiobookshelf_library_matcher_service.rb
+++ b/app/services/audiobookshelf_library_matcher_service.rb
@@ -20,6 +20,8 @@ class AudiobookshelfLibraryMatcherService
 
   def initialize(cache_library_items: true)
     @cache_library_items = cache_library_items
+    @normalized_text_cache = {}
+    @trigram_cache = {}
   end
 
   def self.matches_for_many(results, limit_per_result: 3)
@@ -42,22 +44,34 @@ class AudiobookshelfLibraryMatcherService
     limit = limit.to_i
     return [] if query_title.blank? || limit <= 0
 
+    query_title_trigrams = trigrams(query_title)
+    query_author_trigrams = query_author.present? ? trigrams(query_author) : nil
+
     matches = []
     each_library_item(library_ids) do |item|
       next if oversized_match_text?(item.title)
 
-      item_title = normalize_text(item.title)
-      item_subtitle = oversized_match_text?(item.subtitle) ? "" : normalize_text(item.subtitle)
+      item_title = cached_normalized_text(item, :title)
+      item_subtitle = oversized_match_text?(item.subtitle) ? "" : cached_normalized_text(item, :subtitle)
       item_display_title = [ item_title, item_subtitle ].compact_blank.join(" ")
-      item_author = oversized_match_text?(item.author) ? "" : normalize_text(item.author)
+      item_author = oversized_match_text?(item.author) ? "" : cached_normalized_text(item, :author)
       next if item_title.blank? && item_display_title.blank? && item_author.blank?
       item_titles = [ item_title, item_display_title ].uniq
 
-      score = match_score(
+      item_title_trigrams = cached_trigrams(item, :title)
+      item_display_title_trigrams = item_subtitle.present? ? trigrams(item_display_title) : item_title_trigrams
+      item_author_trigrams = item_author.present? ? cached_trigrams(item, :author) : nil
+
+      score = match_score_precomputed(
         query_title: query_title,
         query_author: query_author,
         item_titles: item_titles,
-        item_author: item_author
+        item_author: item_author,
+        query_title_trigrams: query_title_trigrams,
+        query_author_trigrams: query_author_trigrams,
+        item_title_trigrams: item_title_trigrams,
+        item_display_title_trigrams: item_display_title_trigrams,
+        item_author_trigrams: item_author_trigrams
       )
       next if score < FuzzyThreshold
 
@@ -116,6 +130,32 @@ class AudiobookshelfLibraryMatcherService
     ((title_score * 0.7) + (author_score * 0.3)).round
   end
 
+  def match_score_precomputed(query_title:, query_author:, item_titles:, item_author:,
+    query_title_trigrams:, query_author_trigrams:, item_title_trigrams:,
+    item_display_title_trigrams:, item_author_trigrams:)
+    return 0 if item_titles.blank?
+    return 100 if item_titles.include?(query_title) && query_author == item_author
+
+    title_trigrams = [ item_title_trigrams, item_display_title_trigrams ].uniq
+    title_score = title_trigrams.map { |item_trigrams|
+      trigram_similarity_precomputed(query_title_trigrams, item_trigrams)
+    }.max || 0
+    return title_score if query_author.blank? || item_author.blank?
+
+    author_score = trigram_similarity_precomputed(query_author_trigrams, item_author_trigrams)
+    ((title_score * 0.7) + (author_score * 0.3)).round
+  end
+
+  def cached_normalized_text(item, field)
+    cache_key = [ item.id, field, item.public_send(field) ]
+    @normalized_text_cache[cache_key] ||= normalize_text(item.public_send(field))
+  end
+
+  def cached_trigrams(item, field)
+    cache_key = [ item.id, field, item.public_send(field) ]
+    @trigram_cache[cache_key] ||= trigrams(cached_normalized_text(item, field))
+  end
+
   def normalize_text(text)
     return "" unless text.is_a?(String)
     return "" if text.length > MaxMatchTextLength
@@ -142,6 +182,16 @@ class AudiobookshelfLibraryMatcherService
     intersection = (trigrams_left & trigrams_right).size
     union = (trigrams_left | trigrams_right).size
     ((intersection.to_f / union) * 100).round
+  end
+
+  def trigram_similarity_precomputed(left_trigrams, right_trigrams)
+    return 0 if left_trigrams.nil? || right_trigrams.nil?
+    return 0 if left_trigrams.empty? || right_trigrams.empty?
+    return 100 if left_trigrams == right_trigrams
+
+    intersection_count = (left_trigrams & right_trigrams).size
+    union_count = left_trigrams.size + right_trigrams.size - intersection_count
+    ((intersection_count.to_f / union_count) * 100).round
   end
 
   def trigrams(text)

--- a/app/services/audiobookshelf_library_matcher_service.rb
+++ b/app/services/audiobookshelf_library_matcher_service.rb
@@ -20,8 +20,7 @@ class AudiobookshelfLibraryMatcherService
 
   def initialize(cache_library_items: true)
     @cache_library_items = cache_library_items
-    @normalized_text_cache = {}
-    @trigram_cache = {}
+    @prepared_items = {}
   end
 
   def self.matches_for_many(results, limit_per_result: 3)
@@ -39,44 +38,29 @@ class AudiobookshelfLibraryMatcherService
   end
 
   def matches_for(title:, author:, limit: 3, library_ids: nil)
-    query_title = normalize_text(title)
-    query_author = normalize_text(author)
+    query = prepare_query(title, author)
     limit = limit.to_i
-    return [] if query_title.blank? || limit <= 0
-
-    query_title_trigrams = trigrams(query_title)
-    query_author_trigrams = query_author.present? ? trigrams(query_author) : nil
+    return [] if query.title.blank? || limit <= 0
 
     matches = []
     each_library_item(library_ids) do |item|
-      next if oversized_match_text?(item.title)
+      prepared = prepared_item(item)
+      next unless prepared
 
-      item_title = cached_normalized_text(item, :title)
-      item_subtitle = oversized_match_text?(item.subtitle) ? "" : cached_normalized_text(item, :subtitle)
-      item_display_title = [ item_title, item_subtitle ].compact_blank.join(" ")
-      item_author = oversized_match_text?(item.author) ? "" : cached_normalized_text(item, :author)
-      next if item_title.blank? && item_display_title.blank? && item_author.blank?
-      item_titles = [ item_title, item_display_title ].uniq
-
-      item_title_trigrams = cached_trigrams(item, :title)
-      item_display_title_trigrams = item_subtitle.present? ? trigrams(item_display_title) : item_title_trigrams
-      item_author_trigrams = item_author.present? ? cached_trigrams(item, :author) : nil
-
-      score = match_score_precomputed(
-        query_title: query_title,
-        query_author: query_author,
-        item_titles: item_titles,
-        item_author: item_author,
-        query_title_trigrams: query_title_trigrams,
-        query_author_trigrams: query_author_trigrams,
-        item_title_trigrams: item_title_trigrams,
-        item_display_title_trigrams: item_display_title_trigrams,
-        item_author_trigrams: item_author_trigrams
+      score = match_score(
+        query_title: query.title,
+        query_author: query.author,
+        item_titles: prepared.titles,
+        item_author: prepared.author,
+        query_title_trigrams: query.title_trigrams,
+        query_author_trigrams: query.author_trigrams,
+        item_title_trigrams_by_title: prepared.title_trigrams_by_title,
+        item_author_trigrams: prepared.author_trigrams
       )
       next if score < FuzzyThreshold
 
-      exact_author = query_author.present? && item_author == query_author
-      match_type = item_titles.include?(query_title) && exact_author ? :likely : :possible
+      exact_author = query.author.present? && prepared.author == query.author
+      match_type = prepared.titles.include?(query.title) && exact_author ? :likely : :possible
       matches << Match.new(item: item, score: score, match_type: match_type)
       matches.sort_by! { |match| match_sort_key(match) }
       matches.pop if matches.size > limit
@@ -86,6 +70,10 @@ class AudiobookshelfLibraryMatcherService
   end
 
   private
+
+  PreparedQuery = Data.define(:title, :author, :title_trigrams, :author_trigrams)
+  PreparedItem = Data.define(:title, :titles, :author, :title_trigrams_by_title, :author_trigrams)
+  private_constant :PreparedQuery, :PreparedItem
 
   def library_ids_for_scope(library_ids)
     @library_items_by_ids ||= {}
@@ -112,48 +100,79 @@ class AudiobookshelfLibraryMatcherService
 
   def match_sort_key(match)
     synced_at = match.item.effective_synced_at || Time.at(0)
-    [ -match.score, match.likely? ? 0 : 1, -synced_at.to_f, normalize_text(match.item.title), match.item.id || 0 ]
+    prepared = prepared_item(match.item)
+    normalized_title = prepared ? prepared.title : normalize_text(match.item.title)
+    [ -match.score, match.likely? ? 0 : 1, -synced_at.to_f, normalized_title, match.item.id || 0 ]
   end
 
   def oversized_match_text?(text)
     text.is_a?(String) && text.length > MaxMatchTextLength
   end
 
-  def match_score(query_title:, query_author:, item_titles:, item_author:)
-    return 0 if item_titles.blank?
-    return 100 if item_titles.include?(query_title) && query_author == item_author
-
-    title_score = item_titles.map { |item_title| trigram_similarity(query_title, item_title) }.max || 0
-    return title_score if query_author.blank? || item_author.blank?
-
-    author_score = trigram_similarity(query_author, item_author)
-    ((title_score * 0.7) + (author_score * 0.3)).round
+  def prepare_query(title, author)
+    query_title = normalize_text(title)
+    query_author = normalize_text(author)
+    PreparedQuery.new(
+      title: query_title,
+      author: query_author,
+      title_trigrams: query_title.present? ? trigrams(query_title) : Set.new,
+      author_trigrams: query_author.present? ? trigrams(query_author) : nil
+    )
   end
 
-  def match_score_precomputed(query_title:, query_author:, item_titles:, item_author:,
-    query_title_trigrams:, query_author_trigrams:, item_title_trigrams:,
-    item_display_title_trigrams:, item_author_trigrams:)
+  def prepared_item(item)
+    key = item_prep_cache_key(item)
+    return @prepared_items[key] if @prepared_items.key?(key)
+
+    @prepared_items[key] = build_prepared_item(item)
+  end
+
+  def item_prep_cache_key(item)
+    [ item.id, item.title, item.subtitle, item.author ]
+  end
+
+  def build_prepared_item(item)
+    return nil if oversized_match_text?(item.title)
+
+    item_title = normalize_text(item.title)
+    item_subtitle = oversized_match_text?(item.subtitle) ? "" : normalize_text(item.subtitle)
+    item_display_title = [ item_title, item_subtitle ].compact_blank.join(" ")
+    item_author = oversized_match_text?(item.author) ? "" : normalize_text(item.author)
+    return nil if item_title.blank? && item_display_title.blank? && item_author.blank?
+
+    titles = [ item_title, item_display_title ].uniq
+    PreparedItem.new(
+      title: item_title,
+      titles: titles,
+      author: item_author,
+      title_trigrams_by_title: titles.to_h { |title| [ title, title.present? ? trigrams(title) : Set.new ] },
+      author_trigrams: item_author.present? ? trigrams(item_author) : nil
+    )
+  end
+
+  def match_score(query_title:, query_author:, item_titles:, item_author:,
+    query_title_trigrams: nil, query_author_trigrams: nil,
+    item_title_trigrams_by_title: nil, item_author_trigrams: nil)
     return 0 if item_titles.blank?
     return 100 if item_titles.include?(query_title) && query_author == item_author
 
-    title_trigrams = [ item_title_trigrams, item_display_title_trigrams ].uniq
-    title_score = title_trigrams.map { |item_trigrams|
-      trigram_similarity_precomputed(query_title_trigrams, item_trigrams)
+    title_score = item_titles.map { |item_title|
+      trigram_similarity(
+        query_title,
+        item_title,
+        left_trigrams: query_title_trigrams,
+        right_trigrams: item_title_trigrams_by_title&.[](item_title)
+      )
     }.max || 0
     return title_score if query_author.blank? || item_author.blank?
 
-    author_score = trigram_similarity_precomputed(query_author_trigrams, item_author_trigrams)
+    author_score = trigram_similarity(
+      query_author,
+      item_author,
+      left_trigrams: query_author_trigrams,
+      right_trigrams: item_author_trigrams
+    )
     ((title_score * 0.7) + (author_score * 0.3)).round
-  end
-
-  def cached_normalized_text(item, field)
-    cache_key = [ item.id, field, item.public_send(field) ]
-    @normalized_text_cache[cache_key] ||= normalize_text(item.public_send(field))
-  end
-
-  def cached_trigrams(item, field)
-    cache_key = [ item.id, field, item.public_send(field) ]
-    @trigram_cache[cache_key] ||= trigrams(cached_normalized_text(item, field))
   end
 
   def normalize_text(text)
@@ -170,28 +189,23 @@ class AudiobookshelfLibraryMatcherService
       .strip
   end
 
-  def trigram_similarity(left, right)
+  def trigram_similarity(left, right, left_trigrams: nil, right_trigrams: nil)
     return 0 if left.blank? || right.blank?
     return 100 if left == right
 
-    trigrams_left = trigrams(left)
-    trigrams_right = trigrams(right)
+    trigrams_left = left_trigrams || trigrams(left)
+    trigrams_right = right_trigrams || trigrams(right)
 
     return 0 if trigrams_left.empty? || trigrams_right.empty?
 
-    intersection = (trigrams_left & trigrams_right).size
-    union = (trigrams_left | trigrams_right).size
+    intersection = trigram_overlap_size(trigrams_left, trigrams_right)
+    union = trigrams_left.size + trigrams_right.size - intersection
     ((intersection.to_f / union) * 100).round
   end
 
-  def trigram_similarity_precomputed(left_trigrams, right_trigrams)
-    return 0 if left_trigrams.nil? || right_trigrams.nil?
-    return 0 if left_trigrams.empty? || right_trigrams.empty?
-    return 100 if left_trigrams == right_trigrams
-
-    intersection_count = (left_trigrams & right_trigrams).size
-    union_count = left_trigrams.size + right_trigrams.size - intersection_count
-    ((intersection_count.to_f / union_count) * 100).round
+  def trigram_overlap_size(left, right)
+    smaller, larger = left.size <= right.size ? [ left, right ] : [ right, left ]
+    smaller.count { |trigram| larger.include?(trigram) }
   end
 
   def trigrams(text)

--- a/test/services/audiobookshelf_library_matcher_service_test.rb
+++ b/test/services/audiobookshelf_library_matcher_service_test.rb
@@ -440,6 +440,8 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
     assert_equal [ item.id ], renamed.map { |match| match.item.id }
     assert_equal 100, renamed.first.score
     assert stale.none? { |match| match.item.id == item.id }
+    assert_empty matcher.instance_variable_get(:@prepared_items)
+    assert_equal 0, matcher.instance_variable_get(:@cached_item_trigram_count)
   end
 
   test "optimized scoring stays equivalent to the original algorithm" do
@@ -506,6 +508,26 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
       assert_equal reference, computed, [ left, right ].inspect
       assert_equal reference, precomputed, [ left, right ].inspect
     end
+  end
+
+  test "falls back to uncached scoring after the item trigram budget is exhausted" do
+    matcher = AudiobookshelfLibraryMatcherService.new
+    matcher.singleton_class.define_method(:max_cached_trigrams) { 1 }
+    counts = Hash.new(0)
+    instrument_matcher_prep(matcher, counts)
+    item = LibraryItem.find_by!(audiobookshelf_id: "ab-1")
+
+    prepared = matcher.send(:prepared_item, item)
+    first = serialize_matches(matcher.matches_for(title: "The Hobbit", author: "Tolkien", limit: 3))
+    after_first = counts[:trigrams]
+    second = serialize_matches(matcher.matches_for(title: "The Hobbit", author: "Tolkien", limit: 3))
+
+    assert_nil prepared.title_trigrams_by_title
+    assert_nil prepared.author_trigrams
+    assert_equal first, second
+    assert_equal [ [ item.id, 86, :possible ] ], first
+    assert_operator counts[:trigrams] - after_first, :>, 2
+    assert_operator matcher.instance_variable_get(:@cached_item_trigram_count), :<=, 1
   end
 
   private

--- a/test/services/audiobookshelf_library_matcher_service_test.rb
+++ b/test/services/audiobookshelf_library_matcher_service_test.rb
@@ -338,4 +338,88 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
 
     assert_empty matches
   end
+
+  test "reuses item preprocessing across multiple queries with same matcher instance" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-ender",
+      title: "Ender's Game",
+      author: "Orson Scott Card",
+      synced_at: Time.current
+    )
+
+    matcher = AudiobookshelfLibraryMatcherService.new
+
+    first_matches = matcher.matches_for(
+      title: "Ender's Game",
+      author: "Orson Scott Card",
+      limit: 3
+    )
+
+    second_matches = matcher.matches_for(
+      title: "Dune",
+      author: "Frank Herbert",
+      limit: 3
+    )
+
+    assert_equal 1, first_matches.size
+    assert_equal "ab-ender", first_matches.first.item.audiobookshelf_id
+    assert_equal 1, second_matches.size
+    assert_equal "ab-2", second_matches.first.item.audiobookshelf_id
+  end
+
+  test "produces identical scores with optimized trigram computation" do
+    matcher = AudiobookshelfLibraryMatcherService.new
+
+    first_pass = matcher.matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 5
+    )
+
+    second_pass = matcher.matches_for(
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
+      limit: 5
+    )
+
+    assert_equal first_pass.size, second_pass.size
+    first_pass.zip(second_pass).each do |first, second|
+      assert_equal first.item.id, second.item.id
+      assert_equal first.score, second.score
+      assert_equal first.match_type, second.match_type
+    end
+  end
+
+  test "handles updated library items with fresh preprocessing" do
+    item = LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-foundation",
+      title: "Foundation",
+      author: "Isaac Asimov",
+      synced_at: Time.current
+    )
+
+    matcher = AudiobookshelfLibraryMatcherService.new
+
+    first_matches = matcher.matches_for(
+      title: "Foundation",
+      author: "Isaac Asimov",
+      limit: 3
+    )
+
+    assert_equal 1, first_matches.size
+    assert_equal 100, first_matches.first.score
+
+    item.update!(title: "Foundation and Empire")
+
+    second_matches = AudiobookshelfLibraryMatcherService.new.matches_for(
+      title: "Foundation and Empire",
+      author: "Isaac Asimov",
+      limit: 3
+    )
+
+    assert_equal 1, second_matches.size
+    assert_equal 100, second_matches.first.score
+  end
 end

--- a/test/services/audiobookshelf_library_matcher_service_test.rb
+++ b/test/services/audiobookshelf_library_matcher_service_test.rb
@@ -339,22 +339,28 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
     assert_empty matches
   end
 
-  test "reuses item preprocessing across multiple queries with same matcher instance" do
-    LibraryItem.create!(
-      library_id: "lib-audio",
-      audiobookshelf_id: "ab-ender",
-      title: "Ender's Game",
-      author: "Orson Scott Card",
-      synced_at: Time.current
-    )
+  test "same matcher instance reuses item prep across queries" do
+    20.times do |index|
+      LibraryItem.create!(
+        library_id: "lib-audio",
+        audiobookshelf_id: "ab-filler-#{index}",
+        title: "Filler Title #{index}",
+        subtitle: "Filler Subtitle #{index}",
+        author: "Filler Author #{index}",
+        synced_at: Time.current
+      )
+    end
 
     matcher = AudiobookshelfLibraryMatcherService.new
+    counts = Hash.new(0)
+    instrument_matcher_prep(matcher, counts)
 
     first_matches = matcher.matches_for(
-      title: "Ender's Game",
-      author: "Orson Scott Card",
+      title: "The Hobbit",
+      author: "J.R.R. Tolkien",
       limit: 3
     )
+    after_first = counts.dup
 
     second_matches = matcher.matches_for(
       title: "Dune",
@@ -362,64 +368,258 @@ class AudiobookshelfLibraryMatcherServiceTest < ActiveSupport::TestCase
       limit: 3
     )
 
-    assert_equal 1, first_matches.size
-    assert_equal "ab-ender", first_matches.first.item.audiobookshelf_id
-    assert_equal 1, second_matches.size
-    assert_equal "ab-2", second_matches.first.item.audiobookshelf_id
+    scannable = LibraryItem.available_for_matching.count
+    extra_normalize = counts[:normalize_text] - after_first[:normalize_text]
+    extra_trigrams = counts[:trigrams] - after_first[:trigrams]
+
+    assert_equal [ "ab-1" ], first_matches.map { |match| match.item.audiobookshelf_id }
+    assert_equal [ "ab-2" ], second_matches.map { |match| match.item.audiobookshelf_id }
+    assert_operator scannable, :>=, 20
+    assert_operator after_first[:normalize_text], :>=, scannable
+    assert_operator extra_normalize, :<=, 6
+    assert_operator extra_trigrams, :<=, 4
+    assert_operator extra_normalize, :<, scannable
+    assert_operator extra_trigrams, :<, scannable
   end
 
-  test "produces identical scores with optimized trigram computation" do
+  test "reusing one matcher is cheaper than constructing a matcher per query" do
+    results = [
+      OpenStruct.new(title: "The Hobbit", author: "J.R.R. Tolkien"),
+      OpenStruct.new(title: "Dune", author: "Frank Herbert"),
+      OpenStruct.new(title: "The Hobbit: There and Back Again", author: "J.R.R. Tolkien")
+    ]
+
+    naive_counts = Hash.new(0)
+    results.each do |result|
+      matcher = AudiobookshelfLibraryMatcherService.new
+      instrument_matcher_prep(matcher, naive_counts)
+      matcher.matches_for(title: result.title, author: result.author, limit: 1)
+    end
+
+    shared_counts = Hash.new(0)
+    matcher = AudiobookshelfLibraryMatcherService.new
+    instrument_matcher_prep(matcher, shared_counts)
+    results.each do |result|
+      matcher.matches_for(title: result.title, author: result.author, limit: 1)
+    end
+
+    assert_operator shared_counts[:normalize_text], :<, naive_counts[:normalize_text]
+    assert_operator shared_counts[:trigrams], :<, naive_counts[:trigrams]
+  end
+
+  test "cached matcher refreshes prep when the same in-memory item is updated" do
     matcher = AudiobookshelfLibraryMatcherService.new
 
-    first_pass = matcher.matches_for(
-      title: "The Hobbit",
+    before = matcher.matches_for(title: "Dune", author: "Frank Herbert", limit: 3)
+    item = before.first.item
+    assert_equal "ab-2", item.audiobookshelf_id
+    assert_equal 100, before.first.score
+
+    item.update!(title: "Hyperion", author: "Dan Simmons")
+
+    renamed = matcher.matches_for(title: "Hyperion", author: "Dan Simmons", limit: 3)
+    stale = matcher.matches_for(title: "Dune", author: "Frank Herbert", limit: 3)
+
+    assert_equal [ item.id ], renamed.map { |match| match.item.id }
+    assert_equal 100, renamed.first.score
+    assert stale.none? { |match| match.item.id == item.id }
+  end
+
+  test "streaming matcher refreshes prep after a persisted item update" do
+    item = LibraryItem.find_by!(audiobookshelf_id: "ab-2")
+    matcher = AudiobookshelfLibraryMatcherService.new(cache_library_items: false)
+
+    before = matcher.matches_for(title: "Dune", author: "Frank Herbert", limit: 3)
+    assert_equal [ item.id ], before.map { |match| match.item.id }
+
+    item.update!(title: "Hyperion", author: "Dan Simmons")
+
+    renamed = matcher.matches_for(title: "Hyperion", author: "Dan Simmons", limit: 3)
+    stale = matcher.matches_for(title: "Dune", author: "Frank Herbert", limit: 3)
+
+    assert_equal [ item.id ], renamed.map { |match| match.item.id }
+    assert_equal 100, renamed.first.score
+    assert stale.none? { |match| match.item.id == item.id }
+  end
+
+  test "optimized scoring stays equivalent to the original algorithm" do
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-near-miss",
+      title: "The Hobbit Companion",
       author: "J.R.R. Tolkien",
-      limit: 5
+      synced_at: Time.current
+    )
+    LibraryItem.create!(
+      library_id: "lib-audio",
+      audiobookshelf_id: "ab-blank-author-dune",
+      title: "Dune",
+      author: nil,
+      synced_at: 1.minute.from_now
     )
 
-    second_pass = matcher.matches_for(
-      title: "The Hobbit",
-      author: "J.R.R. Tolkien",
-      limit: 5
-    )
+    matcher = AudiobookshelfLibraryMatcherService.new
+    queries = [
+      { title: "The Hobbit", author: "J.R.R. Tolkien" },
+      { title: "The Hobbit", author: "Tolkien" },
+      { title: "The Hobbit", author: nil },
+      { title: "The Hobbit: There and Back Again", author: "J.R.R. Tolkien" },
+      { title: "Hobbit", author: "J.R.R. Tolkien" },
+      { title: "Dune", author: "Frank Herbert" },
+      { title: "Dune", author: nil },
+      { title: "Completely Different Book", author: "Unknown Author" },
+      { title: "---", author: "J.R.R. Tolkien" },
+      { title: [ "The Hobbit" ], author: "J.R.R. Tolkien" }
+    ]
 
-    assert_equal first_pass.size, second_pass.size
-    first_pass.zip(second_pass).each do |first, second|
-      assert_equal first.item.id, second.item.id
-      assert_equal first.score, second.score
-      assert_equal first.match_type, second.match_type
+    queries.each do |query|
+      optimized = serialize_matches(matcher.matches_for(**query, limit: 5))
+      reference = serialize_matches(original_matches_for(**query, limit: 5))
+      assert_equal reference, optimized, query.inspect
     end
   end
 
-  test "handles updated library items with fresh preprocessing" do
-    item = LibraryItem.create!(
-      library_id: "lib-audio",
-      audiobookshelf_id: "ab-foundation",
-      title: "Foundation",
-      author: "Isaac Asimov",
-      synced_at: Time.current
-    )
-
+  test "precomputed trigram overlap matches original set algebra" do
     matcher = AudiobookshelfLibraryMatcherService.new
+    pairs = [
+      [ "the hobbit", "the hobbit" ],
+      [ "the hobbit", "hobbit" ],
+      [ "the hobbit", "the hobbit there and back again" ],
+      [ "dune", "dune messiah" ],
+      [ "dune", "" ],
+      [ "", "dune" ],
+      [ "straße", "strasse" ],
+      [ "война и мир", "война и мир" ]
+    ]
 
-    first_matches = matcher.matches_for(
-      title: "Foundation",
-      author: "Isaac Asimov",
-      limit: 3
-    )
+    pairs.each do |left, right|
+      reference = original_trigram_similarity(left, right)
+      computed = matcher.send(:trigram_similarity, left, right)
+      precomputed = matcher.send(
+        :trigram_similarity,
+        left,
+        right,
+        left_trigrams: matcher.send(:trigrams, left),
+        right_trigrams: matcher.send(:trigrams, right)
+      )
 
-    assert_equal 1, first_matches.size
-    assert_equal 100, first_matches.first.score
+      assert_equal reference, computed, [ left, right ].inspect
+      assert_equal reference, precomputed, [ left, right ].inspect
+    end
+  end
 
-    item.update!(title: "Foundation and Empire")
+  private
 
-    second_matches = AudiobookshelfLibraryMatcherService.new.matches_for(
-      title: "Foundation and Empire",
-      author: "Isaac Asimov",
-      limit: 3
-    )
+  def instrument_matcher_prep(matcher, counts)
+    matcher.singleton_class.prepend(Module.new {
+      define_method(:normalize_text) do |text|
+        counts[:normalize_text] += 1
+        super(text)
+      end
 
-    assert_equal 1, second_matches.size
-    assert_equal 100, second_matches.first.score
+      define_method(:trigrams) do |text|
+        counts[:trigrams] += 1
+        super(text)
+      end
+    })
+  end
+
+  def serialize_matches(matches)
+    matches.map { |match| [ match.item.id, match.score, match.match_type ] }
+  end
+
+  def original_matches_for(title:, author:, limit: 3)
+    query_title = original_normalize_text(title)
+    query_author = original_normalize_text(author)
+    limit = limit.to_i
+    return [] if query_title.blank? || limit <= 0
+
+    matches = []
+    LibraryItem.available_for_matching.by_synced_at_desc.each do |item|
+      next if original_oversized_match_text?(item.title)
+
+      item_title = original_normalize_text(item.title)
+      item_subtitle = original_oversized_match_text?(item.subtitle) ? "" : original_normalize_text(item.subtitle)
+      item_display_title = [ item_title, item_subtitle ].compact_blank.join(" ")
+      item_author = original_oversized_match_text?(item.author) ? "" : original_normalize_text(item.author)
+      next if item_title.blank? && item_display_title.blank? && item_author.blank?
+      item_titles = [ item_title, item_display_title ].uniq
+
+      score = original_match_score(
+        query_title: query_title,
+        query_author: query_author,
+        item_titles: item_titles,
+        item_author: item_author
+      )
+      next if score < AudiobookshelfLibraryMatcherService::FuzzyThreshold
+
+      exact_author = query_author.present? && item_author == query_author
+      match_type = item_titles.include?(query_title) && exact_author ? :likely : :possible
+      matches << AudiobookshelfLibraryMatcherService::Match.new(item: item, score: score, match_type: match_type)
+      matches.sort_by! { |match| original_match_sort_key(match) }
+      matches.pop if matches.size > limit
+    end
+
+    matches
+  end
+
+  def original_match_sort_key(match)
+    synced_at = match.item.effective_synced_at || Time.at(0)
+    [
+      -match.score,
+      match.likely? ? 0 : 1,
+      -synced_at.to_f,
+      original_normalize_text(match.item.title),
+      match.item.id || 0
+    ]
+  end
+
+  def original_match_score(query_title:, query_author:, item_titles:, item_author:)
+    return 0 if item_titles.blank?
+    return 100 if item_titles.include?(query_title) && query_author == item_author
+
+    title_score = item_titles.map { |item_title| original_trigram_similarity(query_title, item_title) }.max || 0
+    return title_score if query_author.blank? || item_author.blank?
+
+    author_score = original_trigram_similarity(query_author, item_author)
+    ((title_score * 0.7) + (author_score * 0.3)).round
+  end
+
+  def original_trigram_similarity(left, right)
+    return 0 if left.blank? || right.blank?
+    return 100 if left == right
+
+    trigrams_left = original_trigrams(left)
+    trigrams_right = original_trigrams(right)
+    return 0 if trigrams_left.empty? || trigrams_right.empty?
+
+    intersection = (trigrams_left & trigrams_right).size
+    union = (trigrams_left | trigrams_right).size
+    ((intersection.to_f / union) * 100).round
+  end
+
+  def original_trigrams(text)
+    return Set.new if text.blank?
+
+    padded = "  #{text}  "
+    (0..padded.length - 3).map { |i| padded[i, 3] }.to_set
+  end
+
+  def original_normalize_text(text)
+    return "" unless text.is_a?(String)
+    return "" if text.length > AudiobookshelfLibraryMatcherService::MaxMatchTextLength
+
+    text
+      .encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "")
+      .unicode_normalize(:nfkd)
+      .gsub(/\p{Mn}/, "")
+      .downcase(:fold)
+      .gsub(/[^\p{Alnum}\s]/, " ")
+      .gsub(/\s+/, " ")
+      .strip
+  end
+
+  def original_oversized_match_text?(text)
+    text.is_a?(String) && text.length > AudiobookshelfLibraryMatcherService::MaxMatchTextLength
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Assigned issue

Closes #511

## What changed

Behavior-preserving performance refactor of `AudiobookshelfLibraryMatcherService` only. Controllers, routes, and scoring weights are unchanged.

On large synced libraries, admin request index and search enrichment called `matches_for` / `matches_for_many` against the full inventory and re-normalized titles/authors and rebuilt trigram sets for every pair. This PR:

- Precomputes one prepared query (normalized title/author + trigram sets)
- Precomputes one prepared item per library row, including the combined title+subtitle display string and its trigram set, keyed by `[id, title, subtitle, author]`
- Reuses that prep across queries on the same matcher instance (`matches_for_many`, admin request index)
- Passes those sets into the original `match_score` / `trigram_similarity` path, including the string-equality short-circuit
- Counts trigram overlap instead of allocating full intersection/union sets

A first patch used a parallel precomputed scorer that unique'd trigram sets rather than title strings, and it still rebuilt display-title trigrams on every query. This revision removes that second path so scoring cannot drift, and caches the combined title/subtitle representation once per item.

## Verification

**Tests added/extended:**
- Same matcher instance reuses item prep across queries (counts `normalize_text` / `trigrams`; second query stays well below a full rescan)
- One matcher is cheaper than constructing a matcher per query (the `matches_for_many` pattern)
- Cached-mode matcher refreshes prep when the in-memory item it iterates is updated
- Streaming matcher (`cache_library_items: false`) refreshes after a persisted update
- Optimized match lists stay equivalent to a copy of the original algorithm for the same inputs
- Precomputed trigram overlap matches the original `&` / `|` set-algebra scores

**Tests run:**
```
PARALLEL_WORKERS=1 bin/rails test test/services/audiobookshelf_library_matcher_service_test.rb
# 25 runs, 85 assertions, 0 failures, 0 errors

PARALLEL_WORKERS=1 bin/rails test \
  test/services/audiobookshelf_library_matcher_service_test.rb \
  test/controllers/requests_controller_test.rb:2904 \
  test/controllers/search_controller_rendering_test.rb:134
# 27 runs, 93 assertions, 0 failures, 0 errors

bin/rubocop --force-exclusion \
  app/services/audiobookshelf_library_matcher_service.rb \
  test/services/audiobookshelf_library_matcher_service_test.rb
```

Exact Synology / Atom / reverse-proxy wall-clock 502/504 timing was not reproduced 1:1 here. The algorithmic waste is covered by the reuse tests; scoring is locked against the original algorithm.

## Checklist

- [x] The maintainer assigned the linked issue to me before I started implementation
- [x] This pull request stays within the assigned issue's scope
- [x] I added or updated tests for the behavior I changed
- [x] I ran the relevant local quality checks
- [x] I updated documentation for user-visible changes (N/A — internal matcher optimization)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46d51315-7ea9-4f8f-b895-b7108c139e3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46d51315-7ea9-4f8f-b895-b7108c139e3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

