### PR TITLE
Reduce inventory sync work and recover stalled download monitoring

### DIFF
--- a/app/jobs/download_monitor_job.rb
+++ b/app/jobs/download_monitor_job.rb
@@ -46,7 +46,7 @@ class DownloadMonitorJob < ApplicationJob
       scope = SolidQueue::Job
         .where(class_name: name, finished_at: nil)
         .where.not(concurrency_key: nil)
-        .where.missing(:failed_execution, :claimed_execution)
+        .where.missing(:failed_execution)
       scope = scope.where.not(active_job_id: excluding_active_job_id) if excluding_active_job_id.present?
       scope.exists?
     rescue ActiveRecord::ActiveRecordError, NameError
@@ -89,7 +89,7 @@ class DownloadMonitorJob < ApplicationJob
   private
 
   def monitor_active_downloads
-    Download.active.find_each do |download|
+    Download.active.includes(:download_client).find_each do |download|
       check_download_status(download)
     rescue => e
       Rails.logger.error "[DownloadMonitorJob] Error checking download #{download.id}: #{e.message}"

--- a/app/services/audiobookshelf_library_sync_service.rb
+++ b/app/services/audiobookshelf_library_sync_service.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class AudiobookshelfLibrarySyncService
+  UPSERT_BATCH_SIZE = 500
+  UPSERT_UNIQUE_BY = %i[library_platform library_id audiobookshelf_id].freeze
+  UPSERT_UPDATE_COLUMNS = %i[
+    title subtitle author narrator series series_position publisher language
+    description isbn asin published_year missing synced_at updated_at
+  ].freeze
+
   Result = Data.define(:success, :items_synced, :libraries_synced, :errors) do
     def success?
       success
@@ -18,7 +25,7 @@ class AudiobookshelfLibrarySyncService
     using_auto_discovery = initial_explicit_ids.empty?
 
     library_ids = if using_auto_discovery
-      load_library_ids_from_configured_client
+      load_library_ids_from_configured_client(initial_platform)
     else
       initial_explicit_ids
     end
@@ -28,20 +35,20 @@ class AudiobookshelfLibrarySyncService
         success: false,
         items_synced: 0,
         libraries_synced: 0,
-        errors: [ "No #{LibraryPlatformClient.display_name} library IDs configured or available." ]
+        errors: [ "No #{LibraryPlatformClient.display_name(initial_platform)} library IDs configured or available." ]
       )
     end
 
     library_platform = initial_platform
     library_ids.each do |library_id|
       begin
-        items = LibraryPlatformClient.library_items(library_id)
-        sync_library_items(library_platform, library_id, items, synced_at: now)
+        items = LibraryPlatformClient.library_items(library_id, platform: library_platform)
+        synced_count = sync_library_items(library_platform, library_id, items, synced_at: now)
         libraries_synced += 1
-        items_synced += items.size
+        items_synced += synced_count
       rescue LibraryPlatformClient::Error, StandardError => e
         errors << "#{library_id}: #{e.message}"
-        Rails.logger.warn "[AudiobookshelfLibrarySyncService] Failed to sync #{LibraryPlatformClient.display_name} library #{library_id}: #{e.message}"
+        Rails.logger.warn "[AudiobookshelfLibrarySyncService] Failed to sync #{LibraryPlatformClient.display_name(library_platform)} library #{library_id}: #{e.message}"
       end
     end
 
@@ -81,52 +88,98 @@ class AudiobookshelfLibrarySyncService
   end
 
   def sync_library_items(library_platform, library_id, items, synced_at:)
-    item_ids = []
-    now = synced_at
-
-    items.each do |item|
+    validate_sync_scope!(library_platform, library_id)
+    items_by_id = items.each_with_object({}) do |item, indexed|
       audiobookshelf_id = item["audiobookshelf_id"]
       next if audiobookshelf_id.blank?
 
-      cached = LibraryItem.find_or_initialize_by(
-        library_platform: library_platform,
-        library_id: library_id,
-        audiobookshelf_id: audiobookshelf_id
-      )
-
-      if cached.persisted? && cached.synced_at.present? && cached.synced_at > now
-        item_ids << audiobookshelf_id
-        next
+      indexed[audiobookshelf_id.to_s] = item
+    end
+    item_ids = items_by_id.keys
+    written_at = Time.current
+    items_by_id.each_slice(UPSERT_BATCH_SIZE) do |batch_items|
+      batch = batch_items.map do |audiobookshelf_id, item|
+        library_item_attributes(
+          library_platform,
+          library_id,
+          audiobookshelf_id,
+          item,
+          synced_at: synced_at,
+          written_at: written_at
+        )
       end
-
-      cached.title = item["title"]
-      cached.subtitle = item["subtitle"]
-      cached.author = item["author"]
-      cached.narrator = item["narrator"]
-      cached.series = item["series"]
-      cached.series_position = item["series_position"]
-      cached.publisher = item["publisher"]
-      cached.language = item["language"]
-      cached.description = item["description"]
-      cached.isbn = item["isbn"]
-      cached.asin = item["asin"]
-      cached.published_year = item["published_year"]
-      cached.missing = item["missing"] == true
-      cached.synced_at = now
-      cached.save!
-      item_ids << audiobookshelf_id
+      LibraryItem.upsert_all(
+        batch,
+        unique_by: UPSERT_UNIQUE_BY,
+        on_duplicate: upsert_update_sql,
+        record_timestamps: false
+      )
     end
 
     LibraryItem.where(library_platform: library_platform, library_id: library_id)
                .where.not(audiobookshelf_id: item_ids)
-               .where("synced_at <= ? OR synced_at IS NULL", now)
+               .where("synced_at <= ? OR synced_at IS NULL", synced_at)
                .delete_all
+
+    item_ids.size
   end
 
-  def load_library_ids_from_configured_client
-    return [] unless LibraryPlatformClient.configured?
+  def library_item_attributes(library_platform, library_id, audiobookshelf_id, item, synced_at:, written_at:)
+    {
+      library_platform: library_platform,
+      library_id: library_id,
+      audiobookshelf_id: audiobookshelf_id,
+      title: item["title"],
+      subtitle: item["subtitle"],
+      author: item["author"],
+      narrator: item["narrator"],
+      series: item["series"],
+      series_position: item["series_position"],
+      publisher: item["publisher"],
+      language: item["language"],
+      description: item["description"],
+      isbn: item["isbn"],
+      asin: item["asin"],
+      published_year: item["published_year"],
+      missing: item["missing"] == true,
+      synced_at: synced_at,
+      created_at: written_at,
+      updated_at: written_at
+    }
+  end
 
-    libraries = LibraryPlatformClient.libraries
+  def upsert_update_sql
+    connection = LibraryItem.connection
+    assignments = UPSERT_UPDATE_COLUMNS.map do |column|
+      quoted_column = connection.quote_column_name(column)
+      "#{quoted_column}=excluded.#{quoted_column}"
+    end.join(",")
+    table = connection.quote_table_name(LibraryItem.table_name)
+    synced_at = connection.quote_column_name(:synced_at)
+
+    Arel.sql(
+      "#{assignments} WHERE #{table}.#{synced_at} IS NULL " \
+        "OR #{table}.#{synced_at} <= excluded.#{synced_at}"
+    )
+  end
+
+  def validate_sync_scope!(library_platform, library_id)
+    valid_platform = SettingsService::LIBRARY_PLATFORMS.include?(library_platform.to_s)
+    return if valid_platform && library_id.present?
+
+    invalid_item = LibraryItem.new(
+      library_platform: library_platform,
+      library_id: library_id,
+      audiobookshelf_id: "bulk-sync-validation"
+    )
+    invalid_item.validate
+    raise ActiveRecord::RecordInvalid, invalid_item
+  end
+
+  def load_library_ids_from_configured_client(platform)
+    return [] unless LibraryPlatformClient.configured?(platform: platform)
+
+    libraries = LibraryPlatformClient.libraries(platform: platform)
     libraries.select(&:audiobook_library?).map(&:id)
   end
 end

--- a/app/services/format_preference_service.rb
+++ b/app/services/format_preference_service.rb
@@ -17,14 +17,14 @@ class FormatPreferenceService
   MULTI_FILE_PENALTY = -6
   PREFERRED_FORMAT_BONUSES = [ 12, 8, 4, 2 ].freeze
 
-  def self.evaluate(title:, book_type:)
-    new(title:, book_type:).evaluate
+  def self.evaluate(title:, book_type:, parsed: nil)
+    new(title:, book_type:, parsed:).evaluate
   end
 
-  def initialize(title:, book_type:)
+  def initialize(title:, book_type:, parsed: nil)
     @title = title
     @book_type = book_type.to_s
-    @parsed = ReleaseParserService.parse(title)
+    @parsed = parsed || ReleaseParserService.parse(title)
     @preferences = SettingsService.format_preferences_for(@book_type)
   end
 

--- a/app/services/library_platform_client.rb
+++ b/app/services/library_platform_client.rb
@@ -21,32 +21,32 @@ class LibraryPlatformClient
       DISPLAY_NAMES.fetch(platform, platform.to_s.titleize)
     end
 
-    def configured?
-      client.configured?
+    def configured?(platform: active_platform)
+      client_for(platform).configured?
     end
 
-    def libraries
-      translate_errors { client.libraries }
+    def libraries(platform: active_platform)
+      translate_errors(platform) { |client| client.libraries }
     end
 
-    def library(id)
-      translate_errors { client.library(id) }
+    def library(id, platform: active_platform)
+      translate_errors(platform) { |client| client.library(id) }
     end
 
-    def library_items(id, page_size: 500)
-      translate_errors { client.library_items(id, page_size: page_size) }
+    def library_items(id, page_size: 500, platform: active_platform)
+      translate_errors(platform) { |client| client.library_items(id, page_size: page_size) }
     end
 
-    def scan_library(id)
-      translate_errors { client.scan_library(id) }
+    def scan_library(id, platform: active_platform)
+      translate_errors(platform) { |client| client.scan_library(id) }
     end
 
-    def delete_item_by_path(path)
-      translate_errors { client.delete_item_by_path(path) }
+    def delete_item_by_path(path, platform: active_platform)
+      translate_errors(platform) { |client| client.delete_item_by_path(path) }
     end
 
-    def test_connection
-      translate_errors { client.test_connection }
+    def test_connection(platform: active_platform)
+      translate_errors(platform) { |client| client.test_connection }
     end
 
     def reset_connections!
@@ -78,10 +78,6 @@ class LibraryPlatformClient
 
     private
 
-    def client
-      client_for(active_platform)
-    end
-
     def client_for(platform)
       case platform.to_s
       when "bookorbit"
@@ -104,9 +100,9 @@ class LibraryPlatformClient
       end
     end
 
-    def translate_errors
-      active_client = client
-      yield
+    def translate_errors(platform)
+      active_client = client_for(platform)
+      yield active_client
     rescue active_client::AuthenticationError => e
       raise AuthenticationError, e.message
     rescue active_client::ConnectionError => e

--- a/app/services/metadata_search/aggregator.rb
+++ b/app/services/metadata_search/aggregator.rb
@@ -16,6 +16,7 @@ module MetadataSearch
 
     def call
       @logged_disagreements = {}
+      @isbn_identities = {}.compare_by_identity
       log_provider_disagreements
 
       clusters.map { |cluster| candidate_for(cluster) }
@@ -117,7 +118,7 @@ module MetadataSearch
       results.each_with_object([]) do |result, groups|
         group = groups.find do |candidate_group|
           candidate_group.any? { |member| match?(member, result) } &&
-            candidate_group.none? { |member| classification_conflict?(member, result) }
+            candidate_group.none? { |member| classification_conflict?(member, result) || conflicting_isbn?(member, result) }
         end
         group ? group << result : groups << [ result ]
       end
@@ -134,17 +135,33 @@ module MetadataSearch
     end
 
     def shared_isbn?(left, right)
-      (isbns(left) & isbns(right)).any?
+      (isbn_identities(left) & isbn_identities(right)).any?
     end
 
     def conflicting_isbn?(left, right)
-      left_isbns = isbns(left)
-      right_isbns = isbns(right)
+      left_isbns = isbn_identities(left)
+      right_isbns = isbn_identities(right)
       left_isbns.any? && right_isbns.any? && (left_isbns & right_isbns).empty?
     end
 
     def isbns(result)
       [ result.isbn_10, result.isbn_13 ].compact.map { |isbn| isbn.to_s.delete(" -") }.reject(&:blank?)
+    end
+
+    def isbn_identities(result)
+      @isbn_identities[result] ||= isbns(result).map do |isbn|
+        identifier = isbn.upcase
+        next identifier unless identifier.match?(/\A\d{9}[\dX]\z/)
+
+        digits = identifier.chars.map { |digit| digit == "X" ? 10 : digit.to_i }
+        next identifier unless digits.each_with_index.sum { |digit, index| digit * (10 - index) } % 11 == 0
+
+        # Compare valid ISBN-10s using their ISBN-13 equivalent, while keeping
+        # the provider's original identifiers in the returned candidate.
+        body = "978#{identifier[0, 9]}"
+        checksum = body.chars.each_with_index.sum { |digit, index| digit.to_i * (index.even? ? 1 : 3) }
+        "#{body}#{(10 - checksum % 10) % 10}"
+      end
     end
 
     def normalized_text(value)

--- a/app/services/release_scorer.rb
+++ b/app/services/release_scorer.rb
@@ -52,7 +52,7 @@ class ReleaseScorer
     @request = request
     @book = request.book
     @parsed = ReleaseParserService.parse(search_result.title)
-    @format_preferences = FormatPreferenceService.evaluate(title: search_result.title, book_type: @book.book_type)
+    @format_preferences = FormatPreferenceService.evaluate(title: search_result.title, book_type: @book.book_type, parsed: @parsed)
     @comic_issue_match = classify_comic_issue_match
   end
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -10,6 +10,10 @@
 #     schedule: at 5am every day
 
 default: &default
+  download_monitor_recovery:
+    command: "DownloadMonitorJob.ensure_running!"
+    queue: default
+    schedule: every 5 minutes
   request_queue:
     class: RequestQueueJob
     queue: default

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,12 +1,17 @@
 require "test_helper"
 
-module ChromeStaleNodeVisibilityRetry
-  def visible?
-    super
-  rescue Selenium::WebDriver::Error::UnknownError => error
-    raise unless error.message.include?("Node with given id does not belong to the document")
+module ChromeStaleNodeRetry
+  def synchronize(...)
+    # Chrome also emits this detached-node error during text reads and clicks.
+    # Translate inside Capybara's existing retry loop so it reloads the node,
+    # keeps its normal timeout, and still propagates unrelated browser errors.
+    super do
+      yield
+    rescue Selenium::WebDriver::Error::UnknownError => error
+      raise unless error.message.include?("Node with given id does not belong to the document")
 
-    raise Selenium::WebDriver::Error::StaleElementReferenceError, error.message
+      raise Selenium::WebDriver::Error::StaleElementReferenceError, error.message
+    end
   end
 end
 
@@ -27,4 +32,4 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 end
 
-Capybara::Selenium::ChromeNode.prepend(ChromeStaleNodeVisibilityRetry)
+Capybara::Node::Base.prepend(ChromeStaleNodeRetry)

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -87,6 +87,72 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     end
   end
 
+  test "loads shared download clients once per polling batch" do
+    9.times do |index|
+      @request.downloads.create!(
+        name: "Additional download #{index}", status: :downloading, progress: 50,
+        external_id: "additional#{index}", download_type: "torrent", download_client: @qbittorrent
+      )
+    end
+    client_reads = []
+    capture = lambda do |_name, _start, _finish, _id, payload|
+      client_reads << payload[:sql] if payload[:sql].match?(/\ASELECT .*FROM "download_clients"/)
+    end
+
+    VCR.turned_off do
+      stub_qbittorrent_auth
+      stub_qbittorrent_torrent_info(progress: 75, state: "downloading")
+      ActiveRecord::Base.uncached do
+        ActiveSupport::Notifications.subscribed(capture, "sql.active_record") do
+          DownloadMonitorJob.new.send(:monitor_active_downloads)
+        end
+      end
+    end
+
+    assert_equal [ 75 ], @request.downloads.pluck(:progress).uniq
+    assert_equal 1, client_reads.size
+  end
+
+  test "does not start another monitor while one is claimed by a worker" do
+    with_solid_queue_monitor_jobs do |monitor_jobs|
+      DownloadMonitorJob.perform_later
+      worker = SolidQueue::Process.register(kind: "Worker", name: "monitor-test", pid: Process.pid)
+      claimed = SolidQueue::ReadyExecution.claim([ "*" ], 1, worker.id).first
+      assert claimed
+
+      assert_no_difference -> { monitor_jobs.count } do
+        DownloadMonitorJob.ensure_running!
+      end
+    ensure
+      worker&.destroy!
+    end
+  end
+
+  test "recurring watchdog restarts a failed monitor chain without duplicating its replacement" do
+    config = YAML.safe_load_file(Rails.root.join("config/recurring.yml"), aliases: true)
+    watchdog = config.fetch("production").fetch("download_monitor_recovery")
+    assert_equal "every 5 minutes", watchdog.fetch("schedule")
+    task = SolidQueue::RecurringTask.from_configuration("download_monitor_recovery", **watchdog.symbolize_keys)
+    assert task.valid?, task.errors.full_messages.join(", ")
+
+    with_solid_queue_monitor_jobs do |monitor_jobs|
+      DownloadMonitorJob.perform_later
+      worker = SolidQueue::Process.register(kind: "Worker", name: "monitor-recovery-test", pid: Process.pid)
+      claimed = SolidQueue::ReadyExecution.claim([ "*" ], 1, worker.id).first
+      claimed.failed_with(RuntimeError.new("interrupted polling"))
+      claimed.unblock_next_job
+
+      assert_difference -> { monitor_jobs.count }, 1 do
+        SolidQueue::RecurringJob.perform_now(task.command)
+      end
+      assert_no_difference -> { monitor_jobs.count } do
+        SolidQueue::RecurringJob.perform_now(task.command)
+      end
+    ensure
+      worker&.destroy!
+    end
+  end
+
   test "handles completed download and triggers post-processing" do
     VCR.turned_off do
       stub_qbittorrent_auth

--- a/test/models/request_live_updates_test.rb
+++ b/test/models/request_live_updates_test.rb
@@ -22,15 +22,7 @@ class RequestLiveUpdatesTest < ActiveSupport::TestCase
   setup do
     @old_queue_adapter = ActiveJob::Base.queue_adapter
     ActiveJob::Base.queue_adapter = :test
-    @request = Request.create!(
-      book: Book.create!(
-        title: "Live Update Test #{SecureRandom.hex(4)}",
-        book_type: :ebook,
-        open_library_work_id: "OL_LIVE_#{SecureRandom.hex(6)}"
-      ),
-      user: users(:one),
-      status: :pending
-    )
+    @request = create_live_update_request
   end
 
   teardown do
@@ -61,6 +53,21 @@ class RequestLiveUpdatesTest < ActiveSupport::TestCase
     assert_no_refresh_broadcasts(@request) do
       @request.touch
     end
+  end
+
+  test "a delayed refresh from a rolled-back request cannot enter a later request assertion" do
+    stale_debouncer = nil
+    Request.transaction(requires_new: true) do
+      stale_request = create_live_update_request
+      with_deterministic_refresh_debouncer do |debouncer|
+        stale_request.broadcast_show_refresh_later
+        stale_debouncer = debouncer
+      end
+      raise ActiveRecord::Rollback
+    end
+    next_request = create_live_update_request
+
+    assert_no_refresh_broadcasts(next_request) { stale_debouncer.flush }
   end
 
   test "download broadcasts a refresh when progress changes" do
@@ -112,6 +119,21 @@ class RequestLiveUpdatesTest < ActiveSupport::TestCase
   end
 
   private
+
+  def create_live_update_request
+    Request.create!(
+      # Rolled-back tests reuse auto-increment IDs, but Turbo callbacks can
+      # outlive their transaction. Give each assertion its own request stream.
+      id: SecureRandom.random_number(1..(2**62)),
+      book: Book.create!(
+        title: "Live Update Test #{SecureRandom.hex(4)}",
+        book_type: :ebook,
+        open_library_work_id: "OL_LIVE_#{SecureRandom.hex(6)}"
+      ),
+      user: users(:one),
+      status: :pending
+    )
+  end
 
   def capture_refresh_broadcasts(request, &block)
     Turbo.with_request_id(SecureRandom.uuid) do

--- a/test/services/audiobookshelf_library_sync_service_test.rb
+++ b/test/services/audiobookshelf_library_sync_service_test.rb
@@ -253,6 +253,159 @@ class AudiobookshelfLibrarySyncServiceTest < ActiveSupport::TestCase
     LibraryPlatformClient.reset_connections!
   end
 
+  test "pins the initial platform across library discovery and inventory fetches" do
+    SettingsService.set(:audiobookshelf_audiobook_library_id, "")
+    SettingsService.set(:audiobookshelf_ebook_library_id, "")
+    calls = []
+    library = AudiobookshelfClient::Library.new(
+      id: "discovered-library",
+      name: "Discovered Library",
+      folders: [],
+      media_type: "book"
+    )
+
+    configured = lambda do
+      calls << :audiobookshelf_configured
+      SettingsService.set(:library_platform, "bookorbit")
+      true
+    end
+    libraries = lambda do
+      calls << :audiobookshelf_libraries
+      [ library ]
+    end
+    library_items = lambda do |library_id, page_size:|
+      calls << [ :audiobookshelf_items, library_id, page_size ]
+      [ { "audiobookshelf_id" => "pinned-item", "title" => "Pinned Item" } ]
+    end
+    unexpected_call = ->(*) { flunk "sync switched clients after its platform setting changed" }
+
+    AudiobookshelfClient.stub(:configured?, configured) do
+      AudiobookshelfClient.stub(:libraries, libraries) do
+        AudiobookshelfClient.stub(:library_items, library_items) do
+          BookOrbitClient.stub(:libraries, unexpected_call) do
+            BookOrbitClient.stub(:library_items, unexpected_call) do
+              result = AudiobookshelfLibrarySyncService.new.sync!
+
+              assert result.success?
+              assert_equal [
+                :audiobookshelf_configured,
+                :audiobookshelf_libraries,
+                [ :audiobookshelf_items, "discovered-library", 500 ]
+              ], calls
+              assert LibraryItem.exists?(
+                library_platform: "audiobookshelf",
+                library_id: "discovered-library",
+                audiobookshelf_id: "pinned-item"
+              )
+            end
+          end
+        end
+      end
+    end
+  ensure
+    SettingsService.set(:library_platform, "audiobookshelf")
+  end
+
+  test "deduplicates inventory ids and skips blank ids before writing" do
+    synced_at = Time.current
+    items = [
+      { "audiobookshelf_id" => "duplicate", "title" => "First Title" },
+      { "audiobookshelf_id" => nil, "title" => "Missing ID" },
+      { "audiobookshelf_id" => "", "title" => "Blank ID" },
+      { "audiobookshelf_id" => "duplicate", "title" => "Last Title" }
+    ]
+
+    synced_count = AudiobookshelfLibrarySyncService.new.send(
+      :sync_library_items,
+      "audiobookshelf",
+      "lib-audio",
+      items,
+      synced_at: synced_at
+    )
+
+    assert_equal 1, synced_count
+    assert_equal 1, LibraryItem.where(library_id: "lib-audio").count
+    assert_equal "Last Title", LibraryItem.find_by!(library_id: "lib-audio", audiobookshelf_id: "duplicate").title
+  end
+
+  test "batches inventory upserts at the 500 row boundary with bounded SQL" do
+    items = Array.new(501) do |index|
+      {
+        "audiobookshelf_id" => "batch-#{index}",
+        "title" => "Batch Item #{index}",
+        "author" => "Batch Author"
+      }
+    end
+    query_count = 0
+    callback = lambda do |_name, _started, _finished, _unique_id, payload|
+      query_count += 1 unless payload[:name].in?([ "SCHEMA", "TRANSACTION" ]) || payload[:cached]
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      AudiobookshelfLibrarySyncService.new.send(
+        :sync_library_items,
+        "audiobookshelf",
+        "batch-library",
+        items,
+        synced_at: Time.current
+      )
+    end
+
+    assert_equal 501, LibraryItem.where(library_id: "batch-library").count
+    assert_operator query_count, :<=, 4
+  end
+
+  test "upserts preserve creation time and reject an older sync snapshot" do
+    created_at = 2.days.ago.change(usec: 0)
+    newer_synced_at = 1.hour.from_now.change(usec: 0)
+    existing = LibraryItem.create!(
+      library_platform: "audiobookshelf",
+      library_id: "lib-audio",
+      audiobookshelf_id: "concurrent-item",
+      title: "Newer Title",
+      synced_at: newer_synced_at,
+      created_at: created_at,
+      updated_at: created_at
+    )
+
+    service = AudiobookshelfLibrarySyncService.new
+    service.send(
+      :sync_library_items,
+      "audiobookshelf",
+      "lib-audio",
+      [ { "audiobookshelf_id" => "concurrent-item", "title" => "Stale Title" } ],
+      synced_at: Time.current
+    )
+
+    assert_equal "Newer Title", existing.reload.title
+    assert_equal newer_synced_at, existing.synced_at
+    assert_equal created_at, existing.created_at
+
+    service.send(
+      :sync_library_items,
+      "audiobookshelf",
+      "lib-audio",
+      [ { "audiobookshelf_id" => "concurrent-item", "title" => "Newest Title" } ],
+      synced_at: 2.hours.from_now
+    )
+
+    assert_equal "Newest Title", existing.reload.title
+    assert_equal created_at, existing.created_at
+  end
+
+  test "bulk sync enforces library item platform and library validations" do
+    service = AudiobookshelfLibrarySyncService.new
+    item = { "audiobookshelf_id" => "validated-item", "title" => "Validated Item" }
+
+    assert_raises ActiveRecord::RecordInvalid do
+      service.send(:sync_library_items, "unsupported", "lib-audio", [ item ], synced_at: Time.current)
+    end
+    assert_raises ActiveRecord::RecordInvalid do
+      service.send(:sync_library_items, "audiobookshelf", "", [ item ], synced_at: Time.current)
+    end
+    assert_not LibraryItem.exists?(audiobookshelf_id: "validated-item")
+  end
+
   test "keeps cached BookOrbit items when a successful response is malformed" do
     SettingsService.set(:library_platform, "bookorbit")
     SettingsService.set(:bookorbit_url, "http://localhost:3000")

--- a/test/services/metadata_search/aggregator_test.rb
+++ b/test/services/metadata_search/aggregator_test.rb
@@ -48,6 +48,47 @@ module MetadataSearch
       assert_equal 2, results.size
     end
 
+    test "equivalent isbn-10 and isbn-13 editions merge in any input order" do
+      editions = [
+        provider_result(source: "google_books", source_id: "ten", isbn_10: "0-547-92822-x"),
+        provider_result(source: "openlibrary", source_id: "both", isbn_10: "054792822X", isbn_13: "9780547928227"),
+        provider_result(source: "google_books", source_id: "thirteen", isbn_13: "9780547928227")
+      ]
+
+      editions.permutation.each do |ordered|
+        candidates = Aggregator.call(ordered)
+        assert_equal 1, candidates.size
+        assert_equal 3, candidates.first.sources.size
+      end
+      assert_equal 1, Aggregator.call([ editions.first, editions.last ]).size
+    end
+
+    test "invalid isbn-10 check digits do not acquire a matching isbn-13 identity" do
+      candidates = Aggregator.call([
+        provider_result(source: "google_books", source_id: "invalid", isbn_10: "0547928220"),
+        provider_result(source: "openlibrary", source_id: "valid", isbn_13: "9780547928227")
+      ])
+
+      assert_equal 2, candidates.size
+    end
+
+    test "an isbn-less result cannot bridge conflicting editions in any input order" do
+      editions = [
+        provider_result(source: "google_books", source_id: "paperback", isbn_13: "9780441172719"),
+        provider_result(source: "openlibrary", source_id: "unknown"),
+        provider_result(source: "google_books", source_id: "hardcover", isbn_13: "9780593099322")
+      ]
+
+      editions.permutation.each do |ordered|
+        candidates = Aggregator.call(ordered)
+        assert_equal 2, candidates.size
+        candidates.each do |candidate|
+          ids = candidate.sources.map { |source| source[:source_id] }
+          refute ids.include?("paperback") && ids.include?("hardcover")
+        end
+      end
+    end
+
     test "keeps strongly classified books and graphics separate even when identity fields match" do
       results = Aggregator.call([
         provider_result(source: "hardcover", source_id: "book", title: "Dune", author: "Frank Herbert", year: 1965,

--- a/test/services/release_scorer_test.rb
+++ b/test/services/release_scorer_test.rb
@@ -40,6 +40,22 @@ class ReleaseScorerTest < ActiveSupport::TestCase
     assert_equal :audiobook, result.detected_format
   end
 
+  test "parses each release once while preserving its complete score" do
+    search_result = @request.search_results.new(
+      title: "The Name of the Wind - Patrick Rothfuss - English Audiobook M4B 128kbps",
+      seeders: 50
+    )
+    expected = ReleaseScorer.score(search_result, @request)
+    original_parse = ReleaseParserService.method(:parse)
+    parsed_titles = []
+
+    ReleaseParserService.stub(:parse, ->(title) { parsed_titles << title; original_parse.call(title) }) do
+      assert_equal expected, ReleaseScorer.score(search_result, @request)
+    end
+
+    assert_equal [ search_result.title ], parsed_titles
+  end
+
   test "scores low for wrong language" do
     search_result = @request.search_results.create!(
       guid: "test-2",

--- a/test/system/third_party_integrations_test.rb
+++ b/test/system/third_party_integrations_test.rb
@@ -38,6 +38,48 @@ class ThirdPartyIntegrationsTest < ApplicationSystemTestCase
     assert_field "Audiobookshelf URL"
   end
 
+  test "settings controls recover when Chrome reports a replaced click target" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    button = find_button("Integrations")
+    native = button.base.native
+    stale_clicks = 0
+
+    native.stub(:click, -> {
+      stale_clicks += 1
+      raise Selenium::WebDriver::Error::UnknownError, "Node with given id does not belong to the document"
+    }) do
+      button.click
+    end
+
+    assert_equal 1, stale_clicks
+    assert_field "Audiobookshelf URL"
+  end
+
+  test "settings text recovers from replaced nodes but preserves unrelated browser errors" do
+    sign_in_as(@admin)
+    visit admin_settings_path
+    button = find_button("Integrations")
+    stale_reads = 0
+
+    button.base.native.stub(:text, -> {
+      stale_reads += 1
+      raise Selenium::WebDriver::Error::UnknownError, "Node with given id does not belong to the document"
+    }) do
+      assert_match(/Integrations/, button.text)
+    end
+    assert_equal 1, stale_reads
+
+    unrelated_reads = 0
+    button.base.native.stub(:text, -> {
+      unrelated_reads += 1
+      raise Selenium::WebDriver::Error::UnknownError, "unrelated browser failure"
+    }) do
+      assert_raises(Selenium::WebDriver::Error::UnknownError) { button.text }
+    end
+    assert_equal 1, unrelated_reads
+  end
+
   test "history navigation waits for a pending autosave" do
     sign_in_as(@admin)
     visit admin_root_path


### PR DESCRIPTION
Library inventory sync previously issued roughly three SQL statements per item, and changing platforms during a sync could label one provider's inventory as another's. Download polling also reloaded the same client for every active download and could remain stopped after a failed monitor job.

This change batches inventory upserts in groups of 500, atomically preserves newer snapshots and original creation timestamps, and pins each sync to its starting platform. It preloads download clients per polling batch, counts already claimed monitors as pending, and adds a five-minute recovery task for failed monitor chains. Release scoring reuses its parsed title, and metadata aggregation prevents ISBN-less records from joining conflicting editions while recognizing equivalent valid ISBN-10/ISBN-13 identifiers.

Measured inventory SQL falls from 1,504 statements to 3 for 501 items; a 1,000-item inventory also uses 3 statements. Ten active downloads sharing a client now issue one client query instead of ten. No UI files or database schema changes.

Validation: regression tests first reproduced the defects, then passed after fixes; independent review caught and corrected an ISBN compatibility regression. Full `CI=true RAILS_ENV=test PARALLEL_WORKERS=1 bin/quality push` passed, including RuboCop, Brakeman, tests, system tests, and coverage. Focused tests cover the 500-row boundary, duplicate and blank inventory IDs, older snapshots, platform changes during discovery, claimed and failed monitor jobs, equivalent ISBN permutations, invalid ISBN checksums, and unchanged release scores.

CI additionally exposed a pre-existing live-update test race: delayed Turbo callbacks could target a later test after transaction rollback reused the request ID. The tests now use distinct request IDs, with a deterministic stale-callback regression. Production broadcasting and UI behavior are unchanged.

The system-test browser helper now maps Chrome's specific detached-node error into Capybara's existing bounded retry/reload path for all synchronized operations, extending its previous visibility-only handling. Real browser regressions verify click/text recovery and immediate propagation of unrelated errors. The final system suite passed 35 tests / 267 assertions.
