### PR TITLE
Pass indexer seed criteria to the download client

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -1370,7 +1370,7 @@ class DownloadJob < ApplicationJob
     torrent_hash = if search_result.from_anna_archive?
       client.add_torrent(download_url, validate_source_url: true)
     else
-      client.add_torrent(download_url)
+      client.add_torrent(download_url, seed_criteria_options(search_result))
     end
 
     if torrent_hash.present?
@@ -1448,7 +1448,7 @@ class DownloadJob < ApplicationJob
       success = external_id.present?
     else
       # qBittorrent now returns the torrent hash directly
-      external_id = client.add_torrent(download_link)
+      external_id = client.add_torrent(download_link, seed_criteria_options(search_result))
       success = external_id.present?
     end
 
@@ -1469,6 +1469,29 @@ class DownloadJob < ApplicationJob
         download_type: is_usenet ? "usenet" : "torrent"
       )
     end
+  end
+
+  # Seed rules the indexer configured in Prowlarr, translated into add_torrent
+  # options. Returns an empty hash whenever they are unknown so the download
+  # client keeps its own defaults instead of being handed a guess.
+  def seed_criteria_options(search_result)
+    return {} unless IndexerClients::Prowlarr.configured?
+
+    criteria = IndexerClients::Prowlarr.seed_criteria(search_result.indexer_id)
+    return {} unless criteria
+
+    options = {}
+    options[:ratio_limit] = criteria[:ratio] if criteria[:ratio]
+    options[:seeding_time_limit] = criteria[:seed_time] if criteria[:seed_time]
+
+    Rails.logger.info "[DownloadJob] Applying seed criteria from indexer #{search_result.indexer}: #{options.inspect}" if options.any?
+
+    options
+  rescue StandardError => e
+    # Seed limits are an optimisation over the client's defaults; never let a
+    # lookup failure block an otherwise healthy dispatch.
+    Rails.logger.warn "[DownloadJob] Failed to resolve seed criteria: #{e.message}"
+    {}
   end
 
   def claim_dispatch!(download, search_result)

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -579,6 +579,7 @@ class SearchJob < ApplicationJob
     search_result.assign_attributes(
       title: result.title,
       indexer: result.indexer,
+      indexer_id: result.indexer_id,
       size_bytes: result.size_bytes,
       seeders: result.seeders,
       leechers: result.leechers,

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -624,8 +624,39 @@ module DownloadClients
       params[:category] = config.category if config.category.present?
       params[:savepath] = options[:save_path] if options[:save_path].present?
       params[:paused] = options[:paused] ? "true" : "false" if options.key?(:paused)
+      params.merge!(share_limit_params(options))
       params.merge!(adapter_specific_add_torrent_params)
       params
+    end
+
+    # Per-torrent share limits, so a tracker's seed rules win over qBittorrent's
+    # global defaults. Omitted entirely when unknown: sending 0 would read as
+    # "stop immediately", where sending nothing leaves qBittorrent on the
+    # global limit (its -2 sentinel).
+    #
+    # Both qBittorrent's seedingTimeLimit and Prowlarr's seedTime are minutes,
+    # so no conversion is needed here.
+    def share_limit_params(options)
+      params = {}
+      ratio = positive_float(options[:ratio_limit])
+      seeding_time = positive_integer(options[:seeding_time_limit])
+      params[:ratioLimit] = ratio if ratio
+      params[:seedingTimeLimit] = seeding_time if seeding_time
+      params
+    end
+
+    def positive_float(value)
+      numeric = Float(value, exception: false)
+      return nil if numeric.nil? || numeric <= 0
+
+      numeric
+    end
+
+    def positive_integer(value)
+      numeric = Integer(value, exception: false)
+      return nil if numeric.nil? || numeric <= 0
+
+      numeric
     end
 
     def adapter_specific_add_torrent_params

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -37,6 +37,27 @@ module IndexerClients
         handle_response(response) { |data| Array(data) }
       end
 
+      # Seed criteria configured on the indexer in Prowlarr, so the download
+      # client can honour the tracker's rules. Prowlarr only exposes these on
+      # the indexer definition, never on a search result, so they have to be
+      # looked up by the result's indexerId.
+      #
+      # Returns nil when the indexer has no criteria configured or cannot be
+      # read: callers must leave the download client on its own defaults
+      # rather than substituting a guess.
+      def seed_criteria(indexer_id)
+        id = Integer(indexer_id, exception: false)
+        return nil unless id
+
+        indexer = indexers.find { |candidate| candidate["id"].to_i == id }
+        return nil unless indexer
+
+        extract_seed_criteria(indexer)
+      rescue IndexerClients::Base::Error => e
+        Rails.logger.warn "[IndexerClients::Prowlarr] Failed to read seed criteria for indexer #{indexer_id}: #{e.message}"
+        nil
+      end
+
       # Indexers Prowlarr would search on our behalf: every configured indexer,
       # or only the tagged subset when prowlarr_tags is set. Returns nil when
       # Prowlarr's indexer list cannot be read.
@@ -121,6 +142,32 @@ module IndexerClients
         []
       end
 
+      # Prowlarr stores indexer configuration as a flat array of name/value
+      # field hashes. A field carries no "value" key at all when the setting is
+      # empty, which means "use the download client default" and must stay nil.
+      def extract_seed_criteria(indexer)
+        fields = Array(indexer["fields"])
+        ratio = seed_field_value(fields, "torrentBaseSettings.seedRatio")
+        seed_time = seed_field_value(fields, "torrentBaseSettings.seedTime")
+
+        return nil if ratio.nil? && seed_time.nil?
+
+        { ratio: ratio&.to_f, seed_time: seed_time&.to_i }
+      end
+
+      def seed_field_value(fields, name)
+        field = fields.find { |candidate| candidate.is_a?(Hash) && candidate["name"] == name }
+        return nil unless field
+
+        value = field["value"]
+        return nil if value.nil? || value.to_s.strip.blank?
+
+        numeric = Float(value, exception: false)
+        return nil if numeric.nil? || numeric <= 0
+
+        numeric
+      end
+
       def normalized_indexer_tags(tags)
         tags.to_a.flat_map do |tag|
           case tag
@@ -171,6 +218,7 @@ module IndexerClients
           title: item["title"],
           indexer: item["indexer"],
           size_bytes: item["size"],
+          indexer_id: item["indexerId"],
           seeders: item["seeders"],
           leechers: item["leechers"],
           download_url: extract_download_url(item),

--- a/app/services/indexer_clients/result.rb
+++ b/app/services/indexer_clients/result.rb
@@ -2,15 +2,17 @@
 
 module IndexerClients
   Result = Data.define(
-    :guid, :title, :indexer, :size_bytes, :seeders, :leechers,
+    :guid, :title, :indexer, :indexer_id, :size_bytes, :seeders, :leechers,
     :download_url, :magnet_url, :info_url, :published_at, :category_ids
   ) do
     def initialize(
       guid:, title:, indexer:, size_bytes:, seeders:, leechers:,
-      download_url:, magnet_url:, info_url:, published_at:, category_ids: []
+      download_url:, magnet_url:, info_url:, published_at:, category_ids: [],
+      indexer_id: nil
     )
       super(
         guid:, title:, indexer:, size_bytes:, seeders:, leechers:,
+        indexer_id: Integer(indexer_id, exception: false),
         download_url:, magnet_url:, info_url:, published_at:,
         category_ids: Array(category_ids).filter_map { |id| Integer(id, exception: false) }.uniq
       )

--- a/db/migrate/20260907120000_add_indexer_id_to_search_results.rb
+++ b/db/migrate/20260907120000_add_indexer_id_to_search_results.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexerIdToSearchResults < ActiveRecord::Migration[8.1]
+  def change
+    add_column :search_results, :indexer_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_28_230000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -401,6 +401,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_230000) do
     t.string "download_url"
     t.string "guid", null: false
     t.string "indexer"
+    t.integer "indexer_id"
     t.string "info_url"
     t.integer "leechers"
     t.string "magnet_url"

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -1476,4 +1476,72 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
       assert_equal "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", result
     end
   end
+
+  test "add_torrent sends share limits when seed criteria are supplied" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      add_request = stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .with { |req| req.body.include?("ratioLimit=1.1") && req.body.include?("seedingTimeLimit=4320") }
+        .to_return(status: 200, body: "Ok.")
+
+      stub_request(:get, %r{http://localhost:8080/api/v2/torrents/info})
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+      @client.add_torrent("magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                          ratio_limit: 1.1, seeding_time_limit: 4320)
+
+      assert_requested add_request
+    end
+  end
+
+  test "add_torrent omits share limits when seed criteria are absent" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      add_request = stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .with { |req| !req.body.include?("ratioLimit") && !req.body.include?("seedingTimeLimit") }
+        .to_return(status: 200, body: "Ok.")
+
+      stub_request(:get, %r{http://localhost:8080/api/v2/torrents/info})
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+      @client.add_torrent("magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+
+      assert_requested add_request
+    end
+  end
+
+  test "add_torrent omits non-positive share limits rather than stopping the torrent immediately" do
+    VCR.turned_off do
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      add_request = stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .with { |req| !req.body.include?("ratioLimit") && !req.body.include?("seedingTimeLimit") }
+        .to_return(status: 200, body: "Ok.")
+
+      stub_request(:get, %r{http://localhost:8080/api/v2/torrents/info})
+        .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+      @client.add_torrent("magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                          ratio_limit: 0, seeding_time_limit: 0)
+
+      assert_requested add_request
+    end
+  end
 end

--- a/test/services/indexer_clients/prowlarr_seed_criteria_test.rb
+++ b/test/services/indexer_clients/prowlarr_seed_criteria_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class IndexerClients::ProwlarrSeedCriteriaTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:prowlarr_url, "http://localhost:9696")
+    SettingsService.set(:prowlarr_api_key, "prowlarr-api-key")
+    SettingsService.set(:prowlarr_tags, "")
+  end
+
+  teardown do
+    IndexerClients::Prowlarr.reset_connection!
+  end
+
+  test "seed_criteria reads ratio and seed time configured on the indexer" do
+    stub_indexers([
+      indexer_definition(id: 17, name: "Superbits", seed_ratio: 1.1, seed_time: 4320)
+    ])
+
+    criteria = IndexerClients::Prowlarr.seed_criteria(17)
+
+    assert_equal 1.1, criteria[:ratio]
+    assert_equal 4320, criteria[:seed_time]
+  end
+
+  test "seed_criteria returns nil when the indexer configures no seed rules" do
+    stub_indexers([ indexer_definition(id: 6, name: "LimeTorrents") ])
+
+    assert_nil IndexerClients::Prowlarr.seed_criteria(6)
+  end
+
+  test "seed_criteria returns nil for an unknown indexer id" do
+    stub_indexers([
+      indexer_definition(id: 17, name: "Superbits", seed_ratio: 1.1, seed_time: 4320)
+    ])
+
+    assert_nil IndexerClients::Prowlarr.seed_criteria(999)
+  end
+
+  test "seed_criteria returns nil when the indexer id is blank" do
+    assert_nil IndexerClients::Prowlarr.seed_criteria(nil)
+    assert_nil IndexerClients::Prowlarr.seed_criteria("")
+  end
+
+  test "seed_criteria ignores empty field values so client defaults are kept" do
+    stub_indexers([
+      indexer_definition(id: 18, name: "MyAnonamouse", seed_ratio: nil, seed_time: 10080)
+    ])
+
+    criteria = IndexerClients::Prowlarr.seed_criteria(18)
+
+    assert_nil criteria[:ratio]
+    assert_equal 10080, criteria[:seed_time]
+  end
+
+  test "seed_criteria returns nil when prowlarr cannot be reached" do
+    stub_request(:get, "http://localhost:9696/api/v1/indexer")
+      .to_return(status: 500, body: "boom")
+
+    assert_nil IndexerClients::Prowlarr.seed_criteria(17)
+  end
+
+  private
+
+  def stub_indexers(definitions)
+    stub_request(:get, "http://localhost:9696/api/v1/indexer")
+      .to_return(
+        status: 200,
+        body: definitions.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  # Mirrors Prowlarr's shape: a flat fields array where an unset setting simply
+  # carries no "value" key at all.
+  def indexer_definition(id:, name:, seed_ratio: nil, seed_time: nil)
+    fields = []
+    fields << field("torrentBaseSettings.seedRatio", seed_ratio)
+    fields << field("torrentBaseSettings.seedTime", seed_time)
+
+    { "id" => id, "name" => name, "enable" => true, "tags" => [], "fields" => fields }
+  end
+
+  def field(name, value)
+    value.nil? ? { "name" => name } : { "name" => name, "value" => value }
+  end
+end


### PR DESCRIPTION
Fixes #522.

## Problem

Seed ratio and seed time configured on an indexer in Prowlarr were never applied to the torrent, so every download fell back to the download client's global share limits. On a private tracker that means a torrent can stop seeding before the tracker's minimum is met.

## Why the value was lost

Prowlarr exposes these only on the **indexer definition** (`torrentBaseSettings.seedRatio` / `.seedTime` in `GET /api/v1/indexer`) — never on a search result. `GET /api/v1/search` returns no seed-criteria fields at all, which is why they can't simply be read off the result like `seeders`/`leechers`.

So the criteria have to be looked up by the result's `indexerId`. That id was previously discarded in `parse_result`, and search and dispatch are separate jobs, so it also has to be persisted.

## Change

- `IndexerClients::Prowlarr.seed_criteria(indexer_id)` reads the ratio and seed time off the indexer definition.
- `indexer_id` is carried through `IndexerClients::Result` and persisted on `search_results` (new nullable integer column).
- `DownloadClients::Qbittorrent` sends `ratioLimit` / `seedingTimeLimit` on `/torrents/add` — the endpoint accepts both, so no extra API call is needed. Covers both the URL and the `.torrent`-upload paths, since they share `build_add_torrent_params`.
- `DownloadJob` resolves the criteria at dispatch and passes them through.

## Design notes

- **Omitted, never defaulted.** When criteria are unknown the params are left out entirely rather than sent as `0` — a `0` would read as "stop immediately", where sending nothing leaves qBittorrent on its global limit (the `-2` sentinel). Prowlarr also omits the `value` key altogether when a field is empty, which is treated as "use the client default".
- **Units match.** Both qBittorrent's `seedingTimeLimit` and Prowlarr's `seedTime` are minutes, so there is no conversion. Deluge/Transmission use different units, so this deliberately stays in the qBittorrent adapter rather than being hoisted into the caller.
- **Never blocks a dispatch.** A lookup failure is logged and ignored; seed limits are an improvement over the client's defaults, not a precondition for downloading.
- Other indexer clients (Jackett, Newznab) are unaffected — `indexer_id` is an optional keyword defaulting to `nil`, and the other download adapters already ignore unknown option keys.

`packSeedTime` is intentionally out of scope: it needs a notion of "is this release a pack", which doesn't exist in the model yet.

## Testing

- New `test/services/indexer_clients/prowlarr_seed_criteria_test.rb` — 6 tests covering both directions: criteria present, no criteria configured, unknown indexer id, blank id, partially-set fields, and Prowlarr unreachable.
- 3 new qBittorrent adapter tests asserting the params are sent when criteria are supplied, and **absent** when they are not or are non-positive.
- `rails test test/services/download_clients/ test/services/indexer_clients/` → 159 runs, 399 assertions, 0 failures.
- Rubocop clean on all changed files.

Also verified against a live Prowlarr with 22 configured indexers: the 5 private trackers that have criteria set resolve to the expected `ratioLimit`/`seedingTimeLimit`, and the 17 without produce no params at all.
