### PR TITLE
Fix Audible backups with Libation 14.2 and safe device re-registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "faraday-multipart"
 # Fast JSON parser
 gem "oj"
 # Create zip archives for directory downloads
-gem "rubyzip", require: "zip"
+gem "rubyzip", ">= 3.4.0", require: "zip"
 # Parse .torrent files to extract info hash
 gem "bencode"
 # Extract metadata from media files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (3.2.2)
+    rubyzip (3.6.0)
     securerandom (0.4.1)
     selenium-webdriver (4.39.0)
       base64 (~> 0.2)
@@ -572,7 +572,7 @@ DEPENDENCIES
   rotp
   rqrcode
   rubocop-rails-omakase
-  rubyzip
+  rubyzip (>= 3.4.0)
   selenium-webdriver
   simplecov
   solid_cable

--- a/app/controllers/admin/owned_library_connections_controller.rb
+++ b/app/controllers/admin/owned_library_connections_controller.rb
@@ -119,7 +119,8 @@ module Admin
 
       auth_session = @connection.client.start_auth(
         account: params[:account],
-        locale: params[:locale]
+        locale: params[:locale],
+        reregister: ActiveModel::Type::Boolean.new.cast(params[:reregister])
       )
       if auth_session.authenticated
         clear_auth_start_claim(auth_request_token)

--- a/app/services/libation_companion_client.rb
+++ b/app/services/libation_companion_client.rb
@@ -178,7 +178,7 @@ class LibationCompanionClient
     end
   end
 
-  def start_auth(account:, locale:)
+  def start_auth(account:, locale:, reregister: false)
     account = account.to_s.strip
     locale = locale.to_s.strip.downcase
     raise ArgumentError, "Audible account is required" if account.blank? || account.length > 320
@@ -186,7 +186,7 @@ class LibationCompanionClient
 
     payload = post_json(
       "/v1/auth/start",
-      { "account" => account, "locale" => locale }
+      { "account" => account, "locale" => locale, "reregister" => reregister }
     )
 
     if payload["status"].to_s.casecmp("authenticated").zero?

--- a/app/views/admin/owned_library_connections/_account_sign_in_form.html.erb
+++ b/app/views/admin/owned_library_connections/_account_sign_in_form.html.erb
@@ -19,7 +19,7 @@
       <%= form.check_box :reregister, { checked: @audible_connected, class: "mt-1 rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500" }, "true", "false" %>
       <span>
         <span class="font-medium">Replace the stored Libation device registration</span>
-        <span class="mt-1 block text-gray-500">Required after a companion upgrade. Libation keeps the old device serial unless this email is removed and signed in again.</span>
+        <span class="mt-1 block text-gray-500">Use once after upgrading from Libation 13 to 14.2. This replaces the saved sign-in for this email and marketplace; other accounts and scan preferences are kept.</span>
       </span>
     </label>
   </div>

--- a/app/views/admin/owned_library_connections/_account_sign_in_form.html.erb
+++ b/app/views/admin/owned_library_connections/_account_sign_in_form.html.erb
@@ -14,6 +14,15 @@
       {},
       class: "mt-1 block w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-white focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
   </div>
+  <div class="sm:col-span-3">
+    <label class="flex items-start gap-2 text-sm text-gray-300">
+      <%= form.check_box :reregister, { checked: @audible_connected, class: "mt-1 rounded border-gray-600 bg-gray-800 text-blue-600 focus:ring-blue-500" }, "true", "false" %>
+      <span>
+        <span class="font-medium">Replace the stored Libation device registration</span>
+        <span class="mt-1 block text-gray-500">Required after a companion upgrade. Libation keeps the old device serial unless this email is removed and signed in again.</span>
+      </span>
+    </label>
+  </div>
   <%= form.submit "Start sign-in",
     data: { turbo_submits_with: "Starting sign-in…" },
     class: "rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500" %>

--- a/app/views/admin/owned_library_connections/_connection.html.erb
+++ b/app/views/admin/owned_library_connections/_connection.html.erb
@@ -198,7 +198,7 @@
         <p class="text-sm text-gray-400">Account changes become available after the current Libation operation finishes.</p>
       <% elsif @audible_connected %>
         <details class="rounded-md border border-gray-800 bg-gray-950/30">
-          <summary class="cursor-pointer px-4 py-3 text-sm font-medium text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500">Connect another Audible account</summary>
+          <summary class="cursor-pointer px-4 py-3 text-sm font-medium text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500">Reconnect or add an Audible account</summary>
           <div class="border-t border-gray-800 p-4">
             <%= render "account_sign_in_form" %>
           </div>

--- a/docs/audible-backup.md
+++ b/docs/audible-backup.md
@@ -261,7 +261,7 @@ If you already use Libation independently, keep that installation until the firs
 2. Open **Admin > Audible Backup** (or `/admin/owned_library_connections`).
 3. Check **Enable Audible Backup beta**, keep **Allow local/private companion address** enabled for the bundled service, and select **Save connection**.
 4. Enter the Audible account email address and choose its marketplace or region.
-5. Select **Start sign-in**. Shelfarr asks the companion to start Libation's external login flow and displays **Open secure Audible sign-in**.
+5. Select **Start sign-in**. After a companion upgrade that changes Libation's device registration, also check **Replace the stored Libation device registration** so Shelfarr removes the old login and Libation can register again. Ordinary first-time sign-in can leave that box unchecked. Shelfarr then starts Libation's external login flow and displays **Open secure Audible sign-in**.
 6. Complete the password, MFA, CAPTCHA, or account confirmation directly on Amazon/Audible.
 7. Copy the final redirected browser URL and paste it into Shelfarr when prompted.
 8. Select **Complete sign-in**, then run the initial library sync. After it completes, the Overview tab asks whether to queue a one-time backup of eligible existing purchases. That first snapshot is also required before automatic future-purchase backup can be enabled safely.
@@ -314,7 +314,7 @@ Shelfarr keeps the already validated **Open secure Audible sign-in** link only i
 
 The first beta accepts these marketplace choices: United States, United Kingdom, Australia, Canada, France, Germany, India, Italy, Japan, and Spain. Choose the marketplace where the account's Audible library is registered; it is not a display-language preference.
 
-An account may need to be reconnected if Audible expires its authorization or requires a new challenge. After a companion upgrade that changes Libation's device registration, complete sign-in again even if the stored account still looks authenticated; updating the image alone does not replace the old registration. Shelfarr stops automatic authentication retries in that state so it does not repeatedly trigger account security controls.
+An account may need to be reconnected if Audible expires its authorization or requires a new challenge. After a companion upgrade that changes Libation's device registration, expand **Reconnect or add an Audible account**, keep **Replace the stored Libation device registration** checked, and complete sign-in again even if the stored account still looks authenticated. Updating the image alone, or starting sign-in without that option, does not replace the old registration. Shelfarr stops automatic authentication retries in that state so it does not repeatedly trigger account security controls.
 
 ## Sync and back up the library
 
@@ -418,7 +418,7 @@ The bridge is an internal implementation detail and can change during beta. It i
 | `GET /health` | Unauthenticated process health check |
 | `GET /version` | Companion and pinned Libation version |
 | `GET /v1/accounts` | Configured account and authorization status |
-| `POST /v1/auth/start` | Start external login with an account email and locale |
+| `POST /v1/auth/start` | Start external login with an account email and locale. Optional `reregister` removes that stored login first so Libation can register a new device serial |
 | `POST /v1/auth/complete` | Complete the held login session with the final response URL |
 | `POST /v1/sync` | Queue an explicit library scan and export; returns `202 Accepted` |
 | `GET /v1/library` | Return the normalized cached owned library |
@@ -443,7 +443,7 @@ The companion pins Libation `14.2.0` using the immutable image reference:
 rmcrackan/libation:14.2.0@sha256:c0ab061d317621057e914c51506d57238d5b6afb158c4aa5801b2fa29b15d8db
 ```
 
-Libation 14.2 fixes widespread license-denied and `CustomerThrottled` failures caused by registering Android devices with a serial number twice the expected length. Updating the companion image does not replace an already stored device registration. After this upgrade, complete Audible sign-in again from **Admin > Audible Backup** so Libation can register a corrected device serial. If Audible is still rate-limiting the account, wait 24 to 48 hours and retry one title.
+Libation 14.2 fixes widespread license-denied and `CustomerThrottled` failures caused by registering Android devices with a serial number twice the expected length. Updating the companion image does not replace an already stored device registration. After this upgrade, open **Admin > Audible Backup**, expand **Reconnect or add an Audible account**, enter the same email and marketplace, keep **Replace the stored Libation device registration** checked, and complete sign-in again. Submitting the same account without that option still reports that Libation is already authenticated and leaves the old serial in place. If Audible is still rate-limiting the account, wait 24 to 48 hours and retry one title.
 
 The upstream Libation base never follows `latest`; its exact tag and digest are part of the companion build. The Compose example uses the same Shelfarr release selector for both application images:
 

--- a/docs/audible-backup.md
+++ b/docs/audible-backup.md
@@ -261,7 +261,7 @@ If you already use Libation independently, keep that installation until the firs
 2. Open **Admin > Audible Backup** (or `/admin/owned_library_connections`).
 3. Check **Enable Audible Backup beta**, keep **Allow local/private companion address** enabled for the bundled service, and select **Save connection**.
 4. Enter the Audible account email address and choose its marketplace or region.
-5. Select **Start sign-in**. After a companion upgrade that changes Libation's device registration, also check **Replace the stored Libation device registration** so Shelfarr removes the old login and Libation can register again. Ordinary first-time sign-in can leave that box unchecked. Shelfarr then starts Libation's external login flow and displays **Open secure Audible sign-in**.
+5. Select **Start sign-in**. After a companion upgrade that changes Libation's device registration, also check **Replace the stored Libation device registration** so Shelfarr resets the saved sign-in for that email and marketplace and Libation can register again. Other accounts and scan preferences are preserved. Ordinary first-time sign-in can leave that box unchecked. Shelfarr then starts Libation's external login flow and displays **Open secure Audible sign-in**.
 6. Complete the password, MFA, CAPTCHA, or account confirmation directly on Amazon/Audible.
 7. Copy the final redirected browser URL and paste it into Shelfarr when prompted.
 8. Select **Complete sign-in**, then run the initial library sync. After it completes, the Overview tab asks whether to queue a one-time backup of eligible existing purchases. That first snapshot is also required before automatic future-purchase backup can be enabled safely.
@@ -418,7 +418,7 @@ The bridge is an internal implementation detail and can change during beta. It i
 | `GET /health` | Unauthenticated process health check |
 | `GET /version` | Companion and pinned Libation version |
 | `GET /v1/accounts` | Configured account and authorization status |
-| `POST /v1/auth/start` | Start external login with an account email and locale. Optional `reregister` removes that stored login first so Libation can register a new device serial |
+| `POST /v1/auth/start` | Start external login with an account email and locale. Optional `reregister` resets only that email and marketplace registration first so Libation can register a new device serial |
 | `POST /v1/auth/complete` | Complete the held login session with the final response URL |
 | `POST /v1/sync` | Queue an explicit library scan and export; returns `202 Accepted` |
 | `GET /v1/library` | Return the normalized cached owned library |

--- a/docs/audible-backup.md
+++ b/docs/audible-backup.md
@@ -314,7 +314,7 @@ Shelfarr keeps the already validated **Open secure Audible sign-in** link only i
 
 The first beta accepts these marketplace choices: United States, United Kingdom, Australia, Canada, France, Germany, India, Italy, Japan, and Spain. Choose the marketplace where the account's Audible library is registered; it is not a display-language preference.
 
-An account may need to be reconnected if Audible expires its authorization or requires a new challenge. Shelfarr stops automatic authentication retries in that state so it does not repeatedly trigger account security controls.
+An account may need to be reconnected if Audible expires its authorization or requires a new challenge. After a companion upgrade that changes Libation's device registration, complete sign-in again even if the stored account still looks authenticated; updating the image alone does not replace the old registration. Shelfarr stops automatic authentication retries in that state so it does not repeatedly trigger account security controls.
 
 ## Sync and back up the library
 
@@ -437,11 +437,13 @@ Every endpoint except `/health` requires the generated bearer token. The compani
 
 ## Version pinning and upgrades
 
-The first companion beta pins Libation `13.5.1` using the immutable image reference:
+The companion pins Libation `14.2.0` using the immutable image reference:
 
 ```text
-rmcrackan/libation:13.5.1@sha256:71b9db4bbda7d7e14bb9f5efcdcfe980915c90867599bc0d512d958069fb3da0
+rmcrackan/libation:14.2.0@sha256:c0ab061d317621057e914c51506d57238d5b6afb158c4aa5801b2fa29b15d8db
 ```
+
+Libation 14.2 fixes widespread license-denied and `CustomerThrottled` failures caused by registering Android devices with a serial number twice the expected length. Updating the companion image does not replace an already stored device registration. After this upgrade, complete Audible sign-in again from **Admin > Audible Backup** so Libation can register a corrected device serial. If Audible is still rate-limiting the account, wait 24 to 48 hours and retry one title.
 
 The upstream Libation base never follows `latest`; its exact tag and digest are part of the companion build. The Compose example uses the same Shelfarr release selector for both application images:
 
@@ -471,11 +473,11 @@ Shelfarr's integration pages and companion releases include:
 
 - the exact Libation version and source release;
 - links to the [Libation project](https://github.com/rmcrackan/Libation) and [documentation](https://getlibation.com/docs);
-- Libation's [GPL-3.0 license](https://github.com/rmcrackan/Libation/blob/v13.5.1/LICENSE);
+- Libation's [GPL-3.0 license](https://github.com/rmcrackan/Libation/blob/v14.2.0/LICENSE);
 - the Shelfarr bridge source and a description of what Shelfarr adds;
 - preserved upstream notices and source-availability information.
 
-The exact image, digest, source commit, license, and source locations are recorded in the companion's [third-party notices](../services/libation_companion/THIRD_PARTY_NOTICES.md). Every distributed companion image also contains a machine-readable snapshot at `/companion/SOURCES/Libation-13.5.1-source.tar.gz`, so recipients do not depend solely on the continued availability of an upstream tag.
+The exact image, digest, source commit, license, and source locations are recorded in the companion's [third-party notices](../services/libation_companion/THIRD_PARTY_NOTICES.md). Every distributed companion image also contains a machine-readable snapshot at `/companion/SOURCES/Libation-14.2.0-source.tar.gz`, so recipients do not depend solely on the continued availability of an upstream tag.
 
 Report Shelfarr UI, packaging, or bridge problems to Shelfarr. Reproduce a problem against Libation itself before reporting it upstream, so Shelfarr-specific issues do not create support work for Libation's maintainers.
 

--- a/services/libation_companion/Dockerfile
+++ b/services/libation_companion/Dockerfile
@@ -38,20 +38,20 @@ RUN case "${TARGETARCH}" in \
 RUN git init --quiet /tmp/libation-source \
     && install -d /source-artifacts \
     && git -C /tmp/libation-source remote add origin https://github.com/rmcrackan/Libation.git \
-    && git -C /tmp/libation-source fetch --quiet --depth 1 origin 07c2f2b2a1deb8c57601c2b131aba30c95be3097 \
-    && test "$(git -C /tmp/libation-source rev-parse FETCH_HEAD)" = "07c2f2b2a1deb8c57601c2b131aba30c95be3097" \
+    && git -C /tmp/libation-source fetch --quiet --depth 1 origin 087c1076850d63f2ad172417535f3f0b025e722a \
+    && test "$(git -C /tmp/libation-source rev-parse FETCH_HEAD)" = "087c1076850d63f2ad172417535f3f0b025e722a" \
     && git -C /tmp/libation-source archive \
       --format=tar.gz \
-      --prefix=Libation-13.5.1/ \
-      --output=/source-artifacts/Libation-13.5.1-source.tar.gz \
+      --prefix=Libation-14.2.0/ \
+      --output=/source-artifacts/Libation-14.2.0-source.tar.gz \
       FETCH_HEAD \
     && printf '%s  %s\n' \
-      7391b9e4e34375e5d134932246ce0a50e0561efe1a24c2a3aa8f32a1217fac9f \
-      /source-artifacts/Libation-13.5.1-source.tar.gz \
+      662f065621f042c8cacd7c86a3f487f42cc490ed2ae96ce1f7566e7a491678b6 \
+      /source-artifacts/Libation-14.2.0-source.tar.gz \
       | sha256sum --check --strict
 
 # Keep this exact tag and manifest digest in sync with THIRD_PARTY_NOTICES.md.
-FROM rmcrackan/libation:13.5.1@sha256:71b9db4bbda7d7e14bb9f5efcdcfe980915c90867599bc0d512d958069fb3da0
+FROM rmcrackan/libation:14.2.0@sha256:c0ab061d317621057e914c51506d57238d5b6afb158c4aa5801b2fa29b15d8db
 
 USER root
 RUN test -x /libation/LibationCli \
@@ -66,7 +66,7 @@ COPY --chmod=0555 docker/entrypoint.sh /companion/entrypoint.sh
 COPY --chown=1000:1000 THIRD_PARTY_NOTICES.md /companion/THIRD_PARTY_NOTICES.md
 COPY --chown=1000:1000 LICENSES/Libation-GPL-3.0.txt /companion/LICENSES/Libation-GPL-3.0.txt
 COPY --chown=1000:1000 LICENSES/Libation-GPL-3.0.txt /companion/LICENSES/Shelfarr-GPL-3.0.txt
-COPY --from=companion-build --chown=1000:1000 /source-artifacts/Libation-13.5.1-source.tar.gz /companion/SOURCES/Libation-13.5.1-source.tar.gz
+COPY --from=companion-build --chown=1000:1000 /source-artifacts/Libation-14.2.0-source.tar.gz /companion/SOURCES/Libation-14.2.0-source.tar.gz
 
 ENV ASPNETCORE_URLS=http://0.0.0.0:8080 \
     DOTNET_EnableDiagnostics=0 \

--- a/services/libation_companion/README.md
+++ b/services/libation_companion/README.md
@@ -114,7 +114,10 @@ environment variable.
 Audible authentication is a two-request operation:
 
 1. `POST /v1/auth/start` starts one Libation `login-external` process and
-   returns the upstream browser login URL.
+   returns the upstream browser login URL. Pass `"reregister": true` to remove
+   that email from Libation's stored accounts first; a still-valid registration
+   otherwise exits as already authenticated and never issues a new device
+   serial.
 2. The user signs in directly on Amazon/Audible, then copies the final URL from
    the browser address bar.
 3. `POST /v1/auth/complete` writes that URL into the **same** held Libation
@@ -138,7 +141,7 @@ All JSON field names use camel case.
 | `GET /health` | Liveness, pinned versions, busy state, and whether a cached library exists |
 | `GET /version` | Bridge/API/Libation versions and upstream attribution |
 | `GET /v1/accounts` | Configured account, marketplace, scan-enabled and authentication status |
-| `POST /v1/auth/start` | Begin external-browser authentication |
+| `POST /v1/auth/start` | Begin external-browser authentication; optional `reregister` removes the stored login first |
 | `POST /v1/auth/complete` | Complete the held authentication session |
 | `POST /v1/sync` | Queue a serialized Libation scan followed by a normalized JSON export |
 | `GET /v1/library` | Read the complete last successful, local normalized library snapshot; never contacts Audible (legacy compatibility) |
@@ -152,9 +155,16 @@ Start authentication:
 POST /v1/auth/start
 {
   "account": "reader@example.com",
-  "locale": "us"
+  "locale": "us",
+  "reregister": false
 }
 ```
+
+Set `reregister` to `true` after a companion upgrade that changes Libation
+device registration. The companion removes that email from
+`AccountsSettings.json` and starts a new external login so Libation can
+register again. Ordinary first-time sign-in leaves `reregister` false or
+omitted.
 
 ```json
 {

--- a/services/libation_companion/README.md
+++ b/services/libation_companion/README.md
@@ -114,8 +114,8 @@ environment variable.
 Audible authentication is a two-request operation:
 
 1. `POST /v1/auth/start` starts one Libation `login-external` process and
-   returns the upstream browser login URL. Pass `"reregister": true` to remove
-   that email from Libation's stored accounts first; a still-valid registration
+   returns the upstream browser login URL. Pass `"reregister": true` to reset
+   that email and marketplace's stored registration first; a still-valid registration
    otherwise exits as already authenticated and never issues a new device
    serial.
 2. The user signs in directly on Amazon/Audible, then copies the final URL from
@@ -141,7 +141,7 @@ All JSON field names use camel case.
 | `GET /health` | Liveness, pinned versions, busy state, and whether a cached library exists |
 | `GET /version` | Bridge/API/Libation versions and upstream attribution |
 | `GET /v1/accounts` | Configured account, marketplace, scan-enabled and authentication status |
-| `POST /v1/auth/start` | Begin external-browser authentication; optional `reregister` removes the stored login first |
+| `POST /v1/auth/start` | Begin external-browser authentication; optional `reregister` resets the selected email and marketplace registration first |
 | `POST /v1/auth/complete` | Complete the held authentication session |
 | `POST /v1/sync` | Queue a serialized Libation scan followed by a normalized JSON export |
 | `GET /v1/library` | Read the complete last successful, local normalized library snapshot; never contacts Audible (legacy compatibility) |
@@ -161,10 +161,11 @@ POST /v1/auth/start
 ```
 
 Set `reregister` to `true` after a companion upgrade that changes Libation
-device registration. The companion removes that email from
-`AccountsSettings.json` and starts a new external login so Libation can
-register again. Ordinary first-time sign-in leaves `reregister` false or
-omitted.
+device registration. The companion resets only the identity tokens for that
+email and marketplace in `AccountsSettings.json` and starts a new external
+login so Libation can register again. Other registrations, account names, and
+scan preferences are preserved. Ordinary first-time sign-in leaves
+`reregister` false or omitted.
 
 ```json
 {

--- a/services/libation_companion/README.md
+++ b/services/libation_companion/README.md
@@ -12,12 +12,12 @@ The Shelfarr UI and documentation must describe the feature as **Audible Backup
 ## Packaging model
 
 The image is built from the unmodified multi-architecture
-`rmcrackan/libation:13.5.1` image at the manifest digest recorded in the
+`rmcrackan/libation:14.2.0` image at the manifest digest recorded in the
 [third-party notice](THIRD_PARTY_NOTICES.md). Do not replace the digest with a
 floating `latest` tag. The bridge is published as a self-contained .NET 10
 minimal API and the upstream Libation CLI remains a separate process.
 The build also places a machine-readable snapshot of the exact upstream source
-at `/companion/SOURCES/Libation-13.5.1-source.tar.gz`, beside the license and
+at `/companion/SOURCES/Libation-14.2.0-source.tar.gz`, beside the license and
 third-party notice in the distributed image. The independently licensed
 Shelfarr bridge has its own named license copy at
 `/companion/LICENSES/Shelfarr-GPL-3.0.txt`; OCI source and revision labels map
@@ -124,7 +124,7 @@ Audible authentication is a two-request operation:
 The session expires after ten minutes by default. It holds the global Libation
 operation lock because Libation state must not be mutated concurrently.
 
-Supported marketplace values for Libation 13.5.1 are:
+Supported marketplace values for Libation 14.2.0 are:
 
 `us`, `uk`, `australia`, `canada`, `france`, `germany`, `india`, `italy`,
 `japan`, and `spain`.
@@ -264,6 +264,9 @@ their image defaults.
   Libation and can require maintenance when Audible changes its service.
 - The pinned Libation release must be upgraded deliberately and tested against
   an existing state-volume copy. Never use an automatic `latest` updater.
+  Libation 14.2.0 also requires a fresh Audible sign-in after upgrade so the
+  corrected Android device serial can be registered; updating the image alone
+  does not replace an already stored registration.
 
 ## Development
 

--- a/services/libation_companion/THIRD_PARTY_NOTICES.md
+++ b/services/libation_companion/THIRD_PARTY_NOTICES.md
@@ -19,14 +19,14 @@ companion are independent projects and are not affiliated with Audible or
 Amazon.
 
 - Project: [rmcrackan/Libation](https://github.com/rmcrackan/Libation)
-- Version: `13.5.1`
-- Image: `rmcrackan/libation:13.5.1`
-- Manifest digest: `sha256:71b9db4bbda7d7e14bb9f5efcdcfe980915c90867599bc0d512d958069fb3da0`
-- Source commit: `07c2f2b2a1deb8c57601c2b131aba30c95be3097`
-- License: [GNU General Public License v3.0](https://github.com/rmcrackan/Libation/blob/v13.5.1/LICENSE)
-- Source for the distributed version: [Libation v13.5.1](https://github.com/rmcrackan/Libation/tree/v13.5.1)
-- Source snapshot in this image: `/companion/SOURCES/Libation-13.5.1-source.tar.gz`
-- Source snapshot SHA-256: `7391b9e4e34375e5d134932246ce0a50e0561efe1a24c2a3aa8f32a1217fac9f`
+- Version: `14.2.0`
+- Image: `rmcrackan/libation:14.2.0`
+- Manifest digest: `sha256:c0ab061d317621057e914c51506d57238d5b6afb158c4aa5801b2fa29b15d8db`
+- Source commit: `087c1076850d63f2ad172417535f3f0b025e722a`
+- License: [GNU General Public License v3.0](https://github.com/rmcrackan/Libation/blob/v14.2.0/LICENSE)
+- Source for the distributed version: [Libation v14.2.0](https://github.com/rmcrackan/Libation/tree/v14.2.0)
+- Source snapshot in this image: `/companion/SOURCES/Libation-14.2.0-source.tar.gz`
+- Source snapshot SHA-256: `662f065621f042c8cacd7c86a3f487f42cc490ed2ae96ce1f7566e7a491678b6`
 - Documentation: [getlibation.com/docs](https://getlibation.com/docs)
 
 Libation is Copyright (C) its authors and contributors. The Shelfarr project

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/CompanionOptions.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/CompanionOptions.cs
@@ -3,7 +3,7 @@ namespace Shelfarr.Libation.Companion;
 public sealed record CompanionOptions
 {
     public const string ApiVersion = "1";
-    public const string PinnedLibationVersion = "13.5.1";
+    public const string PinnedLibationVersion = "14.2.0";
 
     public required string LibationCliPath { get; init; }
     public required string LibationFilesDirectory { get; init; }

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/CompanionOptions.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/CompanionOptions.cs
@@ -23,6 +23,7 @@ public sealed record CompanionOptions
 
     public string JobsDirectory => Path.Combine(StateDirectory, "jobs");
     public string LibraryFile => Path.Combine(StateDirectory, "library.json");
+    public string AccountsSettingsFile => Path.Combine(LibationFilesDirectory, "AccountsSettings.json");
 
     public static CompanionOptions FromEnvironment()
     {

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Contracts.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Contracts.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 namespace Shelfarr.Libation.Companion;
 
-public sealed record AuthStartRequest(string? Account, string? Locale);
+public sealed record AuthStartRequest(string? Account, string? Locale, bool Reregister = false);
 public sealed record AuthCompleteRequest(string? SessionId, string? ResponseUrl);
 public sealed record AccountStatus(string Account, string Name, string Locale, bool ScanEnabled, bool Authenticated);
 

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AccountListParser.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AccountListParser.cs
@@ -1,0 +1,21 @@
+namespace Shelfarr.Libation.Companion.Libation;
+
+internal static class AccountListParser
+{
+    // Libation 13.5.1 emitted five tab-separated columns. 14.0+ appends an
+    // "also-scans" marketplace list last and keeps the first five stable, so
+    // a client that required exactly five columns would drop every account.
+    public static AccountStatus? TryParse(string line)
+    {
+        var fields = line.Split('\t');
+        if (fields.Length < 5 || string.IsNullOrWhiteSpace(fields[0]))
+            return null;
+
+        return new AccountStatus(
+            fields[0],
+            fields[1],
+            fields[2],
+            fields[3].Equals("yes", StringComparison.OrdinalIgnoreCase),
+            fields[4].Equals("yes", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AccountRegistrationReset.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AccountRegistrationReset.cs
@@ -10,7 +10,7 @@ internal static class AccountRegistrationReset
         WriteIndented = true
     };
 
-    public static int RemoveMatchingAccounts(string accountsFile, string account)
+    public static int ResetMatchingRegistration(string accountsFile, string account, string locale)
     {
         if (!Path.Exists(accountsFile))
             return 0;
@@ -26,21 +26,36 @@ internal static class AccountRegistrationReset
         if (root["Accounts"] is not JsonArray accounts)
             return 0;
 
-        var removed = 0;
-        for (var index = accounts.Count - 1; index >= 0; index--)
+        var reset = 0;
+        foreach (var node in accounts)
         {
-            if (!AccountIdEquals(accounts[index], account))
+            if (node is not JsonObject row || !AccountIdEquals(row, account)
+                || row["IdentityTokens"] is not JsonObject identity
+                || identity["LocaleName"] is not JsonValue localeValue
+                || localeValue.GetValueKind() != JsonValueKind.String
+                || !string.Equals(localeValue.GetValue<string>(), locale, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            accounts.RemoveAt(index);
-            removed++;
+            // AudibleApi 14.1's empty identity is invalid but retains the locale
+            // needed for Libation to upsert this row and start a fresh registration.
+            // Preserve account names, scan preferences, and other marketplaces.
+            row["IdentityTokens"] = new JsonObject
+            {
+                ["LocaleName"] = localeValue.GetValue<string>(),
+                ["ExistingAccessToken"] = new JsonObject
+                {
+                    ["TokenValue"] = "Atna|",
+                    ["Expires"] = "0001-01-01T00:00:00"
+                }
+            };
+            reset++;
         }
 
-        if (removed == 0)
+        if (reset == 0)
             return 0;
 
         WriteAtomically(accountsFile, root);
-        return removed;
+        return reset;
     }
 
     private static bool AccountIdEquals(JsonNode? node, string account)

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AccountRegistrationReset.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AccountRegistrationReset.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Shelfarr.Libation.Companion.Libation;
+
+internal static class AccountRegistrationReset
+{
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public static int RemoveMatchingAccounts(string accountsFile, string account)
+    {
+        if (!Path.Exists(accountsFile))
+            return 0;
+        if (File.ResolveLinkTarget(accountsFile, returnFinalTarget: false) is not null)
+            throw new InvalidOperationException("The Libation accounts file must be a regular file.");
+
+        var json = File.ReadAllText(accountsFile);
+        if (string.IsNullOrWhiteSpace(json))
+            return 0;
+
+        var root = JsonNode.Parse(json) as JsonObject
+            ?? throw new InvalidDataException("Libation accounts file is not a JSON object.");
+        if (root["Accounts"] is not JsonArray accounts)
+            return 0;
+
+        var removed = 0;
+        for (var index = accounts.Count - 1; index >= 0; index--)
+        {
+            if (!AccountIdEquals(accounts[index], account))
+                continue;
+
+            accounts.RemoveAt(index);
+            removed++;
+        }
+
+        if (removed == 0)
+            return 0;
+
+        WriteAtomically(accountsFile, root);
+        return removed;
+    }
+
+    private static bool AccountIdEquals(JsonNode? node, string account)
+    {
+        if (node is not JsonObject row)
+            return false;
+        if (row["AccountId"] is not JsonValue value || value.GetValueKind() != JsonValueKind.String)
+            return false;
+
+        return string.Equals(value.GetValue<string>(), account, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void WriteAtomically(string accountsFile, JsonObject root)
+    {
+        var temporary = $"{accountsFile}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(temporary, root.ToJsonString(WriteOptions));
+            File.Move(temporary, accountsFile, overwrite: true);
+        }
+        finally
+        {
+            File.Delete(temporary);
+        }
+    }
+}

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AuthSessionManager.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AuthSessionManager.cs
@@ -47,7 +47,7 @@ public sealed partial class AuthSessionManager : IAsyncDisposable
         try
         {
             if (reregister)
-                AccountRegistrationReset.RemoveMatchingAccounts(_options.AccountsSettingsFile, account);
+                AccountRegistrationReset.ResetMatchingRegistration(_options.AccountsSettingsFile, account, locale);
 
             process = new Process { StartInfo = CreateStartInfo(account, locale) };
             if (!process.Start())

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AuthSessionManager.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/AuthSessionManager.cs
@@ -31,7 +31,11 @@ public sealed partial class AuthSessionManager : IAsyncDisposable
         _coordinator = coordinator;
     }
 
-    public async Task<AuthStartResult> StartAsync(string account, string locale, CancellationToken cancellationToken)
+    public async Task<AuthStartResult> StartAsync(
+        string account,
+        string locale,
+        CancellationToken cancellationToken,
+        bool reregister = false)
     {
         var lease = await _coordinator.TryAcquireAsync(cancellationToken)
             ?? throw new CompanionBusyException();
@@ -42,6 +46,9 @@ public sealed partial class AuthSessionManager : IAsyncDisposable
 
         try
         {
+            if (reregister)
+                AccountRegistrationReset.RemoveMatchingAccounts(_options.AccountsSettingsFile, account);
+
             process = new Process { StartInfo = CreateStartInfo(account, locale) };
             if (!process.Start())
                 throw new InvalidOperationException("Libation login could not be started.");

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/BackupCliDiagnostics.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Libation/BackupCliDiagnostics.cs
@@ -23,13 +23,22 @@ internal static class BackupCliDiagnostics
                 "Audible did not offer an ADRM download for this title. Libation recommends Widevine for this title.");
         }
 
+        if (Contains(output, "account is being throttled")
+            || Contains(output, "CustomerThrottled")
+            || Contains(output, "Customer id being throttled"))
+        {
+            return new BackupCliFailure(
+                "customer_throttled",
+                "Audible is rate-limiting downloads for this account. Wait 24 to 48 hours, then retry. After upgrading the companion to Libation 14.2, reconnect the Audible account so Libation can register a corrected device serial.");
+        }
+
         if (Contains(output, "Audible denied a content license")
             || Contains(output, "content license denied")
             || Contains(output, "download not allowed for this account/title"))
         {
             return new BackupCliFailure(
                 "content_license_denied",
-                "Audible denied the download license for this account and title. Confirm that it is still downloadable in the connected marketplace.");
+                "Audible denied the download license for this account and title. Confirm that it is still downloadable in the connected marketplace. After a companion upgrade to Libation 14.2, reconnect the account if backups that previously worked now fail.");
         }
 
         if (Contains(output, "Cannot find decrypt. Final audio file already exists"))
@@ -81,10 +90,11 @@ internal static class BackupCliDiagnostics
                 "Libation cancelled the title backup before it completed.");
         }
 
-        // Libation 13.5.1 returns exit code 0 for per-title failures. Its
-        // actionable failures are written to stderr instead. Never expose that
-        // arbitrary text because upstream exception output may include URLs or
-        // account details, but do retain that the CLI itself reported a failure.
+        // Libation still returns exit code 0 for per-title failures as of
+        // 14.2.0. Its actionable failures are written to stderr instead. Never
+        // expose that arbitrary text because upstream exception output may
+        // include URLs or account details, but do retain that the CLI itself
+        // reported a failure.
         if (!string.IsNullOrWhiteSpace(result.StandardError))
         {
             return new BackupCliFailure(

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Program.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Program.cs
@@ -109,7 +109,7 @@ app.MapGet("/v1/accounts", async (CliCoordinator cli, CompanionOptions options, 
 
             var accounts = result.StandardOutput
                 .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(ParseAccount)
+                .Select(AccountListParser.TryParse)
                 .Where(account => account is not null)
                 .Cast<AccountStatus>()
                 .ToArray();
@@ -278,19 +278,6 @@ static string Version()
         return informational.Split('+', 2)[0];
 
     return Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "unknown";
-}
-
-static AccountStatus? ParseAccount(string line)
-{
-    var fields = line.Split('\t');
-    return fields.Length == 5
-        ? new AccountStatus(
-            fields[0],
-            fields[1],
-            fields[2],
-            fields[3].Equals("yes", StringComparison.OrdinalIgnoreCase),
-            fields[4].Equals("yes", StringComparison.OrdinalIgnoreCase))
-        : null;
 }
 
 public partial class Program { }

--- a/services/libation_companion/src/Shelfarr.Libation.Companion/Program.cs
+++ b/services/libation_companion/src/Shelfarr.Libation.Companion/Program.cs
@@ -142,7 +142,7 @@ app.MapPost("/v1/auth/start", async (
 
     try
     {
-        return Results.Ok(await sessions.StartAsync(account, locale, cancellationToken));
+        return Results.Ok(await sessions.StartAsync(account, locale, cancellationToken, request.Reregister));
     }
     catch (CompanionBusyException exception)
     {

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AccountListParserTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AccountListParserTests.cs
@@ -1,0 +1,41 @@
+using Shelfarr.Libation.Companion.Libation;
+
+namespace Shelfarr.Libation.Companion.Tests;
+
+public sealed class AccountListParserTests
+{
+    [Fact]
+    public void ParsesFiveColumnLibation1351BareOutput()
+    {
+        var account = AccountListParser.TryParse("reader@example.com\tReader\tus\tyes\tyes");
+
+        Assert.NotNull(account);
+        Assert.Equal("reader@example.com", account.Account);
+        Assert.Equal("Reader", account.Name);
+        Assert.Equal("us", account.Locale);
+        Assert.True(account.ScanEnabled);
+        Assert.True(account.Authenticated);
+    }
+
+    [Fact]
+    public void ParsesSixColumnLibation14BareOutputWithAlsoScans()
+    {
+        var account = AccountListParser.TryParse(
+            "reader@example.com\tReader\tgermany\tyes\tyes\tuk, us");
+
+        Assert.NotNull(account);
+        Assert.Equal("reader@example.com", account.Account);
+        Assert.Equal("germany", account.Locale);
+        Assert.True(account.ScanEnabled);
+        Assert.True(account.Authenticated);
+    }
+
+    [Theory]
+    [InlineData("No accounts configured.")]
+    [InlineData("reader@example.com\tReader\tus\tyes")]
+    [InlineData("")]
+    public void IgnoresNonAccountLines(string line)
+    {
+        Assert.Null(AccountListParser.TryParse(line));
+    }
+}

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AccountRegistrationResetTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AccountRegistrationResetTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Shelfarr.Libation.Companion.Libation;
+
+namespace Shelfarr.Libation.Companion.Tests;
+
+public sealed class AccountRegistrationResetTests
+{
+    [Fact]
+    public void RemovesMatchingAccountRowsAndPreservesTheRest()
+    {
+        using var temporary = new TemporaryDirectory();
+        var path = Path.Combine(temporary.Path, "AccountsSettings.json");
+        File.WriteAllText(path, """
+            {
+              "Accounts": [
+                { "AccountId": "reader@example.com", "AccountName": "Reader", "LibraryScan": true },
+                { "AccountId": "other@example.com", "AccountName": "Other", "LibraryScan": true }
+              ],
+              "Cdm": "keep-me"
+            }
+            """);
+
+        var removed = AccountRegistrationReset.RemoveMatchingAccounts(path, "Reader@example.com");
+
+        Assert.Equal(1, removed);
+        using var json = JsonDocument.Parse(File.ReadAllText(path));
+        var accounts = json.RootElement.GetProperty("Accounts");
+        Assert.Equal(1, accounts.GetArrayLength());
+        Assert.Equal("other@example.com", accounts[0].GetProperty("AccountId").GetString());
+        Assert.Equal("keep-me", json.RootElement.GetProperty("Cdm").GetString());
+    }
+
+    [Fact]
+    public void LeavesFileUnchangedWhenNoAccountMatches()
+    {
+        using var temporary = new TemporaryDirectory();
+        var path = Path.Combine(temporary.Path, "AccountsSettings.json");
+        const string original = """{"Accounts":[{"AccountId":"keep@example.com"}]}""";
+        File.WriteAllText(path, original);
+
+        Assert.Equal(0, AccountRegistrationReset.RemoveMatchingAccounts(path, "missing@example.com"));
+        Assert.Equal(original, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenTheSeededEmptyObjectHasNoAccounts()
+    {
+        using var temporary = new TemporaryDirectory();
+        var path = Path.Combine(temporary.Path, "AccountsSettings.json");
+        File.WriteAllText(path, "{}");
+
+        Assert.Equal(0, AccountRegistrationReset.RemoveMatchingAccounts(path, "reader@example.com"));
+        Assert.Equal("{}", File.ReadAllText(path));
+    }
+}

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AccountRegistrationResetTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AccountRegistrationResetTests.cs
@@ -6,50 +6,70 @@ namespace Shelfarr.Libation.Companion.Tests;
 public sealed class AccountRegistrationResetTests
 {
     [Fact]
-    public void RemovesMatchingAccountRowsAndPreservesTheRest()
+    public void ResetsOnlySelectedMarketplaceAndPreservesAccountPreferences()
     {
         using var temporary = new TemporaryDirectory();
         var path = Path.Combine(temporary.Path, "AccountsSettings.json");
         File.WriteAllText(path, """
             {
               "Accounts": [
-                { "AccountId": "reader@example.com", "AccountName": "Reader", "LibraryScan": true },
-                { "AccountId": "other@example.com", "AccountName": "Other", "LibraryScan": true }
+                { "AccountId": "reader@example.com", "AccountName": "Reader", "LibraryScan": false,
+                  "AdditionalLocaleNames": ["canada"], "DecryptKey": "keep-key",
+                  "IdentityTokens": {"LocaleName":"us", "DeviceSerialNumber":"old-us-serial", "RefreshToken":"old-token"} },
+                { "AccountId": "reader@example.com", "AccountName": "Reader UK", "LibraryScan": true,
+                  "IdentityTokens": {"LocaleName":"uk", "DeviceSerialNumber":"keep-uk-serial"} },
+                { "AccountId": "other@example.com", "AccountName": "Other", "LibraryScan": true,
+                  "IdentityTokens": {"LocaleName":"us", "DeviceSerialNumber":"keep-other-serial"} }
               ],
               "Cdm": "keep-me"
             }
             """);
+        using var original = JsonDocument.Parse(File.ReadAllText(path));
 
-        var removed = AccountRegistrationReset.RemoveMatchingAccounts(path, "Reader@example.com");
+        var reset = AccountRegistrationReset.ResetMatchingRegistration(path, "Reader@example.com", "us");
 
-        Assert.Equal(1, removed);
+        Assert.Equal(1, reset);
         using var json = JsonDocument.Parse(File.ReadAllText(path));
         var accounts = json.RootElement.GetProperty("Accounts");
-        Assert.Equal(1, accounts.GetArrayLength());
-        Assert.Equal("other@example.com", accounts[0].GetProperty("AccountId").GetString());
+        Assert.Equal(3, accounts.GetArrayLength());
+        Assert.Equal("Reader", accounts[0].GetProperty("AccountName").GetString());
+        Assert.False(accounts[0].GetProperty("LibraryScan").GetBoolean());
+        Assert.Equal("canada", accounts[0].GetProperty("AdditionalLocaleNames")[0].GetString());
+        Assert.Equal("keep-key", accounts[0].GetProperty("DecryptKey").GetString());
+        var identity = accounts[0].GetProperty("IdentityTokens");
+        Assert.Equal("us", identity.GetProperty("LocaleName").GetString());
+        Assert.Equal("Atna|", identity.GetProperty("ExistingAccessToken").GetProperty("TokenValue").GetString());
+        Assert.False(identity.TryGetProperty("DeviceSerialNumber", out _));
+        Assert.False(identity.TryGetProperty("RefreshToken", out _));
+        for (var index = 1; index < 3; index++)
+            Assert.True(JsonElement.DeepEquals(original.RootElement.GetProperty("Accounts")[index], accounts[index]));
         Assert.Equal("keep-me", json.RootElement.GetProperty("Cdm").GetString());
     }
 
-    [Fact]
-    public void LeavesFileUnchangedWhenNoAccountMatches()
+    [Theory]
+    [InlineData("missing@example.com", "us")]
+    [InlineData("keep@example.com", "uk")]
+    public void LeavesFileUnchangedWhenNoAccountAndMarketplaceMatch(string account, string locale)
     {
         using var temporary = new TemporaryDirectory();
         var path = Path.Combine(temporary.Path, "AccountsSettings.json");
-        const string original = """{"Accounts":[{"AccountId":"keep@example.com"}]}""";
+        const string original = """{"Accounts":[{"AccountId":"keep@example.com","IdentityTokens":{"LocaleName":"us"}}]}""";
         File.WriteAllText(path, original);
 
-        Assert.Equal(0, AccountRegistrationReset.RemoveMatchingAccounts(path, "missing@example.com"));
+        Assert.Equal(0, AccountRegistrationReset.ResetMatchingRegistration(path, account, locale));
         Assert.Equal(original, File.ReadAllText(path));
     }
 
-    [Fact]
-    public void ReturnsZeroWhenTheSeededEmptyObjectHasNoAccounts()
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"Accounts\":[null,{\"AccountId\":\"reader@example.com\"}]}")]
+    public void LeavesUnregisteredAccountsUnchanged(string original)
     {
         using var temporary = new TemporaryDirectory();
         var path = Path.Combine(temporary.Path, "AccountsSettings.json");
-        File.WriteAllText(path, "{}");
+        File.WriteAllText(path, original);
 
-        Assert.Equal(0, AccountRegistrationReset.RemoveMatchingAccounts(path, "reader@example.com"));
-        Assert.Equal("{}", File.ReadAllText(path));
+        Assert.Equal(0, AccountRegistrationReset.ResetMatchingRegistration(path, "reader@example.com", "us"));
+        Assert.Equal(original, File.ReadAllText(path));
     }
 }

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/ApiContractTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/ApiContractTests.cs
@@ -9,6 +9,12 @@ public sealed class ApiContractTests
     private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
 
     [Fact]
+    public void PinsTheLibationReleaseThatFixesDeviceSerialThrottling()
+    {
+        Assert.Equal("14.2.0", CompanionOptions.PinnedLibationVersion);
+    }
+
+    [Fact]
     public void BackupJobUsesArtifactPathsAndStringEnums()
     {
         var job = new CompanionJob(

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/ApiContractTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/ApiContractTests.cs
@@ -9,6 +9,17 @@ public sealed class ApiContractTests
     private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
 
     [Fact]
+    public void AuthStartRequestSerializesReregisterInCamelCase()
+    {
+        var request = new AuthStartRequest("reader@example.com", "us", true);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(request, WebJson));
+
+        Assert.True(json.RootElement.GetProperty("reregister").GetBoolean());
+        Assert.False(json.RootElement.TryGetProperty("Reregister", out _));
+    }
+
+    [Fact]
     public void PinsTheLibationReleaseThatFixesDeviceSerialThrottling()
     {
         Assert.Equal("14.2.0", CompanionOptions.PinnedLibationVersion);

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AuthSessionManagerTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AuthSessionManagerTests.cs
@@ -57,7 +57,7 @@ public sealed class AuthSessionManagerTests
     }
 
     [Fact]
-    public async Task ReregisterRemovesTheStoredAccountBeforeStartingLogin()
+    public async Task ReregisterResetsOnlyTheSelectedMarketplaceBeforeStartingLogin()
     {
         if (OperatingSystem.IsWindows() || !File.Exists("/usr/bin/script"))
             return;
@@ -84,7 +84,10 @@ public sealed class AuthSessionManagerTests
         options.EnsureDirectories();
         Directory.CreateDirectory(options.LibationFilesDirectory);
         await File.WriteAllTextAsync(options.AccountsSettingsFile, """
-            {"Accounts":[{"AccountId":"reader@example.com","AccountName":"Reader"}]}
+            {"Accounts":[
+              {"AccountId":"reader@example.com","AccountName":"Reader","IdentityTokens":{"LocaleName":"us","DeviceSerialNumber":"old-us-serial"}},
+              {"AccountId":"reader@example.com","AccountName":"Reader UK","IdentityTokens":{"LocaleName":"uk","DeviceSerialNumber":"keep-uk-serial"}}
+            ]}
             """);
 
         var coordinator = new CliCoordinator(options);
@@ -99,7 +102,12 @@ public sealed class AuthSessionManagerTests
 
         Assert.Equal("waiting_for_browser", started.Status);
         using (var accounts = JsonDocument.Parse(File.ReadAllText(options.AccountsSettingsFile)))
-            Assert.Equal(0, accounts.RootElement.GetProperty("Accounts").GetArrayLength());
+        {
+            var rows = accounts.RootElement.GetProperty("Accounts");
+            Assert.Equal(2, rows.GetArrayLength());
+            Assert.False(rows[0].GetProperty("IdentityTokens").TryGetProperty("DeviceSerialNumber", out _));
+            Assert.Equal("keep-uk-serial", rows[1].GetProperty("IdentityTokens").GetProperty("DeviceSerialNumber").GetString());
+        }
 
         var completed = await sessions.CompleteAsync(
             started.SessionId!,
@@ -108,4 +116,3 @@ public sealed class AuthSessionManagerTests
         Assert.Equal("authenticated", completed!.Status);
     }
 }
-

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AuthSessionManagerTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/AuthSessionManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Shelfarr.Libation.Companion.Libation;
 
 namespace Shelfarr.Libation.Companion.Tests;
@@ -54,4 +55,57 @@ public sealed class AuthSessionManagerTests
         Assert.Equal("authenticated", completed.Status);
         Assert.False(coordinator.IsBusy);
     }
+
+    [Fact]
+    public async Task ReregisterRemovesTheStoredAccountBeforeStartingLogin()
+    {
+        if (OperatingSystem.IsWindows() || !File.Exists("/usr/bin/script"))
+            return;
+
+        using var temporary = new TemporaryDirectory();
+        var wrapper = Path.Combine(temporary.Path, "fake-login.sh");
+        await File.WriteAllTextAsync(wrapper, """
+        #!/bin/sh
+        set -eu
+        echo "Open this URL in your web browser and sign in:"
+        echo "https://www.amazon.com/ap/signin?session=reregister"
+        IFS= read -r _
+        echo "Successfully authenticated account."
+        """);
+        File.SetUnixFileMode(wrapper,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var options = TestOptions.Create(temporary.Path) with
+        {
+            LoginWrapperPath = wrapper,
+            ShortCliTimeout = TimeSpan.FromSeconds(5),
+            AuthenticationSessionTimeout = TimeSpan.FromMinutes(2)
+        };
+        options.EnsureDirectories();
+        Directory.CreateDirectory(options.LibationFilesDirectory);
+        await File.WriteAllTextAsync(options.AccountsSettingsFile, """
+            {"Accounts":[{"AccountId":"reader@example.com","AccountName":"Reader"}]}
+            """);
+
+        var coordinator = new CliCoordinator(options);
+        await using var sessions = new AuthSessionManager(options, coordinator);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var started = await sessions.StartAsync(
+            "reader@example.com",
+            "us",
+            timeout.Token,
+            reregister: true);
+
+        Assert.Equal("waiting_for_browser", started.Status);
+        using (var accounts = JsonDocument.Parse(File.ReadAllText(options.AccountsSettingsFile)))
+            Assert.Equal(0, accounts.RootElement.GetProperty("Accounts").GetArrayLength());
+
+        var completed = await sessions.CompleteAsync(
+            started.SessionId!,
+            "https://www.amazon.com/ap/maplanding?ok=1",
+            timeout.Token);
+        Assert.Equal("authenticated", completed!.Status);
+    }
 }
+

--- a/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/BackupCliDiagnosticsTests.cs
+++ b/services/libation_companion/tests/Shelfarr.Libation.Companion.Tests/BackupCliDiagnosticsTests.cs
@@ -9,6 +9,12 @@ public sealed class BackupCliDiagnosticsTests
         "12 Rules: Audible returned no ADRM license (Sable acr:null). Some rare titles only download with Widevine.",
         "adrm_unavailable")]
     [InlineData(
+        "Audible denied a content license because this account is being throttled. Wait 24 to 48 hours before trying again. This is not a Libation bug.",
+        "customer_throttled")]
+    [InlineData(
+        "ContentLicenseDeniedException: CustomerThrottled\nCustomer id being throttled",
+        "customer_throttled")]
+    [InlineData(
         "Audible denied a content license (download not allowed for this account/title).",
         "content_license_denied")]
     [InlineData("Cannot find decrypt. Final audio file already exists", "existing_audio_not_found")]
@@ -22,6 +28,21 @@ public sealed class BackupCliDiagnosticsTests
 
         Assert.NotNull(failure);
         Assert.Equal(expectedCode, failure.Code);
+    }
+
+    [Fact]
+    public void SurfacesThrottleGuidanceWithoutExposingUpstreamText()
+    {
+        var failure = BackupCliDiagnostics.Classify(new CliResult(
+            0,
+            "",
+            "Audible denied a content license because this account is being throttled. token=secret"));
+
+        Assert.NotNull(failure);
+        Assert.Equal("customer_throttled", failure.Code);
+        Assert.Contains("24 to 48 hours", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("reconnect", failure.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("secret", failure.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/services/libation_companion/tests/container-smoke.sh
+++ b/services/libation_companion/tests/container-smoke.sh
@@ -131,15 +131,15 @@ image_license="$(docker exec -u 0 "${container}" sha256sum /companion/LICENSES/L
 test "${image_license}" = "${expected_license}"
 shelfarr_license="$(docker exec -u 0 "${container}" sha256sum /companion/LICENSES/Shelfarr-GPL-3.0.txt | sed 's/ .*//')"
 test "${shelfarr_license}" = "${expected_license}"
-docker exec -u 23456:23456 "${container}" test -r /companion/SOURCES/Libation-13.5.1-source.tar.gz
+docker exec -u 23456:23456 "${container}" test -r /companion/SOURCES/Libation-14.2.0-source.tar.gz
 source_archive_sha="$(docker exec -u 23456:23456 "${container}" \
-  sha256sum /companion/SOURCES/Libation-13.5.1-source.tar.gz | sed 's/ .*//')"
-test "${source_archive_sha}" = "7391b9e4e34375e5d134932246ce0a50e0561efe1a24c2a3aa8f32a1217fac9f"
-docker exec -u 23456:23456 "${container}" tar -tzf /companion/SOURCES/Libation-13.5.1-source.tar.gz \
-  Libation-13.5.1/Source/LibationCli/LibationCli.csproj >/dev/null
+  sha256sum /companion/SOURCES/Libation-14.2.0-source.tar.gz | sed 's/ .*//')"
+test "${source_archive_sha}" = "662f065621f042c8cacd7c86a3f487f42cc490ed2ae96ce1f7566e7a491678b6"
+docker exec -u 23456:23456 "${container}" tar -tzf /companion/SOURCES/Libation-14.2.0-source.tar.gz \
+  Libation-14.2.0/Source/LibationCli/LibationCli.csproj >/dev/null
 libation_output="$(docker exec -u 23456:23456 "${container}" /libation/LibationCli 2>&1 || true)"
 libation_version="$(printf '%s\n' "${libation_output}" | sed -n '1s/^LibationCli v//p')"
-test "${libation_version}" = "13.5.1"
+test "${libation_version}" = "14.2.0"
 
 unauthorized="$(curl --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${port}/version")"
 test "${unauthorized}" = "401"
@@ -147,7 +147,7 @@ test "${unauthorized}" = "401"
 token="$(docker exec -u 23456:23456 "${container}" sed -n '1p' /control/token)"
 version_response="$(curl --fail --silent -H "Authorization: Bearer ${token}" "http://127.0.0.1:${port}/version")"
 printf '%s' "${version_response}" | grep -q '"companionVersion":"0.0.0"'
-printf '%s' "${version_response}" | grep -q '"libationVersion":"13.5.1"'
+printf '%s' "${version_response}" | grep -q '"libationVersion":"14.2.0"'
 accounts_response="$(curl --fail --silent -H "Authorization: Bearer ${token}" "http://127.0.0.1:${port}/v1/accounts")"
 printf '%s' "${accounts_response}" | grep -q '"accounts":\[\]'
 
@@ -287,7 +287,7 @@ docker exec -u 23456:23456 \
   umask 077
   mkdir -p /config/shelfarr-companion/jobs /config/in-progress/example /data/Example\ Book
   printf "%s" "{\"id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"kind\":\"sync\",\"status\":\"succeeded\",\"createdAt\":\"${JOB_CREATED_AT}\",\"completedAt\":\"${JOB_COMPLETED_AT}\"}" > /config/shelfarr-companion/jobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json
-  printf "%s" "{\"schemaVersion\":1,\"generatedAt\":\"2026-07-18T00:00:00Z\",\"libationVersion\":\"13.5.1\",\"skippedItems\":0,\"items\":[]}" > /config/shelfarr-companion/library.json
+  printf "%s" "{\"schemaVersion\":1,\"generatedAt\":\"2026-07-18T00:00:00Z\",\"libationVersion\":\"14.2.0\",\"skippedItems\":0,\"items\":[]}" > /config/shelfarr-companion/library.json
   printf chunk > /config/in-progress/example/chunk.partial
   printf sidecar > /config/LibationContext.db-wal.audit
   printf audio > "/data/Example Book/example.m4b"

--- a/test/config/docker_workflow_test.rb
+++ b/test/config/docker_workflow_test.rb
@@ -180,19 +180,20 @@ class DockerWorkflowTest < ActiveSupport::TestCase
     assert_includes dockerfile,
       "mcr.microsoft.com/dotnet/sdk:10.0.302-noble@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664"
     assert_includes dockerfile,
-      "rmcrackan/libation:13.5.1@sha256:71b9db4bbda7d7e14bb9f5efcdcfe980915c90867599bc0d512d958069fb3da0"
-    assert_includes dockerfile, "07c2f2b2a1deb8c57601c2b131aba30c95be3097"
-    assert_includes dockerfile, "Libation-13.5.1-source.tar.gz"
+      "rmcrackan/libation:14.2.0@sha256:c0ab061d317621057e914c51506d57238d5b6afb158c4aa5801b2fa29b15d8db"
+    assert_includes dockerfile, "087c1076850d63f2ad172417535f3f0b025e722a"
+    assert_includes dockerfile, "Libation-14.2.0-source.tar.gz"
+    assert_includes dockerfile, "662f065621f042c8cacd7c86a3f487f42cc490ed2ae96ce1f7566e7a491678b6"
     assert_equal "10.0.302", sdk.dig("sdk", "version")
     assert_equal "disable", sdk.dig("sdk", "rollForward")
     assert_equal Rails.root.join("LICENSE").binread, packaged_license
 
-    assert_includes notice, "Version: `13.5.1`"
+    assert_includes notice, "Version: `14.2.0`"
     assert_includes notice,
-      "Manifest digest: `sha256:71b9db4bbda7d7e14bb9f5efcdcfe980915c90867599bc0d512d958069fb3da0`"
-    assert_includes notice, "Source commit: `07c2f2b2a1deb8c57601c2b131aba30c95be3097`"
+      "Manifest digest: `sha256:c0ab061d317621057e914c51506d57238d5b6afb158c4aa5801b2fa29b15d8db`"
+    assert_includes notice, "Source commit: `087c1076850d63f2ad172417535f3f0b025e722a`"
     assert_includes notice,
-      "Source snapshot SHA-256: `7391b9e4e34375e5d134932246ce0a50e0561efe1a24c2a3aa8f32a1217fac9f`"
+      "Source snapshot SHA-256: `662f065621f042c8cacd7c86a3f487f42cc490ed2ae96ce1f7566e7a491678b6`"
   end
 
   test "release build helper images are pinned" do

--- a/test/controllers/admin/owned_library_connections_controller_test.rb
+++ b/test/controllers/admin/owned_library_connections_controller_test.rb
@@ -540,9 +540,10 @@ class Admin::OwnedLibraryConnectionsControllerTest < ActionDispatch::Integration
     connection = create_connection
     client = Object.new
     client.define_singleton_method(:token_file_managed?) { false }
-    client.define_singleton_method(:start_auth) do |account:, locale:|
+    client.define_singleton_method(:start_auth) do |account:, locale:, reregister: false|
       raise "missing starting claim" unless connection.reload.auth_starting?
       raise "unexpected account" unless account == "reader@example.com" && locale == "us"
+      raise "unexpected reregister" if reregister
 
       LibationCompanionClient::AuthSession.new(
         "session-1",
@@ -1015,6 +1016,45 @@ class Admin::OwnedLibraryConnectionsControllerTest < ActionDispatch::Integration
 
     assert_redirected_to admin_owned_library_connections_path(tab: "connection", anchor: "connection")
     assert_match(/already authenticated/, flash[:notice])
+  end
+
+  test "reregister starts a new login instead of accepting the stored registration" do
+    connection = create_connection
+
+    VCR.turned_off do
+      stub_accounts(connection)
+      stub_request(:post, "https://libation.test/v1/auth/start")
+        .with { |request| JSON.parse(request.body)["reregister"] == true }
+        .to_return(
+          status: 200,
+          body: {
+            sessionId: "session-reregister",
+            loginUrl: "https://www.amazon.com/ap/signin?example=1",
+            expiresAt: 10.minutes.from_now.iso8601
+          }.to_json
+        )
+
+      post auth_start_admin_owned_library_connection_url(connection),
+        params: { account: "reader@example.com", locale: "us", reregister: "true" }
+    end
+
+    assert_response :success
+    assert_select "a[href='https://www.amazon.com/ap/signin?example=1']", text: /Open secure Audible sign-in/
+    assert_not_equal "This Audible account is already authenticated in Libation.", flash[:notice]
+  end
+
+  test "connected account form exposes registration replacement" do
+    connection = create_connection
+
+    VCR.turned_off do
+      stub_accounts(connection)
+      get admin_owned_library_connections_url
+    end
+
+    assert_response :success
+    assert_select "summary", text: "Reconnect or add an Audible account"
+    assert_select "input[name='reregister'][value='true']"
+    assert_select "label", text: /Replace the stored Libation device registration/
   end
 
   test "sync queues a background job" do

--- a/test/jobs/download_monitor_job_test.rb
+++ b/test/jobs/download_monitor_job_test.rb
@@ -115,10 +115,10 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
 
   test "does not start another monitor while one is claimed by a worker" do
     with_solid_queue_monitor_jobs do |monitor_jobs|
-      DownloadMonitorJob.perform_later
+      job = DownloadMonitorJob.perform_later
       worker = SolidQueue::Process.register(kind: "Worker", name: "monitor-test", pid: Process.pid)
-      claimed = SolidQueue::ReadyExecution.claim([ "*" ], 1, worker.id).first
-      assert claimed
+      claimed = SolidQueue::ReadyExecution.where(job_id: job.provider_job_id).claim([ "*" ], 1, worker.id).first
+      assert_equal job.job_id, claimed&.job&.active_job_id
 
       assert_no_difference -> { monitor_jobs.count } do
         DownloadMonitorJob.ensure_running!
@@ -136,9 +136,13 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
     assert task.valid?, task.errors.full_messages.join(", ")
 
     with_solid_queue_monitor_jobs do |monitor_jobs|
-      DownloadMonitorJob.perform_later
+      # Other tests can leave unrelated jobs in the queue database. Claim the
+      # specific monitor rather than failing whichever job happens to be first.
+      unrelated_job = SolidQueue::RecurringJob.set(priority: -100).perform_later("nil")
+      job = DownloadMonitorJob.perform_later
       worker = SolidQueue::Process.register(kind: "Worker", name: "monitor-recovery-test", pid: Process.pid)
-      claimed = SolidQueue::ReadyExecution.claim([ "*" ], 1, worker.id).first
+      claimed = SolidQueue::ReadyExecution.where(job_id: job.provider_job_id).claim([ "*" ], 1, worker.id).first
+      assert_equal job.job_id, claimed&.job&.active_job_id
       claimed.failed_with(RuntimeError.new("interrupted polling"))
       claimed.unblock_next_job
 
@@ -148,7 +152,9 @@ class DownloadMonitorJobTest < ActiveJob::TestCase
       assert_no_difference -> { monitor_jobs.count } do
         SolidQueue::RecurringJob.perform_now(task.command)
       end
+      assert SolidQueue::ReadyExecution.exists?(job_id: unrelated_job.provider_job_id)
     ensure
+      SolidQueue::Job.find_by(active_job_id: unrelated_job.job_id)&.destroy! if unrelated_job
       worker&.destroy!
     end
   end

--- a/test/services/libation_companion_client_test.rb
+++ b/test/services/libation_companion_client_test.rb
@@ -217,7 +217,11 @@ class LibationCompanionClientTest < ActiveSupport::TestCase
     VCR.turned_off do
       stub_request(:post, "https://libation.test/v1/auth/start")
         .with do |request|
-          JSON.parse(request.body) == { "account" => "reader@example.com", "locale" => "uk" }
+          JSON.parse(request.body) == {
+            "account" => "reader@example.com",
+            "locale" => "uk",
+            "reregister" => false
+          }
         end
         .to_return(
           status: 200,
@@ -236,6 +240,31 @@ class LibationCompanionClientTest < ActiveSupport::TestCase
 
     assert_raises(ArgumentError) do
       @client.start_auth(account: "reader@example.com", locale: "brazil")
+    end
+  end
+
+  test "asks the companion to replace a stored device registration" do
+    VCR.turned_off do
+      stub_request(:post, "https://libation.test/v1/auth/start")
+        .with do |request|
+          JSON.parse(request.body) == {
+            "account" => "reader@example.com",
+            "locale" => "us",
+            "reregister" => true
+          }
+        end
+        .to_return(
+          status: 200,
+          body: {
+            sessionId: "session-2",
+            loginUrl: "https://www.amazon.com/ap/signin?example=1",
+            expiresAt: 10.minutes.from_now.iso8601
+          }.to_json
+        )
+
+      auth = @client.start_auth(account: "reader@example.com", locale: "us", reregister: true)
+      assert_equal "session-2", auth.session_id
+      assert_not auth.authenticated
     end
   end
 

--- a/test/support/solid_queue_in_puma_probe.rb
+++ b/test/support/solid_queue_in_puma_probe.rb
@@ -149,9 +149,12 @@ begin
 
   if mode == "single"
     Process.kill(:USR2, puma_pid)
-    wait_for("replacement queue supervisor after hot restart") { supervisors.one? && supervisors.first != supervisor_pid }
+    replacement_pid = wait_for("replacement queue supervisor after hot restart") do
+      pids = supervisors
+      pids.first if pids.one? && pids.first != supervisor_pid
+    end
     wait_for("old supervisor exit") { !process_exists?(supervisor_pid) }
-    supervisor_pid = supervisors.first
+    supervisor_pid = replacement_pid
     Process.kill(:TERM, puma_pid)
     raise "Puma did not stop" unless puma_waiter.join(25)
     wait_for("queue shutdown") { !process_exists?(supervisor_pid) }


### PR DESCRIPTION
## Assigned issue

Closes #524

## What changed

Pins the companion to Libation 14.2.0 and its matching image/source digests to pick up the upstream device-serial correction for Audible license-denied and CustomerThrottled failures. Existing registrations also need a fresh sign-in: Admin → Audible Backup now exposes a registration-replacement checkbox and the companion accepts `reregister: true`.

Re-registering an email in the US marketplace resets only that registration's identity tokens. A UK registration for the same email, other accounts, account names, decryption settings, and scan preferences remain intact. Libation then creates a new device registration instead of returning "already authenticated".

Also accepts Libation 14's extra account-list column, classifies the updated throttle message without exposing upstream error text, and documents the upgrade/reconnect steps. The rubyzip 3.6.0 update clears the existing dependency advisory.

CI exposed an existing race in the Puma lifecycle test: two database reads during restart could mistake a temporarily missing supervisor for its replacement. The probe now captures the replacement PID from a single snapshot. A later coverage failure exposed a second test-isolation flaw: the recovery test could claim and fail an unrelated queued job. Both monitor tests now claim their specific enqueued monitor; a regression deliberately queues higher-priority unrelated work and verifies it stays untouched. Production queue behavior is unchanged.

## Verification

- Local `bin/quality push` passed before the test-probe correction, including RuboCop, Brakeman, unit/integration tests, system tests, and coverage.
- Rails controller/client/container-configuration checks: 126 tests, 762 assertions, no failures or errors.
- Companion: locked restore, both format checks, and 103 tests passed using the pinned .NET 10.0.302 SDK image.
- A separate harness feeds the actual reset implementation's output to AudibleApi 14.1.0. It confirms the selected identity becomes unauthenticated, UK/other-email identities remain valid, preferences survive, and the fresh external-login callback is reached.
- Puma lifecycle checks after the probe correction: 11 tests, 40 assertions, no failures or errors, including a run with all three reviewed PRs combined.
- Download-monitor checks after the isolation correction: 38 tests, 120 assertions, no failures or errors. The formerly failing coverage seed also passed locally (3,345 tests, 12,863 assertions, one existing skip).
- The combined changes passed the full local quality gate; the later test-only corrections passed their focused suites.
- Independent adversarial review and follow-up review found no remaining defects. [Final GitHub CI](https://github.com/Pedro-Revez-Silva/shelfarr/actions/runs/34270811617) passed on head `22c0f52`, including quality/coverage, companion, dependency audit, both filesystem architectures, and the container build; CodeQL also passed before merge.

No live Audible credentials or audiobook downloads were used; the reported account's actual post-upgrade recovery remains dependent on completing sign-in and any upstream throttling clearing.

## Screenshots or recordings

The added checkbox and authentication handoff are covered by rendered controller tests. No live UI recording was captured.

## Checklist

- [x] The linked issue is assigned to the PR author
- [x] The change addresses the assigned issue
- [x] Behavior and regression tests are included
- [x] Relevant local quality checks passed
- [x] User-facing upgrade documentation is updated