### PR TITLE
Forward Prowlarr indexer seed criteria to the download client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "faraday-multipart"
 # Fast JSON parser
 gem "oj"
 # Create zip archives for directory downloads
-gem "rubyzip", require: "zip"
+gem "rubyzip", ">= 3.4.0", require: "zip"
 # Parse .torrent files to extract info hash
 gem "bencode"
 # Extract metadata from media files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (3.2.2)
+    rubyzip (3.6.0)
     securerandom (0.4.1)
     selenium-webdriver (4.39.0)
       base64 (~> 0.2)
@@ -572,7 +572,7 @@ DEPENDENCIES
   rotp
   rqrcode
   rubocop-rails-omakase
-  rubyzip
+  rubyzip (>= 3.4.0)
   selenium-webdriver
   simplecov
   solid_cable

--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -1367,11 +1367,7 @@ class DownloadJob < ApplicationJob
     Rails.logger.info "[DownloadJob] Using client '#{client_record.name}' for download ##{download.id}"
 
     # add_torrent now returns the hash directly (or nil on failure)
-    torrent_hash = if search_result.from_anna_archive?
-      client.add_torrent(download_url, validate_source_url: true)
-    else
-      client.add_torrent(download_url)
-    end
+    torrent_hash = client.add_torrent(download_url, torrent_client_options(search_result))
 
     if torrent_hash.present?
       finalize_standard_dispatch!(
@@ -1385,6 +1381,19 @@ class DownloadJob < ApplicationJob
     else
       fail_standard_dispatch!(download, search_result, client_record, download_type: "torrent")
     end
+  end
+
+  def torrent_client_options(search_result)
+    options = {}
+    options[:validate_source_url] = true if search_result.from_anna_archive?
+    options.merge!(seed_criteria_for(search_result))
+    options
+  end
+
+  def seed_criteria_for(search_result)
+    return {} unless search_result.from_prowlarr?
+
+    IndexerClients::Prowlarr.seed_criteria(search_result.indexer_id)
   end
 
   def send_to_usenet_client(download, search_result, nzb_url)
@@ -1448,7 +1457,7 @@ class DownloadJob < ApplicationJob
       success = external_id.present?
     else
       # qBittorrent now returns the torrent hash directly
-      external_id = client.add_torrent(download_link)
+      external_id = client.add_torrent(download_link, torrent_client_options(search_result))
       success = external_id.present?
     end
 

--- a/app/jobs/search_job.rb
+++ b/app/jobs/search_job.rb
@@ -579,6 +579,7 @@ class SearchJob < ApplicationJob
     search_result.assign_attributes(
       title: result.title,
       indexer: result.indexer,
+      indexer_id: result.try(:indexer_id),
       size_bytes: result.size_bytes,
       seeders: result.seeders,
       leechers: result.leechers,

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -631,10 +631,10 @@ module DownloadClients
 
     def apply_seed_limits!(params, options)
       ratio = Float(options[:seed_ratio], exception: false)
-      params[:ratioLimit] = ratio if ratio&.positive?
+      params[:ratioLimit] = ratio if ratio&.finite? && (ratio >= 0 || [ -1, -2 ].include?(ratio))
 
-      time = Float(options[:seed_time], exception: false)&.to_i
-      params[:seedingTimeLimit] = time if time&.positive?
+      time = Integer(options[:seed_time], exception: false)
+      params[:seedingTimeLimit] = time if time && time >= -2
     end
 
     def adapter_specific_add_torrent_params

--- a/app/services/download_clients/qbittorrent.rb
+++ b/app/services/download_clients/qbittorrent.rb
@@ -624,8 +624,17 @@ module DownloadClients
       params[:category] = config.category if config.category.present?
       params[:savepath] = options[:save_path] if options[:save_path].present?
       params[:paused] = options[:paused] ? "true" : "false" if options.key?(:paused)
+      apply_seed_limits!(params, options)
       params.merge!(adapter_specific_add_torrent_params)
       params
+    end
+
+    def apply_seed_limits!(params, options)
+      ratio = Float(options[:seed_ratio], exception: false)
+      params[:ratioLimit] = ratio if ratio&.positive?
+
+      time = Float(options[:seed_time], exception: false)&.to_i
+      params[:seedingTimeLimit] = time if time&.positive?
     end
 
     def adapter_specific_add_torrent_params

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -37,6 +37,25 @@ module IndexerClients
         handle_response(response) { |data| Array(data) }
       end
 
+      # Seed ratio / seed time live on the indexer definition, not on search
+      # results. Look them up by the result's indexerId. Returns only positive
+      # values so callers can omit the params and leave the download client on
+      # its global limits when nothing is configured.
+      def seed_criteria(indexer_id)
+        return {} unless configured?
+
+        id = Integer(indexer_id, exception: false)
+        return {} if id.blank? || id <= 0
+
+        indexer = indexers.find { |item| Integer(item["id"], exception: false) == id }
+        return {} unless indexer.is_a?(Hash)
+
+        extract_seed_criteria(indexer)
+      rescue Base::Error => e
+        Rails.logger.warn "[IndexerClients::Prowlarr] Failed to look up seed criteria for indexer #{id}: #{e.message}"
+        {}
+      end
+
       # Indexers Prowlarr would search on our behalf: every configured indexer,
       # or only the tagged subset when prowlarr_tags is set. Returns nil when
       # Prowlarr's indexer list cannot be read.
@@ -170,6 +189,7 @@ module IndexerClients
           guid: item["guid"],
           title: item["title"],
           indexer: item["indexer"],
+          indexer_id: item["indexerId"],
           size_bytes: item["size"],
           seeders: item["seeders"],
           leechers: item["leechers"],
@@ -179,6 +199,37 @@ module IndexerClients
           published_at: parse_date(item["publishDate"]),
           category_ids: extract_category_ids(item)
         )
+      end
+
+      def extract_seed_criteria(indexer)
+        criteria = {}
+
+        ratio = positive_number(seed_field_value(indexer, "seedRatio"))
+        criteria[:seed_ratio] = ratio if ratio
+
+        time = positive_number(seed_field_value(indexer, "seedTime"))
+        criteria[:seed_time] = time.to_i if time
+
+        criteria
+      end
+
+      def seed_field_value(indexer, field)
+        field_name = "torrentBaseSettings.#{field}"
+        fields = indexer["fields"]
+        if fields.is_a?(Array)
+          match = fields.find { |item| item.is_a?(Hash) && item["name"] == field_name }
+          return match["value"] if match&.key?("value")
+        end
+
+        nested = indexer.dig("torrentBaseSettings", field)
+        return nested["value"] if nested.is_a?(Hash) && nested.key?("value")
+
+        nested
+      end
+
+      def positive_number(value)
+        number = Float(value, exception: false)
+        number if number&.positive?
       end
 
       def extract_category_ids(item)

--- a/app/services/indexer_clients/prowlarr.rb
+++ b/app/services/indexer_clients/prowlarr.rb
@@ -38,21 +38,21 @@ module IndexerClients
       end
 
       # Seed ratio / seed time live on the indexer definition, not on search
-      # results. Look them up by the result's indexerId. Returns only positive
-      # values so callers can omit the params and leave the download client on
-      # its global limits when nothing is configured.
+      # results. Look them up by the result's indexerId. Missing values leave
+      # the client on global limits; zero and qBittorrent's -1/-2 sentinels
+      # are explicit settings and must survive dispatch.
       def seed_criteria(indexer_id)
         return {} unless configured?
 
         id = Integer(indexer_id, exception: false)
         return {} if id.blank? || id <= 0
 
-        indexer = indexers.find { |item| Integer(item["id"], exception: false) == id }
+        indexer = indexers.find { |item| item.is_a?(Hash) && Integer(item["id"], exception: false) == id }
         return {} unless indexer.is_a?(Hash)
 
         extract_seed_criteria(indexer)
-      rescue Base::Error => e
-        Rails.logger.warn "[IndexerClients::Prowlarr] Failed to look up seed criteria for indexer #{id}: #{e.message}"
+      rescue Base::Error, Faraday::Error => e
+        Rails.logger.warn "[IndexerClients::Prowlarr] Failed to look up seed criteria for indexer #{id} (#{e.class})"
         {}
       end
 
@@ -204,10 +204,10 @@ module IndexerClients
       def extract_seed_criteria(indexer)
         criteria = {}
 
-        ratio = positive_number(seed_field_value(indexer, "seedRatio"))
+        ratio = seed_limit(seed_field_value(indexer, "seedRatio"))
         criteria[:seed_ratio] = ratio if ratio
 
-        time = positive_number(seed_field_value(indexer, "seedTime"))
+        time = seed_limit(seed_field_value(indexer, "seedTime"))
         criteria[:seed_time] = time.to_i if time
 
         criteria
@@ -216,20 +216,14 @@ module IndexerClients
       def seed_field_value(indexer, field)
         field_name = "torrentBaseSettings.#{field}"
         fields = indexer["fields"]
-        if fields.is_a?(Array)
-          match = fields.find { |item| item.is_a?(Hash) && item["name"] == field_name }
-          return match["value"] if match&.key?("value")
-        end
+        return unless fields.is_a?(Array)
 
-        nested = indexer.dig("torrentBaseSettings", field)
-        return nested["value"] if nested.is_a?(Hash) && nested.key?("value")
-
-        nested
+        fields.find { |item| item.is_a?(Hash) && item["name"] == field_name }&.fetch("value", nil)
       end
 
-      def positive_number(value)
+      def seed_limit(value)
         number = Float(value, exception: false)
-        number if number&.positive?
+        number if number&.finite? && (number >= 0 || [ -1, -2 ].include?(number))
       end
 
       def extract_category_ids(item)

--- a/app/services/indexer_clients/result.rb
+++ b/app/services/indexer_clients/result.rb
@@ -2,15 +2,17 @@
 
 module IndexerClients
   Result = Data.define(
-    :guid, :title, :indexer, :size_bytes, :seeders, :leechers,
+    :guid, :title, :indexer, :indexer_id, :size_bytes, :seeders, :leechers,
     :download_url, :magnet_url, :info_url, :published_at, :category_ids
   ) do
     def initialize(
       guid:, title:, indexer:, size_bytes:, seeders:, leechers:,
-      download_url:, magnet_url:, info_url:, published_at:, category_ids: []
+      download_url:, magnet_url:, info_url:, published_at:, category_ids: [], indexer_id: nil
     )
       super(
-        guid:, title:, indexer:, size_bytes:, seeders:, leechers:,
+        guid:, title:, indexer:,
+        indexer_id: Integer(indexer_id, exception: false),
+        size_bytes:, seeders:, leechers:,
         download_url:, magnet_url:, info_url:, published_at:,
         category_ids: Array(category_ids).filter_map { |id| Integer(id, exception: false) }.uniq
       )

--- a/db/migrate/20260908120000_add_indexer_id_to_search_results.rb
+++ b/db/migrate/20260908120000_add_indexer_id_to_search_results.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexerIdToSearchResults < ActiveRecord::Migration[8.1]
+  def change
+    add_column :search_results, :indexer_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_28_230000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_08_120000) do
   create_table "acquisition_providers", force: :cascade do |t|
     t.boolean "allow_private_network", default: false, null: false
     t.string "api_key"
@@ -401,6 +401,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_230000) do
     t.string "download_url"
     t.string "guid", null: false
     t.string "indexer"
+    t.integer "indexer_id"
     t.string "info_url"
     t.integer "leechers"
     t.string "magnet_url"

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -2094,6 +2094,29 @@ class DownloadJobTest < ActiveJob::TestCase
     end
   end
 
+  [ 0, -1, -2 ].each do |limit|
+    test "forwards explicit seed limit #{limit} from Prowlarr through torrent dispatch" do
+      configure_prowlarr!
+      magnet = assign_magnet_result!(indexer_id: 11)
+
+      VCR.turned_off do
+        stub_prowlarr_indexers([
+          { "id" => 11, "fields" => [
+            { "name" => "torrentBaseSettings.seedRatio", "value" => limit },
+            { "name" => "torrentBaseSettings.seedTime", "value" => limit }
+          ] }
+        ])
+        captured = stub_qbittorrent_magnet_add(magnet)
+
+        DownloadJob.perform_now(@download.id)
+
+        assert_equal "torrent", @download.reload.download_type
+        assert_equal limit.to_f, Float(captured[:body].fetch("ratioLimit"))
+        assert_equal limit, Integer(captured[:body].fetch("seedingTimeLimit"))
+      end
+    end
+  end
+
   test "omits seed limits when the search result indexer id is blank" do
     configure_prowlarr!
     magnet = assign_magnet_result!(indexer_id: nil)
@@ -2148,6 +2171,24 @@ class DownloadJobTest < ActiveJob::TestCase
       DownloadJob.perform_now(@download.id)
 
       assert @download.reload.downloading?
+      assert_not captured[:body].key?("ratioLimit")
+      assert_not captured[:body].key?("seedingTimeLimit")
+    end
+  end
+
+  test "still dispatches when Prowlarr seed criteria response contains invalid JSON" do
+    configure_prowlarr!
+    magnet = assign_magnet_result!(indexer_id: 11)
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/indexer})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: '[{"id":11,"fields":[')
+      captured = stub_qbittorrent_magnet_add(magnet)
+
+      DownloadJob.perform_now(@download.id)
+
+      assert_equal "torrent", @download.reload.download_type
+      assert_equal magnet, captured[:body]["urls"]
       assert_not captured[:body].key?("ratioLimit")
       assert_not captured[:body].key?("seedingTimeLimit")
     end

--- a/test/jobs/download_job_test.rb
+++ b/test/jobs/download_job_test.rb
@@ -56,6 +56,7 @@ class DownloadJobTest < ActiveJob::TestCase
     SettingsService.set(:gutenberg_url, "https://www.gutenberg.org")
     ZLibraryClient.reset_connection! if defined?(ZLibraryClient)
     GutenbergClient.reset_connection! if defined?(GutenbergClient)
+    IndexerClients::Prowlarr.reset_connection!
   end
 
   test "updates download status to downloading on success" do
@@ -791,7 +792,7 @@ class DownloadJobTest < ActiveJob::TestCase
     removed_ids = []
     claimed_download = @download
     client = Object.new
-    client.define_singleton_method(:add_torrent) do |_url|
+    client.define_singleton_method(:add_torrent) do |_url, _options = {}|
       claimed_download.update!(status: :failed)
       "stale-torrent-hash"
     end
@@ -2029,7 +2030,7 @@ class DownloadJobTest < ActiveJob::TestCase
   test "send_to_torrent_client marks attention when client returns no hash" do
     @download.update!(status: :downloading, download_type: "dispatching")
     client = Object.new
-    def client.add_torrent(_url)
+    def client.add_torrent(_url, _options = {})
       nil
     end
 
@@ -2041,6 +2042,115 @@ class DownloadJobTest < ActiveJob::TestCase
 
     assert @download.reload.failed?
     assert @request.reload.attention_needed?
+  end
+
+  test "forwards indexer seed criteria to qBittorrent as ratioLimit and seedingTimeLimit" do
+    configure_prowlarr!
+    magnet = assign_magnet_result!(indexer_id: 11)
+
+    VCR.turned_off do
+      stub_prowlarr_indexers([
+        {
+          "id" => 11,
+          "name" => "PrivateTracker",
+          "fields" => [
+            { "name" => "torrentBaseSettings.seedRatio", "value" => 1.5 },
+            { "name" => "torrentBaseSettings.seedTime", "value" => 72 }
+          ]
+        }
+      ])
+      captured = stub_qbittorrent_magnet_add(magnet)
+
+      DownloadJob.perform_now(@download.id)
+
+      assert @download.reload.downloading?
+      assert_in_delta 1.5, captured[:body]["ratioLimit"].to_f, 0.0001
+      assert_equal 72, captured[:body]["seedingTimeLimit"].to_i
+    end
+  end
+
+  test "omits seed limits when the indexer has no criteria configured" do
+    configure_prowlarr!
+    magnet = assign_magnet_result!(indexer_id: 11)
+
+    VCR.turned_off do
+      stub_prowlarr_indexers([
+        {
+          "id" => 11,
+          "name" => "PublicTracker",
+          "fields" => [
+            { "name" => "torrentBaseSettings.seedRatio" },
+            { "name" => "torrentBaseSettings.seedTime" }
+          ]
+        }
+      ])
+      captured = stub_qbittorrent_magnet_add(magnet)
+
+      DownloadJob.perform_now(@download.id)
+
+      assert @download.reload.downloading?
+      assert_not captured[:body].key?("ratioLimit")
+      assert_not captured[:body].key?("seedingTimeLimit")
+    end
+  end
+
+  test "omits seed limits when the search result indexer id is blank" do
+    configure_prowlarr!
+    magnet = assign_magnet_result!(indexer_id: nil)
+    indexer_stub = stub_prowlarr_indexers([ { "id" => 11, "name" => "PrivateTracker" } ])
+
+    VCR.turned_off do
+      captured = stub_qbittorrent_magnet_add(magnet)
+
+      DownloadJob.perform_now(@download.id)
+
+      assert @download.reload.downloading?
+      assert_not captured[:body].key?("ratioLimit")
+      assert_not captured[:body].key?("seedingTimeLimit")
+      assert_not_requested indexer_stub
+    end
+  end
+
+  test "omits seed limits when the indexer id is unknown" do
+    configure_prowlarr!
+    magnet = assign_magnet_result!(indexer_id: 99)
+
+    VCR.turned_off do
+      stub_prowlarr_indexers([
+        {
+          "id" => 11,
+          "name" => "PrivateTracker",
+          "fields" => [
+            { "name" => "torrentBaseSettings.seedRatio", "value" => 1.5 },
+            { "name" => "torrentBaseSettings.seedTime", "value" => 72 }
+          ]
+        }
+      ])
+      captured = stub_qbittorrent_magnet_add(magnet)
+
+      DownloadJob.perform_now(@download.id)
+
+      assert @download.reload.downloading?
+      assert_not captured[:body].key?("ratioLimit")
+      assert_not captured[:body].key?("seedingTimeLimit")
+    end
+  end
+
+  test "still dispatches when Prowlarr seed criteria lookup fails" do
+    configure_prowlarr!
+    magnet = assign_magnet_result!(indexer_id: 11)
+
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/indexer})
+        .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+      captured = stub_qbittorrent_magnet_add(magnet)
+
+      DownloadJob.perform_now(@download.id)
+
+      assert @download.reload.downloading?
+      assert_not captured[:body].key?("ratioLimit")
+      assert_not captured[:body].key?("seedingTimeLimit")
+    end
   end
 
   test "check_for_duplicate_external_id logs duplicates without raising" do
@@ -2444,6 +2554,56 @@ class DownloadJobTest < ActiveJob::TestCase
     ftyp = [ 24 ].pack("N") + "ftyp" + "M4B \x00\x00\x00\x00M4B mp42".b
     payload = SecureRandom.random_bytes(2.kilobytes)
     ftyp + [ payload.bytesize + 8 ].pack("N") + "mdat" + payload
+  end
+
+  def configure_prowlarr!
+    SettingsService.set(:prowlarr_url, "http://localhost:9696")
+    SettingsService.set(:prowlarr_api_key, "test-api-key-12345")
+    IndexerClients::Prowlarr.reset_connection!
+  end
+
+  def assign_magnet_result!(indexer_id:)
+    hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+    magnet = "magnet:?xt=urn:btih:#{hash}"
+    @selected_result.update!(
+      indexer_id: indexer_id,
+      source: SearchResult::SOURCE_PROWLARR,
+      download_url: nil,
+      magnet_url: magnet
+    )
+    magnet
+  end
+
+  def stub_prowlarr_indexers(indexers)
+    stub_request(:get, %r{localhost:9696/api/v1/indexer})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: indexers.to_json
+      )
+  end
+
+  def stub_qbittorrent_magnet_add(magnet)
+    hash = MagnetLink.info_hash(magnet)
+    captured = { body: {} }
+
+    stub_qbittorrent_connection("http://localhost:8080")
+
+    stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+      .with { |request|
+        captured[:body] = request.body.is_a?(Hash) ? request.body : URI.decode_www_form(request.body.to_s).to_h
+        true
+      }
+      .to_return(status: 200, body: "Ok.")
+
+    stub_request(:get, "http://localhost:8080/api/v2/torrents/info?hashes=#{hash}")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: [ { "hash" => hash, "name" => "Test Torrent", "progress" => 0, "state" => "downloading", "size" => 1000, "content_path" => "/downloads/Test Torrent" } ].to_json
+      )
+
+    captured
   end
 
   def stub_qbittorrent_success(torrent_url: "http://example.com/download/test.torrent")

--- a/test/jobs/search_job_test.rb
+++ b/test/jobs/search_job_test.rb
@@ -93,6 +93,7 @@ class SearchJobTest < ActiveJob::TestCase
       assert @request.searching?
       assert @request.search_results.any?
       assert_equal "Test Result Book", @request.search_results.first.title
+      assert_equal 7, @request.search_results.first.indexer_id
     end
   end
 
@@ -407,6 +408,29 @@ class SearchJobTest < ActiveJob::TestCase
     assert carried.blocklisted?
     assert_equal "Bad release", carried.blocklist_reason
     assert carried.rejected?
+  end
+
+  test "save_results persists the Prowlarr indexer id from the search result" do
+    tagged_result = tagged_indexer_result(guid: "indexer-id-guid", title: "The Pending Ebook Another Author EPUB")
+    tagged_result[:result] = IndexerClients::Result.new(
+      guid: "indexer-id-guid",
+      title: "The Pending Ebook Another Author EPUB",
+      indexer: "PrivateTracker",
+      indexer_id: 11,
+      size_bytes: 1.megabyte,
+      seeders: 10,
+      leechers: 0,
+      download_url: nil,
+      magnet_url: "magnet:?xt=urn:btih:indexerid",
+      info_url: nil,
+      published_at: nil
+    )
+
+    SearchJob.new.send(:save_results, @request, [ tagged_result ])
+
+    stored = @request.search_results.find_by!(guid: "indexer-id-guid")
+    assert_equal 11, stored.indexer_id
+    assert_equal "PrivateTracker", stored.indexer
   end
 
   test "schedules retry when no results found" do
@@ -2961,6 +2985,7 @@ class SearchJobTest < ActiveJob::TestCase
       "guid" => "test-guid-123",
       "title" => "Test Result Book",
       "indexer" => "TestIndexer",
+      "indexerId" => 7,
       "size" => 52_428_800,
       "seeders" => 25,
       "leechers" => 5,

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -1501,11 +1501,11 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
     end
   end
 
-  test "add_torrent omits non-positive seed limits so the client keeps global limits" do
+  test "add_torrent omits invalid seed limits so the client keeps global limits" do
     VCR.turned_off do
       captured = capture_add_torrent_request(
         "magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        seed_ratio: 0,
+        seed_ratio: -5,
         seed_time: -5
       )
 

--- a/test/services/download_clients/qbittorrent_test.rb
+++ b/test/services/download_clients/qbittorrent_test.rb
@@ -1476,4 +1476,133 @@ class DownloadClients::QbittorrentTest < ActiveSupport::TestCase
       assert_equal "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", result
     end
   end
+
+  test "add_torrent sends ratioLimit and seedingTimeLimit when seed criteria are supplied" do
+    VCR.turned_off do
+      captured = capture_add_torrent_request(
+        "magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        seed_ratio: 1.5,
+        seed_time: 72
+      )
+
+      assert_in_delta 1.5, captured["ratioLimit"].to_f, 0.0001
+      assert_equal 72, captured["seedingTimeLimit"].to_i
+    end
+  end
+
+  test "add_torrent omits seed limits when criteria are absent" do
+    VCR.turned_off do
+      captured = capture_add_torrent_request(
+        "magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+      )
+
+      assert_not captured.key?("ratioLimit")
+      assert_not captured.key?("seedingTimeLimit")
+    end
+  end
+
+  test "add_torrent omits non-positive seed limits so the client keeps global limits" do
+    VCR.turned_off do
+      captured = capture_add_torrent_request(
+        "magnet:?xt=urn:btih:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        seed_ratio: 0,
+        seed_time: -5
+      )
+
+      assert_not captured.key?("ratioLimit")
+      assert_not captured.key?("seedingTimeLimit")
+    end
+  end
+
+  test "add_torrent includes seed limits on the torrent file upload path" do
+    VCR.turned_off do
+      info_dict = {
+        "name" => "Seed Criteria Book.epub",
+        "piece length" => 16384,
+        "pieces" => "s" * 20,
+        "length" => 512
+      }
+      torrent_data = { "info" => info_dict }.bencode
+      expected_hash = Digest::SHA1.hexdigest(info_dict.bencode).downcase
+
+      stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+        .to_return(
+          status: 200,
+          headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+          body: "Ok."
+        )
+
+      stub_request(:get, "http://prowlarr:9696/api/v1/indexer/download/seed-criteria")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/x-bittorrent" },
+          body: torrent_data
+        )
+
+      add_stub = stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+        .with { |request|
+          request.headers["Content-Type"]&.include?("multipart/form-data") &&
+            request.body.include?("name=\"ratioLimit\"") &&
+            request.body.include?("1.5") &&
+            request.body.include?("name=\"seedingTimeLimit\"") &&
+            request.body.include?("72")
+        }
+        .to_return(status: 200, body: "Ok.")
+
+      stub_request(:get, "http://localhost:8080/api/v2/torrents/info?hashes=#{expected_hash}")
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: [ { "hash" => expected_hash, "name" => "Seed Criteria Book.epub", "progress" => 0, "state" => "downloading", "size" => 512, "content_path" => "/downloads" } ].to_json
+        )
+
+      result = @client.add_torrent(
+        "http://prowlarr:9696/api/v1/indexer/download/seed-criteria",
+        seed_ratio: 1.5,
+        seed_time: 72
+      )
+
+      assert_equal expected_hash, result
+      assert_requested(add_stub)
+    end
+  end
+
+  private
+
+  def capture_add_torrent_request(url, **options)
+    hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+    captured = nil
+
+    stub_request(:post, "http://localhost:8080/api/v2/auth/login")
+      .to_return(
+        status: 200,
+        headers: { "Set-Cookie" => "SID=test_session_id; path=/" },
+        body: "Ok."
+      )
+
+    stub_request(:post, "http://localhost:8080/api/v2/torrents/add")
+      .with { |request|
+        captured = add_torrent_params(request)
+        true
+      }
+      .to_return(status: 200, body: "Ok.")
+
+    stub_request(:get, "http://localhost:8080/api/v2/torrents/info?hashes=#{hash}")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: [ { "hash" => hash, "name" => "Test", "progress" => 0, "state" => "downloading", "size" => 100, "content_path" => "/downloads" } ].to_json
+      )
+
+    result = @client.add_torrent(url, options)
+    assert_equal hash, result
+    captured
+  end
+
+  def add_torrent_params(request)
+    body = request.body
+    return body if body.is_a?(Hash)
+
+    URI.decode_www_form(body.to_s).to_h
+  end
 end

--- a/test/services/indexer_clients/prowlarr_seed_criteria_test.rb
+++ b/test/services/indexer_clients/prowlarr_seed_criteria_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class IndexerClients::ProwlarrSeedCriteriaTest < ActiveSupport::TestCase
+  setup do
+    SettingsService.set(:prowlarr_url, "http://localhost:9696")
+    SettingsService.set(:prowlarr_api_key, "test-api-key-12345")
+    IndexerClients::Prowlarr.reset_connection!
+  end
+
+  teardown do
+    IndexerClients::Prowlarr.reset_connection!
+  end
+
+  test "returns seed ratio and seed time from indexer fields" do
+    VCR.turned_off do
+      stub_indexers(
+        indexer_definition(
+          11,
+          fields: [
+            { "name" => "torrentBaseSettings.seedRatio", "value" => 1.5 },
+            { "name" => "torrentBaseSettings.seedTime", "value" => 72 }
+          ]
+        )
+      )
+
+      assert_equal({ seed_ratio: 1.5, seed_time: 72 }, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  test "returns seed criteria from nested torrentBaseSettings" do
+    VCR.turned_off do
+      stub_indexers(
+        {
+          "id" => 11,
+          "name" => "NestedTracker",
+          "torrentBaseSettings" => {
+            "seedRatio" => { "value" => 2.0 },
+            "seedTime" => { "value" => 1440 }
+          }
+        }
+      )
+
+      assert_equal({ seed_ratio: 2.0, seed_time: 1440 }, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  test "omits criteria when Prowlarr fields have no value" do
+    VCR.turned_off do
+      stub_indexers(
+        indexer_definition(
+          11,
+          fields: [
+            { "name" => "torrentBaseSettings.seedRatio" },
+            { "name" => "torrentBaseSettings.seedTime" }
+          ]
+        )
+      )
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  test "returns only the fields that are configured" do
+    VCR.turned_off do
+      stub_indexers(
+        indexer_definition(
+          11,
+          fields: [
+            { "name" => "torrentBaseSettings.seedRatio", "value" => 1.0 },
+            { "name" => "torrentBaseSettings.seedTime" }
+          ]
+        )
+      )
+
+      assert_equal({ seed_ratio: 1.0 }, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  test "returns empty criteria for an unknown indexer id" do
+    VCR.turned_off do
+      stub_indexers(indexer_definition(11, fields: [
+        { "name" => "torrentBaseSettings.seedRatio", "value" => 1.5 }
+      ]))
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(99))
+    end
+  end
+
+  test "returns empty criteria for a blank indexer id" do
+    VCR.turned_off do
+      indexer_stub = stub_indexers(indexer_definition(11))
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(nil))
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(""))
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(" "))
+      assert_not_requested indexer_stub
+    end
+  end
+
+  test "returns empty criteria when Prowlarr is unreachable" do
+    VCR.turned_off do
+      stub_request(:get, %r{localhost:9696/api/v1/indexer})
+        .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  test "returns empty criteria when Prowlarr is not configured" do
+    SettingsService.set(:prowlarr_api_key, "")
+
+    VCR.turned_off do
+      indexer_stub = stub_request(:get, %r{localhost:9696/api/v1/indexer})
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(11))
+      assert_not_requested indexer_stub
+    end
+  end
+
+  test "omits non-positive seed values so the client keeps global limits" do
+    VCR.turned_off do
+      stub_indexers(
+        indexer_definition(
+          11,
+          fields: [
+            { "name" => "torrentBaseSettings.seedRatio", "value" => 0 },
+            { "name" => "torrentBaseSettings.seedTime", "value" => -1 }
+          ]
+        )
+      )
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  private
+
+  def stub_indexers(*indexers)
+    stub_request(:get, %r{localhost:9696/api/v1/indexer})
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: indexers.to_json
+      )
+  end
+
+  def indexer_definition(id, fields: [])
+    {
+      "id" => id,
+      "name" => "Tracker #{id}",
+      "fields" => fields
+    }
+  end
+end

--- a/test/services/indexer_clients/prowlarr_seed_criteria_test.rb
+++ b/test/services/indexer_clients/prowlarr_seed_criteria_test.rb
@@ -29,23 +29,6 @@ class IndexerClients::ProwlarrSeedCriteriaTest < ActiveSupport::TestCase
     end
   end
 
-  test "returns seed criteria from nested torrentBaseSettings" do
-    VCR.turned_off do
-      stub_indexers(
-        {
-          "id" => 11,
-          "name" => "NestedTracker",
-          "torrentBaseSettings" => {
-            "seedRatio" => { "value" => 2.0 },
-            "seedTime" => { "value" => 1440 }
-          }
-        }
-      )
-
-      assert_equal({ seed_ratio: 2.0, seed_time: 1440 }, IndexerClients::Prowlarr.seed_criteria(11))
-    end
-  end
-
   test "omits criteria when Prowlarr fields have no value" do
     VCR.turned_off do
       stub_indexers(
@@ -119,14 +102,33 @@ class IndexerClients::ProwlarrSeedCriteriaTest < ActiveSupport::TestCase
     end
   end
 
-  test "omits non-positive seed values so the client keeps global limits" do
+  test "ignores malformed indexer entries and fields" do
+    VCR.turned_off do
+      stub_indexers(nil, 12, [ "id", 11 ], { "id" => 11, "fields" => "invalid" })
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  test "omits non-finite seed values" do
+    VCR.turned_off do
+      stub_indexers(indexer_definition(11, fields: [
+        { "name" => "torrentBaseSettings.seedRatio", "value" => "1e1000" },
+        { "name" => "torrentBaseSettings.seedTime", "value" => "1e1000" }
+      ]))
+
+      assert_equal({}, IndexerClients::Prowlarr.seed_criteria(11))
+    end
+  end
+
+  test "omits invalid seed values so the client keeps global limits" do
     VCR.turned_off do
       stub_indexers(
         indexer_definition(
           11,
           fields: [
-            { "name" => "torrentBaseSettings.seedRatio", "value" => 0 },
-            { "name" => "torrentBaseSettings.seedTime", "value" => -1 }
+            { "name" => "torrentBaseSettings.seedRatio", "value" => -5 },
+            { "name" => "torrentBaseSettings.seedTime", "value" => -5 }
           ]
         )
       )

--- a/test/services/prowlarr_client_test.rb
+++ b/test/services/prowlarr_client_test.rb
@@ -62,6 +62,7 @@ class ProwlarrClientTest < ActiveSupport::TestCase
               "guid" => "abc123",
               "title" => "Harry Potter Audiobook Collection",
               "indexer" => "TestIndexer",
+              "indexerId" => 11,
               "size" => 1073741824,
               "seeders" => 50,
               "leechers" => 10,
@@ -84,6 +85,7 @@ class ProwlarrClientTest < ActiveSupport::TestCase
       assert_equal "abc123", result.guid
       assert_equal "Harry Potter Audiobook Collection", result.title
       assert_equal "TestIndexer", result.indexer
+      assert_equal 11, result.indexer_id
       assert_equal 50, result.seeders
       assert_equal "magnet:?xt=urn:btih:abc123", result.download_link
       assert_equal [ 7020 ], result.category_ids


### PR DESCRIPTION
## Assigned issue

Closes #522

## What changed

Torrent grabs now carry Prowlarr's `indexerId` from search through persisted search results. At dispatch, Shelfarr reads that indexer's seed ratio and seed time from Prowlarr's indexer `fields` and forwards them to qBittorrent's `ratioLimit` and `seedingTimeLimit` for both URL and torrent-file submissions.

Missing criteria keep the client's global limits. Explicit zero and qBittorrent's -1/-2 sentinel values are preserved. An unavailable Prowlarr endpoint, malformed JSON, or malformed indexer data cannot prevent the selected torrent from being dispatched. Error logs identify the lookup failure without including the provider response body.

`packSeedTime` remains outside this change because Shelfarr does not identify release packs. The rubyzip 3.6.0 update also clears the dependency advisory blocking the security gate.

## Verification

- `bin/quality push` passed locally: RuboCop, Brakeman, unit/integration tests, system tests, and coverage.
- Focused download/search/provider tests: 276 runs, 913 assertions, no failures or errors.
- Reproduced and fixed a truncated JSON response leaving a download in `dispatching` without adding the torrent.
- End-to-end DownloadJob regressions cover configured, absent, unknown, unreachable, malformed, zero, unlimited, and global-default criteria.
- Checked Prowlarr's field schema, warning/force-save semantics, and qBittorrent parameter units against upstream source.
- Independent adversarial review and a second pass over the fixes found no remaining defects.

HTTP APIs were mocked; a live Prowlarr/qBittorrent pair was not used. Fresh GitHub CI runs against the corrected head before merge.

## Screenshots or recordings

Not applicable: backend search and dispatch behavior.

## Checklist

- [x] The linked issue is assigned to the PR author
- [x] The change addresses the assigned issue
- [x] Behavior and regression tests are included
- [x] Relevant local quality checks passed